### PR TITLE
fix(billing): preserve auto-recharge idempotency

### DIFF
--- a/packages/agent/src/subscriptions/billing/auto-recharge.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/auto-recharge.service.spec.ts
@@ -226,15 +226,43 @@ describe('AutoRechargeService', () => {
         expect(profiles.state.autoRechargeInFlightKey).toBeNull();
     });
 
-    it('releases the guard when the provider call throws outright', async () => {
+    it('keeps the guard while an indeterminate provider result awaits a webhook', async () => {
+        const provider = makeProvider({
+            chargeOffSession: jest.fn().mockResolvedValue({
+                paymentId: '',
+                status: 'pending',
+            }),
+        });
+        const profiles = makeProfileRepository();
+        const service = new AutoRechargeService(provider, profiles, makeLedgerService(0));
+
+        expect(await service.maybeRecharge('u1')).toEqual({
+            status: 'pending',
+            paymentId: '',
+            packId: 'credits-5500',
+        });
+        expect(profiles.recordAutoRechargeFailure).not.toHaveBeenCalled();
+        expect(profiles.state.autoRechargeInFlightKey).toEqual(
+            expect.stringMatching(/^auto:u1:credits-5500:/),
+        );
+    });
+
+    it('keeps the guard when the provider call throws with an indeterminate outcome', async () => {
         const provider = makeProvider({
             chargeOffSession: jest.fn().mockRejectedValue(new Error('network down')),
         });
         const profiles = makeProfileRepository();
         const service = new AutoRechargeService(provider, profiles, makeLedgerService(0));
 
-        expect(await service.maybeRecharge('u1')).toEqual({ status: 'failed' });
-        expect(profiles.recordAutoRechargeFailure).toHaveBeenCalled();
+        expect(await service.maybeRecharge('u1')).toEqual({
+            status: 'pending',
+            paymentId: '',
+            packId: 'credits-5500',
+        });
+        expect(profiles.recordAutoRechargeFailure).not.toHaveBeenCalled();
+        expect(profiles.state.autoRechargeInFlightKey).toEqual(
+            expect.stringMatching(/^auto:u1:credits-5500:/),
+        );
     });
 
     it('NEVER writes to the ledger — credits appear only via the webhook', async () => {

--- a/packages/agent/src/subscriptions/billing/auto-recharge.service.ts
+++ b/packages/agent/src/subscriptions/billing/auto-recharge.service.ts
@@ -13,6 +13,8 @@ export type AutoRechargeOutcome =
     | { status: 'already-in-flight' }
     /** Off-session charge placed; the webhook will credit the ledger. */
     | { status: 'charged'; paymentId: string; packId: string }
+    /** Provider outcome is indeterminate; keep the guard until a webhook resolves it. */
+    | { status: 'pending'; paymentId: string; packId: string }
     /** The provider declined; the guard is released and the count bumped. */
     | { status: 'failed'; failureCode?: string };
 
@@ -35,7 +37,8 @@ export type AutoRechargeOutcome =
  *      provider idempotency key so even a retried call resolves to one
  *      payment.
  *   5. The slot is released by the webhook that credits the ledger
- *      (`BillingService.applyPurchase`) or immediately on failure.
+ *      (`BillingService.applyPurchase`) or immediately on a definite
+ *      failure. An indeterminate provider outcome keeps the slot claimed.
  *
  * This service NEVER writes to the ledger. Credits appear only when the
  * signature-verified webhook confirms the money actually moved.
@@ -112,15 +115,18 @@ export class AutoRechargeService {
             // Slot stays claimed until the webhook credits the ledger —
             // that is what prevents a second charge while the first
             // payment is still settling.
+            if (result.status === 'pending') {
+                return { status: 'pending', paymentId: result.paymentId, packId: pack.id };
+            }
+
             return { status: 'charged', paymentId: result.paymentId, packId: pack.id };
         } catch (error) {
-            await this.billingProfileRepository.recordAutoRechargeFailure(userId, now);
             this.logger.warn(
-                `Auto-recharge failed for user ${userId}: ${
-                    error instanceof Error ? error.message : String(error)
-                }`,
+                `Auto-recharge provider call had an indeterminate outcome for user ${userId} (${
+                    error instanceof Error ? error.name : 'unknown error'
+                })`,
             );
-            return { status: 'failed' };
+            return { status: 'pending', paymentId: '', packId: pack.id };
         }
     }
 }

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -237,6 +237,38 @@ describe('StripeBillingProvider — checkout', () => {
 
         expect(result).toEqual({ paymentId: '', status: 'failed', failureCode: 'card_declined' });
     });
+
+    it.each(['StripeConnectionError', 'StripeAPIError'])(
+        'reports %s as pending because Stripe may still have created the payment',
+        async (type) => {
+            const client = fakeClient({
+                paymentIntents: {
+                    create: jest
+                        .fn()
+                        .mockRejectedValue(
+                            Object.assign(new Error('Stripe request outcome unknown'), { type }),
+                        ),
+                },
+            });
+            const { provider } = build(client);
+
+            const result = await provider.chargeOffSession({
+                customerId: 'cus_1',
+                paymentMethodRef: 'pm_1',
+                userId: 'u1',
+                idempotencyKey: 'auto:u1:credits-1000:1',
+                pack: {
+                    id: 'credits-1000',
+                    priceCents: 1000,
+                    credits: 1000,
+                    currency: 'usd',
+                    label: '1,000 credits',
+                },
+            });
+
+            expect(result).toEqual({ paymentId: '', status: 'pending' });
+        },
+    );
 });
 
 describe('StripeBillingProvider — payment methods (billing PRD §3.3)', () => {

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -615,11 +615,23 @@ export class StripeBillingProvider extends BillingProvider {
             };
         } catch (error) {
             const code = (error as { code?: string })?.code;
+            const type = (error as { type?: string })?.type;
             // Never log the error object wholesale — it can echo request
             // params including the payment-method reference.
             this.logger.warn(
-                `Off-session charge failed for user ${request.userId} (code=${code ?? 'unknown'})`,
+                `Off-session charge failed for user ${request.userId} (type=${
+                    type ?? 'unknown'
+                }, code=${code ?? 'unknown'})`,
             );
+
+            // Stripe documents connection and API errors as indeterminate:
+            // the request may have reached Stripe even though no response
+            // reached us. Keep the persisted claim/idempotency key in flight
+            // until a webhook confirms the payment outcome.
+            if (type === 'StripeConnectionError' || type === 'StripeAPIError') {
+                return { paymentId: '', status: 'pending' };
+            }
+
             return { paymentId: '', status: 'failed', failureCode: code };
         }
     }


### PR DESCRIPTION
## Summary
- classify Stripe connection/API failures as indeterminate instead of definite declines
- keep the persisted auto-recharge claim until webhook resolution for pending or thrown provider outcomes
- retain existing release-and-count behavior for definite card failures

## Why
Stripe documents connection and API errors as indeterminate: a PaymentIntent may have been created even when the response did not reach us. Releasing the claim in that state lets the next debit create a fresh millisecond idempotency key and risks a second charge.

## Verification
- RED: 4 new assertions failed against the previous behavior
- `pnpm --filter @ever-works/agent test` (551 suites; 9,863 passed; 3 skipped)
- `pnpm --filter @ever-works/agent type-check`
- targeted Prettier check and `git diff --check`

No database, schema, Stripe account, secrets, stage/main, or live runtime changes.