### PR TITLE
fix(billing): revoke plans after payment reversals

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/licence-purchase.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/licence-purchase.repository.spec.ts
@@ -14,6 +14,7 @@ function build() {
         findOne: jest.fn(),
         find: jest.fn(),
         count: jest.fn(),
+        update: jest.fn(),
         create: jest.fn((value) => value),
         save: jest.fn(),
     } as any;
@@ -47,5 +48,31 @@ describe('LicencePurchaseRepository', () => {
         repository.save.mockRejectedValue(failure);
 
         await expect(service.recordPurchase(write)).rejects.toBe(failure);
+    });
+
+    it('finds a purchase by its provider payment correlation', async () => {
+        const { service, repository } = build();
+        const purchase = { id: 'licence-1', ...write, status: 'active' };
+        repository.findOne.mockResolvedValue(purchase);
+
+        await expect(service.findByProviderPayment('stripe', 'pi_1')).resolves.toBe(purchase);
+        expect(repository.findOne).toHaveBeenCalledWith({
+            where: { provider: 'stripe', providerPaymentId: 'pi_1' },
+        });
+    });
+
+    it('marks an active purchase refunded once and reports replay as idempotent', async () => {
+        const { service, repository } = build();
+        const now = new Date('2026-08-24T20:00:00Z');
+        repository.update
+            .mockResolvedValueOnce({ affected: 1 })
+            .mockResolvedValueOnce({ affected: 0 });
+
+        await expect(service.markRefunded('licence-1', now)).resolves.toBe(true);
+        await expect(service.markRefunded('licence-1', now)).resolves.toBe(false);
+        expect(repository.update).toHaveBeenCalledWith(
+            { id: 'licence-1', status: 'active' },
+            { status: 'refunded', refundedAt: now },
+        );
     });
 });

--- a/packages/agent/src/database/repositories/licence-purchase.repository.ts
+++ b/packages/agent/src/database/repositories/licence-purchase.repository.ts
@@ -38,6 +38,22 @@ export class LicencePurchaseRepository {
         return this.repository.count({ where: { userId, planCode } });
     }
 
+    findByProviderPayment(
+        provider: string,
+        providerPaymentId: string,
+    ): Promise<LicencePurchase | null> {
+        return this.repository.findOne({ where: { provider, providerPaymentId } });
+    }
+
+    /** Compare-and-set transition: true only for the first successful reversal. */
+    async markRefunded(id: string, refundedAt: Date = new Date()): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, status: LicencePurchaseStatus.ACTIVE },
+            { status: LicencePurchaseStatus.REFUNDED, refundedAt },
+        );
+        return (result.affected ?? 0) > 0;
+    }
+
     /**
      * Provider-event idempotency: webhook replay and return-route sync both
      * carry the same payment id and converge on the same row. A previously

--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -477,6 +477,15 @@ export interface BillingWebhookEvent {
     readonly subscription?: BillingSubscriptionSnapshot;
     /** Provider payment id, for correlation on refunds. */
     readonly paymentId: string | null;
+    /**
+     * Provider truth about a payment reversal. `charge.refunded` is also
+     * emitted for partial refunds, so entitlement code must never infer a
+     * full reversal from the event type alone.
+     */
+    readonly reversal?: {
+        readonly reason: 'refund' | 'dispute';
+        readonly fullyReversed: boolean;
+    };
     /** Raw provider event type, for logging/diagnostics. Never a secret. */
     readonly providerType: string;
     /**
@@ -491,6 +500,11 @@ export interface BillingWebhookEvent {
     readonly currentPeriodEnd?: Date | null;
     /** The provider will not renew at `currentPeriodEnd`. */
     readonly cancelAtPeriodEnd?: boolean | null;
