### PR TITLE
fix(web): scope public auth callbacks personally

### DIFF
--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -293,6 +293,9 @@ export const authAPI = {
             data,
             method: 'POST',
             wrapInData: false,
+            // Email callbacks live under /api and intentionally bypass the
+            // workspace proxy. Authentication tokens are never org-scoped.
+            publicRouteScope: 'personal',
         });
     },
 
@@ -323,6 +326,7 @@ export const authAPI = {
     validatePasswordResetToken: async (token: string) => {
         return serverFetch<TokenValidationResponse>(
             `/auth/validate-reset-token?token=${encodeURIComponent(token)}`,
+            { publicRouteScope: 'personal' },
         );
     },
 

--- a/apps/web/src/lib/api/server-api.ts
+++ b/apps/web/src/lib/api/server-api.ts
@@ -95,6 +95,8 @@ export async function getFrontendUrl(): Promise<string> {
 
 interface ServerFetchOptions extends RequestInit {
     rawResponse?: boolean;
+    /** Public server routes outside the workspace proxy may opt into personal scope only. */
+    publicRouteScope?: 'personal';
 }
 
 export async function serverFetch<T>(
@@ -102,12 +104,13 @@ export async function serverFetch<T>(
     options: ServerFetchOptions = {},
 ): Promise<T> {
     const requestHeaders = await headers();
-    const selectedScope = parseWorkspaceSelector(
-        requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER),
-    );
+    const { rawResponse, publicRouteScope, ...fetchOptions } = options;
+    const selectedScope =
+        publicRouteScope === 'personal'
+            ? { kind: 'personal' as const }
+            : parseWorkspaceSelector(requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER));
     const frontendUrl = await getFrontendUrl();
     const t = await getTranslations('api.errors');
-    const { rawResponse, ...fetchOptions } = options;
 
     const doFetch = async (authToken?: string) => {
         const reqHeaders = new Headers(fetchOptions.headers);
@@ -242,16 +245,19 @@ export async function serverMutation<T>({
     method = 'POST',
     wrapInData = false,
     headers,
+    publicRouteScope,
 }: {
     endpoint: string;
     data: any;
     method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     wrapInData: boolean;
     headers?: Record<string, string>;
+    publicRouteScope?: 'personal';
 }): Promise<T> {
     return serverFetch<T>(endpoint, {
         method,
         headers,
         body: JSON.stringify(wrapInData ? { data } : data),
+        publicRouteScope,
     });
 }

--- a/apps/web/src/lib/api/server-api.unit.spec.ts
+++ b/apps/web/src/lib/api/server-api.unit.spec.ts
@@ -67,6 +67,20 @@ describe('serverFetch workspace scope transport', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 
+    it('allows a server-owned public auth call to select personal scope explicitly', async () => {
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+
+        await serverFetch('/auth/verify-email', {
+            method: 'POST',
+            body: '{}',
+            publicRouteScope: 'personal',
+        });
+
+        const init = vi.mocked(fetch).mock.calls[0][1];
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+        expect(init).not.toHaveProperty('publicRouteScope');
+    });
+
     it.each([
         ['ever', '/org/ever/dashboard'],
         [null, '/'],


### PR DESCRIPTION
## What changed

- allow trusted public server routes outside the workspace proxy to opt into personal scope only
- apply that narrow scope to email verification and password-reset token validation
- preserve the fail-closed default when no trusted proxy selector exists

## Root cause

Stage E2E shard 12 showed /api/auth/verify-email returning erify_email_failed. Server logs proved the underlying error was Invalid workspace scope: /api/* is intentionally excluded from the workspace proxy, so the callback never received the trusted selector required by serverFetch and failed before contacting the API.

## Verification

- red control: new focused unit failed with Invalid workspace scope before implementation
- server-api.unit.spec.ts + verify-email route unit: 16/16 passed
- web type-check passed
- exact API-backed Playwright scenario passed against in-memory API + current Next server: 1/1
- Prettier and git diff --check passed

No data/schema/secret changes.