### PR TITLE
fix(git): give isomorphic-git its own HTTP agent — Node's 5s globalAgent timeout kills generations mid-push

### DIFF
--- a/packages/plugin/src/git/__tests__/git-http-agent.spec.ts
+++ b/packages/plugin/src/git/__tests__/git-http-agent.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import * as nodeHttp from 'isomorphic-git/http/node';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { http } from '../git-operations.js';
+
+/**
+ * Regression cover for the generation-killing git timeout.
+ *
+ * Node >= 19 gives `http(s).globalAgent` a `timeout: 5000` SOCKET-IDLE deadline. `isomorphic-git`'s node
+ * HTTP client passes no `agent`, so it inherits that deadline and `simple-get` rejects with the literal
+ * string `Request timed out` — which the push retry list does not match, so a whole generation dies.
+ *
+ * The control below is the important half: it asserts the RAW client still fails at ~5s. Without it a
+ * green subject test would prove nothing (it would pass just as well if the server were fast).
+ */
+
+const SERVER_DELAY_MS = 8_000;
+const TEST_TIMEOUT_MS = 30_000;
+
+let server: Server;
+
+function startSlowServer(): Promise<string> {
+	return new Promise((resolve) => {
+		server = createServer((req, res) => {
+			// Drain the request body, then deliberately stay silent past the 5s global-agent deadline.
+			req.resume();
+			req.on('end', () => {
+				setTimeout(() => {
+					res.writeHead(200, { 'Content-Type': 'text/plain' });
+					res.end('ok');
+				}, SERVER_DELAY_MS);
+			});
+		});
+		server.listen(0, '127.0.0.1', () => {
+			const { port } = server.address() as AddressInfo;
+			resolve(`http://127.0.0.1:${port}/slow`);
+		});
+	});
+}
+
+afterAll(() => {
+	server?.close();
+});
+
+describe('git HTTP client agent timeout', () => {
+	it(
+		'CONTROL: the raw isomorphic-git client inherits the 5s global agent timeout and fails',
+		async () => {
+			// Guard the premise: if a future Node drops this default the control is meaningless, and this
+			// assertion tells us so instead of the suite silently going green for the wrong reason.
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const { globalAgent } = await import('node:https');
+			expect(globalAgent.options.timeout).toBe(5000);
+
+			const url = await startSlowServer();
+			const started = Date.now();
+
+			await expect(
+				nodeHttp.request({ url, method: 'GET', headers: {} } as Parameters<typeof nodeHttp.request>[0])
+			).rejects.toThrow(/timed out/i);
+
+			const elapsed = Date.now() - started;
+			expect(elapsed).toBeLessThan(SERVER_DELAY_MS);
+		},
+		TEST_TIMEOUT_MS
+	);
+
+	it(
+		'SUBJECT: the wrapped client supplies an agent and survives a slow server',
+		async () => {
+			const url = await startSlowServer();
+			const started = Date.now();
+
+			const response = await http.request({
+				url,
+				method: 'GET',
+				headers: {}
+			} as Parameters<typeof nodeHttp.request>[0]);
+
+			expect(response.statusCode).toBe(200);
+			// It really did wait out the slow server rather than short-circuiting.
+			expect(Date.now() - started).toBeGreaterThanOrEqual(SERVER_DELAY_MS - 500);
+		},
+		TEST_TIMEOUT_MS
+	);
+});

--- a/packages/plugin/src/git/__tests__/git-http-agent.spec.ts
+++ b/packages/plugin/src/git/__tests__/git-http-agent.spec.ts
@@ -19,11 +19,13 @@ import { http } from '../git-operations.js';
 const SERVER_DELAY_MS = 8_000;
 const TEST_TIMEOUT_MS = 30_000;
 
