### PR TITLE
fix(credits): size plan grants atomically

### DIFF
--- a/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
@@ -103,6 +103,23 @@ describe('CreditLedgerRepository.recordAtomic', () => {
         expect(entryRepo.save).not.toHaveBeenCalled();
     });
 
+    it('locks before the idempotency read so ref-window sums cannot inherit a stale mysql snapshot', async () => {
+        const { repository, entryRepo, userRepo } = makeHarness({ driver: 'mysql' });
+        entryRepo.findOne.mockResolvedValue({
+            id: 'existing',
+            idempotencyKey: 'grant:plan:user-1:2026-08-23:standard',
+        });
+
+        await repository.recordAtomic({
+            ...BASE_WRITE,
+            idempotencyKey: 'grant:plan:user-1:2026-08-23:standard',
+        });
+
+        expect(userRepo.findOne.mock.invocationCallOrder[0]).toBeLessThan(
+            entryRepo.findOne.mock.invocationCallOrder[0],
+        );
+    });
+
     it('resolves a concurrent-duplicate unique violation to the surviving row', async () => {
         const { repository, manager, topLevelRepository } = makeHarness();
         const survivor = { id: 'survivor', idempotencyKey: 'run:run-9' };
@@ -168,6 +185,72 @@ describe('CreditLedgerRepository.recordAtomic', () => {
         );
 
         expect(result).toEqual({ status: 'skipped', balance: 80 });
+        expect(entryRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('sizes a plan grant from the ref-window total while holding the user lock', async () => {
+        const { repository, entryRepo, userRepo } = makeHarness({
+            balance: 3000,
+            driver: 'postgres',
+        });
+        const windowTotal = makeQb(0);
+        windowTotal.getRawOne.mockResolvedValue({ total: 3000 });
+        entryRepo.createQueryBuilder
+            .mockReturnValueOnce(makeQb(3000))
+            .mockReturnValueOnce(windowTotal);
+
+        const result = await repository.recordAtomic(
+            {
+                ...BASE_WRITE,
+                amountCredits: 25000,
+                refType: 'plan-allowance',
+                idempotencyKey: 'grant:plan:user-1:2026-08-23:premium',
+            },
+            {
+                maxRefTypeAmountInWindow: {
+                    refType: 'plan-allowance',
+                    from: new Date('2026-08-23T10:00:00.000Z'),
+                    to: new Date('2026-09-23T10:00:00.000Z'),
+                    maxAmountCredits: 25000,
+                },
+            },
+        );
+
+        expect(result.status).toBe('created');
+        expect(entryRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({ amountCredits: 22000, balanceAfter: 25000 }),
+        );
+        expect(userRepo.findOne.mock.invocationCallOrder[0]).toBeLessThan(
+            entryRepo.createQueryBuilder.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('skips a differently-keyed plan grant once the ref-window target is covered', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 25000 });
+        const windowTotal = makeQb(0);
+        windowTotal.getRawOne.mockResolvedValue({ total: 25000 });
+        entryRepo.createQueryBuilder
+            .mockReturnValueOnce(makeQb(25000))
+            .mockReturnValueOnce(windowTotal);
+
+        const result = await repository.recordAtomic(
+            {
+                ...BASE_WRITE,
+                amountCredits: 25000,
+                refType: 'plan-allowance',
+                idempotencyKey: 'grant:plan:user-1:2026-08-23:premium',
+            },
+            {
+                maxRefTypeAmountInWindow: {
+                    refType: 'plan-allowance',
+                    from: new Date('2026-08-23T10:00:00.000Z'),
+                    to: new Date('2026-09-23T10:00:00.000Z'),
+                    maxAmountCredits: 25000,
+                },
+            },
+        );
+
+        expect(result).toEqual({ status: 'skipped', balance: 25000 });
         expect(entryRepo.save).not.toHaveBeenCalled();
     });
 

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -49,6 +49,18 @@ export interface RecordAtomicOptions {
      */
     maxBalanceAfter?: number | null;
     /**
+     * Clamp a positive write so movements with one `refType` inside the
+     * half-open window never exceed this total. The sum is read only after
+     * the per-user lock is held, so differently-keyed plan-change grants
+     * cannot both size themselves from the same stale total.
+     */
+    maxRefTypeAmountInWindow?: {
+        refType: string;
+        from: Date;
+        to: Date;
+        maxAmountCredits: number;
+    } | null;
+    /**
      * Clock for bucket expiry decisions inside the transaction (tests);
      * defaults to `new Date()`.
      */
@@ -124,6 +136,11 @@ export class CreditLedgerRepository {
             return await this.repository.manager.transaction(async (manager) => {
                 const repo = manager.getRepository(CreditLedgerEntry);
 
+                // Lock before ANY consistent read. Besides serializing writes,
+                // this ensures MySQL/MariaDB REPEATABLE READ establishes its
+                // snapshot only after an earlier writer has committed.
+                await this.lockUserRow(manager, write.userId);
+
                 if (write.idempotencyKey) {
                     const existing = await repo.findOne({
                         where: { idempotencyKey: write.idempotencyKey },
@@ -132,8 +149,6 @@ export class CreditLedgerRepository {
                         return { status: 'idempotent' as const, entry: existing };
                     }
                 }
-
-                await this.lockUserRow(manager, write.userId);
 
                 // Expire on touch: any bucket whose expiry has passed is
                 // closed BEFORE the balance is read, so a debit can never
@@ -144,17 +159,30 @@ export class CreditLedgerRepository {
                 const balance = await this.sumBalance(manager, write.userId);
 
                 let amount = write.amountCredits;
+                const refWindowCeiling = options.maxRefTypeAmountInWindow;
+                if (refWindowCeiling) {
+                    const amountInWindow = await this.sumByRefTypeInWindowWithRepository(
+                        repo,
+                        write.userId,
+                        refWindowCeiling.refType,
+                        refWindowCeiling.from,
+                        refWindowCeiling.to,
+                    );
+                    const headroom = refWindowCeiling.maxAmountCredits - amountInWindow;
+                    if (amount > headroom) {
+                        amount = headroom;
+                    }
+                }
                 if (options.maxBalanceAfter !== null && options.maxBalanceAfter !== undefined) {
                     const headroom = options.maxBalanceAfter - balance;
                     if (amount > headroom) {
                         amount = headroom;
                     }
-                    // A positive grant fully clamped away (balance already
-                    // at/above the ceiling) writes nothing — a ceiling must
-                    // never turn a grant into a debit.
-                    if (write.amountCredits > 0 && amount <= 0) {
-                        return { status: 'skipped' as const, balance };
-                    }
+                }
+                // A positive grant fully clamped away writes nothing — a
+                // ceiling must never turn a grant into a debit.
+                if (write.amountCredits > 0 && amount <= 0) {
+                    return { status: 'skipped' as const, balance };
                 }
 
                 const balanceAfter = balance + amount;
@@ -461,7 +489,7 @@ export class CreditLedgerRepository {
     /**
      * Sum of movements of ONE `refType` inside a half-open `[from, to)`
      * window. Used by the monthly plan grant to top UP to the best
-     * allowance the user has held this calendar month, so a mid-cycle
+     * allowance the user has held this allowance period, so a mid-cycle
      * upgrade adds only the difference and a downgrade removes nothing.
      *
      * No unary minus here on purpose - see the long note on
@@ -474,7 +502,17 @@ export class CreditLedgerRepository {
         from: Date,
         to: Date,
     ): Promise<number> {
-        const row = await this.repository
+        return this.sumByRefTypeInWindowWithRepository(this.repository, userId, refType, from, to);
+    }
+
+    private async sumByRefTypeInWindowWithRepository(
+        repository: Repository<CreditLedgerEntry>,
+        userId: string,
+        refType: string,
+        from: Date,
+        to: Date,
+    ): Promise<number> {
+        const row = await repository
             .createQueryBuilder('e')
             .select('COALESCE(SUM(e.amountCredits), 0)', 'total')
             .where('e.userId = :userId', { userId })

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -160,6 +160,36 @@ describe('CreditLedgerService', () => {
 
             expect(entry).toBe(existing);
         });
+
+        it('passes a ref-window ceiling into the atomic write path', async () => {
+            const { service, ledgerRepository } = makeService();
+            const from = new Date('2026-08-23T10:00:00.000Z');
+            const to = new Date('2026-09-23T10:00:00.000Z');
+
+            await service.record({
+                userId: 'u1',
+                kind: CreditLedgerKind.GRANT,
+                amountCredits: 25000,
+                refType: 'plan-allowance',
+                maxRefTypeAmountInWindow: {
+                    from,
+                    to,
+                    maxAmountCredits: 25000,
+                },
+            });
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ refType: 'plan-allowance', amountCredits: 25000 }),
+                expect.objectContaining({
+                    maxRefTypeAmountInWindow: {
+                        refType: 'plan-allowance',
+                        from,
+                        to,
+                        maxAmountCredits: 25000,
+                    },
+                }),
+            );
+        });
     });
 
     describe('consumeForRun — the costCents → credits bridge', () => {

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -48,6 +48,16 @@ export interface RecordCreditEntryOptions {
     /** Ceiling for non-accumulating grants; a full clamp returns null. */
     maxBalanceAfter?: number | null;
     /**
+     * Atomically top this ref type up to a target inside a half-open time
+     * window. Used for plan upgrades whose idempotency key changes with the
+     * plan code while the user's allowance period stays the same.
+     */
+    maxRefTypeAmountInWindow?: {
+        from: Date;
+        to: Date;
+        maxAmountCredits: number;
+    } | null;
+    /**
      * Bucket expiry for a positive write (plan allowance grants carry
      * their allowance-month end). Ignored on debits; absent = never.
      */
@@ -148,6 +158,9 @@ export class CreditLedgerService {
         if (options.amountCredits === 0) {
             throw new Error('amountCredits must be non-zero');
         }
+        if (options.maxRefTypeAmountInWindow && !options.refType) {
+            throw new Error('refType is required for a ref-window credit ceiling');
+        }
 
         const allowNegative =
             options.allowNegativeBalance ?? config.billing.credits.allowOverdraft();
@@ -171,6 +184,12 @@ export class CreditLedgerService {
         const result = await this.creditLedgerRepository.recordAtomic(write, {
             minBalanceAfter: options.amountCredits < 0 && !allowNegative ? 0 : null,
             maxBalanceAfter: options.maxBalanceAfter ?? null,
+            maxRefTypeAmountInWindow: options.maxRefTypeAmountInWindow
+                ? {
+                      ...options.maxRefTypeAmountInWindow,
+                      refType: options.refType!,
+                  }
+                : null,
             now: options.now,
         });
 

--- a/packages/agent/src/subscriptions/credits/plan-credit-grant.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/plan-credit-grant.service.spec.ts
@@ -125,7 +125,7 @@ describe('PlanCreditGrantService.grantCurrentAllowance', () => {
         expect(creditLedgerService.record).not.toHaveBeenCalled();
     });
 
-    it('grants only the upgrade delta already owed in the same allowance period', async () => {
+    it('delegates upgrade-delta sizing to the atomic ref-window ceiling', async () => {
         const { service, creditLedgerService, userSubscriptionRepository } = makeHarness();
         userSubscriptionRepository.findActiveByUser.mockResolvedValue(
             proSubscription({
@@ -137,14 +137,20 @@ describe('PlanCreditGrantService.grantCurrentAllowance', () => {
                 },
             }),
         );
-        creditLedgerService.sumByRefTypeInWindow.mockResolvedValue(3000);
-
         await expect(service.grantCurrentAllowance('user-1', utc(2026, 9, 10))).resolves.toBe(
             'granted',
         );
         expect(creditLedgerService.record).toHaveBeenCalledWith(
-            expect.objectContaining({ amountCredits: 22000 }),
+            expect.objectContaining({
+                amountCredits: 25000,
+                maxRefTypeAmountInWindow: {
+                    from: utc(2026, 8, 23, 10),
+                    to: utc(2026, 9, 23, 10),
+                    maxAmountCredits: 25000,
+                },
+            }),
         );
+        expect(creditLedgerService.sumByRefTypeInWindow).not.toHaveBeenCalled();
     });
 
     it('writes a grant bucket for the current allowance month with the month end as expiry', async () => {
@@ -177,6 +183,25 @@ describe('PlanCreditGrantService.grantCurrentAllowance', () => {
             'already-granted',
         );
         expect(creditLedgerService.record).not.toHaveBeenCalled();
+    });
+
+    it('reports already-granted when the atomic window ceiling is covered by another plan key', async () => {
+        const { service, creditLedgerService, userSubscriptionRepository } = makeHarness();
+        userSubscriptionRepository.findActiveByUser.mockResolvedValue(
+            proSubscription({
+                plan: {
+                    code: 'premium',
+                    displayName: 'Enterprise',
+                    hosting: 'cloud',
+                    monthlyCredits: 25000,
+                },
+            }),
+        );
+        creditLedgerService.record.mockResolvedValue(null);
+
+        await expect(service.grantCurrentAllowance('user-1', utc(2026, 9, 10))).resolves.toBe(
+            'already-granted',
+        );
     });
 
     it('uses a new key once the allowance month rolls', async () => {

--- a/packages/agent/src/subscriptions/credits/plan-credit-grant.service.ts
+++ b/packages/agent/src/subscriptions/credits/plan-credit-grant.service.ts
@@ -211,14 +211,7 @@ export class PlanCreditGrantService {
             return 'already-granted';
         }
 
-        const alreadyGranted = await this.creditLedgerService.sumByRefTypeInWindow(
-            subscription.userId,
-            PLAN_GRANT_REF_TYPE,
-            period.start,
-            period.end,
-        );
-        const amountCredits = Math.trunc(monthlyCredits) - alreadyGranted;
-        if (amountCredits <= 0) return 'already-granted';
+        const amountCredits = Math.trunc(monthlyCredits);
 
         const entry = await this.creditLedgerService.record({
             userId: subscription.userId,
@@ -233,9 +226,14 @@ export class PlanCreditGrantService {
                 .slice(0, 10)})`,
             idempotencyKey,
             expiresAt: period.end,
+            maxRefTypeAmountInWindow: {
+                from: period.start,
+                to: period.end,
+                maxAmountCredits: amountCredits,
+            },
             now,
         });
-        return entry ? 'granted' : 'not-eligible';
+        return entry ? 'granted' : 'already-granted';
     }
 }
 


### PR DESCRIPTION
## Summary
- clamp monthly plan allowance grants inside the ledger's per-user transaction
- lock before idempotency and allowance reads so PostgreSQL/MySQL writers observe the preceding commit
- size plan upgrades from the current allowance-window total even when plan-code idempotency keys differ

## Why
The grant service previously read the allowance total before `recordAtomic`. Two sweeps racing a plan change could both size from the same stale total and write under different plan-code keys, over-granting the account.

## Verification
- regression was red before implementation: missing ref-window ceiling contracts
- focused ledger/grant suites: 73/73
- full billing + credits regression: 20 suites, 513/513
- Agent TypeScript check
- focused Prettier and `git diff --check`

## Data / rollback
No schema or live-data mutation in this PR. Runtime writes remain append-only ledger entries. Roll back by reverting this merge; retain ledger history already written.