### PR TITLE
fix(billing): make plan seeding atomic

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/subscription-plan.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/subscription-plan.repository.spec.ts
@@ -3,7 +3,7 @@ import { SubscriptionPlanRepository } from '../subscription-plan.repository';
 import { SubscriptionPlan } from '@src/entities/subscription-plan.entity';
 import { SubscriptionPlanCode } from '@src/entities/types';
 type Mocked = jest.Mocked<
-    Pick<Repository<SubscriptionPlan>, 'find' | 'findOne' | 'update' | 'create' | 'save'>
+    Pick<Repository<SubscriptionPlan>, 'find' | 'findOne' | 'update' | 'upsert' | 'create' | 'save'>
 >;
 
 describe('SubscriptionPlanRepository', () => {
@@ -15,6 +15,7 @@ describe('SubscriptionPlanRepository', () => {
             find: jest.fn(),
             findOne: jest.fn(),
             update: jest.fn(),
+            upsert: jest.fn(),
             create: jest.fn(),
             save: jest.fn(),
         };
@@ -59,35 +60,56 @@ describe('SubscriptionPlanRepository', () => {
     });
 
     describe('upsert', () => {
-        it('updates by id and refetches when an existing plan with the same code is found', async () => {
-            const existing = { id: 'p1', code: SubscriptionPlanCode.FREE } as SubscriptionPlan;
+        it('uses one database-atomic conflict operation for a coded plan', async () => {
+            const persisted = {
+                id: 'p1',
+                code: SubscriptionPlanCode.FREE,
+                maxWorks: 5,
+            } as SubscriptionPlan;
+            repository.upsert.mockResolvedValueOnce({} as never);
+            repository.findOne.mockResolvedValueOnce(persisted);
+
+            await expect(
+                service.upsert({ code: SubscriptionPlanCode.FREE, maxWorks: 5 }),
+            ).resolves.toBe(persisted);
+
+            expect(repository.upsert).toHaveBeenCalledWith(
+                { code: SubscriptionPlanCode.FREE, maxWorks: 5 },
+                { conflictPaths: ['code'] },
+            );
+            expect(repository.update).not.toHaveBeenCalled();
+            expect(repository.create).not.toHaveBeenCalled();
+            expect(repository.save).not.toHaveBeenCalled();
+        });
+
+        it('atomically updates and refetches when a plan with the same code exists', async () => {
             const updated = {
                 id: 'p1',
                 code: SubscriptionPlanCode.FREE,
                 maxWorks: 5,
             } as SubscriptionPlan;
-            repository.findOne
-                .mockResolvedValueOnce(existing) // findByCode lookup
-                .mockResolvedValueOnce(updated); // refetch by id
+            repository.upsert.mockResolvedValueOnce({} as never);
+            repository.findOne.mockResolvedValueOnce(updated);
 
             const result = await service.upsert({ code: SubscriptionPlanCode.FREE, maxWorks: 5 });
 
             expect(result).toBe(updated);
-            expect(repository.update).toHaveBeenCalledWith(existing.id, {
-                code: SubscriptionPlanCode.FREE,
-                maxWorks: 5,
-            });
+            expect(repository.upsert).toHaveBeenCalledWith(
+                { code: SubscriptionPlanCode.FREE, maxWorks: 5 },
+                { conflictPaths: ['code'] },
+            );
+            expect(repository.update).not.toHaveBeenCalled();
             expect(repository.create).not.toHaveBeenCalled();
             expect(repository.save).not.toHaveBeenCalled();
-            expect(repository.findOne).toHaveBeenNthCalledWith(2, { where: { id: existing.id } });
+            expect(repository.findOne).toHaveBeenCalledWith({
+                where: { code: SubscriptionPlanCode.FREE },
+            });
         });
 
-        it('creates and saves when no plan with the code exists', async () => {
-            const created = { code: SubscriptionPlanCode.PREMIUM } as SubscriptionPlan;
+        it('atomically inserts and refetches when no plan with the code exists', async () => {
             const saved = { id: 'p2', code: SubscriptionPlanCode.PREMIUM } as SubscriptionPlan;
-            repository.findOne.mockResolvedValueOnce(null);
-            repository.create.mockReturnValueOnce(created);
-            repository.save.mockResolvedValueOnce(saved);
+            repository.upsert.mockResolvedValueOnce({} as never);
+            repository.findOne.mockResolvedValueOnce(saved);
 
             const result = await service.upsert({
                 code: SubscriptionPlanCode.PREMIUM,
@@ -95,12 +117,25 @@ describe('SubscriptionPlanRepository', () => {
             });
 
             expect(result).toBe(saved);
-            expect(repository.create).toHaveBeenCalledWith({
-                code: SubscriptionPlanCode.PREMIUM,
-                displayName: 'Premium',
-            });
-            expect(repository.save).toHaveBeenCalledWith(created);
+            expect(repository.upsert).toHaveBeenCalledWith(
+                {
+                    code: SubscriptionPlanCode.PREMIUM,
+                    displayName: 'Premium',
+                },
+                { conflictPaths: ['code'] },
+            );
+            expect(repository.create).not.toHaveBeenCalled();
+            expect(repository.save).not.toHaveBeenCalled();
             expect(repository.update).not.toHaveBeenCalled();
+        });
+
+        it('fails loudly if the coded row cannot be read after the atomic write', async () => {
+            repository.upsert.mockResolvedValueOnce({} as never);
+            repository.findOne.mockResolvedValueOnce(null);
+
+            await expect(
+                service.upsert({ code: SubscriptionPlanCode.STANDARD, displayName: 'Standard' }),
+            ).rejects.toThrow('Subscription plan standard missing after upsert');
         });
 
         it('skips the findByCode lookup entirely when the partial has no code', async () => {

--- a/packages/agent/src/database/repositories/subscription-plan.repository.integration.spec.ts
+++ b/packages/agent/src/database/repositories/subscription-plan.repository.integration.spec.ts
@@ -1,0 +1,54 @@
+import { DataSource } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { SubscriptionPlan } from '../../entities/subscription-plan.entity';
+import { SubscriptionPlanCode, WorkScheduleCadence } from '../../entities/types';
+import { SubscriptionPlanRepository } from './subscription-plan.repository';
+
+describe('SubscriptionPlanRepository — concurrent seeding (better-sqlite3)', () => {
+    let dataSource: DataSource;
+    let plans: SubscriptionPlanRepository;
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+        plans = new SubscriptionPlanRepository(dataSource.getRepository(SubscriptionPlan));
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('lets simultaneous boot seeders converge on one row and update it in place', async () => {
+        const seed = {
+            code: SubscriptionPlanCode.FREE,
+            displayName: 'Free',
+            maxWorks: 1,
+            allowedCadences: [WorkScheduleCadence.DAILY],
+            monthlyPrice: '0.00',
+            overagePricePerRun: '0.00',
+            currency: 'usd',
+            active: true,
+        };
+
+        const seeded = await Promise.all(Array.from({ length: 20 }, () => plans.upsert(seed)));
+        const originalId = seeded[0].id;
+
+        expect(new Set(seeded.map((plan) => plan.id))).toEqual(new Set([originalId]));
+        expect(await dataSource.getRepository(SubscriptionPlan).count()).toBe(1);
+
+        const updated = await plans.upsert({ ...seed, displayName: 'Free forever', maxWorks: 2 });
+        expect(updated).toMatchObject({
+            id: originalId,
+            code: SubscriptionPlanCode.FREE,
+            displayName: 'Free forever',
+            maxWorks: 2,
+        });
+        expect(await dataSource.getRepository(SubscriptionPlan).count()).toBe(1);
+    });
+});

--- a/packages/agent/src/database/repositories/subscription-plan.repository.ts
+++ b/packages/agent/src/database/repositories/subscription-plan.repository.ts
@@ -19,11 +19,17 @@ export class SubscriptionPlanRepository {
     }
 
     async upsert(plan: Partial<SubscriptionPlan>): Promise<SubscriptionPlan> {
-        let existing = plan.code ? await this.findByCode(plan.code as SubscriptionPlanCode) : null;
-
-        if (existing) {
-            await this.repository.update(existing.id, plan);
-            return this.repository.findOne({ where: { id: existing.id } });
+        if (plan.code) {
+            // API replicas seed the same catalog concurrently during rolling starts.
+            // A find-then-save sequence lets both replicas observe a missing code and
+            // makes one lose the UNIQUE(code) race inside onModuleInit. Let the database
+            // resolve that conflict atomically on every supported driver instead.
+            await this.repository.upsert(plan, { conflictPaths: ['code'] });
+            const persisted = await this.findByCode(plan.code as SubscriptionPlanCode);
+            if (!persisted) {
+                throw new Error(`Subscription plan ${plan.code} missing after upsert`);
+            }
+            return persisted;
         }
 
         const created = this.repository.create(plan);


### PR DESCRIPTION
## Summary
- replace coded subscription-plan check-then-insert with a database-atomic upsert on the unique plan code
- keep uncoded partial create/save behavior unchanged
- prove 20 simultaneous SQLite seeders converge on one row and preserve in-place updates

## Verification
- subscription plan repository unit specs: 9/9
- subscription service + repository specs: 90/90
- better-sqlite3 concurrency integration: 1/1
- @ever-works/agent type-check
- Prettier and git diff --check