### PR TITLE
fix(web): restore Next locale rewrite normalization

### DIFF
--- a/apps/web/e2e-smoke/login-ingress-rewrite.spec.ts
+++ b/apps/web/e2e-smoke/login-ingress-rewrite.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('renders the unprefixed login route behind an ingress authority', async ({ request }) => {
+    const forwardedHost = process.env.SMOKE_FORWARDED_HOST;
+    const response = await request.get('/login', {
+        headers: forwardedHost
+            ? {
+                  host: forwardedHost,
+                  'x-forwarded-host': forwardedHost,
+                  'x-forwarded-proto': 'https',
+              }
+            : undefined,
+        maxRedirects: 0,
+    });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers().location).toBeUndefined();
+    await expect(response.text()).resolves.toContain('Sign In');
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -99,7 +99,11 @@ const nextConfig: NextConfig = {
     // Next normalizes next-intl's rewrite back to its internal `localhost`
     // origin; behind a differently named listener/reverse proxy that becomes
     // an external rewrite and re-enters the proxy.
-    skipProxyUrlNormalize: true,
+    //
+    // Compatibility note: the hypothesis above was disproven by a real
+    // ingress-shaped `next start` probe. Retain the switch, but default to
+    // Next's native normalization; opt-in is for rollback/debug only.
+    skipProxyUrlNormalize: process.env.LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED === 'true',
     // Dev-only (Next ignores this in production builds): let the e2e/CI
     // harness reach the dev server over 127.0.0.1. The self-hosted CI
     // runner resolves `localhost` to IPv6 `::1`, where the dev servers

--- a/apps/web/src/proxy.prod-shape.unit.spec.ts
+++ b/apps/web/src/proxy.prod-shape.unit.spec.ts
@@ -17,34 +17,7 @@ vi.mock('./lib/constants', async (importOriginal) => ({
 
 import proxy from './proxy';
 
-/**
- * The locale rewrite must reach Next as a PATH, never as an absolute URL.
- *
- * Next treats an absolute `x-middleware-rewrite` as internal only when its
- * origin matches the server's init URL. Behind ingress, next-intl derives its
- * rewrite from `req.nextUrl.origin` — the PUBLIC authority — so it emits an
- * absolute URL, Next answers with a redirect instead of rendering, and the
- * redirect re-enters this middleware and loops.
- *
- * Three fixes changed WHICH origin was emitted and all three failed in
- * production, because any absolute origin loses that comparison:
- *   7e1f58a44 (#2152)  public authority + :3000  -> undialable -> HTTP 500
- *   14bd578a2 (#2219)  public authority          -> ERR_TOO_MANY_REDIRECTS
- *   57d44302e (#2227)  http://$HOSTNAME:$PORT    -> still looping
- *   #2243              early-return if relative  -> never fired; behind ingress
- *                                                   the rewrite is ALREADY absolute
- *
- * Measured on the running prod pod carrying the #2243 image, same pod:
- *   GET /login  (bare)             -> 200, rewrite '/en/login'
- *   GET /login  + X-Forwarded-Host -> 307 'location: /login',
- *                                     rewrite 'http://<pod>:3000/en/login'
- *
- * The first case below is the one that matters: it feeds the middleware the
- * ABSOLUTE rewrite next-intl really emits behind ingress and asserts a bare
- * path comes out. No previous test modelled that input, which is why three
- * fixes shipped green while production stayed broken.
- */
-describe('ingress locale rewrite reaches Next as a path', () => {
+describe('proxy delegates ingress locale rewrite normalization to Next', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         getAuthFromRequestMock.mockResolvedValue({ isAuthenticated: true, isExpired: false });
@@ -66,7 +39,7 @@ describe('ingress locale rewrite reaches Next as a path', () => {
         });
     }
 
-    it('strips the origin from the absolute rewrite next-intl emits behind ingress', async () => {
+    it('preserves the absolute rewrite next-intl emits behind ingress', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
@@ -79,12 +52,11 @@ describe('ingress locale rewrite reaches Next as a path', () => {
         const response = await proxy(ingressRequest());
         const rewrite = response.headers.get('x-middleware-rewrite');
 
-        expect(rewrite).toBe('/en/login');
-        // Belt and braces: no scheme, no authority, in any form.
-        expect(rewrite).not.toMatch(/^[a-z]+:\/\//i);
+        expect(rewrite).toBe('https://app.ever.works/en/login');
+        expect(response.headers.get('location')).toBeNull();
     });
 
-    it('preserves the query string when stripping the origin', async () => {
+    it('preserves the complete rewrite including its query string', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
@@ -96,7 +68,9 @@ describe('ingress locale rewrite reaches Next as a path', () => {
 
         const response = await proxy(ingressRequest('/missions?status=active'));
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/missions?status=active');
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'https://app.ever.works/en/missions?status=active',
+        );
     });
 
     it('leaves an already-relative rewrite exactly as emitted', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -122,15 +122,9 @@ function isPublicRoute(pathname: string): boolean {
     });
 }
 
-/**
- * next-intl emits an absolute `x-middleware-rewrite` URL. Behind a reverse
- * proxy (and in the IPv4 E2E harness), Next's internal request origin can be
- * `localhost` while the browser origin is a different host. Next then treats
- * the locale rewrite as external and performs a second proxy request, losing
- * the original Organization URL rewrite. Locale targets are app-internal by
- * contract, so align their origin with the validated request authority while
- * preserving next-intl's path/query.
- */
+// Compatibility implementation retained behind an opt-in gate. The default
+// delegates locale-rewrite normalization to Next itself; that is the only mode
+// proven by the real ingress-shaped production smoke.
 const SAFE_REQUEST_HOST = /^(?:\[[0-9a-f:.]+\]|[a-z0-9.-]+)(?::\d{1,5})?$/i;
 
 function isAllowedRequestHostname(hostname: string): boolean {
@@ -148,34 +142,11 @@ function isAllowedRequestHostname(hostname: string): boolean {
     });
 }
 
-/**
- * Force next-intl's locale rewrite to stay RELATIVE.
- *
- * Next only treats an `x-middleware-rewrite` as internal when it is relative or
- * its origin matches the server's init URL. Behind ingress, next-intl derives
- * its rewrite from `req.nextUrl.origin` — which is the PUBLIC authority — so it
- * emits an absolute URL, Next treats it as external, and answers with a
- * redirect instead of rendering. The redirect re-enters this middleware and
- * loops.
- *
- * Measured on the running production pod, same pod, same build (2026-08-24):
- *
- *   GET /login  (no forwarded headers) -> 200, rewrite '/en/login'
- *   GET /login  + X-Forwarded-Host     -> 307 'location: /login',
- *                                        rewrite '<absolute>/en/login'
- *
- * Three previous attempts changed WHICH origin was emitted and all three
- * failed, because any absolute origin loses this comparison:
- *   7e1f58a44 (#2152)  public authority + :3000  -> undialable -> 500
- *   14bd578a2 (#2219)  public authority          -> redirect loop
- *   57d44302e (#2227)  http://$HOSTNAME:$PORT    -> redirect loop
- *   #2243              relative-only early return -> never fired, because the
- *                      rewrite is ALREADY absolute in this path
- *
- * So drop the origin entirely and hand Next a path. That is the one form it
- * cannot treat as external.
- */
 function alignLocaleRewriteOrigin(_req: NextRequest, response: NextResponse): NextResponse {
+    if (process.env.LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED !== 'true') {
+        return response;
+    }
+
     const rewrite = response.headers.get('x-middleware-rewrite');
     if (!rewrite) return response;
     if (rewrite.startsWith('/')) return response;
@@ -184,7 +155,6 @@ function alignLocaleRewriteOrigin(_req: NextRequest, response: NextResponse): Ne
     try {
         target = new URL(rewrite);
     } catch {
-        // Not an absolute URL we can parse — leave it exactly as emitted.
         return response;
     }
 
@@ -197,6 +167,7 @@ function alignLocaleRewriteOrigin(_req: NextRequest, response: NextResponse): Ne
     );
     return response;
 }
+
 /**
  * Strip a legacy `/<locale>/...` prefix from a pathname.
  *

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -62,11 +62,7 @@ describe('canonical Organization workspace proxy', () => {
         expect(intlMock).not.toHaveBeenCalled();
     });
 
-    // Was: asserted the rewrite was re-pointed at the request authority. That
-    // absolutising is the defect that took production down twice (500, then
-    // ERR_TOO_MANY_REDIRECTS); the intent — the rewrite must stay INTERNAL — is
-    // now satisfied by emitting a path, which Next cannot treat as external.
-    it('keeps next-intl rewrites internal when the runtime request host differs', async () => {
+    it('leaves next-intl rewrite normalization to the Next runtime', async () => {
         intlMock.mockResolvedValueOnce(
             new Response(null, {
                 status: 200,
@@ -87,13 +83,12 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(runtimeRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/missions?status=active');
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'http://localhost:3000/en/missions?status=active',
+        );
     });
 
-    // Was: asserted the runtime origin (http://$HOSTNAME:$PORT). Measured on the
-    // running prod pod, that origin STILL lost Next's internal comparison and
-    // produced a 307 loop (#2227). A path wins it unconditionally.
-    it('keeps a reverse-proxy locale rewrite internal', async () => {
+    it('does not replace a reverse-proxy locale rewrite authority', async () => {
         vi.stubEnv('HOSTNAME', 'ever-works-web-pod');
         vi.stubEnv('PORT', '3000');
         intlMock.mockResolvedValueOnce(
@@ -112,7 +107,7 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(ingressRequest);
 
-        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
+        expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
     });
 
     it('does not align an internal rewrite to a non-allowlisted Host header', async () => {
@@ -128,10 +123,9 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(hostileRequest);
 
-        // Security intent unchanged and strengthened: a hostile Host header must
-        // not steer the rewrite. It no longer CAN — the emitted value carries no
-        // authority at all.
-        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
+        // A hostile Host header cannot steer the rewrite because application
+        // code no longer reconstructs its authority.
+        expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
     });
 
     it('ignores an untrusted forwarded authority and falls back to the allowlisted Host', async () => {
@@ -151,9 +145,9 @@ describe('canonical Organization workspace proxy', () => {
 
         const response = await proxy(requestWithHostFallback);
 
-        // Same intent: an untrusted forwarded authority must not steer the
-        // rewrite. It cannot — the emitted value is a path with no authority.
-        expect(response.headers.get('x-middleware-rewrite')).toBe('/en/login');
+        // Application code must not use an untrusted forwarded authority to
+        // reconstruct framework-owned rewrite metadata.
+        expect(response.headers.get('x-middleware-rewrite')).toBe('http://localhost:3000/en/login');
     });
 
     it.each(['/settings/dashboard', '/org/dashboard'])(


### PR DESCRIPTION
## Cause

PR #2152 enabled \skipProxyUrlNormalize\ and began rewriting framework-owned \x-middleware-rewrite\ metadata. Behind ingress that turned next-intl's internal locale rewrite into an external/re-entrant route. The subsequent origin variants looped; #2244's path-only value crashes Next 16.2.11 with \ERR_INVALID_URL\.

## Repair

- restore Next's native rewrite normalization by default
- retain the legacy override behind \LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true\ (off by default)
- add a real deployed/runtime smoke for ingress-shaped \/login\
- preserve the Organization scope/path mapping from #2152

## Verification

- regression RED on main@36bd17154: real \
ext start\ + forwarded ingress headers returned 500
- exact repaired production build: successful
- unchanged real-server smoke: 200, no Location, Sign In content
- Organization route probe: 307 to \/login\, no 5xx
- focused proxy tests: 15/15
- web type-check: passed

Supersedes the broken #2244 runtime behavior. Production is currently down, so this PR is on the emergency recovery path documented in MAINTENANCE.md.