### PR TITLE
fix(billing): fail closed on missing plan table

### DIFF
--- a/apps/api/src/migrations/1786940000000-AddPlanHostingSeatsAndCredits.ts
+++ b/apps/api/src/migrations/1786940000000-AddPlanHostingSeatsAndCredits.ts
@@ -47,7 +47,14 @@ export class AddPlanHostingSeatsAndCredits1786940000000 implements MigrationInte
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         const table = await queryRunner.getTable('subscription_plans');
-        if (!table) return;
+        if (!table) {
+            // Returning here would make TypeORM record the migration as applied
+            // even though none of its columns exist. A missing prerequisite is
+            // schema drift, not an idempotent rerun, so stop startup loudly.
+            throw new Error(
+                'Cannot add plan hosting, seats, and credits: prerequisite table "subscription_plans" does not exist',
+            );
+        }
 
         const addColumn = async (name: string, ddl: string) => {
             if (!table.findColumnByName(name)) {

--- a/apps/api/src/migrations/__tests__/AddPlanHostingSeatsAndCredits.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddPlanHostingSeatsAndCredits.spec.ts
@@ -1,0 +1,105 @@
+import { DataSource } from 'typeorm';
+import { AddPlanHostingSeatsAndCredits1786940000000 } from '../1786940000000-AddPlanHostingSeatsAndCredits';
+
+describe('AddPlanHostingSeatsAndCredits1786940000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddPlanHostingSeatsAndCredits1786940000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    async function createBaseTable(): Promise<void> {
+        await dataSource.query(
+            `CREATE TABLE "subscription_plans" ("id" varchar PRIMARY KEY NOT NULL, "code" varchar NOT NULL UNIQUE)`,
+        );
+        await dataSource.query(
+            `INSERT INTO "subscription_plans" ("id", "code") VALUES ('plan-1', 'free')`,
+        );
+    }
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("subscription_plans")`,
+        );
+        return rows.map((row) => row.name);
+    }
+
+    it('fails loudly when its prerequisite subscription_plans table is absent', async () => {
+        const runner = dataSource.createQueryRunner();
+
+        await expect(migration.up(runner)).rejects.toThrow(
+            'Cannot add plan hosting, seats, and credits: prerequisite table "subscription_plans" does not exist',
+        );
+
+        await runner.release();
+    });
+
+    it('adds all six columns with backward-compatible defaults for existing plans', async () => {
+        await createBaseTable();
+        const runner = dataSource.createQueryRunner();
+
+        await migration.up(runner);
+        await runner.release();
+
+        expect(await columnNames()).toEqual(
+            expect.arrayContaining([
+                'hosting',
+                'annualPrice',
+                'lifetimePrice',
+                'seatsIncluded',
+                'seatMonthlyPrice',
+                'monthlyCredits',
+            ]),
+        );
+        const [existing] = await dataSource.query(
+            `SELECT "hosting", "annualPrice", "lifetimePrice", "seatsIncluded", "seatMonthlyPrice", "monthlyCredits" FROM "subscription_plans" WHERE "id" = 'plan-1'`,
+        );
+        expect(existing).toEqual({
+            hosting: 'cloud',
+            annualPrice: 0,
+            lifetimePrice: null,
+            seatsIncluded: null,
+            seatMonthlyPrice: null,
+            monthlyCredits: 0,
+        });
+    });
+
+    it('is idempotent when all guarded columns already exist', async () => {
+        await createBaseTable();
+        const runner = dataSource.createQueryRunner();
+
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await runner.release();
+
+        expect((await columnNames()).filter((name) => name === 'hosting')).toHaveLength(1);
+        expect((await columnNames()).filter((name) => name === 'monthlyCredits')).toHaveLength(1);
+    });
+
+    it('keeps down tolerant and removes every added column', async () => {
+        await createBaseTable();
+        const runner = dataSource.createQueryRunner();
+
+        await migration.up(runner);
+        await migration.down(runner);
+        await runner.release();
+
+        expect(await columnNames()).toEqual(['id', 'code']);
+
+        const emptyRunner = dataSource.createQueryRunner();
+        await dataSource.query(`DROP TABLE "subscription_plans"`);
+        await expect(migration.down(emptyRunner)).resolves.toBeUndefined();
+        await emptyRunner.release();
+    });
+});


### PR DESCRIPTION
## Summary
- fail the plan hosting/seats/credits migration when its prerequisite table is absent instead of letting TypeORM record a silent no-op as applied
- preserve per-column rerun guards and tolerant down behavior
- cover missing-table, defaults, idempotency, and rollback paths with real better-sqlite3

## Verification
- focused migration spec: 4/4
- Prettier and git diff --check
- changed TypeScript compiled through Jest

## Local typecheck note
The broader API typecheck reaches an unrelated stale workspace-link declaration: the linked shared checkout's @ever-works/agent declaration lacks listOwnedLicenceCodes, while the current worktree's freshly built declaration contains it. No subscription controller or Agent source is changed here.