### PR TITLE
feat(billing): persist perpetual licence ownership

### DIFF
--- a/apps/api/src/migrations/1787600000000-CreateLicencePurchases.ts
+++ b/apps/api/src/migrations/1787600000000-CreateLicencePurchases.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Durable self-hosted commercial-licence ownership.
+ *
+ * The table starts empty and is written only after a billing-verified one-off
+ * payment. It is separate from `user_subscriptions`: a licence applies to the
+ * buyer's own deployment and must never grant a hosted tier.
+ *
+ * `down` deliberately preserves financial records. Behavioral rollback can
+ * stop readers/writers while retaining the audit trail.
+ */
+export class CreateLicencePurchases1787600000000 implements MigrationInterface {
+    name = 'CreateLicencePurchases1787600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('licence_purchases')) return;
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'licence_purchases',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'planCode', type: 'varchar', length: '64' },
+                    { name: 'provider', type: 'varchar', length: '32' },
+                    { name: 'providerPaymentId', type: 'varchar', length: '128' },
+                    { name: 'amountCents', type: 'int' },
+                    { name: 'currency', type: 'varchar', length: '8' },
+                    { name: 'status', type: 'varchar', length: '16', default: "'active'" },
+                    { name: 'refundedAt', type: 'timestamp', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+        await queryRunner.createIndex(
+            'licence_purchases',
+            new TableIndex({
+                name: 'idx_licence_purchases_user_plan',
+                columnNames: ['userId', 'planCode'],
+            }),
+        );
+        await queryRunner.createIndex(
+            'licence_purchases',
+            new TableIndex({
+                name: 'idx_licence_purchases_provider_payment',
+                columnNames: ['provider', 'providerPaymentId'],
+                isUnique: true,
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'licence_purchases',
+            new TableForeignKey({
+                name: 'fk_licence_purchases_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        // Financial/audit records are intentionally retained.
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateLicencePurchases.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateLicencePurchases.spec.ts
@@ -1,0 +1,64 @@
+import { DataSource } from 'typeorm';
+import { CreateLicencePurchases1787600000000 } from '../1787600000000-CreateLicencePurchases';
+
+describe('CreateLicencePurchases1787600000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateLicencePurchases1787600000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`CREATE TABLE "users" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "users" ("id") VALUES ('u1')`);
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('creates an owner-scoped payment ledger with provider idempotency', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        await dataSource.query(
+            `INSERT INTO "licence_purchases" ("id", "userId", "planCode", "provider", "providerPaymentId", "amountCents", "currency", "createdAt", "updatedAt")
+             VALUES ('l1', 'u1', 'selfhosted_pro', 'stripe', 'pi_1', 9900, 'usd', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        );
+        const rows = await dataSource.query(
+            `SELECT "userId", "planCode", "providerPaymentId", "status" FROM "licence_purchases"`,
+        );
+        expect(rows).toEqual([
+            {
+                userId: 'u1',
+                planCode: 'selfhosted_pro',
+                providerPaymentId: 'pi_1',
+                status: 'active',
+            },
+        ]);
+
+        await expect(
+            dataSource.query(
+                `INSERT INTO "licence_purchases" ("id", "userId", "planCode", "provider", "providerPaymentId", "amountCents", "currency", "createdAt", "updatedAt")
+                 VALUES ('l2', 'u1', 'selfhosted_pro', 'stripe', 'pi_1', 9900, 'usd', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+            ),
+        ).rejects.toThrow(/UNIQUE/i);
+    });
+
+    it('is idempotent and preserves financial records on down', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await migration.down(runner);
+        await runner.release();
+
+        await expect(
+            dataSource.query(`SELECT COUNT(*) AS count FROM "licence_purchases"`),
+        ).resolves.toEqual([{ count: 0 }]);
+    });
+});

--- a/apps/api/src/subscriptions/subscriptions.controller.spec.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.spec.ts
@@ -26,7 +26,11 @@ jest.mock('../auth', () => ({
 
 import { BadRequestException } from '@nestjs/common';
 import { SubscriptionsController } from './subscriptions.controller';
-import type { EntitlementsService, SubscriptionService } from '@ever-works/agent/subscriptions';
+import type {
+    EntitlementsService,
+    PlanSubscriptionService,
+    SubscriptionService,
+} from '@ever-works/agent/subscriptions';
 import type { AuthService } from '../auth';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 
@@ -43,6 +47,9 @@ describe('SubscriptionsController', () => {
     >;
     let authService: jest.Mocked<Pick<AuthService, 'getUser'>>;
     let entitlementsService: jest.Mocked<Pick<EntitlementsService, 'getNumber'>>;
+    let planSubscriptionService: jest.Mocked<
+        Pick<PlanSubscriptionService, 'listOwnedLicenceCodes'>
+    >;
     let controller: SubscriptionsController;
 
     const auth: AuthenticatedUser = {
@@ -74,10 +81,14 @@ describe('SubscriptionsController', () => {
         entitlementsService = {
             getNumber: jest.fn().mockResolvedValue(0),
         } as any;
+        planSubscriptionService = {
+            listOwnedLicenceCodes: jest.fn().mockResolvedValue([]),
+        } as any;
         controller = new SubscriptionsController(
             subscriptionService as unknown as SubscriptionService,
             authService as unknown as AuthService,
             entitlementsService as unknown as EntitlementsService,
+            planSubscriptionService as unknown as PlanSubscriptionService,
         );
     });
 
@@ -245,6 +256,32 @@ describe('SubscriptionsController', () => {
             expect(result.licences[0].lifetimePrice).toBe('99');
             // A licence never becomes "your current plan" on this deployment.
             expect(result.licences[0].isCurrent).toBe(false);
+            expect(result.licences[0].owned).toBe(false);
+        });
+
+        it('marks a durable self-hosted licence as owned for this user', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'free', displayName: 'Free' },
+                allowances: [],
+            } as any);
+            subscriptionService.listPlans.mockResolvedValue(seededPlans);
+            subscriptionService.listSelfHostedPlans.mockResolvedValue([
+                {
+                    code: 'selfhosted_pro',
+                    displayName: 'Pro Edition',
+                    hosting: 'selfhosted',
+                    monthlyPrice: '49',
+                    lifetimePrice: '99',
+                    currency: 'usd',
+                },
+            ] as any[]);
+            planSubscriptionService.listOwnedLicenceCodes.mockResolvedValue(['selfhosted_pro']);
+
+            const result = await controller.listPlans(auth);
+
+            expect(planSubscriptionService.listOwnedLicenceCodes).toHaveBeenCalledWith('user-1');
+            expect(result.licences[0].owned).toBe(true);
         });
 
         it('falls back to free as the current plan when subscriptions are disabled', async () => {

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -13,6 +13,7 @@ import { AuthSessionGuard, AuthService, CurrentUser } from '@src/auth';
 import {
     ENTITLEMENT_KEYS,
     EntitlementsService,
+    PlanSubscriptionService,
     SubscriptionService,
 } from '@ever-works/agent/subscriptions';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
@@ -35,6 +36,7 @@ export class SubscriptionsController {
         // Wave 13 (Billing page) — per-plan daily-free-credits for the
         // credits-forward plan switcher (`GET plans` below).
         private readonly entitlementsService: EntitlementsService,
+        private readonly planSubscriptionService: PlanSubscriptionService,
     ) {}
 
     @Get('plan')
@@ -82,11 +84,13 @@ export class SubscriptionsController {
     @ApiResponse({ status: 200, description: 'Active plans + current plan code' })
     async listPlans(@CurrentUser() auth: AuthenticatedUser) {
         const user = await this.authService.getUser(auth.userId);
-        const [summary, plans, licences] = await Promise.all([
+        const [summary, plans, licences, ownedLicenceCodes] = await Promise.all([
             this.subscriptionService.summarizePlan(user),
             this.subscriptionService.listPlans(),
             this.subscriptionService.listSelfHostedPlans(),
+            this.planSubscriptionService.listOwnedLicenceCodes(auth.userId),
         ]);
+        const ownedLicenceSet = new Set(ownedLicenceCodes);
         const currentPlanCode = summary.enabled ? summary.plan.code : 'free';
 
         // Plan count is tiny (seeded catalog) and EntitlementsService
@@ -143,6 +147,7 @@ export class SubscriptionsController {
             currency: plan.currency,
             // A licence never becomes "your current plan" on this deployment.
             isCurrent: false,
+            owned: ownedLicenceSet.has(plan.code),
             dailyFreeCredits: 0,
         }));
 

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -815,7 +815,15 @@ export function BillingSettings({
                                 <p className="mt-2 text-xs text-muted-foreground">
                                     {t('licence.explainer')}
                                 </p>
-                                {licenceConfirmCode === licence.code ? (
+                                {licence.owned ? (
+                                    <Button
+                                        className="mt-3 text-xs"
+                                        data-testid={`billing-licence-owned-${licence.code}`}
+                                        disabled
+                                    >
+                                        {t('invoices.statuses.paid')}
+                                    </Button>
+                                ) : licenceConfirmCode === licence.code ? (
                                     <div className="mt-3 flex flex-col gap-2">
                                         <p className="text-xs text-muted-foreground">
                                             {t('licence.confirmBody')}

--- a/apps/web/src/lib/api/credits.shared.ts
+++ b/apps/web/src/lib/api/credits.shared.ts
@@ -191,6 +191,8 @@ export interface SubscriptionPlanListItem {
     overagePricePerRun: string;
     currency: string;
     isCurrent: boolean;
+    /** True when this owner holds an active durable self-hosted licence. */
+    owned?: boolean;
     dailyFreeCredits: number;
 }
 

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -136,6 +136,7 @@ import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
 import { BillingProfile } from '../entities/billing-profile.entity';
 import { Invoice } from '../entities/invoice.entity';
+import { LicencePurchase } from '../entities/licence-purchase.entity';
 import { CreditMeterEvent } from '../entities/credit-meter-event.entity';
 import { FleetNode } from '../entities/fleet-node.entity';
 import { FleetAgentNodeAffinity } from '../entities/fleet-agent-node-affinity.entity';
@@ -339,6 +340,7 @@ export const ENTITIES = [
     // written exclusively by the signature-verified webhook.
     BillingProfile,
     Invoice,
+    LicencePurchase,
     CreditMeterEvent,
     // Fleet (Wave 12, slice 1) — enrolled execution nodes (desktop /
     // headless) with hashed credentials + heartbeat status.

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -110,6 +110,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // Invoice mirror (billing PRD §3.5) — provider invoices/receipts,
     // written only by the signature-verified webhook
     'Invoice',
+    // Durable self-hosted commercial-licence ownership.
+    'LicencePurchase',
     // Agent Plugins MCP slice — manual external MCP server registry.
     'McpServerConnection',
     // Meetings v1 (Wave 8, feature a) — captured meetings w/ transcripts

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -44,6 +44,7 @@ import { GitHubAppInstallationRepoRepository } from './repositories/github-app-i
 import { GitHubAppInstallationRepository } from './repositories/github-app-installation.repository';
 import { GitHubAppUserLinkRepository } from './repositories/github-app-user-link.repository';
 import { InvoiceRepository } from './repositories/invoice.repository';
+import { LicencePurchaseRepository } from './repositories/licence-purchase.repository';
 import { CreditMeterEventRepository } from './repositories/credit-meter-event.repository';
 import { MemoryFolderRepository } from './repositories/memory-folder.repository';
 import { NotificationChannelDeliveryLogRepository } from './repositories/notification-channel-delivery-log.repository';
@@ -101,6 +102,7 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     GitHubAppInstallationRepository,
     GitHubAppUserLinkRepository,
     InvoiceRepository,
+    LicencePurchaseRepository,
     CreditMeterEventRepository,
     MemoryFolderRepository,
     NotificationChannelDeliveryLogRepository,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -26,6 +26,7 @@ export * from './repositories/plan-entitlement.repository';
 // (customer + payment-method summary + auto-recharge) and the invoice mirror
 export * from './repositories/billing-profile.repository';
 export * from './repositories/invoice.repository';
+export * from './repositories/licence-purchase.repository';
 // Streaming-terminal M9 / D1 — append-only terminal transcript chunks.
 export * from './repositories/terminal-transcript-chunk.repository';
 export * from './repositories/work-budget.repository';

--- a/packages/agent/src/database/repositories/__tests__/licence-purchase.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/licence-purchase.repository.spec.ts
@@ -1,0 +1,51 @@
+import { LicencePurchaseRepository } from '../licence-purchase.repository';
+
+const write = {
+    userId: 'u1',
+    planCode: 'selfhosted_pro',
+    provider: 'stripe',
+    providerPaymentId: 'pi_1',
+    amountCents: 9900,
+    currency: 'usd',
+};
+
+function build() {
+    const repository = {
+        findOne: jest.fn(),
+        find: jest.fn(),
+        count: jest.fn(),
+        create: jest.fn((value) => value),
+        save: jest.fn(),
+    } as any;
+    return { service: new LicencePurchaseRepository(repository), repository };
+}
+
+describe('LicencePurchaseRepository', () => {
+    it('returns the provider-correlated winner on webhook replay', async () => {
+        const { service, repository } = build();
+        const existing = { id: 'licence-1', ...write, status: 'active' };
+        repository.findOne.mockResolvedValue(existing);
+
+        await expect(service.recordPurchase(write)).resolves.toBe(existing);
+        expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('converges when webhook and return-route inserts race', async () => {
+        const { service, repository } = build();
+        const winner = { id: 'licence-1', ...write, status: 'active' };
+        repository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(winner);
+        repository.save.mockRejectedValue(Object.assign(new Error('duplicate'), { code: '23505' }));
+
+        await expect(service.recordPurchase(write)).resolves.toBe(winner);
+        expect(repository.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not swallow an unrelated persistence failure', async () => {
+        const { service, repository } = build();
+        const failure = new Error('database unavailable');
+        repository.findOne.mockResolvedValue(null);
+        repository.save.mockRejectedValue(failure);
+
+        await expect(service.recordPurchase(write)).rejects.toBe(failure);
+    });
+});

--- a/packages/agent/src/database/repositories/licence-purchase.repository.ts
+++ b/packages/agent/src/database/repositories/licence-purchase.repository.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LicencePurchase, LicencePurchaseStatus } from '@src/entities/licence-purchase.entity';
+
+export interface LicencePurchaseWrite {
+    userId: string;
+    planCode: string;
+    provider: string;
+    providerPaymentId: string;
+    amountCents: number;
+    currency: string;
+}
+
+@Injectable()
+export class LicencePurchaseRepository {
+    constructor(
+        @InjectRepository(LicencePurchase)
+        private readonly repository: Repository<LicencePurchase>,
+    ) {}
+
+    findActiveByUserAndPlan(userId: string, planCode: string): Promise<LicencePurchase | null> {
+        return this.repository.findOne({
+            where: { userId, planCode, status: LicencePurchaseStatus.ACTIVE },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    async listActivePlanCodes(userId: string): Promise<string[]> {
+        const rows = await this.repository.find({
+            where: { userId, status: LicencePurchaseStatus.ACTIVE },
+            order: { createdAt: 'ASC' },
+        });
+        return [...new Set(rows.map((row) => row.planCode))];
+    }
+
+    countByUserAndPlan(userId: string, planCode: string): Promise<number> {
+        return this.repository.count({ where: { userId, planCode } });
+    }
+
+    /**
+     * Provider-event idempotency: webhook replay and return-route sync both
+     * carry the same payment id and converge on the same row. A previously
+     * refunded row is returned unchanged; replay must never reactivate it.
+     */
+    async recordPurchase(write: LicencePurchaseWrite): Promise<LicencePurchase> {
+        const existing = await this.repository.findOne({
+            where: {
+                provider: write.provider,
+                providerPaymentId: write.providerPaymentId,
+            },
+        });
+        if (existing) return existing;
+
+        try {
+            return await this.repository.save(
+                this.repository.create({
+                    ...write,
+                    status: LicencePurchaseStatus.ACTIVE,
+                    refundedAt: null,
+                }),
+            );
+        } catch (error) {
+            // Two app instances can race the webhook against the checkout
+            // return. Only the provider-payment UNIQUE constraint is expected;
+            // re-read and return its winner instead of surfacing a false 500.
+            const raced = await this.repository.findOne({
+                where: {
+                    provider: write.provider,
+                    providerPaymentId: write.providerPaymentId,
+                },
+            });
+            if (raced) return raced;
+            throw error;
+        }
+    }
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -150,6 +150,7 @@ export * from './plan-entitlement.entity';
 // payment-method summary + auto-recharge state, and the invoice mirror
 export * from './billing-profile.entity';
 export * from './invoice.entity';
+export * from './licence-purchase.entity';
 export * from './credit-meter-event.entity';
 // Fleet (Wave 12, slice 1) — enrolled execution nodes with heartbeat
 export * from './fleet-node.entity';

--- a/packages/agent/src/entities/licence-purchase.entity.ts
+++ b/packages/agent/src/entities/licence-purchase.entity.ts
@@ -1,0 +1,63 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { PortableDateColumn } from './_types';
+
+export enum LicencePurchaseStatus {
+    ACTIVE = 'active',
+    REFUNDED = 'refunded',
+}
+
+/**
+ * Durable ownership record for one paid self-hosted commercial licence.
+ *
+ * A licence is not a hosted subscription and must never be written to
+ * `user_subscriptions`. This separate, provider-correlated record lets the
+ * owner-scoped API show that the licence is already held, prevents another
+ * checkout, and gives a later refund/chargeback path an exact record to revoke.
+ */
+@Entity({ name: 'licence_purchases' })
+@Index('idx_licence_purchases_user_plan', ['userId', 'planCode'])
+@Index('idx_licence_purchases_provider_payment', ['provider', 'providerPaymentId'], {
+    unique: true,
+})
+export class LicencePurchase {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @Column({ type: 'varchar', length: 64 })
+    planCode: string;
+
+    @Column({ type: 'varchar', length: 32 })
+    provider: string;
+
+    /** Opaque provider payment reference, never a secret. */
+    @Column({ type: 'varchar', length: 128 })
+    providerPaymentId: string;
+
+    @Column({ type: 'int' })
+    amountCents: number;
+
+    @Column({ type: 'varchar', length: 8 })
+    currency: string;
+
+    @Column({ type: 'varchar', length: 16, default: LicencePurchaseStatus.ACTIVE })
+    status: LicencePurchaseStatus;
+
+    @PortableDateColumn({ nullable: true })
+    refundedAt?: Date | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -166,6 +166,8 @@ export interface PlanCheckoutRequest {
     readonly cancelUrl: string;
     /** `{userId}:{planCode}` — echoed back on the signed provider event. */
     readonly referenceId: string;
+    /** Stable provider retry key for one logical checkout attempt. */
+    readonly idempotencyKey?: string | null;
 }
 
 export interface PlanCheckoutSession {
@@ -198,6 +200,10 @@ export interface CheckoutSessionSnapshot {
     readonly customerId: string | null;
     /** Provider subscription id, for plan sessions. */
     readonly subscriptionId: string | null;
+    /** Provider payment id, present for a settled one-off licence. */
+    readonly paymentId: string | null;
+    readonly amountCents: number | null;
+    readonly currency: string | null;
     readonly currentPeriodEnd: Date | null;
 }
 

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -135,6 +135,16 @@ function makeSubscriptionService(overrides: Record<string, unknown> = {}) {
     } as any;
 }
 
+function makeLicencePurchaseRepository(overrides: Record<string, unknown> = {}) {
+    return {
+        findActiveByUserAndPlan: jest.fn().mockResolvedValue(null),
+        countByUserAndPlan: jest.fn().mockResolvedValue(0),
+        listActivePlanCodes: jest.fn().mockResolvedValue([]),
+        recordPurchase: jest.fn().mockResolvedValue({ id: 'licence-1', status: 'active' }),
+        ...overrides,
+    } as any;
+}
+
 function build(
     overrides: {
         provider?: any;
@@ -144,6 +154,7 @@ function build(
         userRepository?: any;
         subscriptionService?: any;
         planCreditGrantService?: any;
+        licencePurchaseRepository?: any;
     } = {},
 ) {
     const provider = overrides.provider ?? makeProvider();
@@ -153,13 +164,16 @@ function build(
     const userRepository = overrides.userRepository ?? makeUserRepository();
     const subscriptionService = overrides.subscriptionService ?? makeSubscriptionService();
     const planCreditGrantService = overrides.planCreditGrantService;
-    const service = new PlanSubscriptionService(
+    const licencePurchaseRepository =
+        overrides.licencePurchaseRepository ?? makeLicencePurchaseRepository();
+    const service = new (PlanSubscriptionService as any)(
         provider,
         planRepository,
         subscriptionRepository,
         profileRepository,
         userRepository,
         subscriptionService,
+        licencePurchaseRepository,
         planCreditGrantService,
     );
     return {
@@ -171,6 +185,7 @@ function build(
         userRepository,
         subscriptionService,
         planCreditGrantService,
+        licencePurchaseRepository,
     };
 }
 
@@ -215,8 +230,45 @@ describe('startPlanCheckout — the server prices everything', () => {
             }),
         ).resolves.toBeDefined();
         expect(provider.createPlanCheckoutSession).toHaveBeenCalledWith(
-            expect.objectContaining({ plan: expect.objectContaining({ mode: 'payment' }) }),
+            expect.objectContaining({
+                plan: expect.objectContaining({ mode: 'payment' }),
+                idempotencyKey: 'licence:u1:selfhosted_pro:1',
+            }),
         );
+    });
+
+    it('refuses another lifetime checkout when the licence is already owned', async () => {
+        const licencePurchaseRepository = makeLicencePurchaseRepository({
+            findActiveByUserAndPlan: jest.fn().mockResolvedValue({ id: 'licence-1' }),
+        });
+        const { service, provider } = build({ licencePurchaseRepository });
+
+        const error = await service
+            .startPlanCheckout({
+                ...checkoutOptions,
+                planCode: 'selfhosted_pro',
+                interval: 'lifetime',
+            })
+            .catch((caught) => caught);
+        expect(error).toMatchObject({ name: 'LicenceAlreadyOwnedError' });
+        // The existing checkout controller maps this parent error to HTTP 409.
+        expect(error).toBeInstanceOf(ActivePlanSubscriptionError);
+        expect(provider.ensureCustomer).not.toHaveBeenCalled();
+        expect(provider.createPlanCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('lists the active licence plan codes for an owner', async () => {
+        const licencePurchaseRepository = makeLicencePurchaseRepository({
+            listActivePlanCodes: jest
+                .fn()
+                .mockResolvedValue(['selfhosted_pro', 'selfhosted_enterprise']),
+        });
+        const { service } = build({ licencePurchaseRepository });
+
+        await expect((service as any).listOwnedLicenceCodes('u1')).resolves.toEqual([
+            'selfhosted_pro',
+            'selfhosted_enterprise',
+        ]);
     });
 
     it('prices the checkout from the SERVER plan row', async () => {
@@ -524,6 +576,9 @@ describe('syncCheckoutReturn — a session id is not an authorization', () => {
             packId: null,
             customerId: 'cus_1',
             subscriptionId: 'sub_1',
+            paymentId: null,
+            amountCents: 2900,
+            currency: 'usd',
             currentPeriodEnd: new Date('2026-09-01T00:00:00Z'),
             ...overrides,
         };
@@ -554,6 +609,33 @@ describe('syncCheckoutReturn — a session id is not an authorization', () => {
             expect.objectContaining({ id: 'u1' }),
             'standard',
         );
+    });
+
+    it('records a settled lifetime licence from the provider read-back', async () => {
+        const licencePurchaseRepository = makeLicencePurchaseRepository();
+        const { service, subscriptionRepository } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest.fn().mockResolvedValue(
+                    paidPlanSnapshot({
+                        planCode: 'selfhosted_pro',
+                        subscriptionId: null,
+                        paymentId: 'pi_licence_1',
+                        amountCents: 9900,
+                    }),
+                ),
+            }),
+            licencePurchaseRepository,
+        });
+
+        await expect(service.syncCheckoutReturn('u1', 'cs_plan_1')).resolves.toEqual({
+            status: 'active',
+            activated: true,
+            planCode: 'selfhosted_pro',
+        });
+        expect(licencePurchaseRepository.recordPurchase).toHaveBeenCalledWith(
+            expect.objectContaining({ providerPaymentId: 'pi_licence_1', amountCents: 9900 }),
+        );
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
     });
 
     it('REFUSES a session belonging to another account, without leaking existence', async () => {
@@ -747,9 +829,40 @@ describe('applyWebhook — activation and revocation', () => {
         });
 
         await expect(
-            service.applyWebhook(event({ planCode: 'selfhosted_pro', subscriptionId: null })),
+            service.applyWebhook(
+                event({
+                    planCode: 'selfhosted_pro',
+                    subscriptionId: null,
+                    paymentId: 'pi_licence_1',
+                }),
+            ),
         ).resolves.toBe('subscription-activated');
         expect(planCreditGrantService.grantCurrentAllowance).not.toHaveBeenCalled();
+    });
+
+    it('acknowledges a recurring self-hosted licence without treating it as perpetual ownership', async () => {
+        const { service, subscriptionService, subscriptionRepository, licencePurchaseRepository } =
+            build({
+                planRepository: makePlanRepository({
+                    findByCode: jest.fn().mockResolvedValue(SELFHOSTED_PRO_PLAN),
+                }),
+                profileRepository: makeProfileRepository({
+                    findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+                }),
+            });
+
+        await expect(
+            service.applyWebhook(
+                event({
+                    planCode: 'selfhosted_pro',
+                    subscriptionId: 'sub_selfhosted_1',
+                    paymentId: null,
+                }),
+            ),
+        ).resolves.toBe('subscription-activated');
+        expect(licencePurchaseRepository.recordPurchase).not.toHaveBeenCalled();
+        expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
+        expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
     });
 
     /**
@@ -760,12 +873,13 @@ describe('applyWebhook — activation and revocation', () => {
      * nothing and grants nothing, because a licence applies to the buyer's own deployment. This is
      * the path that runs for every $99 sale.
      */
-    it('activates a perpetual licence even though it carries NO subscription id', async () => {
-        const { service, subscriptionService, subscriptionRepository } = build({
-            profileRepository: makeProfileRepository({
-                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
-            }),
-        });
+    it('records a perpetual licence even though it carries NO subscription id', async () => {
+        const { service, subscriptionService, subscriptionRepository, licencePurchaseRepository } =
+            build({
+                profileRepository: makeProfileRepository({
+                    findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+                }),
+            });
 
         await expect(
             service.applyWebhook(
@@ -773,14 +887,21 @@ describe('applyWebhook — activation and revocation', () => {
                     planCode: 'selfhosted_pro',
                     referenceId: 'u1:selfhosted_pro',
                     subscriptionId: null,
+                    paymentId: 'pi_licence_1',
                     amountCents: 9900,
                     currentPeriodEnd: null,
                 }),
             ),
         ).resolves.toBe('subscription-activated');
 
-        // Nothing is written and nothing granted — the licence lives on the Stripe payment intent
-        // (stamped ever_works_licence), which is what manual fulfilment searches.
+        expect(licencePurchaseRepository.recordPurchase).toHaveBeenCalledWith({
+            userId: 'u1',
+            planCode: 'selfhosted_pro',
+            provider: 'stripe',
+            providerPaymentId: 'pi_licence_1',
+            amountCents: 9900,
+            currency: 'usd',
+        });
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
         expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
     });
@@ -794,11 +915,12 @@ describe('applyWebhook — activation and revocation', () => {
      * know they hold a licence, for support and for the manual document fulfilment.
      */
     it('writes NO subscription row and grants NO tier for a self-hosted licence', async () => {
-        const { service, subscriptionService, subscriptionRepository } = build({
-            profileRepository: makeProfileRepository({
-                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
-            }),
-        });
+        const { service, subscriptionService, subscriptionRepository, licencePurchaseRepository } =
+            build({
+                profileRepository: makeProfileRepository({
+                    findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+                }),
+            });
 
         await expect(
             service.applyWebhook(
@@ -806,6 +928,7 @@ describe('applyWebhook — activation and revocation', () => {
                     planCode: 'selfhosted_pro',
                     referenceId: 'u1:selfhosted_pro',
                     subscriptionId: null,
+                    paymentId: 'pi_licence_1',
                     amountCents: 9900,
                     currentPeriodEnd: null,
                 }),
@@ -821,6 +944,7 @@ describe('applyWebhook — activation and revocation', () => {
         // Assert the OUTCOME (nothing written, nothing granted), not the guard.
         expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+        expect(licencePurchaseRepository.recordPurchase).toHaveBeenCalledTimes(1);
     });
 
     it('still grants a CLOUD purchase as the tier — the guard must not break the paying path', async () => {
@@ -839,23 +963,28 @@ describe('applyWebhook — activation and revocation', () => {
     });
 
     it('is idempotent for a licence too — a replayed delivery records it once, not twice', async () => {
-        const { service, subscriptionService, subscriptionRepository } = build({
-            profileRepository: makeProfileRepository({
-                findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
-            }),
-        });
+        const { service, subscriptionService, subscriptionRepository, licencePurchaseRepository } =
+            build({
+                profileRepository: makeProfileRepository({
+                    findByCustomerId: jest.fn().mockResolvedValue({ userId: 'u1' }),
+                }),
+            });
 
         const licence = event({
             planCode: 'selfhosted_pro',
             referenceId: 'u1:selfhosted_pro',
             subscriptionId: null,
+            paymentId: 'pi_licence_1',
             amountCents: 9900,
             currentPeriodEnd: null,
         });
         await service.applyWebhook(licence);
         await service.applyWebhook(licence);
 
-        // Replaying a licence delivery must stay inert: no row, no grant, however many times.
+        expect(licencePurchaseRepository.recordPurchase).toHaveBeenCalledTimes(2);
+        expect(licencePurchaseRepository.recordPurchase.mock.calls[0][0]).toEqual(
+            licencePurchaseRepository.recordPurchase.mock.calls[1][0],
+        );
         expect(subscriptionRepository.createOrUpdate).not.toHaveBeenCalled();
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
     });

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -3,6 +3,7 @@ import { BillingProfileRepository } from '@src/database/repositories/billing-pro
 import { SubscriptionPlanRepository } from '@src/database/repositories/subscription-plan.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
 import { UserSubscriptionRepository } from '@src/database/repositories/user-subscription.repository';
+import { LicencePurchaseRepository } from '@src/database/repositories/licence-purchase.repository';
 import { SubscriptionPlan } from '@src/entities/subscription-plan.entity';
 import { SubscriptionPlanCode } from '@src/entities/types';
 import {
@@ -50,6 +51,15 @@ export class ActivePlanSubscriptionError extends Error {
             'An active paid subscription already exists. Manage or cancel it before starting another recurring plan checkout.',
         );
         this.name = 'ActivePlanSubscriptionError';
+    }
+}
+
+/** A perpetual licence is already active for this owner and plan. */
+class LicenceAlreadyOwnedError extends ActivePlanSubscriptionError {
+    constructor() {
+        super();
+        this.message = 'This commercial licence is already owned.';
+        this.name = 'LicenceAlreadyOwnedError';
     }
 }
 
@@ -172,6 +182,7 @@ export class PlanSubscriptionService {
         private readonly billingProfileRepository: BillingProfileRepository,
         private readonly userRepository: UserRepository,
         private readonly subscriptionService: SubscriptionService,
+        private readonly licencePurchaseRepository: LicencePurchaseRepository,
         /**
          * Monthly plan-allowance grants (billing spec FR-4). Appended
          * LAST + `@Optional()` so every positional construction in the
@@ -198,6 +209,25 @@ export class PlanSubscriptionService {
         }
 
         const interval: CatalogInterval = options.interval ?? 'monthly';
+        let licenceIdempotencyKey: string | null = null;
+
+        if (interval === 'lifetime') {
+            const owned = await this.licencePurchaseRepository.findActiveByUserAndPlan(
+                options.userId,
+                options.planCode,
+            );
+            if (owned) throw new LicenceAlreadyOwnedError();
+
+            // Concurrent/retried clicks before the first webhook share one
+            // provider session. A refunded prior purchase increments the
+            // generation so a legitimate repurchase gets a fresh session.
+            const generation =
+                (await this.licencePurchaseRepository.countByUserAndPlan(
+                    options.userId,
+                    options.planCode,
+                )) + 1;
+            licenceIdempotencyKey = `licence:${options.userId}:${options.planCode}:${generation}`;
+        }
 
         // The local model tracks one provider subscription per owner. A second
         // recurring checkout can create a second live Stripe subscription while
@@ -276,6 +306,7 @@ export class PlanSubscriptionService {
             successUrl: options.successUrl,
             cancelUrl: options.cancelUrl,
             referenceId: `${options.userId}:${plan.code}`,
+            ...(licenceIdempotencyKey ? { idempotencyKey: licenceIdempotencyKey } : {}),
         });
 
         return {
@@ -371,6 +402,9 @@ export class PlanSubscriptionService {
             providerSubscriptionId: snapshot.subscriptionId,
             currentPeriodEnd: snapshot.currentPeriodEnd,
             cancelAtPeriodEnd: false,
+            providerPaymentId: snapshot.paymentId,
+            amountCents: snapshot.amountCents,
+            currency: snapshot.currency,
         });
 
         return {
@@ -405,6 +439,9 @@ export class PlanSubscriptionService {
                 cancelAtPeriodEnd: event.cancelAtPeriodEnd ?? false,
                 seats: event.subscription?.seats,
                 seatItemId: event.subscription?.seatItemId,
+                providerPaymentId: event.paymentId,
+                amountCents: event.amountCents,
+                currency: event.currency,
             });
             return activated ? 'subscription-activated' : 'ignored';
         }
@@ -441,6 +478,10 @@ export class PlanSubscriptionService {
 
     // ── Persistence ──────────────────────────────────────────────────
 
+    listOwnedLicenceCodes(userId: string): Promise<string[]> {
+        return this.licencePurchaseRepository.listActivePlanCodes(userId);
+    }
+
     /**
      * Put a user on a paid plan. Idempotent: re-running for the same
      * plan rewrites the same row and re-asserts the same default plan, so
@@ -456,6 +497,9 @@ export class PlanSubscriptionService {
         /** Extra seats the provider bills for; `undefined` = no snapshot here. */
         seats?: number | null;
         seatItemId?: string | null;
+        providerPaymentId?: string | null;
+        amountCents?: number | null;
+        currency?: string | null;
     }): Promise<boolean> {
         const plan = input.planCode ? await this.findPlanByCode(input.planCode) : null;
         if (!plan) {
@@ -479,12 +523,43 @@ export class PlanSubscriptionService {
         //     cloud customer who also bought a licence would have their real subscription row
         //     OVERWRITTEN — losing the plan, the period end and the provider subscription id.
         //
-        // The licence is still recorded where it actually matters: on the Stripe payment intent,
-        // stamped `ever_works_licence=perpetual-commercial`, which is what the manual fulfilment
-        // process searches. Nothing here needs a row to know the sale happened.
+        // The licence gets its own durable purchase row below. It also remains stamped on the
+        // Stripe PaymentIntent (`ever_works_licence=perpetual-commercial`) for provider-side audit
+        // and manual document fulfilment. Neither record is a hosted tier grant.
         if (plan.hosting === 'selfhosted') {
+            // Monthly/annual self-hosted commercial subscriptions are also
+            // licences, but they are not the one-off perpetual SKU this table
+            // models. Preserve their existing acknowledgement without turning
+            // them into a hosted tier; provider lifecycle remains on the
+            // subscription id.
+            if (input.providerSubscriptionId) {
+                this.logger.log(
+                    `Recorded recurring self-hosted licence subscription for user ${input.userId} ` +
+                        `(plan '${plan.code}', provider subscription present). No hosted tier granted.`,
+                );
+                return true;
+            }
+            if (
+                !input.providerPaymentId ||
+                input.amountCents === null ||
+                input.amountCents === undefined ||
+                !input.currency
+            ) {
+                this.logger.warn(
+                    `Licence activation skipped for user ${input.userId}: settled payment details are missing`,
+                );
+                return false;
+            }
+            await this.licencePurchaseRepository.recordPurchase({
+                userId: input.userId,
+                planCode: plan.code,
+                provider: this.billingProvider.getProviderId(),
+                providerPaymentId: input.providerPaymentId,
+                amountCents: input.amountCents,
+                currency: input.currency,
+            });
             this.logger.log(
-                `Recorded a self-hosted licence purchase for user ${input.userId} (plan ` +
+                `Recorded durable self-hosted licence ownership for user ${input.userId} (plan ` +
                     `'${plan.code}'). No hosted subscription row written and no tier granted — a ` +
                     `licence applies to the buyer's OWN deployment, not to this one.`,
             );

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1080,6 +1080,20 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         );
     });
 
+    it('passes the durable licence attempt key to Stripe', async () => {
+        const { provider, client } = build();
+
+        await provider.createPlanCheckoutSession({
+            ...planRequest,
+            plan: { ...planRequest.plan, mode: 'payment', code: 'selfhosted_pro' },
+            idempotencyKey: 'licence:u1:selfhosted_pro:1',
+        });
+
+        expect(client.checkout.sessions.create.mock.calls[0][1]).toEqual({
+            idempotencyKey: 'licence:u1:selfhosted_pro:1',
+        });
+    });
+
     it('marks a licence sale so manual fulfilment can find it', async () => {
         const { provider, client } = build();
 
@@ -1089,8 +1103,9 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         });
 
         const params = client.checkout.sessions.create.mock.calls[0][0];
-        // Issuing the licence document is manual for now, so this marker is the only way to list
-        // who is owed one. It must be on BOTH objects.
+        // Issuing the licence document is manual for now. The durable local record is the product
+        // view; this marker keeps the same sale independently auditable in Stripe. It must be on
+        // BOTH objects.
         expect(params.metadata[STRIPE_METADATA_KEYS.licence]).toBe(STRIPE_PERPETUAL_LICENCE);
         expect(params.payment_intent_data.metadata[STRIPE_METADATA_KEYS.licence]).toBe(
             STRIPE_PERPETUAL_LICENCE,
@@ -1442,6 +1457,9 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
             payment_status: 'paid',
             customer: 'cus_1',
             subscription: { id: 'sub_1', current_period_end: 1790000000 },
+            payment_intent: 'pi_1',
+            amount_total: 2900,
+            currency: 'usd',
             metadata: {
                 [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
                 [STRIPE_METADATA_KEYS.userId]: 'u1',
@@ -1462,6 +1480,9 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
                 planCode: 'standard',
                 customerId: 'cus_1',
                 subscriptionId: 'sub_1',
+                paymentId: 'pi_1',
+                amountCents: 2900,
+                currency: 'usd',
             }),
         );
         expect(snapshot.currentPeriodEnd).toEqual(new Date(1790000000 * 1000));
@@ -1548,6 +1569,7 @@ describe('StripeBillingProvider — subscription event normalization (audit B24)
                     customer: 'cus_1',
                     client_reference_id: 'u1:standard',
                     subscription: 'sub_1',
+                    payment_intent: 'pi_1',
                     amount_total: 2900,
                     currency: 'usd',
                     metadata: planMeta,
@@ -1560,6 +1582,7 @@ describe('StripeBillingProvider — subscription event normalization (audit B24)
                 kind: 'subscription.activated',
                 planCode: 'standard',
                 subscriptionId: 'sub_1',
+                paymentId: 'pi_1',
                 customerId: 'cus_1',
                 referenceId: 'u1:standard',
             }),

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -334,7 +334,7 @@ export class StripeBillingProvider extends BillingProvider {
 
         const lineItems = await this.buildPlanLineItems(request);
 
-        const session = await stripe.checkout.sessions.create({
+        const params: Stripe.Checkout.SessionCreateParams = {
             mode: isPerpetual ? 'payment' : 'subscription',
             customer: customerId,
             client_reference_id: request.referenceId,
@@ -346,17 +346,8 @@ export class StripeBillingProvider extends BillingProvider {
             line_items: lineItems,
             metadata,
             // A `mode: 'payment'` sale emits no `invoice.*` event unless invoice
-            // creation is asked for explicitly. Without this, a successful $99
-            // perpetual-licence payment produces NO invoice, NO ledger row and NO
-            // subscription row — by design, since a licence grants no hosted
-            // tier — so the billing page after paying is byte-identical to
-            // before, with the same enabled "$99" button. The buyer concludes it
-            // failed and pays again, and nothing on this path is idempotent
-            // (`checkout.sessions.create` carries no idempotency key here).
-            //
-            // Turning it on routes the sale through the existing
-            // `invoice.updated` -> `mirrorInvoice` path, so the buyer gets a
-            // receipt in-app through plumbing that already exists.
+            // creation is asked for explicitly. Turning it on routes the sale
+            // through the existing invoice mirror so the buyer gets a receipt.
             ...(isPerpetual ? { invoice_creation: { enabled: true } } : {}),
             // `subscription_data` is rejected outright in payment mode; the one-off equivalent is
             // `payment_intent_data`, which is also where the licence marker has to be mirrored so a
@@ -364,7 +355,12 @@ export class StripeBillingProvider extends BillingProvider {
             ...(isPerpetual
                 ? { payment_intent_data: { metadata } }
                 : { subscription_data: { metadata } }),
-        });
+        };
+        const session = request.idempotencyKey
+            ? await stripe.checkout.sessions.create(params, {
+                  idempotencyKey: request.idempotencyKey,
+              })
+            : await stripe.checkout.sessions.create(params);
 
         if (!session.url) {
             throw new BillingProviderError('Checkout session did not return a redirect URL');
@@ -543,6 +539,9 @@ export class StripeBillingProvider extends BillingProvider {
             packId: meta[STRIPE_METADATA_KEYS.packId] ?? null,
             customerId: asId(session.customer),
             subscriptionId: asId(subscription),
+            paymentId: asId(session.payment_intent),
+            amountCents: session.amount_total ?? null,
+            currency: session.currency ?? null,
             currentPeriodEnd:
                 subscription && typeof subscription === 'object'
                     ? readCurrentPeriodEnd(subscription as Stripe.Subscription)
@@ -949,6 +948,7 @@ export class StripeBillingProvider extends BillingProvider {
                         referenceId: session.client_reference_id ?? null,
                         planCode: meta[STRIPE_METADATA_KEYS.planCode] ?? null,
                         subscriptionId: asId(session.subscription),
+                        paymentId: asId(session.payment_intent),
                         amountCents: session.amount_total ?? null,
                         currency: session.currency ?? null,
                         cancelAtPeriodEnd: false,


### PR DESCRIPTION
## Summary
- persist durable one-off perpetual self-hosted licence ownership
- converge checkout return and Stripe webhook recording through provider payment identity
- prevent duplicate lifetime checkout and expose owned plan state to API/web
- preserve existing recurring self-hosted acknowledgement without granting hosted entitlements

## Data impact
- additive empty `licence_purchases` table migration only; no existing rows are rewritten
- rollback reverts application code while retaining the unused financial record table

## Verification
- TDD red: 6 expected behavioural failures before implementation
- Agent: 13 suites / 399 tests passed
- API and migration: 2 suites / 16 tests passed
- Agent, API, and Web type checks passed
- focused Prettier and `git diff --check` passed
- database entity/repository inventory passed