### PR TITLE
fix(api/jest): resolve deep imports under @src/generators/

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -37,7 +37,17 @@ module.exports = {
     // recommendation for CI stability.
     testTimeout: 30000,
     moduleNameMapper: {
-        '^@src/generators/(.*)$': '<rootDir>/../../../packages/agent/src/generators/$1/index.ts',
+        // 🛑 ARRAY, not a single target. This rule appended `/index.ts`
+        // unconditionally, so a DEEP file import
+        // (`@src/generators/data-generator/data-generator.service`) resolved to
+        // `.../data-generator.service/index.ts` and could not be found. It also
+        // SHADOWS the generic `^@src/(.*)$` fallback below for this prefix, so
+        // fixing that rule alone did not help. Try the path as given first,
+        // then the directory-index form the original rule assumed.
+        '^@src/generators/(.*)$': [
+            '<rootDir>/../../../packages/agent/src/generators/$1',
+            '<rootDir>/../../../packages/agent/src/generators/$1/index.ts',
+        ],
         // Items-generator's source lives under @ever-works/agent, but
         // entities import it via the api `@src/...` alias. Map it through
         // so cross-package tests (claim-account.service.spec,


### PR DESCRIPTION
Groundwork for **EW-757**. Honest framing up front: **this does not deliver the DI-compile guard that ticket asks for.** It removes one of two blockers and measures the other.

## The bug

```js
'^@src/generators/(.*)$': '.../packages/agent/src/generators/$1/index.ts'
```

`/index.ts` is appended unconditionally, so a **deep file import** resolves to a path that cannot exist:

```
@src/generators/data-generator/data-generator.service
  ->  .../data-generator/data-generator.service/index.ts     ✗
```

It also **shadows** the generic `^@src/(.*)$` array fallback for this prefix, so the earlier fix to *that* rule couldn't help here — the specific rule wins.

Now an array: the path as given first, then the directory-index form the original rule assumed. Nothing removed; both shapes resolve.

## Evidence

From a throwaway probe importing `ApiModule`:

- **before** — `Could not locate module @src/generators/data-generator/data-generator.service`
- **after** — that error is gone; the probe advances to a different, unrelated blocker

I could not write a spec that *proves* the fix in isolation, because every module reachable through that path also pulls in pure-ESM dependencies that Jest won't transform (below). So the evidence is the probe's failure mode changing, not a green test. Flagging that rather than dressing it up.

## No regression

`apps/api` — **301 suites / 4486 tests passing, identical with and without this change.**

The 2 suites that fail (`plan-checkout.controller.spec`, `fleet-agent-task-dispatch.spec`, 9 tests) fail **the same way on clean `develop`**. Cause is a stale local `packages/agent/dist`: `ActivePlanSubscriptionError` exists in source (`plan-subscription.service.ts:47`) but not in the older `dist` (10:57 vs source 12:48). CI builds before testing, so it's a workstation artifact, not a repo fault.

## Why EW-757 stays open

I re-probed the app-wide guard now the mapping is fixed. The remaining blocker is that **no package here configures `transformIgnorePatterns`**, so any pure-ESM dependency reached through the module graph fails to parse. It's a chain, not a single package — clearing `p-map` surfaced `github-slugger`, and so on. Both of these were measured, not assumed:

- allow-listing packages one at a time: still failing, **172s** to reach the next error
- `transformIgnorePatterns: []` (transform everything): still failing, **250s**

A per-module guard doesn't dodge it either — `BillingApiModule` alone hits the same chain. So an `apps/api` DI-compile guard needs the ESM transform story solved first, which has repo-wide blast radius on test runtime and deserves its own change. Recorded on the ticket with these numbers.

The agent-package guard from [#2237](https://github.com/ever-works/ever-works/pull/2237) is unaffected and still runs in ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)