### PR TITLE
fix(billing): reject plan catalog currency drift

### DIFF
--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -140,7 +140,7 @@ describe('SubscriptionService', () => {
 
     describe('onModuleInit + seedPlans (idempotent boot-time seeding)', () => {
         it('upserts every PLAN_SEED_DATA row via the plan repository on boot', async () => {
-            process.env.BILLING_DEFAULT_CURRENCY = 'eur';
+            process.env.BILLING_DEFAULT_CURRENCY = 'usd';
             const { service, planRepository } = makeService();
 
             await service.onModuleInit();
@@ -245,12 +245,25 @@ describe('SubscriptionService', () => {
             ).toBe(true);
         });
 
-        it('forwards the configured default currency on every upsert + sets active=true', async () => {
+        it('refuses to seed plan rows in a currency that disagrees with the Stripe catalog', async () => {
             process.env.BILLING_DEFAULT_CURRENCY = 'eur';
             const { service, planRepository } = makeService();
+
+            await expect(service.seedPlans()).rejects.toThrow(
+                /BILLING_DEFAULT_CURRENCY.*eur.*catalog.*usd/i,
+            );
+            expect(planRepository.upsert).not.toHaveBeenCalled();
+        });
+
+        it('normalizes equivalent configured currency casing and seeds the catalog currency', async () => {
+            process.env.BILLING_DEFAULT_CURRENCY = ' USD ';
+            const { service, planRepository } = makeService();
+
             await service.seedPlans();
+
+            expect(planRepository.upsert).toHaveBeenCalledTimes(6);
             for (const call of planRepository.upsert.mock.calls) {
-                expect(call[0].currency).toBe('eur');
+                expect(call[0].currency).toBe('usd');
                 expect(call[0].active).toBe(true);
             }
         });

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -17,6 +17,7 @@ import { UserRepository } from '@src/database/repositories/user.repository';
 import { PlanEntitlementRepository } from '@src/database/repositories/plan-entitlement.repository';
 import { WorkScheduleBillingMode, WorkScheduleCadence, SubscriptionPlanCode } from '@src/entities';
 import type { SubscriptionPlanHosting } from '@src/entities/types';
+import { CATALOG_CURRENCY } from './billing/stripe-catalog';
 
 const ALL_CADENCES: WorkScheduleCadence[] = [
     WorkScheduleCadence.MONTHLY,
@@ -278,11 +279,18 @@ export class SubscriptionService implements OnModuleInit {
     }
 
     async seedPlans() {
+        const configuredCurrency = config.billing.getDefaultCurrency().trim().toLowerCase();
+        if (configuredCurrency !== CATALOG_CURRENCY) {
+            throw new Error(
+                `BILLING_DEFAULT_CURRENCY resolves to "${configuredCurrency}", but the git-backed Stripe catalog currency is "${CATALOG_CURRENCY}". Refusing to seed plan rows that checkout would charge in a different currency.`,
+            );
+        }
+
         await Promise.all(
             PLAN_SEED_DATA.map((plan) =>
                 this.planRepository.upsert({
                     ...plan,
-                    currency: config.billing.getDefaultCurrency(),
+                    currency: CATALOG_CURRENCY,
                     active: true,
                 }),
             ),


### PR DESCRIPTION
## Summary
- fail API boot before any plan upsert when BILLING_DEFAULT_CURRENCY disagrees with the git-backed Stripe catalog
- normalize equivalent casing/whitespace and persist the canonical catalog currency
- replace the old drift-pinning test with mismatch and normalization regressions

## Verification
- red first: mismatch test resolved and six EUR rows were accepted before the fix
- packages/agent SubscriptionService: 81/81
- packages/agent type-check
- focused Prettier and git diff --check
- redacted live preflight: dev, stage, and prod all currently match catalog USD

No data/schema/Stripe object/secret/runtime change. CI may remain queued; owner directed merge after local review without waiting on queued CI.