### PR TITLE
fix(billing): hide checkout session existence

### DIFF
--- a/packages/agent/src/subscriptions/billing/billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/billing.provider.ts
@@ -39,6 +39,10 @@ export class BillingProviderNotConfiguredError extends Error {
     }
 }
 
+export const BILLING_PROVIDER_ERROR_CODES = {
+    CHECKOUT_SESSION_NOT_FOUND: 'checkout-session-not-found',
+} as const;
+
 /** A provider call failed for a reason the caller may surface as 4xx. */
 export class BillingProviderError extends Error {
     constructor(

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.spec.ts
@@ -5,7 +5,12 @@ import {
     PlanSubscriptionService,
     UnknownSubscriptionPlanError,
 } from './plan-subscription.service';
-import { BillingProviderNotConfiguredError, type BillingWebhookEvent } from './billing.provider';
+import {
+    BILLING_PROVIDER_ERROR_CODES,
+    BillingProviderError,
+    BillingProviderNotConfiguredError,
+    type BillingWebhookEvent,
+} from './billing.provider';
 import { SubscriptionStatus } from '@src/entities/user-subscription.entity';
 
 /**
@@ -668,6 +673,25 @@ describe('syncCheckoutReturn — a session id is not an authorization', () => {
         });
 
         await expect(service.syncCheckoutReturn('u1', 'cs_plan_1')).rejects.toBeInstanceOf(
+            CheckoutSessionNotFoundError,
+        );
+    });
+
+    it('answers a provider-confirmed missing session exactly like a foreign session', async () => {
+        const { service } = build({
+            provider: makeProvider({
+                retrieveCheckoutSession: jest
+                    .fn()
+                    .mockRejectedValue(
+                        new BillingProviderError(
+                            'Checkout session not found',
+                            BILLING_PROVIDER_ERROR_CODES.CHECKOUT_SESSION_NOT_FOUND,
+                        ),
+                    ),
+            }),
+        });
+
+        await expect(service.syncCheckoutReturn('u1', 'cs_missing')).rejects.toBeInstanceOf(
             CheckoutSessionNotFoundError,
         );
     });

--- a/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
+++ b/packages/agent/src/subscriptions/billing/plan-subscription.service.ts
@@ -14,9 +14,12 @@ import {
 import { SubscriptionService } from '../subscription.service';
 import { PlanCreditGrantService } from '../credits/plan-credit-grant.service';
 import {
+    BILLING_PROVIDER_ERROR_CODES,
     BillingProvider,
+    BillingProviderError,
     BillingProviderNotConfiguredError,
     type BillingWebhookEvent,
+    type CheckoutSessionSnapshot,
 } from './billing.provider';
 import {
     billableSeats,
@@ -388,7 +391,18 @@ export class PlanSubscriptionService {
             throw new BillingProviderNotConfiguredError();
         }
 
-        const snapshot = await this.billingProvider.retrieveCheckoutSession(sessionId);
+        let snapshot: CheckoutSessionSnapshot;
+        try {
+            snapshot = await this.billingProvider.retrieveCheckoutSession(sessionId);
+        } catch (error) {
+            if (
+                error instanceof BillingProviderError &&
+                error.code === BILLING_PROVIDER_ERROR_CODES.CHECKOUT_SESSION_NOT_FOUND
+            ) {
+                throw new CheckoutSessionNotFoundError();
+            }
+            throw error;
+        }
         if (!snapshot.userId || snapshot.userId !== userId) {
             throw new CheckoutSessionNotFoundError();
         }

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -1611,7 +1611,24 @@ describe('StripeBillingProvider — paid-plan checkout (audit B24)', () => {
         expect(snapshot.planCode).toBeNull();
     });
 
-    it('never echoes the provider message when a session cannot be read', async () => {
+    it('classifies Stripe resource_missing without echoing the requested session id', async () => {
+        const client = fakeClient();
+        client.checkout.sessions.retrieve = jest.fn().mockRejectedValue({
+            type: 'StripeInvalidRequestError',
+            code: 'resource_missing',
+            statusCode: 404,
+            message: 'No such checkout.session: cs_secret; req_123',
+        });
+        const { provider } = build(client);
+
+        await expect(provider.retrieveCheckoutSession('cs_missing')).rejects.toMatchObject({
+            name: 'BillingProviderError',
+            message: 'Checkout session not found',
+            code: 'checkout-session-not-found',
+        });
+    });
+
+    it('never echoes the provider message when a non-missing session read fails', async () => {
         const client = fakeClient();
         client.checkout.sessions.retrieve = jest
             .fn()

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.ts
@@ -8,6 +8,7 @@ import Stripe from 'stripe';
 import { config } from '@src/config';
 import type { BillingSubscriptionStatus } from '@src/entities/billing-profile.entity';
 import {
+    BILLING_PROVIDER_ERROR_CODES,
     BillingProvider,
     BillingProviderError,
     BillingProviderNotConfiguredError,
@@ -513,8 +514,14 @@ export class StripeBillingProvider extends BillingProvider {
             session = await stripe.checkout.sessions.retrieve(sessionId, {
                 expand: ['subscription'],
             });
-        } catch {
+        } catch (error) {
             // Never echo the provider message — it can quote request params.
+            if (isStripeResourceMissing(error)) {
+                throw new BillingProviderError(
+                    'Checkout session not found',
+                    BILLING_PROVIDER_ERROR_CODES.CHECKOUT_SESSION_NOT_FOUND,
+                );
+            }
             throw new BillingProviderError('Checkout session could not be read');
         }
 
@@ -1341,6 +1348,22 @@ function defaultStripeClient(secretKey: string): Stripe {
 
 function nonEmpty(value: string | undefined | null): boolean {
     return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Stripe's stable missing-resource shape; no provider message or requested id escapes. */
+function isStripeResourceMissing(error: unknown): boolean {
+    if (!error || typeof error !== 'object') return false;
+    const candidate = error as {
+        code?: unknown;
+        statusCode?: unknown;
+        raw?: { code?: unknown; statusCode?: unknown };
+    };
+    return (
+        candidate.code === 'resource_missing' ||
+        candidate.raw?.code === 'resource_missing' ||
+        candidate.statusCode === 404 ||
+        candidate.raw?.statusCode === 404
+    );
 }
 
 /** Stripe expandable fields are `string | Object | null`. */


### PR DESCRIPTION
## Summary
- classify Stripe resource_missing checkout reads with a stable sanitized provider code
- translate only that code to the same opaque not-found error used for foreign sessions
- preserve generic provider failures as the existing conflict path

## Verification
- red first: valid missing provider session remained BillingProviderError while a foreign session was CheckoutSessionNotFoundError
- provider + plan subscription suites: 162/162
- API checkout controller boundary: 25/25
- Agent type-check
- focused Prettier and git diff --check

No data/schema/Stripe object/secret/runtime change. CI may remain queued; owner directed merge after local review without waiting on queued CI.