-let server: Server;
+// Every started server is tracked so afterAll can close ALL of them. Tracking a single handle would
+// leak the first server (each test starts its own), which can keep the vitest process alive in CI.
+const servers: Server[] = [];
 
 function startSlowServer(): Promise<string> {
 	return new Promise((resolve) => {
-		server = createServer((req, res) => {
+		const server = createServer((req, res) => {
 			// Drain the request body, then deliberately stay silent past the 5s global-agent deadline.
 			req.resume();
 			req.on('end', () => {
@@ -33,6 +35,7 @@ function startSlowServer(): Promise<string> {
 				}, SERVER_DELAY_MS);
 			});
 		});
+		servers.push(server);
 		server.listen(0, '127.0.0.1', () => {
 			const { port } = server.address() as AddressInfo;
 			resolve(`http://127.0.0.1:${port}/slow`);
@@ -40,8 +43,15 @@ function startSlowServer(): Promise<string> {
 	});
 }
 
-afterAll(() => {
-	server?.close();
+afterAll(async () => {
+	await Promise.all(
+		servers.map(
+			(s) =>
+				new Promise<void>((resolve) => {
+					s.close(() => resolve());
+				})
+		)
+	);
 });
 
 describe('git HTTP client agent timeout', () => {

--- a/packages/plugin/src/git/git-operations.ts
+++ b/packages/plugin/src/git/git-operations.ts
@@ -2,7 +2,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import git from 'isomorphic-git';
-import * as http from 'isomorphic-git/http/node';
+import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+import * as nodeHttp from 'isomorphic-git/http/node';
 import type {
 	IGitOperations,
 	GitAuth,
@@ -13,6 +15,39 @@ import type {
 	GitFileChange,
 	GitFileStatus
 } from '../contracts/capabilities/git-provider.interface.js';
+
+/**
+ * Node >= 19 ships `http(s).globalAgent` with `timeout: 5000` - a SOCKET-IDLE deadline, not a
+ * total-request budget. `isomorphic-git/http/node` never passes an `agent`, so every git-over-HTTP
+ * request inherits it and `simple-get` rejects with the literal string `Request timed out` after ~5s.
+ *
+ * That string matches none of the entries in the push retry list below, so the whole operation fails
+ * on the first attempt. Worse, the abort is CLIENT-side: on 2026-08-23 a generation pushed 8 files that
+ * GitHub accepted (commits 4100128f + d006ac78) and then failed 9s later recording 0 items, leaving the
+ * data repo and the platform database silently divergent.
+ *
+ * isomorphic-git is pure JavaScript (inflate / SHA-1 / packfile indexing run on the main thread), so a
+ * busy event loop or a receive-pack that thinks for >5s trips the timer. Supplying our own agent with a
+ * realistic ceiling removes the trap. Keep this FINITE - 0 would let a genuinely dead socket hang.
+ */
+const GIT_HTTP_TIMEOUT_MS = Number(process.env.GIT_HTTP_TIMEOUT_MS ?? 300_000);
+
+const gitHttpAgent = new HttpAgent({ keepAlive: true, timeout: GIT_HTTP_TIMEOUT_MS });
+const gitHttpsAgent = new HttpsAgent({ keepAlive: true, timeout: GIT_HTTP_TIMEOUT_MS });
+
+/**
+ * Drop-in replacement for the raw `isomorphic-git/http/node` client that injects the agents above.
+ * Exported so tests can exercise it directly against a deliberately slow server.
+ */
+export const http = {
+	request: (request: Parameters<typeof nodeHttp.request>[0]) =>
+		nodeHttp.request({
+			...request,
+			agent:
+				(request as { agent?: unknown }).agent ??
+				(String(request.url).startsWith('https:') ? gitHttpsAgent : gitHttpAgent)
+		} as Parameters<typeof nodeHttp.request>[0])
+};
 
 const DEFAULT_BRANCHES = ['main', 'master'] as const;
 
@@ -186,7 +221,10 @@ export class GitOperations implements IGitOperations {
 					errorMessage.includes('cannot lock ref') ||
 					errorMessage.includes('failed to lock') ||
 					errorMessage.includes('ETIMEDOUT') ||
-					errorMessage.includes('ECONNRESET');
+					errorMessage.includes('ECONNRESET') ||
+					// Defence in depth for the agent-timeout trap documented above: simple-get rejects with the
+					// lower-case literal 'Request timed out', which none of the codes above match.
+					errorMessage.toLowerCase().includes('timed out');
 
 				if (!isRetryable || attempt === maxRetries) {
 					throw error;


### PR DESCRIPTION
## The bug

Every directory generation can die mid-push with:

```
GENERATION_FAILED: Failed to complete data repository initialization: Request timed out
```

**Root cause:** Node ≥19 ships `http(s).globalAgent` with `timeout: 5000` — a **socket-idle** deadline, not a
request budget. `isomorphic-git/http/node` never passes an `agent`, so every git-over-HTTP request inherits
it, and `simple-get` rejects with the literal string `Request timed out`. That string matches **none** of the
entries in `push()`'s retry list (`cannot lock ref`, `failed to lock`, `ETIMEDOUT`, `ECONNRESET`), so the
first attempt throws and the whole generation fails.

isomorphic-git is pure JavaScript — inflate, SHA-1 and packfile indexing all run on the main thread (this
repo documents that in `git.facade.ts:238-256`) — so a busy event loop, or a `receive-pack` that thinks for
more than 5 seconds, trips the timer. It is timing-dependent, which is why the same Work sometimes succeeds.

## Why this is worse than a failed run

The abort is **client-side**. Run `run_cmt6f1pv16m822x1o4g0uz42c` (2026-08-23 23:06Z, worker `20260823.5`):

| time | what happened |
|---|---|
| 23:15:18Z | `4100128f` — `.works/works.yml`, `references.yml`, `tags.yml` **accepted by GitHub** |
| 23:15:20Z | `d006ac78` — 5 item files **accepted by GitHub** |
| 23:15:29Z | run marked **ERROR**, recorded `newItemsCount=0, updatedItemsCount=0` |

GitHub applied the refs; the client gave up waiting for the response. The data repo gained content while the
platform recorded a failure — the repo and the database **silently diverged**, and everything after the push
(`itemsCount`, `refreshDataCache`, `domainType`, PR creation) never ran.

## The fix

Wrap `isomorphic-git/http/node` so every request carries our own keep-alive agent with a finite,
env-overridable ceiling (`GIT_HTTP_TIMEOUT_MS`, default 300s). All five call sites — clone, clone-branch,
push, pull, fetch — are **unchanged**; they keep passing `http`, which is now the wrapper.

Kept **finite** deliberately: `0` would let a genuinely dead socket hang the task.

Also adds `timed out` to the push retry list as defence in depth.

## Tests — and proof they bite

New spec drives a deliberately slow (8s) local server:

- **CONTROL** — the *raw* client must still fail at ~5s, and asserts `globalAgent.options.timeout === 5000`
  so a future Node change surfaces as a failure rather than a silently meaningless green.
- **SUBJECT** — the wrapped client must survive and return 200 at ~8s.

**Revert-proven:** with the fix removed, SUBJECT fails at exactly **5025 ms** with `Error: Request timed out`
— the exact production error and deadline. With the fix, both pass.

`393/393` `packages/plugin` tests pass; `tsc --noEmit` clean; prettier clean.

## Deployment note

`packages/plugins/github/dist/index.js` **inlines** `GitOperations` from `@ever-works/plugin/git`, so the
github plugin bundle must be rebuilt and the Trigger worker redeployed for this to take effect. A worker
deployed before this merges does **not** contain the fix.

There is no no-code-change alternative: Node exposes no environment variable for `globalAgent.timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
