### PR TITLE
docs(credits): the daily-grant docstring said the opposite of what the code does

### DIFF
--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -333,11 +333,23 @@ export class CreditLedgerService {
 
     /**
      * Daily free-credit sweep (RPC target of the `credits-daily-grant`
-     * cron, 00:05 UTC). For every active user, on EVERY plan, tops the
-     * balance back UP TO the plan's `daily-free-credits` level (platform
-     * default 50) — non-accumulating per the PRD: a balance already at or
-     * above the level receives nothing. Idempotency key
-     * `daily:{userId}:{date}` makes cron re-runs a no-op.
+     * cron, 00:05 UTC). For every active user, on EVERY plan, GRANTS the
+     * plan's `daily-free-credits` level (platform default 50). Idempotency
+     * key `daily:{userId}:{date}` makes cron re-runs a no-op.
+     *
+     * 🛑 This is ADDITIVE and does NOT expire. It is not a top-up to a
+     * ceiling, whatever the PRD says — see the long comment in
+     * `grantDailyForPlan` for why the `maxBalanceAfter` ceiling was removed
+     * (it silently denied the advertised daily credits to paid tiers and to
+     * anyone who had BOUGHT a credit pack). An idle free user therefore
+     * accrues 50 credits/day without bound, which is a deliberate, accepted
+     * consequence and NOT an oversight.
+     *
+     * This docstring previously described the removed ceiling behaviour and
+     * claimed the grant was "non-accumulating" — the exact opposite of what
+     * the code does. Corrected 2026-08-25. Whether accrual should be bounded
+     * is EW-753; if it ever is, bound it by lot expiry or by a cap scoped to
+     * `DAILY_FREE` buckets, never by a total-balance ceiling.
      */
     async dispatchDailyGrants(now: Date = new Date()): Promise<DailyGrantSummary> {
         const summary: DailyGrantSummary = {


### PR DESCRIPTION
Comment-only. Found while answering the EW-753 question "does the daily allowance expire?".

## The contradiction

`dispatchDailyGrants` was documented as:

> tops the balance back **UP TO** the plan's `daily-free-credits` level … **non-accumulating** per the PRD: a balance already at or above the level receives nothing

The code does the opposite. `grantDailyForPlan` carries a long comment explaining why the `maxBalanceAfter` ceiling was **deliberately removed**: a total-balance ceiling silently denied the advertised daily credits to two groups — paid tiers carrying a monthly allowance, and free users who had **bought** a credit pack (a $200 25,000-pack buyer would get nothing for ~500 days). Both looked identical in the logs to a healthy topped-up user.

So the grant is additive, sets no `expiresAt`, and an idle free user accrues **50 credits/day without bound**.

## Why this is worth a commit on its own

That accrual is an *accepted* consequence — the removal comment says so explicitly. The problem is that the method's own docstring asserts it cannot happen, on the money path, where the next reader is deciding exactly this question. At 1 credit = 1¢ that's **$0.50/day, ~$182/year per idle free account**.

I nearly answered the owner's question wrong from the stale docstring before reading the implementation.

## Also recorded

The constraint any future cap must respect: bound accrual by **lot expiry**, or by a cap **scoped to `DAILY_FREE` buckets** — never by a total-balance ceiling, which is the thing that already failed. The removal comment says "any balance ceiling is unfixable for someone who bought credits", and that's true of a *total-balance* ceiling; a kind-scoped one doesn't have the defect.

No behaviour change. 53 credit-ledger tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)