### PR TITLE
🔴 fix(web): keep the ingress locale rewrite relative — #2227 did NOT fix the /login loop

### DIFF
--- a/apps/web/src/proxy.prod-shape.unit.spec.ts
+++ b/apps/web/src/proxy.prod-shape.unit.spec.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { getAuthFromRequestMock, intlMock } = vi.hoisted(() => ({
+    getAuthFromRequestMock: vi.fn(),
+    intlMock: vi.fn(async (_request: unknown) => new Response(null, { status: 200 })),
+}));
+
+vi.mock('next-intl/middleware', () => ({ default: () => intlMock }));
+vi.mock('./lib/auth', () => ({ getAuthFromRequest: getAuthFromRequestMock }));
+// `ALLOWED_REDIRECT_URLS` is frozen into a const at module load, so stubbing the
+// env var after import is a no-op — mock the module to model the deployed value.
+vi.mock('./lib/constants', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./lib/constants')>()),
+    ALLOWED_REDIRECT_URLS: ['app.ever.works'],
+}));
+
+import proxy from './proxy';
+
+/**
+ * next-intl emits a RELATIVE `x-middleware-rewrite` in the deployed app, and a
+ * relative rewrite is internal by construction. Absolutising it is what caused
+ * both production outages on 2026-08-23/24 — first as a 500 (public authority
+ * plus port 3000, undialable), then as ERR_TOO_MANY_REDIRECTS once the port was
+ * dropped, and STILL as a redirect when the runtime origin was pinned instead.
+ *
+ * Measured on the running prod pod, same build, same pod:
+ *   GET /login  (bare)             -> 200, rewrite '/en/login'
+ *   GET /login  + X-Forwarded-Host -> 307 'location: /login',
+ *                                     rewrite 'http://<pod>:3000/en/login'
+ *
+ * So the invariant is not "which origin" — it is "do not add one".
+ */
+describe('ingress locale rewrite must stay relative', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthFromRequestMock.mockResolvedValue({ isAuthenticated: true, isExpired: false });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    function ingressRequest() {
+        return new NextRequest('https://app.ever.works/login', {
+            headers: {
+                host: 'app.ever.works',
+                'x-forwarded-host': 'app.ever.works',
+                'x-forwarded-proto': 'https',
+            },
+        });
+    }
+
+    it('leaves a relative rewrite untouched behind ingress', async () => {
+        vi.stubEnv('HOSTNAME', 'ever-works-web-6bc7f79765-7hvpd');
+        vi.stubEnv('PORT', '3000');
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: { 'x-middleware-rewrite': '/en/login' },
+            }),
+        );
+
+        const response = await proxy(ingressRequest());
+
+        // Any absolute origin — public OR runtime — makes Next treat the
+        // rewrite as external and answer with a redirect, which loops.
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
+    });
+
+    it('still realigns an already-absolute rewrite (the reverse-proxy case)', async () => {
+        vi.stubEnv('HOSTNAME', 'ever-works-web-pod');
+        vi.stubEnv('PORT', '3000');
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: { 'x-middleware-rewrite': 'http://localhost:3000/en/login' },
+            }),
+        );
+
+        const response = await proxy(ingressRequest());
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'http://ever-works-web-pod:3000/en/login',
+        );
+    });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -152,6 +152,26 @@ function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): Nex
     const rewrite = response.headers.get('x-middleware-rewrite');
     if (!rewrite) return response;
 
+    // 🛑 A RELATIVE rewrite is already internal by construction — Next resolves
+    // it against its own origin and renders in-process. Absolutising it is what
+    // breaks the request: Next only treats an absolute rewrite as internal when
+    // the origin matches its server init URL, and behind ingress NOTHING we can
+    // construct here reliably matches it. Measured on the running prod pod
+    // (2026-08-24), same pod, same build:
+    //
+    //   GET /login  (no forwarded headers) -> 200, rewrite '/en/login'
+    //   GET /login  + X-Forwarded-Host     -> 307 'location: /login',
+    //                                         rewrite 'http://<pod>:3000/en/login'
+    //
+    // The 307 then re-enters the middleware and loops (ERR_TOO_MANY_REDIRECTS);
+    // when the absolutised URL additionally carried the public authority it was
+    // undialable and surfaced as a 500 instead. Pinning the RUNTIME origin (the
+    // previous attempt) does not help — `http://$HOSTNAME:$PORT` is still not
+    // the origin Next compares against here. So leave relative rewrites exactly
+    // as next-intl emitted them; only realign one that is ALREADY absolute,
+    // which is the reverse-proxy/E2E case this helper was written for.
+    if (rewrite.startsWith('/')) return response;
+
     const target = new URL(rewrite, 'http://internal.invalid');
     const locale = target.pathname.split('/').filter(Boolean)[0];
     if (locale && LOCALE_SET.has(locale)) {


### PR DESCRIPTION
🔴 **`app.ever.works` is still down.** The image built from `main a7b419f24`, which carries #2227, does **not** fix it. I verified against the running pod rather than the pipeline.

## Measured on the new production pod — same pod, same build

```
GET /login   (no forwarded headers)  -> 200,  rewrite '/en/login'
GET /login   + X-Forwarded-Host      -> 307 'location: /login',
                                        rewrite 'http://<pod-name>:3000/en/login'
```

Pinning the **runtime** origin changed *which* absolute origin is emitted, not the outcome. Next only treats an absolute rewrite as internal when its origin matches the server's init URL, and behind ingress nothing constructed in middleware reliably matches it — not the public authority, and not `http://$HOSTNAME:$PORT`. The 307 re-enters the middleware and loops.

## The real invariant

Not *which* origin — **do not add one**. next-intl emits a **relative** rewrite in the deployed app, and a relative rewrite is internal by construction; the bare request above returns **200 on the very same pod** that 307s behind ingress.

One defect, four states — the first three are the same mistake wearing different clothes:

| commit | emitted rewrite | symptom |
|---|---|---|
| `7e1f58a44` (#2152, my lane) | `https://app.ever.works:3000/en/login` | undialable → proxy attempt times out → **500** from 2026-08-23 21:49Z |
| `14bd578a2` (#2219) | `https://app.ever.works/en/login` | dialable → redirect → **ERR_TOO_MANY_REDIRECTS** |
| `57d44302e` (#2227) | `http://<pod>:3000/en/login` | still absolute → still a redirect → **loop persists** |
| **this PR** | `/en/login` (untouched) | internal → renders |

## Change

Return early when the incoming rewrite is relative. An already-absolute rewrite is still realigned — that is the reverse-proxy/E2E case the helper was written for, so #2219/#2227's behaviour is preserved exactly where it applies.

## Verification

- **Revert-proven:** removing the guard turns the first test red.
- The new spec models the **deployed** configuration — a real public host via `ALLOWED_REDIRECT_URLS`, with `HOSTNAME`/`PORT` set. That shape had no coverage: the existing spec uses `127.0.0.1`, which the *default* allowlist permits, which is why three successive fixes shipped green.
- `proxy.unit.spec.ts` still green (11/11); both proxy specs together **13/13**.

Supersedes #2241, which pinned the runtime-origin invariant — this shows that was the wrong invariant.