### PR TITLE
fix(billing): reconcile cumulative partial refunds

### DIFF
--- a/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
@@ -45,6 +45,7 @@ function makeHarness(options: { balance?: number | string; driver?: string } = {
         update: jest.fn().mockResolvedValue(undefined),
         create: jest.fn((value: any) => value),
         save: jest.fn(async (value: any) => ({ id: 'entry-1', ...value })),
+        sum: jest.fn().mockResolvedValue(0),
         createQueryBuilder: jest.fn(() => makeQb(options.balance ?? 0)),
         findAndCount: jest.fn().mockResolvedValue([[], 0]),
     };
@@ -197,6 +198,143 @@ describe('CreditLedgerRepository.recordAtomic', () => {
         const sqlite = makeHarness({ driver: 'better-sqlite3' });
         await sqlite.repository.recordAtomic({ ...BASE_WRITE });
         expect(sqlite.userRepo.findOne).not.toHaveBeenCalled();
+    });
+});
+
+describe('CreditLedgerRepository.recordCumulativeRefundAtomic', () => {
+    const PURCHASE = {
+        id: 'purchase-1',
+        userId: 'user-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        kind: CreditLedgerKind.PURCHASE,
+        amountCredits: 5500,
+        costCentsRef: 5000,
+        refType: 'billing-payment',
+        refId: 'pi_1',
+    };
+
+    it('writes only the incremental credits for a later cumulative partial-refund event', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 6000, driver: 'postgres' });
+        entryRepo.findOne.mockImplementation(async ({ where }: any) => {
+            if (where.idempotencyKey) return null;
+            if (where.kind === CreditLedgerKind.PURCHASE) return PURCHASE;
+            return null;
+        });
+        // First Stripe event reported 50% cumulative and already reversed 2,750 credits.
+        entryRepo.sum.mockResolvedValue(-2750);
+
+        const result = await repository.recordCumulativeRefundAtomic({
+            refType: 'billing-payment',
+            refId: 'pi_1',
+            cumulativeRefundedCents: 5000,
+            idempotencyKey: 'stripe:evt:evt_refund_2',
+            description: 'Refund / chargeback reversal',
+        });
+
+        expect(result.status).toBe('created');
+        expect(result.creditsReversed).toBe(2750);
+        expect(entryRepo.sum).toHaveBeenCalledWith('amountCredits', {
+            refType: 'billing-payment',
+            refId: 'pi_1',
+            kind: CreditLedgerKind.ADJUSTMENT,
+        });
+        expect(entryRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: 'user-1',
+                amountCredits: -2750,
+                balanceAfter: 3250,
+                idempotencyKey: 'stripe:evt:evt_refund_2',
+            }),
+        );
+    });
+
+    it('caps an over-reported cumulative amount at the original credit grant', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 6000, driver: 'postgres' });
+        entryRepo.findOne.mockImplementation(async ({ where }: any) => {
+            if (where.idempotencyKey) return null;
+            if (where.kind === CreditLedgerKind.PURCHASE) return PURCHASE;
+            return null;
+        });
+
+        const result = await repository.recordCumulativeRefundAtomic({
+            refType: 'billing-payment',
+            refId: 'pi_1',
+            cumulativeRefundedCents: 999999,
+            idempotencyKey: 'stripe:evt:evt_overreported',
+        });
+
+        expect(result.creditsReversed).toBe(5500);
+        expect(entryRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({ amountCredits: -5500, balanceAfter: 500 }),
+        );
+    });
+
+    it('locks the purchase owner before reading prior reversals and ignores an older out-of-order total', async () => {
+        const { repository, entryRepo, userRepo } = makeHarness({
+            balance: 500,
+            driver: 'postgres',
+        });
+        entryRepo.findOne.mockImplementation(async ({ where }: any) => {
+            if (where.idempotencyKey) return null;
+            if (where.kind === CreditLedgerKind.PURCHASE) return PURCHASE;
+            return null;
+        });
+        // A newer full-refund event won the race and already reversed the whole grant.
+        entryRepo.sum.mockResolvedValue(-5500);
+
+        const result = await repository.recordCumulativeRefundAtomic({
+            refType: 'billing-payment',
+            refId: 'pi_1',
+            cumulativeRefundedCents: 2500,
+            idempotencyKey: 'stripe:evt:evt_older_half',
+        });
+
+        expect(result).toEqual({ status: 'covered', creditsReversed: 0 });
+        expect(entryRepo.save).not.toHaveBeenCalled();
+        expect(userRepo.findOne.mock.invocationCallOrder[0]).toBeLessThan(
+            entryRepo.sum.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('returns the existing row before doing refund math when the event was already recorded', async () => {
+        const { repository, entryRepo, userRepo } = makeHarness({ driver: 'postgres' });
+        const existing = { id: 'refund-1', idempotencyKey: 'stripe:evt:evt_refund_1' };
+        entryRepo.findOne.mockResolvedValue(existing);
+
+        const result = await repository.recordCumulativeRefundAtomic({
+            refType: 'billing-payment',
+            refId: 'pi_1',
+            cumulativeRefundedCents: 2500,
+            idempotencyKey: 'stripe:evt:evt_refund_1',
+        });
+
+        expect(result).toEqual({ status: 'idempotent', entry: existing, creditsReversed: 0 });
+        expect(userRepo.findOne).not.toHaveBeenCalled();
+        expect(entryRepo.sum).not.toHaveBeenCalled();
+    });
+
+    it('fully reverses a legacy purchase with no stored charge amount when the event has no amount', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 6000, driver: 'postgres' });
+        entryRepo.findOne.mockImplementation(async ({ where }: any) => {
+            if (where.idempotencyKey) return null;
+            if (where.kind === CreditLedgerKind.PURCHASE) {
+                return { ...PURCHASE, costCentsRef: null };
+            }
+            return null;
+        });
+
+        const result = await repository.recordCumulativeRefundAtomic({
+            refType: 'billing-payment',
+            refId: 'pi_legacy',
+            cumulativeRefundedCents: null,
+            idempotencyKey: 'stripe:evt:evt_legacy_refund',
+        });
+
+        expect(result.creditsReversed).toBe(5500);
+        expect(entryRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({ amountCredits: -5500, balanceAfter: 500 }),
+        );
     });
 });
 

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -72,6 +72,21 @@ export type RecordAtomicResult =
     /** maxBalanceAfter ceiling clamped the amount to ≤ 0 — no write. */
     | { status: 'skipped'; balance: number };
 