+}
+
+export interface PerpetualLicencePaymentReference {
+    readonly userId: string;
+    readonly planCode: string;
 }
 
 export abstract class BillingProvider {
@@ -555,6 +569,22 @@ export abstract class BillingProvider {
      */
     async retrieveCheckoutSession(_sessionId: string): Promise<CheckoutSessionSnapshot> {
         throw new BillingProviderNotConfiguredError();
+    }
+
+    /**
+     * Resolve a settled invoice PaymentIntent back to a recurring plan
+     * subscription sold by this application. Providers without an invoice
+     * payment graph return null; callers must never guess by customer id.
+     */
+    async findPlanSubscriptionIdForPayment(_paymentId: string): Promise<string | null> {
+        return null;
+    }
+
+    /** Resolve a one-off perpetual licence PaymentIntent stamped by us. */
+    async findPerpetualLicenceForPayment(
+        _paymentId: string,
+    ): Promise<PerpetualLicencePaymentReference | null> {
+        return null;
     }
 
     /** Off-session charge against a stored payment method (auto-recharge). */

--- a/packages/agent/src/subscriptions/billing/billing.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.spec.ts
@@ -642,6 +642,34 @@ describe('BillingService — webhook: refunds', () => {
         expect(ledgerService.record).not.toHaveBeenCalled();
     });
 
+    it('delegates a non-credit payment reversal to the plan reconciler', async () => {
+        const plans = {
+            applyPaymentReversal: jest.fn().mockResolvedValue({ action: 'plan-revoked' }),
+        };
+        const provider = makeProvider({
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(
+                event({
+                    id: 'evt_plan_refund',
+                    kind: 'credits.refunded',
+                    customerId: null,
+                    paymentId: 'pi_plan_1',
+                    amountCents: 2900,
+                    reversal: { reason: 'refund', fullyReversed: true },
+                }),
+            ),
+        });
+        const { service } = build({ provider, plans });
+
+        await expect(service.handleWebhook('{}', 'sig')).resolves.toEqual({
+            eventId: 'evt_plan_refund',
+            kind: 'credits.refunded',
+            action: 'plan-revoked',
+        });
+        expect(plans.applyPaymentReversal).toHaveBeenCalledWith(
+            expect.objectContaining({ paymentId: 'pi_plan_1' }),
+        );
+    });
+
     it('delegates cumulative refund accounting to the atomic ledger path', async () => {
         const ledgerRepo = makeLedgerRepository({
             recordCumulativeRefundAtomic: jest.fn().mockResolvedValue({

--- a/packages/agent/src/subscriptions/billing/billing.service.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.ts
@@ -119,6 +119,8 @@ export interface WebhookOutcome {
         | 'credited-idempotent'
         | 'reversed'
         | 'reversed-idempotent'
+        | 'plan-revoked'
+        | 'licence-refunded'
         | 'invoice-mirrored'
         | 'payment-method-updated'
         | 'payment-method-removed'
@@ -621,6 +623,10 @@ export class BillingService {
             description: 'Refund / chargeback reversal',
         });
         if (result.status === 'missing-purchase') {
+            if (this.planSubscriptionService) {
+                const reversal = await this.planSubscriptionService.applyPaymentReversal(event);
+                return { eventId: event.id, kind: event.kind, action: reversal.action };
+            }
             this.logger.warn(
                 `Billing webhook ${event.id}: refund has no matching purchase — ignored`,
             );

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -79,6 +79,8 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
             customerId: 'cus_1',
         }),
         retrieveCheckoutSession: jest.fn(),
+        findPlanSubscriptionIdForPayment: jest.fn().mockResolvedValue(null),
+        findPerpetualLicenceForPayment: jest.fn().mockResolvedValue(null),
         ...overrides,
     } as any;
 }
@@ -141,6 +143,8 @@ function makeLicencePurchaseRepository(overrides: Record<string, unknown> = {}) 
         countByUserAndPlan: jest.fn().mockResolvedValue(0),
         listActivePlanCodes: jest.fn().mockResolvedValue([]),
         recordPurchase: jest.fn().mockResolvedValue({ id: 'licence-1', status: 'active' }),
+        findByProviderPayment: jest.fn().mockResolvedValue(null),
+        markRefunded: jest.fn().mockResolvedValue(false),
         ...overrides,
     } as any;
 }
@@ -1122,5 +1126,157 @@ describe('applyWebhook — activation and revocation', () => {
         // …but the privileged grant is not attempted on a deploy that
         // has subscriptions switched off (it would throw by contract).
         expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+    });
+
+    it('does not revoke entitlement for a partial refund', async () => {
+        const { service, provider, subscriptionRepository, licencePurchaseRepository } = build();
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    kind: 'credits.refunded',
+                    paymentId: 'pi_partial',
+                    reversal: { reason: 'refund', fullyReversed: false },
+                }),
+            ),
+        ).resolves.toEqual({ action: 'ignored' });
+        expect(licencePurchaseRepository.findByProviderPayment).not.toHaveBeenCalled();
+        expect(provider.findPlanSubscriptionIdForPayment).not.toHaveBeenCalled();
+        expect(subscriptionRepository.cancel).not.toHaveBeenCalled();
+    });
+
+    it('revokes a durable perpetual licence on a full refund', async () => {
+        const licencePurchaseRepository = makeLicencePurchaseRepository({
+            findByProviderPayment: jest.fn().mockResolvedValue({
+                id: 'licence-1',
+                userId: 'u1',
+                status: 'active',
+            }),
+            markRefunded: jest.fn().mockResolvedValue(true),
+        });
+        const { service, provider, subscriptionRepository } = build({
+            licencePurchaseRepository,
+        });
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    id: 'evt_licence_refund',
+                    kind: 'credits.refunded',
+                    paymentId: 'pi_licence_1',
+                    reversal: { reason: 'refund', fullyReversed: true },
+                }),
+            ),
+        ).resolves.toEqual({ action: 'licence-refunded' });
+        expect(licencePurchaseRepository.markRefunded).toHaveBeenCalledWith('licence-1');
+        expect(provider.findPlanSubscriptionIdForPayment).not.toHaveBeenCalled();
+        expect(subscriptionRepository.cancel).not.toHaveBeenCalled();
+    });
+
+    it('revokes the exact recurring plan and its current allowance on a dispute', async () => {
+        const subscription = {
+            id: 'sub-row-1',
+            userId: 'u1',
+            createdAt: new Date('2026-08-23T10:00:00Z'),
+            plan: STANDARD_PLAN,
+        };
+        const provider = makeProvider({
+            findPlanSubscriptionIdForPayment: jest.fn().mockResolvedValue('sub_provider_1'),
+        });
+        const subscriptionRepository = makeSubscriptionRepository({
+            findByProviderSubscriptionId: jest.fn().mockResolvedValue(subscription),
+        });
+        const planCreditGrantService = {
+            reverseCurrentAllowance: jest.fn().mockResolvedValue('reversed'),
+        };
+        const { service, subscriptionService } = build({
+            provider,
+            subscriptionRepository,
+            planCreditGrantService,
+        });
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    id: 'evt_dispute',
+                    kind: 'credits.refunded',
+                    customerId: null,
+                    referenceId: null,
+                    paymentId: 'pi_plan_1',
+                    reversal: { reason: 'dispute', fullyReversed: true },
+                }),
+            ),
+        ).resolves.toEqual({ action: 'plan-revoked' });
+        expect(subscriptionRepository.cancel).toHaveBeenCalledWith('sub-row-1');
+        expect(planCreditGrantService.reverseCurrentAllowance).toHaveBeenCalledWith(
+            subscription,
+            'stripe:evt:evt_dispute',
+        );
+        expect(subscriptionService.changePlanSelfService).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'u1' }),
+            'free',
+        );
+    });
+
+    it('is idempotent when a perpetual licence refund event is replayed', async () => {
+        const licencePurchaseRepository = makeLicencePurchaseRepository({
+            findByProviderPayment: jest.fn().mockResolvedValue({
+                id: 'licence-1',
+                userId: 'u1',
+                status: 'refunded',
+            }),
+            markRefunded: jest.fn().mockResolvedValue(false),
+        });
+        const { service } = build({ licencePurchaseRepository });
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    id: 'evt_licence_refund',
+                    kind: 'credits.refunded',
+                    paymentId: 'pi_licence_1',
+                    reversal: { reason: 'refund', fullyReversed: true },
+                }),
+            ),
+        ).resolves.toEqual({ action: 'reversed-idempotent' });
+    });
+
+    it('fails retryably when Stripe identifies our recurring plan but activation has not persisted yet', async () => {
+        const provider = makeProvider({
+            findPlanSubscriptionIdForPayment: jest.fn().mockResolvedValue('sub_provider_1'),
+        });
+        const { service } = build({ provider });
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    id: 'evt_early_refund',
+                    kind: 'credits.refunded',
+                    paymentId: 'pi_plan_early',
+                    reversal: { reason: 'refund', fullyReversed: true },
+                }),
+            ),
+        ).rejects.toThrow('not on file yet');
+    });
+
+    it('fails retryably when a perpetual licence reversal races its activation event', async () => {
+        const provider = makeProvider({
+            findPerpetualLicenceForPayment: jest.fn().mockResolvedValue({
+                userId: 'u1',
+                planCode: 'selfhosted_pro',
+            }),
+        });
+        const { service } = build({ provider });
+
+        await expect(
+            service.applyPaymentReversal(
+                event({
+                    id: 'evt_early_licence_refund',
+                    kind: 'credits.refunded',
+                    paymentId: 'pi_licence_early',
+                    reversal: { reason: 'refund', fullyReversed: true },
+                }),
+            ),
+        ).rejects.toThrow('not on file yet');
     });
 });

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -9,6 +9,7 @@ import { SubscriptionPlanCode } from '@src/entities/types';
 import {
     SubscriptionBillingProvider,
     SubscriptionStatus,
+    type UserSubscription,
 } from '@src/entities/user-subscription.entity';
 import { SubscriptionService } from '../subscription.service';
 import { PlanCreditGrantService } from '../credits/plan-credit-grant.service';
