### PR TITLE
fix(e2e): isolate seat limits from fixture setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -349,6 +349,11 @@ jobs:
           # b709f9cb) but several specs assert paid-tier transitions
           # that only fire when the module is on.
           SUBSCRIPTIONS_ENABLED: 'true'
+          # The suite enables subscriptions to cover billing behavior, while
+          # hundreds of unrelated scenarios create agents/members as fixtures.
+          # Fresh free users already consume their one included seat, so keep
+          # fixture setup unbounded. The config getter ignores this in prod.
+          E2E_BYPASS_SEAT_LIMITS: 'true'
           # E2E-only escape hatch (hard-gated off in production â€” ignored
           # unless NODE_ENV !== 'production'). Without a real billing
           # integration wired in, the only path to a PAID plan is the

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -612,6 +612,26 @@ describe('agent/config', () => {
             expect(config.subscriptions.isEnabled()).toBe(false);
         });
 
+        describe('bypassSeatLimitsInE2E', () => {
+            it('is off by default and requires the literal true flag outside production', () => {
+                process.env.NODE_ENV = 'test';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+
+                process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(true);
+
+                process.env.E2E_BYPASS_SEAT_LIMITS = '1';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+            });
+
+            it('is hard-gated off in production even when the flag is set', () => {
+                process.env.NODE_ENV = 'production';
+                process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+            });
+        });
+
         describe('scheduledUpdatesEnabled (default-on)', () => {
             it('defaults to true when unset', () => {
                 expect(config.subscriptions.scheduledUpdatesEnabled()).toBe(true);

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -499,6 +499,23 @@ export const config = {
                 process.env.SUBSCRIPTIONS_ALLOW_SELF_SERVE_PAID === 'true'
             );
         },
+        /**
+         * E2E-only fixture escape hatch for seat-consuming setup writes.
+         *
+         * The sharded suite enables subscriptions so billing scenarios can
+         * exercise real plan behavior, but its unrelated scenarios create
+         * agents and members for fresh users. A fresh free user already uses
+         * the plan's one seat, so those fixture writes otherwise fail with a
+         * 402 before the behavior under test is reached.
+         *
+         * Production ignores this value even if it is configured by mistake.
+         */
+        bypassSeatLimitsInE2E() {
+            return (
+                process.env.NODE_ENV !== 'production' &&
+                process.env.E2E_BYPASS_SEAT_LIMITS === 'true'
+            );
+        },
         scheduledUpdatesEnabled() {
             return process.env.SCHEDULED_UPDATES_ENABLED !== 'false';
         },

--- a/packages/agent/src/subscriptions/billing/seats.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/seats.service.spec.ts
@@ -131,6 +131,7 @@ function makeHarness(
 
 afterEach(() => {
     delete process.env.SUBSCRIPTIONS_ENABLED;
+    delete process.env.E2E_BYPASS_SEAT_LIMITS;
 });
 
 describe('SeatsService.getSeats', () => {
@@ -212,6 +213,15 @@ describe('SeatsService.getSeats', () => {
 });
 
 describe('SeatsService.assertSeatAvailable', () => {
+    it('bypasses seat admission only through the non-production E2E escape hatch', async () => {
+        process.env.NODE_ENV = 'test';
+        process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+        const h = makeHarness({ members: 99, agents: 99 });
+
+        await expect(h.service.assertSeatAvailable('owner-1')).resolves.toBeUndefined();
+        expect(h.userSubscriptionRepository.findActiveByUser).not.toHaveBeenCalled();
+    });
+
     it('admits while a seat is left and refuses when the next one would exceed the allowance', async () => {
         const full = makeHarness({ members: 10, agents: 4 }); // 14 used, allowance 10
         await expect(full.service.assertSeatAvailable('owner-1')).rejects.toBeInstanceOf(

--- a/packages/agent/src/subscriptions/billing/seats.service.ts
+++ b/packages/agent/src/subscriptions/billing/seats.service.ts
@@ -132,7 +132,9 @@ export class SeatsService {
      * agent). Fail-open on every axis except a genuinely full allowance.
      */
     async assertSeatAvailable(ownerUserId: string, count = 1): Promise<void> {
-        if (!config.subscriptions.isEnabled()) return;
+        if (!config.subscriptions.isEnabled() || config.subscriptions.bypassSeatLimitsInE2E()) {
+            return;
+        }
         let seats: SeatsView;
         try {
             seats = await this.getSeats(ownerUserId);


### PR DESCRIPTION
## What changed
- add a literal E2E-only seat-admission bypass, ignored in production
- enable it only in the sharded E2E workflow
- pin default/literal/production behavior and the no-lookup service fast path

## Why
Stage E2E run 32753184043 proves unrelated fixture setup is returning HTTP 402 `SeatLimitExceeded` (`used=1`, `allowance=1`) because the workflow enables subscriptions and every fresh free user already consumes the included seat. This preserves live billing enforcement while letting non-billing scenarios reach the behavior they test.

## Verification
- `pnpm --filter @ever-works/agent test -- src/config/config.spec.ts src/subscriptions/billing/seats.service.spec.ts` (189/189)
- `pnpm --filter @ever-works/agent type-check`
- Prettier check for all touched TypeScript files
- `git diff --check`

No data, schema, Stripe, catalog, environment branch, or live runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * End-to-end test setup can now create members and agents without being blocked by seat limits.
  * Seat-limit bypassing is restricted to test environments and remains disabled in production.
  * Added coverage to verify seat-limit behavior and safeguard production restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->