### PR TITLE
test(ci): bite-proven guard for the /login locale-rewrite defect class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,12 +285,16 @@ jobs:
           probe() { # $1=port $2=fwd|bare -> "status|location|marker"
             local port="$1" mode="$2" code loc mark
             if [ "$mode" = fwd ]; then
-              code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
+              if ! code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
                 -H 'Host: app.ever.works' -H 'X-Forwarded-Host: app.ever.works' \
-                -H 'X-Forwarded-Proto: https' "http://127.0.0.1:$port/login" 2>/dev/null || echo 000)
+                -H 'X-Forwarded-Proto: https' "http://127.0.0.1:$port/login" 2>/dev/null); then
+                code=000
+              fi
             else
-              code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
-                "http://127.0.0.1:$port/login" 2>/dev/null || echo 000)
+              if ! code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
+                "http://127.0.0.1:$port/login" 2>/dev/null); then
+                code=000
+              fi
             fi
             loc=no; grep -qi '^location:' /tmp/g.hdr 2>/dev/null && loc=yes
             mark=no; grep -q 'Sign In' /tmp/g.html 2>/dev/null && mark=yes
@@ -335,9 +339,10 @@ jobs:
             echo "::error::bite proof only counts when a LIVE server answers with a non-200."
             sed -n '1,40p' /tmp/guard-bite.log
             rc=1
-          elif [ "$BITE" = "$PASS" ]; then
+          elif [ "$BITE_CODE" = "200" ]; then
             echo "::error::BITE PROOF FAILED: with LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true the"
-            echo "::error::guard still passed, so it cannot detect the defect and its green above is"
+            echo "::error::bite server still answered HTTP 200, so the guard cannot detect the defect"
+            echo "::error::regardless of its Location/body markers, and its green above is"
             echo "::error::worthless. Either the override no longer re-enables the rewrite collapse"
             echo "::error::(apps/web/src/proxy.ts) or the probe never reached the middleware."
             rc=1
@@ -705,4 +710,3 @@ jobs:
 
       - name: Test @ever-works/secret-store-${{ matrix.provider }}-plugin
         run: pnpm --filter @ever-works/secret-store-${{ matrix.provider }}-plugin test
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,171 @@ jobs:
         if: steps.scope.outputs.code == 'true'
         run: pnpm test
 
