### PR TITLE
fix(ci): keep all-green uptime probes successful

### DIFF
--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -361,11 +361,19 @@ jobs:
           # what is CURRENTLY failing rather than staying frozen at whatever the
           # first failure was.
           FAIL_COUNT="$(printf '%s' "${FAILING_URLS}" | grep -c . || true)"
-          FIRST_FAIL="$(printf '%s' "${FAILING_URLS}" | grep . | head -1 | sed 's#https\?://##; s#/$##')"
-          if [ "${FAIL_COUNT}" -gt 1 ]; then
-            FAIL_SUMMARY="${FIRST_FAIL} +$(( FAIL_COUNT - 1 )) more"
+          if [ "${FAIL_COUNT}" -eq 0 ]; then
+            # An all-green run has no first failure. Do not feed the empty list
+            # through `grep | head`: the inherited `bash -e -o pipefail` turns
+            # grep's expected no-match status into a failed monitor run.
+            FIRST_FAIL=""
+            FAIL_SUMMARY=""
           else
-            FAIL_SUMMARY="${FIRST_FAIL}"
+            FIRST_FAIL="$(sed -n '/./{s#https\?://##; s#/$##; p; q;}' <<< "${FAILING_URLS}")"
+            if [ "${FAIL_COUNT}" -gt 1 ]; then
+              FAIL_SUMMARY="${FIRST_FAIL} +$(( FAIL_COUNT - 1 )) more"
+            else
+              FAIL_SUMMARY="${FIRST_FAIL}"
+            fi
           fi
 
           {

--- a/apps/node/src/core/external-uptime-monitor.contract.spec.ts
+++ b/apps/node/src/core/external-uptime-monitor.contract.spec.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = join(__dirname, '../../../..');
+const workflowPath = join(repositoryRoot, '.github/workflows/external-uptime-monitor.yml');
+
+async function summaryBlock(): Promise<string> {
+	const workflow = await readFile(workflowPath, 'utf8');
+	const start = workflow.indexOf('# A short human summary for the issue TITLE');
+	const end = workflow.indexOf('\n\n          {', start);
+
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+
+	return workflow
+		.slice(start, end)
+		.replace(/\r\n/g, '\n')
+		.replace(/^ {10}/gm, '');
+}
+
+function exerciseSummary(block: string, failingUrls: string) {
+	const shellLiteral = failingUrls.replace(/'/g, `'"'"'`);
+	const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : 'bash';
+	return spawnSync(
+		bash,
+		[
+			'-euo',
+			'pipefail',
+			'-c',
+			`FAILING_URLS='${shellLiteral}'\n${block}\nprintf '<%s>|<%s>|<%s>' "\${FAIL_COUNT}" "\${FIRST_FAIL}" "\${FAIL_SUMMARY}"\n`
+		],
+		{
+			encoding: 'utf8',
+			env: process.env
+		}
+	);
+}
+
+describe('external uptime monitor summary contract', () => {
+	it('survives an empty failure list under the workflow Bash flags', async () => {
+		const result = exerciseSummary(await summaryBlock(), '');
+
+		expect(result.stderr).toBe('');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('<0>|<>|<>');
+	});
+
+	it('keeps the first failing host in the alert summary', async () => {
+		const result = exerciseSummary(
+			await summaryBlock(),
+			'https://demo.ever.works/\nhttps://mcp.ever.works/health\n'
+		);
+
+		expect(result.stderr).toBe('');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('<2>|<demo.ever.works>|<demo.ever.works +1 more>');
+	});
+});


### PR DESCRIPTION
## Summary
- treat an empty external-uptime failure list as the healthy case under inherited Bash \-e -o pipefail\`n- avoid the \grep | head\ pipeline when deriving the first failed endpoint
- execute the exact workflow summary block in a focused contract test for zero and multiple failures

## Evidence
- run 32784629404: all 9 production targets returned HTTP 200 with expected markers, but the probe step exited 1 before outputs
- red before fix: focused contract test failed only the empty-list case with exit 1
- green after fix: focused contract 2/2; \ver-works-node\ type-check; Prettier; git diff check
- broader Node suite: 486 passed / 6 skipped; two unrelated environment-sensitive failures in existing files (missing native Windows helper artifact and real shell process-tree cancellation). Neither file differs from develop.

No data, secrets, runtime, endpoint roster, or alert behavior changed.