### PR TITLE
ci(k8s-build): run on x64-8 — x64-16 is unschedulable, not merely busy

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -38,7 +38,34 @@ jobs:
     # x64-16 (maxRunners=5) is referenced by no other workflow and was completely idle.
     # The chain falls back to x64-4 and then ubuntu-latest, so nothing breaks if the
     # variable is unset.
-    runs-on: ${{ vars.RUNNER_LINUX_X64_16 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    # 🛑 x64-8, NOT x64-16 — because x64-16 is currently unschedulable, not merely busy.
+    #
+    # Measured 2026-08-24 11:26Z: all five `ever-works-linux-x64-16` pods `Pending`
+    # (two for 3h38m / 3h44m) on `Insufficient cpu/memory`, while eight
+    # `ever-works-linux-x64-8` pods were `2/2 Running` with visible turnover
+    # (ages 8m / 14m / 15m alongside 3h). That is the distinction that matters:
+    # x64-8 is CONTENDED BUT ALIVE, x64-16 is DEAD. Queueing behind runners that
+    # cycle resolves; waiting on pods that never schedule does not. Four hours of
+    # 0/4 jobs started, twice, held a production credit-ledger fix AND a login
+    # outage fix out of prod.
+    #
+    # The tier delta is only memory REQUEST: x64-16 asks 1 CPU/12Gi, x64-8 asks
+    # 1 CPU/8Gi. This workflow ran on x64-4 (6Gi) until `c447c3417` moved it, and
+    # that move was to escape a JAMMED pool, not because the build needed 12Gi —
+    # so 8Gi is amply evidenced.
+    #
+    # ⚠️ Honest risk, not a free win: `work` (16Gi) and `docker-storage` (32Gi) are
+    # still `emptyDir medium=Memory`, and their sizeLimits do NOT shrink with the
+    # tier. Lowering the request lowers the GUARANTEE, not the usage, so a heavy
+    # layer could push the pod past its request and be evicted mid-build. That
+    # failure reads as "the repoint did not work" — so it must be watched for
+    # explicitly (Evicted/OOMKilled), never inferred from a job merely starting.
+    #
+    # REVERT when x64-16 has capacity again: restore `vars.RUNNER_LINUX_X64_16` as
+    # the first term. The fallback chain is CONFIG-time, not runtime — it will
+    # never move off a pool that cannot schedule, which is why this needed an edit
+    # rather than resolving itself.
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**`k8s-build` is the only lane that publishes what the clusters pull, and it has not started a single job in ~4 hours.** Two consecutive prod builds sat at `0/4` with `steps=0`, holding both the credit-ledger fix and the login-outage fix out of production.

### The measurement

| pool | request | state at 11:26Z |
|---|---|---|
| `ever-works-linux-x64-16` | 1 CPU / **12Gi** | **5 Pending** (two 3h38m / 3h44m) |
| `ever-works-linux-x64-8` | 1 CPU / **8Gi** | **8 Running**, turnover 8m / 14m / 15m |

**x64-8 is contended but alive; x64-16 is dead.** Queueing behind runners that cycle resolves. Waiting on pods that never schedule does not.

The delta is only the memory **request**. This workflow ran on x64-4 (**6Gi**) until `c447c3417` moved it, and that move was to escape a *jammed* pool — not because the build needed 12Gi. So 8Gi is amply evidenced.

### ⚠️ The risk, stated plainly

`work` (16Gi) and `docker-storage` (32Gi) are still `emptyDir medium=Memory`, and their sizeLimits **do not shrink with the tier**. Lowering the request lowers the *guarantee*, not the usage — a heavy layer could push the pod past its request and be **evicted mid-build**. That strands prod exactly as a cancelled build does and reads as *"the repoint didn't work"*.

So this trades a **certain indefinite wait** for a **probable success with a real eviction risk**. It must be paired with watching for `Evicted`/`OOMKilled` — a started job is not a finished one. I have a monitor armed on exactly that.

### Revert

Restore `vars.RUNNER_LINUX_X64_16` as the first term once that pool has capacity. Note the `||` chain is **config-time, not runtime**: it will never move off a pool that cannot schedule, which is why this needed an edit rather than resolving itself.

### Scope
One `runs-on` line plus explanatory comment. **No ARC/pool config touched** — that belongs to the CI lane, and this deliberately avoids it. Workflow re-parsed with js-yaml: jobs intact, matrix intact, `cancel-in-progress: false` preserved.

Credit for the pool-tier measurements and the RAM-backed-workspace caveat to the session running the outage lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)