+      # --- Regression guard: the /login locale-rewrite defect class -----------
+      #
+      # On 2026-08-24 `app.ever.works/login` was down ~8.5 h. FIVE fixes were
+      # attempted; FOUR shipped with a fully green CI. Nothing here could catch
+      # it, because every test stops short of the boundary where it fails: the
+      # unit specs mock `next-intl/middleware` and assert the header string
+      # `proxy()` RETURNS, but the failure happens AFTER `proxy()` returns,
+      # inside Next's middleware adapter when it reparses `x-middleware-rewrite`:
+      #   * an ABSOLUTE origin not matching the server's init URL is treated as
+      #     an EXTERNAL rewrite -> 307 -> re-enters middleware -> infinite loop;
+      #   * a PATH-ONLY value is reparsed as `new NextURL(v)` with NO base and
+      #     throws ERR_INVALID_URL -> HTTP 500.
+      #
+      # This boots the artifact the previous step already built and makes ONE
+      # request that CROSSES that boundary. Three ingredients, each necessary,
+      # each missing from at least one existing test:
+      #
+      #  1. Host / X-Forwarded-Host must DIFFER from the listen address. That
+      #     difference IS the defect. `e2e.yml` uses 127.0.0.1 with no forwarded
+      #     headers, so its reconstructed authority equals the internal one and
+      #     the bug cannot manifest there at all.
+      #  2. X-Forwarded-Proto: https MUST be sent. Next derives its comparison
+      #     URL's SCHEME from it, and the #2243 attempt hardcoded 'http:' - host
+      #     and port matched, only the scheme diverged. Without this header a
+      #     broken build answers 200 and this guard would pass. Recorded nowhere
+      #     else in the repo; do not drop it.
+      #  3. ALLOWED_REDIRECT_URLS must contain the authority spoofed below. It
+      #     defaults to 'localhost,127.0.0.1' (apps/web/src/lib/constants.ts),
+      #     and dev/stage allowlist only ONE of their two public hostnames -
+      #     which is why "green on stage" was never evidence about prod.
+      #     Inheriting a stage-shaped allowlist here would rebuild that blind
+      #     spot inside CI.
+      #
+      # ASSERT THE OUTCOME - status + absence of Location + a body marker. NEVER
+      # assert the `x-middleware-rewrite` value: pinning that header is exactly
+      # what left the two unit specs unable to fail (the value is identical in
+      # the fixed state and in broken state 14bd578a2).
+      #
+      # The step proves itself on every run:
+      #   * KNOWN-PRESENT CONTROL - the same request WITHOUT forwarded headers
+      #     must also be 200, so a green can never come from a probe that was
+      #     incapable of succeeding.
+      #   * BITE PROOF - a SECOND server on its own port with
+      #     LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true re-enables the collapse and
+      #     MUST NOT return 200. Measured locally 2026-08-24: it returns 500 with
+      #     ERR_INVALID_URL. No rebuild is needed because `proxy.ts` reads that
+      #     flag per request, so this costs seconds. Without a bite proof the step
+      #     could be structurally incapable of going red - the exact failure mode
+      #     of the two unit specs it replaces.
+      #     A DEAD bite server also fails the guard, which would satisfy the proof
+      #     vacuously, so a 000 (no answer) is treated as an ERROR, not a pass.
+      - name: 'Guard: /login renders behind a foreign authority'
+        if: steps.scope.outputs.code == 'true'
+        working-directory: apps/web
+        env:
+          NODE_ENV: production
+          ALLOWED_REDIRECT_URLS: https://app.ever.works
+          # A secret under 32 chars makes every auth route 500, which would turn
+          # this guard red for the wrong reason. Probe-only; unused elsewhere.
+          AUTH_SECRET: ci-guard-probe-secret-at-least-32-chars
+          COOKIE_SECRET: ci-guard-probe-secret-at-least-32-chars
+        run: |
+          set -uo pipefail
+
+          # Two servers on two ports, started once and never restarted mid-step. Killing a
+          # `pnpm start` wrapper orphans its `next start` child, which keeps holding the
+          # port and then silently answers the next probe from the WRONG configuration —
+          # that is a real failure this harness hit while being written, and it made the
+          # bite proof report a false pass. Separate ports remove the possibility.
+          HEALTHY_PORT=34119
+          BITE_PORT=34120
+
+          start_server() { # $1=label $2=port $3=optional extra env assignment
+            local label="$1" port="$2" extra="${3:-}"
+            local log="/tmp/guard-$label.log"
+            rm -f "$log"
+            if [ -n "$extra" ]; then
+              ( export "$extra"; pnpm exec next start -p "$port" ) >"$log" 2>&1 &
+            else
+              ( pnpm exec next start -p "$port" ) >"$log" 2>&1 &
+            fi
+            for _ in $(seq 1 90); do
+              # Readiness must name OUR port: on a shared runner a stale listener would
+              # otherwise serve these probes and the result would describe someone else's
+              # process.
+              if grep -qiE 'ready in' "$log" && grep -q "$port" "$log"; then
+                echo "  [$label] ready on $port"
+                return 0
+              fi
+              sleep 1
+            done
+            echo "::error::[$label] web server never became ready on port $port"
+            sed -n '1,40p' "$log"
+            return 1
+          }
+
+          probe() { # $1=port $2=fwd|bare -> "status|location|marker"
+            local port="$1" mode="$2" code loc mark
+            if [ "$mode" = fwd ]; then
+              code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
+                -H 'Host: app.ever.works' -H 'X-Forwarded-Host: app.ever.works' \
+                -H 'X-Forwarded-Proto: https' "http://127.0.0.1:$port/login" 2>/dev/null || echo 000)
+            else
+              code=$(curl -sS -o /tmp/g.html -D /tmp/g.hdr --max-redirs 0 -m 30 -w '%{http_code}' \
+                "http://127.0.0.1:$port/login" 2>/dev/null || echo 000)
+            fi
+            loc=no; grep -qi '^location:' /tmp/g.hdr 2>/dev/null && loc=yes
+            mark=no; grep -q 'Sign In' /tmp/g.html 2>/dev/null && mark=yes
+            echo "${code}|${loc}|${mark}"
+          }
+
+          PASS="200|no|yes"
+          rc=0
+
+          start_server healthy "$HEALTHY_PORT" "" || exit 1
+          start_server bite    "$BITE_PORT" "LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true" || exit 1
+
+          GUARD=$(probe "$HEALTHY_PORT" fwd)
+          echo "guard   (foreign authority + https) -> $GUARD   [want $PASS]"
+          if [ "$GUARD" != "$PASS" ]; then
+            echo "::error::/login FAILED behind a foreign authority ($GUARD). This is the defect"
+            echo "::error::class behind the 2026-08-24 outage: a 3xx WITH a location header is the"
+            echo "::error::redirect loop; a 500 is the ERR_INVALID_URL path-only variant. Start with"
+            echo "::error::apps/web/src/proxy.ts and next.config.ts (skipProxyUrlNormalize)."
+            sed -n '1,60p' /tmp/guard-healthy.log
+            rc=1
+          fi
+
+          CONTROL=$(probe "$HEALTHY_PORT" bare)
+          echo "control (no forwarded headers)      -> $CONTROL   [want $PASS]"
+          if [ "$CONTROL" != "$PASS" ]; then
+            echo "::error::KNOWN-PRESENT CONTROL failed ($CONTROL) - the harness itself is broken"
+            echo "::error::(build, env or port), so the guard line above proves nothing in either"
+            echo "::error::direction. Fix this before trusting any green here."
+            rc=1
+          fi
+
+          BITE=$(probe "$BITE_PORT" fwd)
+          BITE_CODE="${BITE%%|*}"
+          echo "bite    (legacy override enabled)   -> $BITE   [want a real HTTP status that is NOT $PASS]"
+          if [ "$BITE_CODE" = "000" ]; then
+            # A dead bite server also "is not 200", so without this branch a failed server
+            # would silently satisfy the bite proof. That is the exact vacuity this step
+            # exists to prevent, so it must be an error, not a pass.
+            echo "::error::BITE PROOF INCONCLUSIVE: the bite server did not answer at all (000)."
+            echo "::error::A dead server trivially 'fails' the guard, which proves nothing. The"
+            echo "::error::bite proof only counts when a LIVE server answers with a non-200."
+            sed -n '1,40p' /tmp/guard-bite.log
+            rc=1
+          elif [ "$BITE" = "$PASS" ]; then
+            echo "::error::BITE PROOF FAILED: with LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true the"
+            echo "::error::guard still passed, so it cannot detect the defect and its green above is"
+            echo "::error::worthless. Either the override no longer re-enables the rewrite collapse"
+            echo "::error::(apps/web/src/proxy.ts) or the probe never reached the middleware."
+            rc=1
+          else
+            echo "  bite proof OK: the guard demonstrably goes red when the defect is re-enabled."
+          fi
+
+          # Best-effort cleanup; the runner is ephemeral, so a survivor harms nothing.
+          pkill -f "next start -p $HEALTHY_PORT" 2>/dev/null || true
+          pkill -f "next start -p $BITE_PORT" 2>/dev/null || true
+
+          exit $rc
+
       - name: Build Internal CLI
         if: steps.scope.outputs.code == 'true'
         working-directory: apps/internal-cli

