### PR TITLE
fix(ci): format credit-meter-event spec — develop was failing format:check for every PR

### DIFF
--- a/packages/agent/src/database/repositories/credit-meter-event.reservation.integration.spec.ts
+++ b/packages/agent/src/database/repositories/credit-meter-event.reservation.integration.spec.ts
@@ -1,9 +1,6 @@
 import { DataSource, Repository } from 'typeorm';
 import { BillingProfile } from '@src/entities/billing-profile.entity';
-import {
-    CreditMeterEvent,
-    CreditMeterEventStatus,
-} from '@src/entities/credit-meter-event.entity';
+import { CreditMeterEvent, CreditMeterEventStatus } from '@src/entities/credit-meter-event.entity';
 import { CreditMeterEventRepository } from './credit-meter-event.repository';
 
 describe('CreditMeterEventRepository — cap reservation (integration)', () => {


### PR DESCRIPTION
`pnpm format:check` is the **first** gate in `lint-and-test`, and it has been failing on `develop` itself since `5474a607b` ("fix(billing): harden PAYG caps and lifecycle"). Because it runs before the build/test steps, **every PR targeting `develop` went red on a file it never touched** — so nobody could get a meaningful green, and any wait on one was a wait on nothing.

One import statement, reflowed to the repo's prettier config:

```diff
-import {
-    CreditMeterEvent,
-    CreditMeterEventStatus,
-} from '@src/entities/credit-meter-event.entity';
+import { CreditMeterEvent, CreditMeterEventStatus } from '@src/entities/credit-meter-event.entity';
```

**Verified formatting-only, not asserted:** with whitespace *and* trailing commas normalised, the file is byte-identical before and after — the token stream is unchanged. (My first check normalised only whitespace and flagged a false difference; the removed trailing comma was the cause.)

**Verified complete, not partial:** repo-wide `prettier --check "**/*.{ts,tsx,jsx,json,css,md}"` — the exact CI command — now reports *All matched files use Prettier code style!*, and this was the only offending file.

Found by another session whose unrelated PR (#2234) went red on it. Not from my commits; raising and fixing it because it blocks everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)