@@ -145,6 +146,10 @@ export type PlanWebhookAction =
     | 'subscription-reconciled'
     | 'ignored'
     | 'unattributed';
+
+export interface PlanPaymentReversalResult {
+    action: 'plan-revoked' | 'licence-refunded' | 'reversed-idempotent' | 'ignored';
+}
 
 /**
  * Paid-plan purchase (audit B24).
@@ -483,6 +488,64 @@ export class PlanSubscriptionService {
     }
 
     /**
+     * Reconcile a signature-verified full refund or dispute after the credit
+     * purchase path has proved the payment is not a credit pack. Correlation
+     * is exact: perpetual licences use their durable payment row; recurring
+     * plans use Stripe's Invoice Payment -> Subscription mapping.
+     */
+    async applyPaymentReversal(event: BillingWebhookEvent): Promise<PlanPaymentReversalResult> {
+        if (!event.paymentId || !event.reversal?.fullyReversed) {
+            return { action: 'ignored' };
+        }
+
+        const provider = this.billingProvider.getProviderId();
+        const licence = await this.licencePurchaseRepository.findByProviderPayment(
+            provider,
+            event.paymentId,
+        );
+        if (licence) {
+            const changed = await this.licencePurchaseRepository.markRefunded(licence.id);
+            return { action: changed ? 'licence-refunded' : 'reversed-idempotent' };
+        }
+
+        const providerSubscriptionId = await this.billingProvider.findPlanSubscriptionIdForPayment(
+            event.paymentId,
+        );
+        if (!providerSubscriptionId) {
+            const pendingLicence = await this.billingProvider.findPerpetualLicenceForPayment(
+                event.paymentId,
+            );
+            if (pendingLicence) {
+                throw new Error(
+                    `Plan payment reversal ${event.id} is ours but its licence purchase is not on file yet`,
+                );
+            }
+            return { action: 'ignored' };
+        }
+
+        const subscription =
+            await this.userSubscriptionRepository.findByProviderSubscriptionId(
+                providerSubscriptionId,
+            );
+        if (!subscription) {
+            throw new Error(
+                `Plan payment reversal ${event.id} is ours but its subscription is not on file yet`,
+            );
+        }
+
+        // Cancel first so the daily sweep cannot select this row for another
+        // allowance grant while the clawback is being appended.
+        await this.cancelSubscriptionRow(subscription);
+        if (this.planCreditGrantService) {
+            await this.planCreditGrantService.reverseCurrentAllowance(
+                subscription,
+                `${provider}:evt:${event.id}`,
+            );
+        }
+        return { action: 'plan-revoked' };
+    }
+
+    /**
      * Put a user on a paid plan. Idempotent: re-running for the same
      * plan rewrites the same row and re-asserts the same default plan, so
      * a webhook replay (or a webhook racing the return route) moves
@@ -649,10 +712,15 @@ export class PlanSubscriptionService {
             );
             return false;
         }
+        await this.cancelSubscriptionRow(subscription);
+        return Boolean(subscription);
+    }
+
+    private async cancelSubscriptionRow(subscription: UserSubscription): Promise<void> {
         await this.userSubscriptionRepository.cancel(subscription.id);
 
         if (this.subscriptionService.isEnabled()) {
-            const user = await this.userRepository.findById(userId);
+            const user = await this.userRepository.findById(subscription.userId);
             if (user) {
                 // Free plans are exactly what `changePlanSelfService`
                 // permits (sign-up default / downgrade / cancel).
@@ -662,7 +730,6 @@ export class PlanSubscriptionService {
                 );
             }
         }
-        return Boolean(subscription);
     }
 
     // ── Resolution helpers ───────────────────────────────────────────

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -56,6 +56,10 @@ function fakeClient(overrides: Record<string, unknown> = {}) {
         },
         paymentIntents: {
             create: jest.fn().mockResolvedValue({ id: 'pi_1', status: 'succeeded' }),
+            retrieve: jest.fn().mockResolvedValue({ id: 'pi_1', metadata: {} }),
+        },
+        invoicePayments: {
+            list: jest.fn().mockResolvedValue({ data: [] }),
         },
         tax: {
             calculations: {
@@ -654,7 +658,7 @@ describe('StripeBillingProvider — event normalization', () => {
         );
     });
 
-    it('normalizes a refund and a dispute to credits.refunded', async () => {
+    it('normalizes a refund and a dispute with an explicit entitlement-reversal posture', async () => {
         const refund = await parse({
             id: 'evt_6',
             type: 'charge.refunded',
@@ -662,6 +666,7 @@ describe('StripeBillingProvider — event normalization', () => {
                 object: {
                     customer: 'cus_1',
                     amount_refunded: 2500,
+                    refunded: false,
                     currency: 'usd',
                     payment_intent: 'pi_1',
                 },
@@ -672,6 +677,7 @@ describe('StripeBillingProvider — event normalization', () => {
                 kind: 'credits.refunded',
                 amountCents: 2500,
                 paymentId: 'pi_1',
+                reversal: { reason: 'refund', fullyReversed: false },
             }),
         );
 
@@ -681,8 +687,89 @@ describe('StripeBillingProvider — event normalization', () => {
             data: { object: { amount: 5000, currency: 'usd', payment_intent: 'pi_2' } },
         });
         expect(dispute).toEqual(
-            expect.objectContaining({ kind: 'credits.refunded', amountCents: 5000 }),
+            expect.objectContaining({
+                kind: 'credits.refunded',
+                amountCents: 5000,
+                reversal: { reason: 'dispute', fullyReversed: true },
+            }),
         );
+    });
+
+    it('maps a recurring plan payment intent back to our exact subscription through Invoice Payments', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+        const client = fakeClient();
+        client.invoicePayments.list.mockResolvedValue({
+            data: [
+                {
+                    invoice: {
+                        parent: {
+                            type: 'subscription_details',
+                            subscription_details: {
+                                subscription: 'sub_plan_1',
+                                metadata: {
+                                    [STRIPE_METADATA_KEYS.kind]:
+                                        STRIPE_PURCHASE_KINDS.planSubscription,
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+        const { provider } = build(client);
+
+        await expect(provider.findPlanSubscriptionIdForPayment('pi_plan_1')).resolves.toBe(
+            'sub_plan_1',
+        );
+        expect(client.invoicePayments.list).toHaveBeenCalledWith({
+            payment: { type: 'payment_intent', payment_intent: 'pi_plan_1' },
+            status: 'paid',
+            limit: 1,
+            expand: ['data.invoice'],
+        });
+    });
+
+    it('does not map an invoice payment whose subscription metadata is not ours', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+        const client = fakeClient();
+        client.invoicePayments.list.mockResolvedValue({
+            data: [
+                {
+                    invoice: {
+                        parent: {
+                            type: 'subscription_details',
+                            subscription_details: {
+                                subscription: 'sub_foreign',
+                                metadata: {},
+                            },
+                        },
+                    },
+                },
+            ],
+        });
+        const { provider } = build(client);
+
+        await expect(provider.findPlanSubscriptionIdForPayment('pi_foreign')).resolves.toBeNull();
+    });
+
+    it('recognizes a perpetual licence from PaymentIntent metadata copied to its charge', async () => {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+        const client = fakeClient();
+        client.paymentIntents.retrieve.mockResolvedValue({
+            id: 'pi_licence',
+            metadata: {
+                [STRIPE_METADATA_KEYS.kind]: STRIPE_PURCHASE_KINDS.planSubscription,
+                [STRIPE_METADATA_KEYS.licence]: STRIPE_PERPETUAL_LICENCE,
+                [STRIPE_METADATA_KEYS.userId]: 'u1',
+                [STRIPE_METADATA_KEYS.planCode]: 'selfhosted_pro',
+            },
+        });
+        const { provider } = build(client);
+
+        await expect(provider.findPerpetualLicenceForPayment('pi_licence')).resolves.toEqual({
+            userId: 'u1',
+            planCode: 'selfhosted_pro',
+        });
     });
 
     it('normalizes an invoice event into a vendor-neutral snapshot', async () => {

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -550,6 +550,50 @@ export class StripeBillingProvider extends BillingProvider {
     }
 
     /**
+     * Stripe does not copy Subscription metadata onto the invoice's
+     * PaymentIntent/Charge. Invoice Payments are the provider-owned mapping
+     * from that PaymentIntent back to its Invoice; the Invoice carries an
+     * immutable snapshot of the originating Subscription metadata.
+     */
+    async findPlanSubscriptionIdForPayment(paymentId: string): Promise<string | null> {
+        const stripe = this.requireClient();
+        const payments = await stripe.invoicePayments.list({
+            payment: { type: 'payment_intent', payment_intent: paymentId },
+            status: 'paid',
+            limit: 1,
+            expand: ['data.invoice'],
+        });
+        const invoice = payments.data[0]?.invoice;
+        if (!invoice || typeof invoice === 'string' || !('parent' in invoice)) return null;
+        const parent = invoice.parent;
+        const details =
+            parent?.type === 'subscription_details' ? parent.subscription_details : null;
+        if (
+            details?.metadata?.[STRIPE_METADATA_KEYS.kind] !==
+            STRIPE_PURCHASE_KINDS.planSubscription
+        ) {
+            return null;
+        }
+        return asId(details.subscription);
+    }
+
+    async findPerpetualLicenceForPayment(
+        paymentId: string,
+    ): Promise<{ userId: string; planCode: string } | null> {
+        const intent = await this.requireClient().paymentIntents.retrieve(paymentId);
+        const metadata = intent.metadata ?? {};
+        if (
+            metadata[STRIPE_METADATA_KEYS.kind] !== STRIPE_PURCHASE_KINDS.planSubscription ||
+            metadata[STRIPE_METADATA_KEYS.licence] !== STRIPE_PERPETUAL_LICENCE
+        ) {
+            return null;
+        }
+        const userId = metadata[STRIPE_METADATA_KEYS.userId];
+        const planCode = metadata[STRIPE_METADATA_KEYS.planCode];
+        return userId && planCode ? { userId, planCode } : null;
+    }
+
+    /**
      * Tax-inclusive off-session credit-pack charge.
      *
      * Checkout uses `automatic_tax`, but PaymentIntents use Stripe Tax's custom
@@ -1002,6 +1046,7 @@ export class StripeBillingProvider extends BillingProvider {
                     amountCents: charge.amount_refunded ?? null,
                     currency: charge.currency ?? null,
                     paymentId: asId(charge.payment_intent),
+                    reversal: { reason: 'refund', fullyReversed: charge.refunded === true },
                 };
             }
 
@@ -1013,6 +1058,7 @@ export class StripeBillingProvider extends BillingProvider {
                     amountCents: dispute.amount ?? null,
                     currency: dispute.currency ?? null,
                     paymentId: asId(dispute.payment_intent),
+                    reversal: { reason: 'dispute', fullyReversed: true },
                 };
             }
 

--- a/packages/agent/src/subscriptions/credits/plan-credit-grant.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/plan-credit-grant.service.spec.ts
@@ -224,6 +224,60 @@ describe('PlanCreditGrantService.grantCurrentAllowance', () => {
     });
 });
 
+describe('PlanCreditGrantService.reverseCurrentAllowance', () => {
+    it('claws back the current allowance and permits a negative balance after spend', async () => {
+        const { service, creditLedgerService } = makeHarness();
+        creditLedgerService.sumByRefTypeInWindow.mockResolvedValue(3000);
+        const subscription = proSubscription();
+        const now = utc(2026, 9, 10);
+
+        await expect(
+            service.reverseCurrentAllowance(subscription as any, 'stripe:evt:evt_refund', now),
+        ).resolves.toBe('reversed');
+        expect(creditLedgerService.record).toHaveBeenCalledWith({
+            userId: 'user-1',
+            organizationId: 'org-1',
+            tenantId: null,
+            kind: CreditLedgerKind.ADJUSTMENT,
+            amountCredits: -3000,
+            refType: PLAN_GRANT_REF_TYPE,
+            refId: 'sub-1',
+            description: 'Plan allowance reversed after payment reversal',
+            idempotencyKey: 'revoke:plan:stripe:evt:evt_refund',
+            allowNegativeBalance: true,
+            now,
+        });
+    });
+
+    it('is idempotent on a replayed provider event', async () => {
+        const { service, creditLedgerService } = makeHarness();
+        creditLedgerService.hasEntry.mockResolvedValue(true);
+
+        await expect(
+            service.reverseCurrentAllowance(
+                proSubscription() as any,
+                'stripe:evt:evt_refund',
+                utc(2026, 9, 10),
+            ),
+        ).resolves.toBe('already-reversed');
+        expect(creditLedgerService.sumByRefTypeInWindow).not.toHaveBeenCalled();
+        expect(creditLedgerService.record).not.toHaveBeenCalled();
+    });
+
+    it('does not invent a debit when no allowance was granted in this period', async () => {
+        const { service, creditLedgerService } = makeHarness();
+
+        await expect(
+            service.reverseCurrentAllowance(
+                proSubscription() as any,
+                'stripe:evt:evt_refund',
+                utc(2026, 9, 10),
+            ),
+        ).resolves.toBe('nothing-to-reverse');
+        expect(creditLedgerService.record).not.toHaveBeenCalled();
+    });
+});
+
 describe('PlanCreditGrantService.dispatchPlanGrants', () => {
     it('walks active subscriptions in batches and tallies outcomes; one failure does not stop the pass', async () => {
         const { service, creditLedgerService, userSubscriptionRepository } = makeHarness();

--- a/packages/agent/src/subscriptions/credits/plan-credit-grant.service.ts
+++ b/packages/agent/src/subscriptions/credits/plan-credit-grant.service.ts
@@ -25,6 +25,8 @@ export type PlanGrantOutcome =
     /** No active cloud subscription with a monthly allowance. */
     | 'not-eligible';
 