--- a/.github/workflows/smoke-deployed.yml
+++ b/.github/workflows/smoke-deployed.yml
@@ -144,7 +144,17 @@ jobs:
           SMOKE_BASE_URL: ${{ steps.target.outputs.web }}
           SMOKE_API_URL: ${{ steps.target.outputs.api }}
           SMOKE_ALLOW_WRITES: ${{ steps.target.outputs.writes }}
-        run: npx playwright test -c playwright.smoke.config.ts --project=smoke
+        run: |
+          # `login-ingress-rewrite.spec.ts` reads SMOKE_FORWARDED_HOST and, when it
+          # is unset, takes the `undefined` branch of its ternary and sends NO
+          # ingress-shaped headers at all - i.e. the one capability that spec
+          # exists for was dead. It was set by nothing repo-wide until now.
+          # Derive it from the target so each environment spoofs its own authority.
+          SMOKE_FORWARDED_HOST="${SMOKE_BASE_URL#*://}"
+          SMOKE_FORWARDED_HOST="${SMOKE_FORWARDED_HOST%%/*}"
+          export SMOKE_FORWARDED_HOST
+          echo "smoke target=$SMOKE_BASE_URL forwarded-host=$SMOKE_FORWARDED_HOST"
+          npx playwright test -c playwright.smoke.config.ts --project=smoke
 
       - name: Upload report on failure
         if: failure()