+export interface CumulativeRefundWrite {
+    refType: string;
+    refId: string;
+    /** Stripe's charge.amount_refunded: total refunded so far, not this event's delta. */
+    cumulativeRefundedCents: number | null;
+    idempotencyKey: string;
+    description?: string | null;
+}
+
+export type CumulativeRefundResult =
+    | { status: 'created'; entry: CreditLedgerEntry; creditsReversed: number }
+    | { status: 'idempotent'; entry: CreditLedgerEntry; creditsReversed: 0 }
+    | { status: 'covered'; creditsReversed: 0 }
+    | { status: 'missing-purchase'; creditsReversed: 0 };
+
 export interface CreditLedgerQuery {
     from?: Date;
     to?: Date;
@@ -177,6 +192,119 @@ export class CreditLedgerRepository {
                 const existing = await this.findByIdempotencyKey(write.idempotencyKey);
                 if (existing) {
                     return { status: 'idempotent', entry: existing };
+                }
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Atomically reconcile one provider's CUMULATIVE refund total.
+     *
+     * Stripe sends `charge.amount_refunded`, which grows across partial
+     * refunds. Serializing on the purchase owner's row before summing prior
+     * reversals makes sequential, concurrent, duplicate, and out-of-order
+     * deliveries converge on one target instead of reversing that cumulative
+     * amount once per event.
+     */
+    async recordCumulativeRefundAtomic(
+        write: CumulativeRefundWrite,
+        now: Date = new Date(),
+    ): Promise<CumulativeRefundResult> {
+        try {
+            return await this.repository.manager.transaction(async (manager) => {
+                const repo = manager.getRepository(CreditLedgerEntry);
+                const existing = await repo.findOne({
+                    where: { idempotencyKey: write.idempotencyKey },
+                });
+                if (existing) {
+                    return {
+                        status: 'idempotent' as const,
+                        entry: existing,
+                        creditsReversed: 0 as const,
+                    };
+                }
+
+                const purchase = await repo.findOne({
+                    where: {
+                        refType: write.refType,
+                        refId: write.refId,
+                        kind: CreditLedgerKind.PURCHASE,
+                    },
+                    order: { createdAt: 'DESC' },
+                });
+                if (!purchase || purchase.amountCredits <= 0) {
+                    return { status: 'missing-purchase' as const, creditsReversed: 0 as const };
+                }
+
+                await this.lockUserRow(manager, purchase.userId);
+
+                const priorAdjustmentTotal = await repo.sum('amountCredits', {
+                    refType: write.refType,
+                    refId: write.refId,
+                    kind: CreditLedgerKind.ADJUSTMENT,
+                });
+                const alreadyReversed = Math.min(
+                    purchase.amountCredits,
+                    Math.max(0, -Number(priorAdjustmentTotal ?? 0)),
+                );
+
+                const chargedCents = purchase.costCentsRef ?? 0;
+                const refundedCents = Math.max(0, write.cumulativeRefundedCents ?? chargedCents);
+                const share =
+                    chargedCents > 0
+                        ? Math.min(1, refundedCents / chargedCents)
+                        : write.cumulativeRefundedCents === null || refundedCents > 0
+                          ? 1
+                          : 0;
+                const targetReversed = Math.min(
+                    purchase.amountCredits,
+                    Math.max(0, Math.round(purchase.amountCredits * share)),
+                );
+                const creditsReversed = targetReversed - alreadyReversed;
+                if (creditsReversed <= 0) {
+                    return { status: 'covered' as const, creditsReversed: 0 as const };
+                }
+
+                await this.expireDueBucketsInTx(manager, purchase.userId, now);
+                const balance = await this.sumBalance(manager, purchase.userId);
+                const incrementalRefundedCents =
+                    chargedCents > 0
+                        ? Math.min(
+                              refundedCents,
+                              Math.max(
+                                  1,
+                                  Math.round(
+                                      (chargedCents * creditsReversed) / purchase.amountCredits,
+                                  ),
+                              ),
+                          )
+                        : refundedCents;
+                const entry = await repo.save(
+                    repo.create({
+                        userId: purchase.userId,
+                        organizationId: purchase.organizationId ?? null,
+                        tenantId: purchase.tenantId ?? null,
+                        kind: CreditLedgerKind.ADJUSTMENT,
+                        amountCredits: -creditsReversed,
+                        costCentsRef: incrementalRefundedCents,
+                        refType: write.refType,
+                        refId: write.refId,
+                        description: write.description ?? null,
+                        idempotencyKey: write.idempotencyKey,
+                        balanceAfter: balance - creditsReversed,
+                        remainingCredits: null,
+                        expiresAt: null,
+                    }),
+                );
+                await this.allocateDebit(manager, purchase.userId, creditsReversed, now);
+                return { status: 'created' as const, entry, creditsReversed };
+            });
+        } catch (error) {
+            if (this.isUniqueViolation(error)) {
+                const existing = await this.findByIdempotencyKey(write.idempotencyKey);
+                if (existing) {
+                    return { status: 'idempotent', entry: existing, creditsReversed: 0 };
                 }
             }
             throw error;

--- a/packages/agent/src/subscriptions/billing/billing.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.spec.ts
@@ -95,11 +95,36 @@ function makeInvoiceRepository(overrides: Record<string, unknown> = {}) {
 }
 
 function makeLedgerRepository(overrides: Record<string, unknown> = {}) {
-    return {
+    const repository = {
         findByIdempotencyKey: jest.fn().mockResolvedValue(null),
         findLatestByRef: jest.fn().mockResolvedValue(null),
         ...overrides,
     } as any;
+    repository.recordCumulativeRefundAtomic =
+        (overrides.recordCumulativeRefundAtomic as jest.Mock | undefined) ??
+        jest.fn().mockImplementation(async (write: any) => {
+            const existing = await repository.findByIdempotencyKey(write.idempotencyKey);
+            if (existing) {
+                return { status: 'idempotent', entry: existing, creditsReversed: 0 };
+            }
+            const purchase = await repository.findLatestByRef(write.refType, write.refId);
+            if (!purchase) {
+                return { status: 'missing-purchase', creditsReversed: 0 };
+            }
+            const chargedCents = purchase.costCentsRef ?? 0;
+            const refundedCents = write.cumulativeRefundedCents ?? chargedCents;
+            const share = chargedCents > 0 ? Math.min(1, refundedCents / chargedCents) : 1;
+            const creditsReversed = Math.min(
+                purchase.amountCredits,
+                Math.round(purchase.amountCredits * share),
+            );
+            return {
+                status: 'created',
+                entry: { ...purchase, amountCredits: -creditsReversed },
+                creditsReversed,
+            };
+        });
+    return repository;
 }
 
 function makeLedgerService(overrides: Record<string, unknown> = {}) {
@@ -430,15 +455,20 @@ describe('BillingService — webhook: refunds', () => {
 
         const outcome = await service.handleWebhook('{}', 'sig');
 
-        expect(outcome.action).toBe('reversed');
-        expect(ledgerService.record).toHaveBeenCalledWith(
+        expect(outcome).toEqual({
+            eventId: 'evt_ref',
+            kind: 'credits.refunded',
+            action: 'reversed',
+            creditsDelta: -5500,
+        });
+        expect(ledgerRepo.recordCumulativeRefundAtomic).toHaveBeenCalledWith(
             expect.objectContaining({
-                kind: CreditLedgerKind.ADJUSTMENT,
-                amountCredits: -5500,
+                refId: 'pi_1',
+                cumulativeRefundedCents: 5000,
                 idempotencyKey: 'stripe:evt:evt_ref',
-                allowNegativeBalance: true,
             }),
         );
+        expect(ledgerService.record).not.toHaveBeenCalled();
     });
 
     it('reverses proportionally on a partial refund', async () => {
@@ -458,11 +488,11 @@ describe('BillingService — webhook: refunds', () => {
                 }),
             ),
         });
-        const { service, ledgerService } = build({ provider, profiles, ledgerRepo });
+        const { service } = build({ provider, profiles, ledgerRepo });
 
-        await service.handleWebhook('{}', 'sig');
+        const outcome = await service.handleWebhook('{}', 'sig');
 
-        expect(ledgerService.record.mock.calls[0][0].amountCredits).toBe(-2750);
+        expect(outcome.creditsDelta).toBe(-2750);
     });
 
     it('never reverses more than was granted, even if the event over-reports', async () => {
@@ -482,11 +512,11 @@ describe('BillingService — webhook: refunds', () => {
                 }),
             ),
         });
-        const { service, ledgerService } = build({ provider, profiles, ledgerRepo });
+        const { service } = build({ provider, profiles, ledgerRepo });
 
-        await service.handleWebhook('{}', 'sig');
+        const outcome = await service.handleWebhook('{}', 'sig');
 
-        expect(ledgerService.record.mock.calls[0][0].amountCredits).toBe(-1000);
+        expect(outcome.creditsDelta).toBe(-1000);
     });
 
     it('is idempotent on replay of the same refund event', async () => {
@@ -552,16 +582,11 @@ describe('BillingService — webhook: refunds', () => {
         const outcome = await service.handleWebhook('{}', 'sig');
 
         expect(outcome.action).toBe('reversed');
-        expect(ledgerService.record).toHaveBeenCalledWith(
-            expect.objectContaining({
-                userId: 'u_disputed',
-                organizationId: 'org_9',
-                tenantId: 't_9',
-                kind: CreditLedgerKind.ADJUSTMENT,
-                amountCredits: -25000,
-                allowNegativeBalance: true,
-            }),
+        expect(outcome.creditsDelta).toBe(-25000);
+        expect(ledgerRepo.recordCumulativeRefundAtomic).toHaveBeenCalledWith(
+            expect.objectContaining({ refId: 'pi_disputed' }),
         );
+        expect(ledgerService.record).not.toHaveBeenCalled();
     });
 
     it('always reverses the purchase owner even when the current billing profile points elsewhere', async () => {
@@ -591,13 +616,10 @@ describe('BillingService — webhook: refunds', () => {
 
         await service.handleWebhook('{}', 'sig');
 
-        expect(ledgerService.record).toHaveBeenCalledWith(
-            expect.objectContaining({
-                userId: 'u_original',
-                organizationId: 'org_original',
-                tenantId: 'tenant_original',
-            }),
+        expect(ledgerRepo.recordCumulativeRefundAtomic).toHaveBeenCalledWith(
+            expect.objectContaining({ refId: 'pi_repointed' }),
         );
+        expect(ledgerService.record).not.toHaveBeenCalled();
     });
 
     it('ignores a refund with no matching purchase rather than guessing', async () => {
@@ -617,6 +639,45 @@ describe('BillingService — webhook: refunds', () => {
         const outcome = await service.handleWebhook('{}', 'sig');
 
         expect(outcome.action).toBe('ignored');
+        expect(ledgerService.record).not.toHaveBeenCalled();
+    });
+
+    it('delegates cumulative refund accounting to the atomic ledger path', async () => {
+        const ledgerRepo = makeLedgerRepository({
+            recordCumulativeRefundAtomic: jest.fn().mockResolvedValue({
+                status: 'created',
+                entry: { id: 'refund-2', amountCredits: -2750 },
+                creditsReversed: 2750,
+            }),
+        });
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(
+                event({
+                    id: 'evt_refund_2',
+                    kind: 'credits.refunded',
+                    customerId: 'cus_1',
+                    amountCents: 5000,
+                    paymentId: 'pi_1',
+                }),
+            ),
+        });
+        const { service, ledgerService } = build({ provider, ledgerRepo });
+
+        const outcome = await service.handleWebhook('{}', 'sig');
+
+        expect(ledgerRepo.recordCumulativeRefundAtomic).toHaveBeenCalledWith({
+            refType: BILLING_PAYMENT_REF_TYPE,
+            refId: 'pi_1',
+            cumulativeRefundedCents: 5000,
+            idempotencyKey: 'stripe:evt:evt_refund_2',
+            description: 'Refund / chargeback reversal',
+        });
+        expect(outcome).toEqual({
+            eventId: 'evt_refund_2',
+            kind: 'credits.refunded',
+            action: 'reversed',
+            creditsDelta: -2750,
+        });
         expect(ledgerService.record).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/subscriptions/billing/billing.service.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.ts
@@ -605,79 +605,33 @@ export class BillingService {
     }
 
     private async applyRefund(event: BillingWebhookEvent): Promise<WebhookOutcome> {
-        // 🛑 The originating ledger row is looked up BEFORE the owner is
-        // resolved, because on a CHARGEBACK it is the only thing that knows
-        // who the owner is. A Stripe `Dispute` object carries no `customer`
-        // field at all — only `charge` and `payment_intent` — so
-        // `charge.dispute.created` normalises with `customerId: null` (the
-        // `base` default) and no `referenceId`, and those are the only two
-        // inputs `resolveProfile` has. It therefore returned null and the
-        // whole reversal was skipped as "unattributed": the customer kept the
-        // credits AND got the money back, with nothing in the ledger to show
-        // for it. `charge.refunded` was never affected because it does set
-        // `customerId` from `charge.customer`.
-        //
-        // The purchase row is the better identity anyway: it is the row that
-        // GRANTED these credits, so reversing against its owner cannot debit
-        // the wrong account even if a billing profile is later re-pointed at
-        // a different Stripe customer.
-        // Size the reversal from what was actually GRANTED for this
-        // payment, scaled by the refunded share. Re-deriving from the pack
-        // table would misprice a refund of a pack that has since changed.
-        const original = event.paymentId
-            ? await this.creditLedgerRepository.findLatestByRef(
-                  BILLING_PAYMENT_REF_TYPE,
-                  event.paymentId,
-              )
-            : null;
-        if (!original || original.amountCredits <= 0) {
+        if (!event.paymentId) {
             this.logger.warn(
                 `Billing webhook ${event.id}: refund has no matching purchase — ignored`,
             );
             return { eventId: event.id, kind: event.kind, action: 'ignored' };
         }
 
-        // The purchase row is the authority for ownership as well as amount.
-        // A billing profile can be re-pointed after purchase; using its current
-        // owner could debit an unrelated account for an older payment.
-        const owner = {
-            userId: original.userId,
-            organizationId: original.organizationId ?? null,
-            tenantId: original.tenantId ?? null,
-        };
-
-        const chargedCents = original.costCentsRef ?? 0;
-        const refundedCents = event.amountCents ?? chargedCents;
-        const share = chargedCents > 0 ? Math.min(1, Math.max(0, refundedCents / chargedCents)) : 1;
-        const reverseCredits = Math.min(
-            original.amountCredits,
-            Math.max(1, Math.round(original.amountCredits * share)),
-        );
-
         const idempotencyKey = this.eventKey(event.id);
-        const already = await this.creditLedgerRepository.findByIdempotencyKey(idempotencyKey);
-
-        await this.creditLedgerService.record({
-            userId: owner.userId,
-            organizationId: owner.organizationId,
-            tenantId: owner.tenantId,
-            kind: CreditLedgerKind.ADJUSTMENT,
-            amountCredits: -reverseCredits,
-            costCentsRef: refundedCents,
+        const result = await this.creditLedgerRepository.recordCumulativeRefundAtomic({
             refType: BILLING_PAYMENT_REF_TYPE,
-            refId: event.paymentId ?? null,
-            description: 'Refund / chargeback reversal',
-            // A reversal must land even if it drives the balance negative —
-            // the user already spent credits they were refunded for.
-            allowNegativeBalance: true,
+            refId: event.paymentId,
+            cumulativeRefundedCents: event.amountCents,
             idempotencyKey,
+            description: 'Refund / chargeback reversal',
         });
+        if (result.status === 'missing-purchase') {
+            this.logger.warn(
+                `Billing webhook ${event.id}: refund has no matching purchase — ignored`,
+            );
+            return { eventId: event.id, kind: event.kind, action: 'ignored' };
+        }
 
         return {
             eventId: event.id,
             kind: event.kind,
-            action: already ? 'reversed-idempotent' : 'reversed',
-            creditsDelta: already ? 0 : -reverseCredits,
+            action: result.status === 'created' ? 'reversed' : 'reversed-idempotent',
+            creditsDelta: result.creditsReversed === 0 ? 0 : -result.creditsReversed,
         };
     }
 


### PR DESCRIPTION
## Summary
- reconcile Stripe's cumulative refund total inside one ledger transaction
- serialize refund adjustments by purchase owner and write only the incremental reversal
- preserve duplicate, concurrent, out-of-order, legacy, and over-reported refund behavior

## Verification
- 75 focused repository/billing tests passed
- 336 billing tests passed
- agent type-check passed
- Prettier and git diff checks passed

No schema, data, secret, Stripe-account, or deployment change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refunds now support cumulative processing, including partial, full, and over-reported refunds.
  - Refund credits are calculated proportionally to the original purchase amount.
  - Refund handling is idempotent and safely supports concurrent processing.

- **Bug Fixes**
  - Prevented duplicate credit reversals when the same refund event is received multiple times.
  - Added graceful handling for missing or legacy purchase records.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->