+export type PlanGrantReversalOutcome = 'reversed' | 'already-reversed' | 'nothing-to-reverse';
+
 export interface PlanGrantSummary {
     scanned: number;
     granted: number;
@@ -98,6 +100,48 @@ export class PlanCreditGrantService {
         const subscription = await this.userSubscriptionRepository.findActiveByUser(userId);
         if (!subscription) return 'not-eligible';
         return this.grantForSubscription(subscription, now);
+    }
+
+    /**
+     * Claw back the allowance month in force when a full plan payment is
+     * reversed. The debit may take the account negative: already-spent
+     * credits cannot become free merely because the provider returned the
+     * money. The provider event key makes delivery replay a no-op.
+     */
+    async reverseCurrentAllowance(
+        subscription: UserSubscription,
+        providerEventKey: string,
+        now: Date = new Date(),
+    ): Promise<PlanGrantReversalOutcome> {
+        const idempotencyKey = `revoke:plan:${providerEventKey}`;
+        if (await this.creditLedgerService.hasEntry(idempotencyKey)) {
+            return 'already-reversed';
+        }
+
+        const anchor = subscription.createdAt ?? now;
+        const period = PlanCreditGrantService.allowancePeriodFor(anchor, now);
+        const granted = await this.creditLedgerService.sumByRefTypeInWindow(
+            subscription.userId,
+            PLAN_GRANT_REF_TYPE,
+            period.start,
+            period.end,
+        );
+        if (granted <= 0) return 'nothing-to-reverse';
+
+        await this.creditLedgerService.record({
+            userId: subscription.userId,
+            organizationId: subscription.organizationId ?? null,
+            tenantId: subscription.tenantId ?? null,
+            kind: CreditLedgerKind.ADJUSTMENT,
+            amountCredits: -granted,
+            refType: PLAN_GRANT_REF_TYPE,
+            refId: subscription.id,
+            description: 'Plan allowance reversed after payment reversal',
+            idempotencyKey,
+            allowNegativeBalance: true,
+            now,
+        });
+        return 'reversed';
     }
 
     /**


### PR DESCRIPTION
## Summary
- distinguish partial refunds from full refunds/disputes before changing entitlement
- map recurring Stripe PaymentIntents through Invoice Payments to the exact Ever Works subscription
- revoke the hosted tier and current monthly allowance on a full reversal, allowing spent credits to produce a negative balance
- mark perpetual licence ownership refunded with compare-and-set idempotency
- retry exact Ever Works reversals that race activation persistence instead of acknowledging them as lost

## Data impact
- no schema or live data mutation in this PR
- future signature-verified full refunds/disputes append a grant-reversal ledger entry and update the exact subscription/licence record
- partial refunds preserve plan/licence entitlement

## Verification
- TDD red established the five missing reversal contracts
- full billing regression: 12 suites / 378 tests passed
- focused reversal regression: 5 suites / 244 tests passed
- Agent type-check passed
- focused Prettier and git diff checks passed