--- a/.github/workflows/smoke-deployed.yml
+++ b/.github/workflows/smoke-deployed.yml
@@ -34,6 +34,9 @@ concurrency:
   group: smoke-${{ github.event.workflow_run.head_branch || inputs.environment }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     # Only for branches that map to an environment, and only when the deploy
@@ -110,6 +113,8 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/apps/web/src/proxy.prod-shape.unit.spec.ts
+++ b/apps/web/src/proxy.prod-shape.unit.spec.ts
@@ -17,6 +17,34 @@ vi.mock('./lib/constants', async (importOriginal) => ({
 
 import proxy from './proxy';
 
+/**
+ * 🛑 THIS SUITE CANNOT CATCH THE /login LOCALE-REWRITE DEFECT. Do not treat it
+ * as the regression guard for it, and do not add assertions here hoping to.
+ *
+ * It mocks `next-intl/middleware` wholesale and asserts the header string
+ * `proxy()` RETURNS. The defect happens AFTER `proxy()` returns, inside Next's
+ * middleware adapter, which reparses `x-middleware-rewrite`:
+ *   - an absolute origin that does not match the server's init URL is treated
+ *     as an EXTERNAL rewrite -> redirect -> the request re-enters and loops;
+ *   - a path-only value is reparsed as `new NextURL(value)` with NO base and
+ *     throws `ERR_INVALID_URL` -> HTTP 500.
+ * Neither outcome is reachable from this file, because the adapter is mocked away.
+ *
+ * Concretely: `https://app.ever.works/en/login` is the value `proxy()` returns
+ * in the FIXED state AND the value it returned in broken state `14bd578a2`
+ * (#2219, ERR_TOO_MANY_REDIRECTS). Identical on both sides, so no assertion on
+ * it can discriminate. This suite was green through all five states of an
+ * ~8.5 h production outage on 2026-08-24.
+ *
+ * What it legitimately pins: `proxy()` must not MANGLE the rewrite (that is how
+ * #2243/#2244 broke it) and must not introduce a `location` header of its own.
+ * That is a narrow, real property — just not the outage guard.
+ *
+ * THE ACTUAL GUARD is the "Guard: /login renders behind a foreign authority"
+ * step in `.github/workflows/ci.yml` (`lint-and-test`), which boots the built
+ * artifact and makes one request that CROSSES the adapter boundary. If you are
+ * here because that guard went red, the bug is real — do not weaken it here.
+ */
 describe('proxy delegates ingress locale rewrite normalization to Next', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -52,8 +80,12 @@ describe('proxy delegates ingress locale rewrite normalization to Next', () => {
         const response = await proxy(ingressRequest());
         const rewrite = response.headers.get('x-middleware-rewrite');
 
+        // OUTCOME at this seam: unmangled passthrough + proxy() added no redirect
+        // of its own. Status/redirect behaviour proper is Next's, and is asserted by
+        // the CI guard, not here.
         expect(rewrite).toBe('https://app.ever.works/en/login');
         expect(response.headers.get('location')).toBeNull();
+        expect(response.status).toBe(200);
     });
 
     it('preserves the complete rewrite including its query string', async () => {

--- a/apps/web/src/proxy.unit.spec.ts
+++ b/apps/web/src/proxy.unit.spec.ts
@@ -18,6 +18,26 @@ function request(path: string, selector = 'attacker-supplied'): NextRequest {
     });
 }
 
+/**
+ * 🛑 NOTE ON SCOPE: the locale-rewrite assertions in this file CANNOT catch the
+ * /login locale-rewrite defect class, and must not be relied on for it.
+ *
+ * They mock `next-intl/middleware` and assert the header string `proxy()`
+ * returns. The failure occurs after `proxy()` returns, inside Next's middleware
+ * adapter — mocked away here. They are also shaped so the bug cannot appear:
+ * the requests use `127.0.0.1`/`localhost`, which `ALLOWED_REDIRECT_URLS`
+ * permits BY DEFAULT (`'localhost,127.0.0.1'`, see src/lib/constants.ts), so the
+ * reconstructed public authority equals the internal one and the origin mismatch
+ * that IS the defect never arises.
+ *
+ * These stayed green through all five states of an ~8.5 h production outage on
+ * 2026-08-24. The real guard is the "Guard: /login renders behind a foreign
+ * authority" step in .github/workflows/ci.yml, which crosses the adapter
+ * boundary with a FOREIGN authority and `X-Forwarded-Proto: https`.
+ *
+ * Kept because they pin a genuine narrower property — `proxy()` must not mangle
+ * the rewrite header nor invent a redirect. Retained per the no-removal rule.
+ */
 describe('canonical Organization workspace proxy', () => {
     beforeEach(() => {
         vi.clearAllMocks();


### PR DESCRIPTION
## Why

The 2026-08-24 `app.ever.works/login` outage lasted **~8.5 h** and survived **five** fix attempts — **four of which shipped with a fully green CI**. Nothing in this repo could catch it, and nothing here could catch a sixth. This adds the smallest thing that can.

## Why the existing tests cannot catch it

`proxy.unit.spec.ts` and `proxy.prod-shape.unit.spec.ts` mock `next-intl/middleware` wholesale and assert the header string `proxy()` **returns**. The failure happens **after** `proxy()` returns, inside Next's middleware adapter when it reparses `x-middleware-rewrite`:

- an **absolute** origin not matching the server's init URL becomes an EXTERNAL rewrite → 307 → re-enters middleware → loop;
- a **path-only** value is reparsed with no base → `ERR_INVALID_URL` → 500.

Worse: the value they pin (`https://app.ever.works/en/login`) is **identical in the fixed state and in broken state `14bd578a2`**, so no assertion on it can discriminate. They were green through all five states.

They are **kept** (no-removal rule) and now carry a banner stating they are not the guard, and why.

## The guard

One step in `lint-and-test` — the only required check on `main`/`develop`/`stage` — boots the artifact that job **already built** and makes one request that **crosses the adapter boundary**. Three ingredients, each necessary, each missing from at least one existing test:

| # | ingredient | why |
|---|---|---|
| 1 | `Host`/`X-Forwarded-Host` ≠ listen address | that difference **is** the defect. `e2e.yml` uses `127.0.0.1` with no forwarded headers, so its authority equals the internal one and the bug cannot manifest |
| 2 | `X-Forwarded-Proto: https` | Next derives its comparison **scheme** from it; #2243 hardcoded `http:` so only the scheme diverged. Without it a broken build answers 200. Recorded nowhere else in the repo |
| 3 | `ALLOWED_REDIRECT_URLS` contains the spoofed authority | it defaults to `localhost,127.0.0.1`, and dev/stage allowlist only **one** of their two public hostnames — which is why "green on stage" was never evidence about prod |

It asserts the **outcome** (status + absence of `Location` + body marker), never the `x-middleware-rewrite` value. Pinning that header is precisely what left the unit specs unable to fail.

## It proves itself on every run

- **Known-present control** — the same request *without* forwarded headers must also be 200, so a green can never come from a probe incapable of succeeding.
- **Bite proof** — a second server with `LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED=true` must **not** return 200. Measured: **500, `ERR_INVALID_URL`**. No rebuild needed (`proxy.ts` reads the flag per request), so it costs seconds.
- **Vacuity trap closed** — a *dead* bite server also "fails" the guard, which would satisfy the proof for the wrong reason, so a `000` is an **error**, not a pass.

**Two ports, not restart-in-place:** killing a `pnpm start` wrapper orphans its `next start` child, which keeps the port and silently answers the next probe from the *wrong* configuration. That produced a false bite result while this was being written — the harness caught its own bug.

## Also

`SMOKE_FORWARDED_HOST` was set by **nothing** repo-wide (one occurrence: the spec's own line 4), so `login-ingress-rewrite.spec.ts` always took the `undefined` branch and never sent the ingress-shaped headers it exists to send. Now derived from the smoke target.

## Verification

Run **verbatim as extracted from `ci.yml`** against the real built artifact:

```
guard   (foreign authority + https) -> 200|no|yes   [want 200|no|yes]
control (no forwarded headers)      -> 200|no|yes   [want 200|no|yes]
bite    (legacy override enabled)   -> 500|no|no    bite proof OK
EXIT: 0
```

Both proxy specs **15/15**. `ci.yml` diff is **165 insertions / 0 deletions** (pure addition — no unrelated reformatting; note YAML is outside the `format:check` glob).

## Risk

Adds ~40 s to `lint-and-test`. If the guard is ever red, `/login` is broken behind an ingress-shaped request — that is the point. 🛑 Do **not** set `LEGACY_LOCALE_REWRITE_OVERRIDE_ENABLED` in a live namespace: it is a 500 switch, not a rollback switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened validation for `/login` requests using foreign HTTPS authorities, including response status, content, redirects, and forwarded-header behavior.
  - Added checks to detect incorrect behavior from legacy rewrite overrides.

- **Tests**
  - Improved server-based regression checks with readiness detection, diagnostics, failure handling, and cleanup.
  - Clarified coverage boundaries for locale-rewrite tests and strengthened passthrough response assertions.

- **Security**
  - Hardened deployed smoke-test workflow permissions and checkout credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->