### PR TITLE
fix(format): unblock the monorepo test suite — one import was failing format:check

### DIFF
--- a/packages/agent/src/database/repositories/credit-meter-event.reservation.integration.spec.ts
+++ b/packages/agent/src/database/repositories/credit-meter-event.reservation.integration.spec.ts
@@ -1,9 +1,6 @@
 import { DataSource, Repository } from 'typeorm';
 import { BillingProfile } from '@src/entities/billing-profile.entity';
-import {
-    CreditMeterEvent,
-    CreditMeterEventStatus,
-} from '@src/entities/credit-meter-event.entity';
+import { CreditMeterEvent, CreditMeterEventStatus } from '@src/entities/credit-meter-event.entity';
 import { CreditMeterEventRepository } from './credit-meter-event.repository';
 
 describe('CreditMeterEventRepository — cap reservation (integration)', () => {


### PR DESCRIPTION
## Impact first

`pnpm format:check` has been failing on **develop, stage and main**. In [ci.yml](.github/workflows/ci.yml) it runs at step ~142, before:

```
- name: Build all packages          # ~181
- name: run test on all packages    # ~185
```

Neither has `continue-on-error`, and their `if:` is `steps.scope.outputs.code == 'true'` — no `always()`. A failing step fails the job and skips the rest, so **not one test in the monorepo has executed in CI** while this was red. `lint-and-test (22.x)` is the only required check on develop, and it cannot go green.

One multi-line import was holding the entire suite hostage.

## The fix

Prettier wants the import on one line (it fits the 120-col budget):

```diff
-import {
-    CreditMeterEvent,
-    CreditMeterEventStatus,
-} from '@src/entities/credit-meter-event.entity';
+import { CreditMeterEvent, CreditMeterEventStatus } from '@src/entities/credit-meter-event.entity';
```

It arrived with the credit-meter work.

## Verification — and a trap worth documenting

Running `pnpm format:check` on a **Windows** checkout reports **~560 files**, which makes this look like unfixable repo-wide drift. It is not. With `core.autocrlf=true` almost all of those are CRLF artifacts that Linux CI never sees.

To get the truth I checked out the tree with LF and ran the same command:

```bash
git -c core.autocrlf=false worktree add --detach /tmp/lfverify HEAD
cd /tmp/lfverify && prettier --check "**/*.{ts,tsx,jsx,json,css,md}"
```

- **Before:** exactly 1 genuine offender (this file).
- **After:** `All matched files use Prettier code style!`

Second trap: `packages/agent/src/works-config/schema/works.v2.schema.json` *looks* like an offender if you glob it by absolute path, and it does have expanded arrays prettier would collapse. It is listed in `.prettierignore`, so CI skips it — glob it directly and you bypass the ignore file and chase a phantom. Left untouched deliberately.

## Follow-on

This is what has been keeping [#2237](https://github.com/ever-works/ever-works/pull/2237) (the DI-compile guard) from ever running its own test in CI. Merging this first makes that check meaningful rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)