### PR TITLE
🔴 fix(web): hand Next a PATH, not an origin — the fourth and actual fix for the /login loop

### DIFF
--- a/apps/web/src/proxy.prod-shape.unit.spec.ts
+++ b/apps/web/src/proxy.prod-shape.unit.spec.ts
@@ -18,31 +18,46 @@ vi.mock('./lib/constants', async (importOriginal) => ({
 import proxy from './proxy';
 
 /**
- * next-intl emits a RELATIVE `x-middleware-rewrite` in the deployed app, and a
- * relative rewrite is internal by construction. Absolutising it is what caused
- * both production outages on 2026-08-23/24 — first as a 500 (public authority
- * plus port 3000, undialable), then as ERR_TOO_MANY_REDIRECTS once the port was
- * dropped, and STILL as a redirect when the runtime origin was pinned instead.
+ * The locale rewrite must reach Next as a PATH, never as an absolute URL.
  *
- * Measured on the running prod pod, same build, same pod:
+ * Next treats an absolute `x-middleware-rewrite` as internal only when its
+ * origin matches the server's init URL. Behind ingress, next-intl derives its
+ * rewrite from `req.nextUrl.origin` — the PUBLIC authority — so it emits an
+ * absolute URL, Next answers with a redirect instead of rendering, and the
+ * redirect re-enters this middleware and loops.
+ *
+ * Three fixes changed WHICH origin was emitted and all three failed in
+ * production, because any absolute origin loses that comparison:
+ *   7e1f58a44 (#2152)  public authority + :3000  -> undialable -> HTTP 500
+ *   14bd578a2 (#2219)  public authority          -> ERR_TOO_MANY_REDIRECTS
+ *   57d44302e (#2227)  http://$HOSTNAME:$PORT    -> still looping
+ *   #2243              early-return if relative  -> never fired; behind ingress
+ *                                                   the rewrite is ALREADY absolute
+ *
+ * Measured on the running prod pod carrying the #2243 image, same pod:
  *   GET /login  (bare)             -> 200, rewrite '/en/login'
  *   GET /login  + X-Forwarded-Host -> 307 'location: /login',
  *                                     rewrite 'http://<pod>:3000/en/login'
  *
- * So the invariant is not "which origin" — it is "do not add one".
+ * The first case below is the one that matters: it feeds the middleware the
+ * ABSOLUTE rewrite next-intl really emits behind ingress and asserts a bare
+ * path comes out. No previous test modelled that input, which is why three
+ * fixes shipped green while production stayed broken.
  */
-describe('ingress locale rewrite must stay relative', () => {
+describe('ingress locale rewrite reaches Next as a path', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         getAuthFromRequestMock.mockResolvedValue({ isAuthenticated: true, isExpired: false });
+        vi.stubEnv('HOSTNAME', 'ever-works-web-767565cfbc-qr6rv');
+        vi.stubEnv('PORT', '3000');
     });
 
     afterEach(() => {
         vi.unstubAllEnvs();
     });
 
-    function ingressRequest() {
-        return new NextRequest('https://app.ever.works/login', {
+    function ingressRequest(path = '/login') {
+        return new NextRequest(`https://app.ever.works${path}`, {
             headers: {
                 host: 'app.ever.works',
                 'x-forwarded-host': 'app.ever.works',
@@ -51,9 +66,40 @@ describe('ingress locale rewrite must stay relative', () => {
         });
     }
 
-    it('leaves a relative rewrite untouched behind ingress', async () => {
-        vi.stubEnv('HOSTNAME', 'ever-works-web-6bc7f79765-7hvpd');
-        vi.stubEnv('PORT', '3000');
+    it('strips the origin from the absolute rewrite next-intl emits behind ingress', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                // Exactly what next-intl produces when req.nextUrl.origin is the
+                // public authority — i.e. every request arriving via ingress.
+                headers: { 'x-middleware-rewrite': 'https://app.ever.works/en/login' },
+            }),
+        );
+
+        const response = await proxy(ingressRequest());
+        const rewrite = response.headers.get('x-middleware-rewrite');
+
+        expect(rewrite).toBe('/en/login');
+        // Belt and braces: no scheme, no authority, in any form.
+        expect(rewrite).not.toMatch(/^[a-z]+:\/\//i);
+    });
+
+    it('preserves the query string when stripping the origin', async () => {
+        intlMock.mockResolvedValueOnce(
+            new Response(null, {
+                status: 200,
+                headers: {
+                    'x-middleware-rewrite': 'https://app.ever.works/en/missions?status=active',
+                },
+            }),
+        );
+
+        const response = await proxy(ingressRequest('/missions?status=active'));
+
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/missions?status=active');
+    });
+
+    it('leaves an already-relative rewrite exactly as emitted', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
@@ -63,25 +109,21 @@ describe('ingress locale rewrite must stay relative', () => {
 
         const response = await proxy(ingressRequest());
 
-        // Any absolute origin — public OR runtime — makes Next treat the
-        // rewrite as external and answer with a redirect, which loops.
         expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
     });
 
-    it('still realigns an already-absolute rewrite (the reverse-proxy case)', async () => {
-        vi.stubEnv('HOSTNAME', 'ever-works-web-pod');
-        vi.stubEnv('PORT', '3000');
+    it('does not touch a rewrite whose first segment is not a locale', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
-                headers: { 'x-middleware-rewrite': 'http://localhost:3000/en/login' },
+                headers: { 'x-middleware-rewrite': 'https://app.ever.works/api/health' },
             }),
         );
 
         const response = await proxy(ingressRequest());
 
         expect(response.headers.get('x-middleware-rewrite')).toBe(
-            'http://ever-works-web-pod:3000/en/login',
+            'https://app.ever.works/api/health',
         );
     });
 });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -148,90 +148,55 @@ function isAllowedRequestHostname(hostname: string): boolean {
     });
 }
 
-function alignLocaleRewriteOrigin(req: NextRequest, response: NextResponse): NextResponse {
+/**
+ * Force next-intl's locale rewrite to stay RELATIVE.
+ *
+ * Next only treats an `x-middleware-rewrite` as internal when it is relative or
+ * its origin matches the server's init URL. Behind ingress, next-intl derives
+ * its rewrite from `req.nextUrl.origin` — which is the PUBLIC authority — so it
+ * emits an absolute URL, Next treats it as external, and answers with a
+ * redirect instead of rendering. The redirect re-enters this middleware and
+ * loops.
+ *
+ * Measured on the running production pod, same pod, same build (2026-08-24):
+ *
+ *   GET /login  (no forwarded headers) -> 200, rewrite '/en/login'
+ *   GET /login  + X-Forwarded-Host     -> 307 'location: /login',
+ *                                        rewrite '<absolute>/en/login'
+ *
+ * Three previous attempts changed WHICH origin was emitted and all three
+ * failed, because any absolute origin loses this comparison:
+ *   7e1f58a44 (#2152)  public authority + :3000  -> undialable -> 500
+ *   14bd578a2 (#2219)  public authority          -> redirect loop
+ *   57d44302e (#2227)  http://$HOSTNAME:$PORT    -> redirect loop
+ *   #2243              relative-only early return -> never fired, because the
+ *                      rewrite is ALREADY absolute in this path
+ *
+ * So drop the origin entirely and hand Next a path. That is the one form it
+ * cannot treat as external.
+ */
+function alignLocaleRewriteOrigin(_req: NextRequest, response: NextResponse): NextResponse {
     const rewrite = response.headers.get('x-middleware-rewrite');
     if (!rewrite) return response;
-
-    // 🛑 A RELATIVE rewrite is already internal by construction — Next resolves
-    // it against its own origin and renders in-process. Absolutising it is what
-    // breaks the request: Next only treats an absolute rewrite as internal when
-    // the origin matches its server init URL, and behind ingress NOTHING we can
-    // construct here reliably matches it. Measured on the running prod pod
-    // (2026-08-24), same pod, same build:
-    //
-    //   GET /login  (no forwarded headers) -> 200, rewrite '/en/login'
-    //   GET /login  + X-Forwarded-Host     -> 307 'location: /login',
-    //                                         rewrite 'http://<pod>:3000/en/login'
-    //
-    // The 307 then re-enters the middleware and loops (ERR_TOO_MANY_REDIRECTS);
-    // when the absolutised URL additionally carried the public authority it was
-    // undialable and surfaced as a 500 instead. Pinning the RUNTIME origin (the
-    // previous attempt) does not help — `http://$HOSTNAME:$PORT` is still not
-    // the origin Next compares against here. So leave relative rewrites exactly
-    // as next-intl emitted them; only realign one that is ALREADY absolute,
-    // which is the reverse-proxy/E2E case this helper was written for.
     if (rewrite.startsWith('/')) return response;
 
-    const target = new URL(rewrite, 'http://internal.invalid');
-    const locale = target.pathname.split('/').filter(Boolean)[0];
-    if (locale && LOCALE_SET.has(locale)) {
-        const requestOrigin = new URL(req.nextUrl.origin);
-        const forwardedHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
-        const requestHost = req.headers.get('host')?.trim();
-        const forwardedProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
-        const runtimeHostname = process.env.HOSTNAME?.trim();
-        const runtimePort = process.env.PORT?.trim();
-        let usedRuntimeOrigin = false;
-
-        if (forwardedHost && SAFE_REQUEST_HOST.test(forwardedHost)) {
-            try {
-                const forwardedAuthority = new URL(`${requestOrigin.protocol}//${forwardedHost}`);
-                const runtimeAuthority = runtimePort
-                    ? `${runtimeHostname}:${runtimePort}`
-                    : runtimeHostname;
-                if (
-                    isAllowedRequestHostname(forwardedAuthority.hostname) &&
-                    runtimeAuthority &&
-                    SAFE_REQUEST_HOST.test(runtimeAuthority)
-                ) {
-                    // Next's router only treats a middleware rewrite as internal
-                    // when its origin matches the standalone server's init URL.
-                    // Behind ingress that URL is http://$HOSTNAME:$PORT, not the
-                    // browser authority carried by X-Forwarded-Host.
-                    requestOrigin.protocol = 'http:';
-                    requestOrigin.hostname = runtimeHostname!;
-                    requestOrigin.port = runtimePort || '';
-                    usedRuntimeOrigin = true;
-                }
-            } catch {
-                // Fall through to the validated request authority.
-            }
-        }
-
-        for (const requestAuthority of usedRuntimeOrigin ? [] : [forwardedHost, requestHost]) {
-            if (!requestAuthority || !SAFE_REQUEST_HOST.test(requestAuthority)) continue;
-            try {
-                const authority = new URL(`${requestOrigin.protocol}//${requestAuthority}`);
-                if (isAllowedRequestHostname(authority.hostname)) {
-                    requestOrigin.hostname = authority.hostname;
-                    requestOrigin.port = authority.port;
-                    break;
-                }
-            } catch {
-                // Try the next authority, then keep Next's parsed origin.
-            }
-        }
-        if (!usedRuntimeOrigin && (forwardedProto === 'http' || forwardedProto === 'https')) {
-            requestOrigin.protocol = `${forwardedProto}:`;
-        }
-        target.protocol = requestOrigin.protocol;
-        target.hostname = requestOrigin.hostname;
-        target.port = requestOrigin.port;
-        response.headers.set('x-middleware-rewrite', target.toString());
+    let target: URL;
+    try {
+        target = new URL(rewrite);
+    } catch {
+        // Not an absolute URL we can parse — leave it exactly as emitted.
+        return response;
     }
+
+    const locale = target.pathname.split('/').filter(Boolean)[0];
+    if (!locale || !LOCALE_SET.has(locale)) return response;
+
+    response.headers.set(
+        'x-middleware-rewrite',
+        `${target.pathname}${target.search}${target.hash}`,
+    );
     return response;
 }
-
 /**
  * Strip a legacy `/<locale>/...` prefix from a pathname.
  *

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -62,6 +62,10 @@ describe('canonical Organization workspace proxy', () => {
         expect(intlMock).not.toHaveBeenCalled();
     });
 
+    // Was: asserted the rewrite was re-pointed at the request authority. That
+    // absolutising is the defect that took production down twice (500, then
+    // ERR_TOO_MANY_REDIRECTS); the intent — the rewrite must stay INTERNAL — is
+    // now satisfied by emitting a path, which Next cannot treat as external.
     it('keeps next-intl rewrites internal when the runtime request host differs', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
@@ -83,12 +87,13 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(runtimeRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe(
-            'http://127.0.0.1:3000/en/missions?status=active',
-        );
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/missions?status=active');
     });
 
-    it('keeps a reverse-proxy locale rewrite on the runtime server origin', async () => {
+    // Was: asserted the runtime origin (http://$HOSTNAME:$PORT). Measured on the
+    // running prod pod, that origin STILL lost Next's internal comparison and
+    // produced a 307 loop (#2227). A path wins it unconditionally.
+    it('keeps a reverse-proxy locale rewrite internal', async () => {
         vi.stubEnv('HOSTNAME', 'ever-works-web-pod');
         vi.stubEnv('PORT', '3000');
         intlMock.mockResolvedValueOnce(
@@ -107,9 +112,7 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(ingressRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe(
-            'http://ever-works-web-pod:3000/en/login',
-        );
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
     });
 
     it('does not align an internal rewrite to a non-allowlisted Host header', async () => {
@@ -125,7 +128,10 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(hostileRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
+        // Security intent unchanged and strengthened: a hostile Host header must
+        // not steer the rewrite. It no longer CAN — the emitted value carries no
+        // authority at all.
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
     });
 
     it('ignores an untrusted forwarded authority and falls back to the allowlisted Host', async () => {
@@ -145,7 +151,9 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(requestWithHostFallback);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('http://127.0.0.1:3000/en/login');
+        // Same intent: an untrusted forwarded authority must not steer the
+        // rewrite. It cannot — the emitted value is a path with no authority.
+        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
     });
 
     it.each(['/settings/dashboard', '/org/dashboard'])(


### PR DESCRIPTION
🔴 **`app.ever.works` is still down.** #2243 did not fix it either, and I found out by probing the pod that runs its image rather than trusting the green build.

## Measured on the running prod pod carrying #2243 — same pod, same build

```
GET /login  (bare)             -> 200, rewrite '/en/login'
GET /login  + X-Forwarded-Host -> 307 'location: /login',
                                  rewrite 'http://<pod>:3000/en/login'
```

**Why #2243 missed:** it returned early when the rewrite was relative — but behind ingress it never is. next-intl derives its rewrite from `req.nextUrl.origin`, which **is the public authority** for a request arriving through ingress, so the value is already absolute and the guard never fired.

## The fix

Drop the origin entirely and emit a **path**. That is the one form Next cannot treat as external. Every previous attempt changed *which* origin was emitted, and all four lost the same comparison:

| attempt | emitted rewrite | outcome |
|---|---|---|
| `7e1f58a44` (#2152) | `https://app.ever.works:3000/en/login` | undialable → **HTTP 500** from 08-23 21:49Z |
| `14bd578a2` (#2219) | `https://app.ever.works/en/login` | dialable → **ERR_TOO_MANY_REDIRECTS** |
| `57d44302e` (#2227) | `http://$HOSTNAME:$PORT/en/login` | still absolute → **still looping** |
| #2243 | early-return if relative | **never fired** behind ingress |
| **this** | `/en/login` | internal → renders |

## Evidence

- **Revert-proven:** re-emitting `target.toString()` turns **six** tests red across both specs, with the exact production string. *(My first attempt at this proof was invalid — it printed success without checking the replacement matched. Redone with the edit verified.)*
- **The production control:** the bare request on the real pod already returns **200** with a relative rewrite. This change makes the ingress path emit that same shape.
- 15/15 green, `type-check` and `prettier` clean.

**Limitation, stated plainly:** I tried to validate end-to-end against a locally built server and could not — the local app 500s even on the bare request that returns 200 in prod (no API reachable), so the harness isn't representative. The chain above is empirical but the last link is verified in prod after deploy, not before.

## Four existing tests updated, not deleted

Each asserted an absolute origin — the behaviour production has now disproved three times. Their intent is preserved and annotated: *"stays internal"* and *"a hostile Host / forwarded authority must not steer the rewrite"* are both satisfied **more strongly** by a value that carries no authority at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved locale-based navigation rewrites behind ingress and reverse proxies.
  - Preserved query parameters when converting absolute locale rewrites to relative paths.
  - Prevented unrelated absolute rewrites from being modified.
  - Ensured internal rewrites remain stable across different runtime, forwarded-host, and protocol configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->