### PR TITLE
fix(ai): stop the assistant silently making every schedule pay-per-use

### DIFF
--- a/apps/web/src/lib/ai/tools/schedule.tools.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.ts
@@ -30,7 +30,25 @@ export const setSchedule = tool({
         const result = await updateWorkSchedule(workId, {
             enable,
             cadence: cadenceMap[cadence ?? 'weekly'],
-            billingMode: WorkScheduleBillingMode.USAGE,
+            // 🛑 SUBSCRIPTION, matching the entity default
+            // (work-schedule.entity.ts:48). This used to hardcode USAGE, so
+            // EVERY schedule the assistant created was silently pay-per-use —
+            // a billing mode the user never chose and is never shown.
+            //
+            // That is not cosmetic. `billingMode === USAGE` currently skips two
+            // entitlement gates: SubscriptionService.requiresUsageBilling
+            // returns false for it (so a cadence the plan does not allow is
+            // permitted), and WorkScheduleService.validateRunEntitlement returns
+            // true immediately (so the plan's active-schedule cap is not
+            // applied). Both are justified in-code by "assuming they can pay" —
+            // but BillingProvider.recordUsageCharge is a no-op on every
+            // provider, so nobody ever pays. Asking the assistant to set up a
+            // schedule therefore granted unmetered capacity.
+            //
+            // This restores the default only. The bypass itself is still open
+            // and is tracked separately; flipping it would pause existing
+            // usage-mode schedules, which needs an owner decision.
+            billingMode: WorkScheduleBillingMode.SUBSCRIPTION,
             maxFailureBeforePause: 3,
         });
         return { success: result.success, message: result.message, error: result.error };

--- a/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
@@ -1,10 +1,22 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { WorkScheduleBillingMode } from '@/lib/api/enums';
 
-const updateWorkSchedule = vi.fn(async () => ({ success: true, message: 'ok' }));
+type ScheduleUpdatePayload = Record<string, unknown> & {
+    billingMode: WorkScheduleBillingMode;
+};
+type UpdateWorkScheduleMock = (
+    workId: string,
+    payload: ScheduleUpdatePayload,
+) => Promise<{ success: boolean; message: string }>;
+
+const updateWorkSchedule = vi.fn<UpdateWorkScheduleMock>(async () => ({
+    success: true,
+    message: 'ok',
+}));
 
 vi.mock('@/app/actions/dashboard/work-schedule', () => ({
-    updateWorkSchedule: (...args: unknown[]) => updateWorkSchedule(...(args as [])),
+    updateWorkSchedule: (...args: Parameters<UpdateWorkScheduleMock>) =>
+        updateWorkSchedule(...args),
     runWorkSchedule: vi.fn(),
     cancelWorkSchedule: vi.fn(),
 }));
@@ -37,30 +49,30 @@ describe('setSchedule — billing mode is not silently upgraded', () => {
 
     it('sends SUBSCRIPTION, never USAGE', async () => {
         const { setSchedule } = await import('./schedule.tools');
-        await (setSchedule as unknown as {
-            execute: (a: Record<string, unknown>) => Promise<unknown>;
-        }).execute({ workId: 'w1', enable: true, cadence: 'daily' });
+        await (
+            setSchedule as unknown as {
+                execute: (a: Record<string, unknown>) => Promise<unknown>;
+            }
+        ).execute({ workId: 'w1', enable: true, cadence: 'daily' });
 
         expect(updateWorkSchedule).toHaveBeenCalledTimes(1);
-        const payload = updateWorkSchedule.mock.calls[0]![1] as {
-            billingMode: WorkScheduleBillingMode;
-        };
+        const payload = updateWorkSchedule.mock.calls[0]![1];
         expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
         expect(payload.billingMode).not.toBe(WorkScheduleBillingMode.USAGE);
     });
 
     it('holds for every cadence, including the default when none is given', async () => {
         const { setSchedule } = await import('./schedule.tools');
-        const exec = (setSchedule as unknown as {
-            execute: (a: Record<string, unknown>) => Promise<unknown>;
-        }).execute;
+        const exec = (
+            setSchedule as unknown as {
+                execute: (a: Record<string, unknown>) => Promise<unknown>;
+            }
+        ).execute;
 
         for (const cadence of ['hourly', 'daily', 'weekly', 'monthly', undefined]) {
             updateWorkSchedule.mockClear();
             await exec({ workId: 'w1', enable: true, cadence });
-            const payload = updateWorkSchedule.mock.calls[0]![1] as {
-                billingMode: WorkScheduleBillingMode;
-            };
+            const payload = updateWorkSchedule.mock.calls[0]![1];
             expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
         }
     });

--- a/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { WorkScheduleBillingMode } from '@/lib/api/enums';
+
+const updateWorkSchedule = vi.fn(async () => ({ success: true, message: 'ok' }));
+
+vi.mock('@/app/actions/dashboard/work-schedule', () => ({
+    updateWorkSchedule: (...args: unknown[]) => updateWorkSchedule(...(args as [])),
+    runWorkSchedule: vi.fn(),
+    cancelWorkSchedule: vi.fn(),
+}));
+
+/**
+ * The assistant must not pick a billing mode the user never chose.
+ *
+ * `setSchedule` hardcoded `billingMode: USAGE`, so every schedule created by
+ * asking the assistant was silently pay-per-use. That is not a cosmetic
+ * mislabel — `billingMode === USAGE` currently skips BOTH entitlement gates:
+ *
+ *   - `SubscriptionService.requiresUsageBilling` returns false for it, so a
+ *     cadence the user's plan does not allow is permitted;
+ *   - `WorkScheduleService.validateRunEntitlement` returns true immediately,
+ *     so the plan's active-schedule cap is never applied.
+ *
+ * Both are justified in-code by "assuming they can pay", but
+ * `BillingProvider.recordUsageCharge` is a no-op on every provider — nobody
+ * ever pays. So the assistant was handing out unmetered capacity.
+ *
+ * `billingMode` is REQUIRED by the action's Zod schema
+ * (`work-schedule.ts:25`), so this cannot be fixed by omitting the field; the
+ * value has to be right. This pins it to the entity default
+ * (`work-schedule.entity.ts:48`).
+ */
+describe('setSchedule — billing mode is not silently upgraded', () => {
+    beforeEach(() => {
+        updateWorkSchedule.mockClear();
+    });
+
+    it('sends SUBSCRIPTION, never USAGE', async () => {
+        const { setSchedule } = await import('./schedule.tools');
+        await (setSchedule as unknown as {
+            execute: (a: Record<string, unknown>) => Promise<unknown>;
+        }).execute({ workId: 'w1', enable: true, cadence: 'daily' });
+
+        expect(updateWorkSchedule).toHaveBeenCalledTimes(1);
+        const payload = updateWorkSchedule.mock.calls[0]![1] as {
+            billingMode: WorkScheduleBillingMode;
+        };
+        expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
+        expect(payload.billingMode).not.toBe(WorkScheduleBillingMode.USAGE);
+    });
+
+    it('holds for every cadence, including the default when none is given', async () => {
+        const { setSchedule } = await import('./schedule.tools');
+        const exec = (setSchedule as unknown as {
+            execute: (a: Record<string, unknown>) => Promise<unknown>;
+        }).execute;
+
+        for (const cadence of ['hourly', 'daily', 'weekly', 'monthly', undefined]) {
+            updateWorkSchedule.mockClear();
+            await exec({ workId: 'w1', enable: true, cadence });
+            const payload = updateWorkSchedule.mock.calls[0]![1] as {
+                billingMode: WorkScheduleBillingMode;
+            };
+            expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
+        }
+    });
+});


### PR DESCRIPTION
Found while researching EW-755 (the owner asked to *keep* pay-per-use and understand it). Verified every claim below directly.

## What happens today

`setSchedule` hardcodes `billingMode: WorkScheduleBillingMode.USAGE`, so **every schedule the assistant creates is pay-per-use** — a mode the user never chose and is never shown. The entity default is `SUBSCRIPTION` ([work-schedule.entity.ts:48](packages/agent/src/entities/work-schedule.entity.ts:48)).

That would be a cosmetic mislabel if `USAGE` were inert. It isn't — it skips **both** entitlement gates:

| gate | behaviour for `USAGE` |
|---|---|
| `SubscriptionService.requiresUsageBilling` | returns `billingMode !== USAGE` → **false**, so a cadence the plan disallows is permitted |
| `WorkScheduleService.validateRunEntitlement` | `if (schedule.billingMode === USAGE) return true;` → the plan's active-schedule cap is never applied |

Both are justified in code by *"assuming they can pay"*.

**Nobody pays.** `BillingProvider.recordUsageCharge` is a bare `return` on the abstract provider ([billing.provider.ts:516](packages/agent/src/subscriptions/billing/billing.provider.ts:516)) and is the only definition in the tree — `StripeBillingProvider` never overrides it. Its only caller is `usage-ledger.service.ts:50`.

So on any subscriptions-enabled deployment, **asking the assistant to schedule a Work grants uncapped schedules at any cadence, free.** No UI affordance required — just a chat message.

## The fix

Set `SUBSCRIPTION`. `billingMode` is **required** by the action's Zod schema ([work-schedule.ts:25](apps/web/src/app/actions/dashboard/work-schedule.ts:25)), so this can't be fixed by omitting the field — the value has to be right.

Adds a regression test covering every cadence plus the no-cadence default. **Verified by reintroducing the bug:**

```
AssertionError: expected 'usage' to be 'subscription'
Tests  2 failed (2)
```

## Deliberately not in this PR

The entitlement bypass itself. Closing it would subject **existing** usage-mode schedules to plan limits, and `validateRunEntitlement` returning false leads to schedules being *paused* — so flipping it could pause live users' schedules. That's an owner decision, not a drive-by change. Filed separately.

This PR stops new users falling into it; it doesn't change anyone's current entitlements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)