### PR TITLE
chore(release): promote post-review fixes to production

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -349,6 +349,11 @@ jobs:
           # b709f9cb) but several specs assert paid-tier transitions
           # that only fire when the module is on.
           SUBSCRIPTIONS_ENABLED: 'true'
+          # The suite enables subscriptions to cover billing behavior, while
+          # hundreds of unrelated scenarios create agents/members as fixtures.
+          # Fresh free users already consume their one included seat, so keep
+          # fixture setup unbounded. The config getter ignores this in prod.
+          E2E_BYPASS_SEAT_LIMITS: 'true'
           # E2E-only escape hatch (hard-gated off in production â€” ignored
           # unless NODE_ENV !== 'production'). Without a real billing
           # integration wired in, the only path to a PAID plan is the

--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -361,11 +361,19 @@ jobs:
           # what is CURRENTLY failing rather than staying frozen at whatever the
           # first failure was.
           FAIL_COUNT="$(printf '%s' "${FAILING_URLS}" | grep -c . || true)"
-          FIRST_FAIL="$(printf '%s' "${FAILING_URLS}" | grep . | head -1 | sed 's#https\?://##; s#/$##')"
-          if [ "${FAIL_COUNT}" -gt 1 ]; then
-            FAIL_SUMMARY="${FIRST_FAIL} +$(( FAIL_COUNT - 1 )) more"
+          if [ "${FAIL_COUNT}" -eq 0 ]; then
+            # An all-green run has no first failure. Do not feed the empty list
+            # through `grep | head`: the inherited `bash -e -o pipefail` turns
+            # grep's expected no-match status into a failed monitor run.
+            FIRST_FAIL=""
+            FAIL_SUMMARY=""
           else
-            FAIL_SUMMARY="${FIRST_FAIL}"
+            FIRST_FAIL="$(sed -n '/./{s#https\?://##; s#/$##; p; q;}' <<< "${FAILING_URLS}")"
+            if [ "${FAIL_COUNT}" -gt 1 ]; then
+              FAIL_SUMMARY="${FIRST_FAIL} +$(( FAIL_COUNT - 1 )) more"
+            else
+              FAIL_SUMMARY="${FIRST_FAIL}"
+            fi
           fi
 
           {

--- a/apps/node/src/core/external-uptime-monitor.contract.spec.ts
+++ b/apps/node/src/core/external-uptime-monitor.contract.spec.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = join(__dirname, '../../../..');
+const workflowPath = join(repositoryRoot, '.github/workflows/external-uptime-monitor.yml');
+
+async function summaryBlock(): Promise<string> {
+	const workflow = await readFile(workflowPath, 'utf8');
+	const start = workflow.indexOf('# A short human summary for the issue TITLE');
+	const end = workflow.indexOf('\n\n          {', start);
+
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+
+	return workflow
+		.slice(start, end)
+		.replace(/\r\n/g, '\n')
+		.replace(/^ {10}/gm, '');
+}
+
+function exerciseSummary(block: string, failingUrls: string) {
+	const shellLiteral = failingUrls.replace(/'/g, `'"'"'`);
+	const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : 'bash';
+	return spawnSync(
+		bash,
+		[
+			'-euo',
+			'pipefail',
+			'-c',
+			`FAILING_URLS='${shellLiteral}'\n${block}\nprintf '<%s>|<%s>|<%s>' "\${FAIL_COUNT}" "\${FIRST_FAIL}" "\${FAIL_SUMMARY}"\n`
+		],
+		{
+			encoding: 'utf8',
+			env: process.env
+		}
+	);
+}
+
+describe('external uptime monitor summary contract', () => {
+	it('survives an empty failure list under the workflow Bash flags', async () => {
+		const result = exerciseSummary(await summaryBlock(), '');
+
+		expect(result.stderr).toBe('');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('<0>|<>|<>');
+	});
+
+	it('keeps the first failing host in the alert summary', async () => {
+		const result = exerciseSummary(
+			await summaryBlock(),
+			'https://demo.ever.works/\nhttps://mcp.ever.works/health\n'
+		);
+
+		expect(result.stderr).toBe('');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('<2>|<demo.ever.works>|<demo.ever.works +1 more>');
+	});
+});

--- a/apps/web/e2e/flow-kb-inherited.spec.ts
+++ b/apps/web/e2e/flow-kb-inherited.spec.ts
@@ -129,22 +129,20 @@ test.describe('flow: KB org→Work inheritance acceptance (A33/A34/A35)', () => 
             body: `# Policy ${id}\n\norg-level policy inherited by paired Works\n`,
         });
 
-        // Before pairing, the org doc is not visible to the Work.
-        const beforePair = await resolveInheritable(request, owner.access_token, workId, orgId);
-        // Without a pairing, the inheritable endpoint still trusts the orgId
-        // query and returns the org doc — but the kb page server component
-        // never calls it without a paired Work.organizationId. Pin pairing
-        // explicitly so the assertion below isn't dependent on that quirk.
+        // Before pairing, the attacker-controlled orgId query must not widen
+        // the Work's scope. The route derives scope from Work.organizationId
+        // and rejects the mismatched query.
+        const beforePair = await request.get(
+            `${API_BASE}/api/works/${workId}/kb/inheritable?orgId=${encodeURIComponent(orgId)}`,
+            { headers: authedHeaders(owner.access_token) },
+        );
+        expect(beforePair.status(), 'unpaired Work rejects the orgId query').toBe(403);
+
         await setWorkOrganizationId(request, owner.access_token, workId, orgId);
         const afterPair = await resolveInheritable(request, owner.access_token, workId, orgId);
 
         const orgScoped = afterPair.filter((d) => d.workId === null).map((d) => d.path);
         expect(orgScoped, 'paired Work sees the org doc as inherited').toContain(orgPath);
-
-        // beforePair is sanity — also surfaces it (trust-the-query-param
-        // behaviour) so flipping that contract is caught by the spec rather
-        // than going silent.
-        expect(beforePair.some((d) => d.path === orgPath)).toBeTruthy();
     });
 
     test('A34 — Work-scope override at same path hides the org-scope sibling', async ({

--- a/apps/web/e2e/flow-kb-lifecycle-consolidate-memory-chain.spec.ts
+++ b/apps/web/e2e/flow-kb-lifecycle-consolidate-memory-chain.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from './helpers/api';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
 import { createOrganizationViaAPI } from './helpers/organizations';
 
 /**
@@ -33,9 +33,10 @@ import { createOrganizationViaAPI } from './helpers/organizations';
  *     GET /api/memory with workId null AND GET /works/:id/kb/inheritable).
  *
  * ── PROBED CONTRACTS (verified live) ─────────────────────────────────────
- *  A fresh POST /api/organizations becomes the caller's active scope; a Work
- *    created afterward (organization:false) inherits `work.organizationId` =
- *    that org, so its KB docs fan into GET /api/memory.
+ *  Organization routes are selected per request. A Work created with an
+ *    explicit `X-Scope-Slug` (organization:false) inherits
+ *    `work.organizationId` = that org, so its KB docs fan into GET /api/memory
+ *    when the same scope header is present.
  *  POST /api/works/:id/kb/documents {path,title,class,body,...} → 201 full
  *    KbDocumentBodyDto { id, workId, organizationId:null, path, slug, title,
  *    class, tags, categories, status:'active', locked:false, lockMode:null,
@@ -159,35 +160,56 @@ interface ConsolReport {
 
 interface Chain {
     token: string;
-    userId: string;
+    headers: Record<string, string>;
     orgId: string;
     workId: string;
 }
 
-/** Register a fresh user, mint an Org (→ active scope), and a Work in it. */
+function scopedHeaders(token: string, orgSlug: string): Record<string, string> {
+    return { ...authedHeaders(token), 'X-Scope-Slug': orgSlug };
+}
+
+/** Register a fresh user, mint an Org, and explicitly create a Work in it. */
 async function buildChain(request: APIRequestContext): Promise<Chain> {
     const user = await registerUserViaAPI(request);
     const org = await createOrganizationViaAPI(request, user.access_token, `Cortex Org ${stamp()}`);
-    const work = await createWorkViaAPI(request, user.access_token, {
-        name: `Cortex Work ${stamp()}`,
-        slug: `cortex-work-${stamp()}`,
+    const headers = scopedHeaders(user.access_token, org.slug);
+    const workCreate = await request.post(`${API_BASE}/api/works`, {
+        headers,
+        data: {
+            name: `Cortex Work ${stamp()}`,
+            slug: `cortex-work-${stamp()}`,
+            description: 'org-scoped KB lifecycle chain',
+            organization: false,
+        },
     });
-    expect(work.id).toMatch(UUID_RE);
-    // The Work must join the active Org, else its KB docs never surface.
-    const workRead = await request.get(`${API_BASE}/api/works/${work.id}`, {
-        headers: authedHeaders(user.access_token),
+    expect(
+        [200, 201],
+        `scoped Work create body=${await workCreate.text().catch(() => '')}`,
+    ).toContain(workCreate.status());
+    const workBody = await workCreate.json();
+    const workId = workBody?.work?.id ?? workBody?.id ?? workBody?.data?.id ?? '';
+    expect(workId).toMatch(UUID_RE);
+    // The Work must join the explicitly selected Org, else its KB docs never surface.
+    const workRead = await request.get(`${API_BASE}/api/works/${workId}`, {
+        headers,
     });
     const wb = (await workRead.json()) as {
         work?: { organizationId?: string };
         organizationId?: string;
     };
     expect((wb.work ?? wb).organizationId).toBe(org.id);
-    return { token: user.access_token, userId: user.user.id, orgId: org.id, workId: work.id };
+    return {
+        token: user.access_token,
+        headers,
+        orgId: org.id,
+        workId,
+    };
 }
 
 async function createKbDoc(
     request: APIRequestContext,
-    token: string,
+    headers: Record<string, string>,
     workId: string,
     body: {
         path: string;
@@ -199,7 +221,7 @@ async function createKbDoc(
     },
 ): Promise<KbDoc> {
     const res = await request.post(`${API_BASE}/api/works/${workId}/kb/documents`, {
-        headers: authedHeaders(token),
+        headers,
         data: body,
     });
     expect(res.status(), `kb create body=${await res.text().catch(() => '')}`).toBe(201);
@@ -210,12 +232,12 @@ async function createKbDoc(
 
 async function createOrgDoc(
     request: APIRequestContext,
-    token: string,
+    headers: Record<string, string>,
     orgId: string,
     body: { path: string; title: string; class: string; body: string },
 ): Promise<KbDoc> {
     const res = await request.post(`${API_BASE}/api/organizations/${orgId}/kb/documents`, {
-        headers: authedHeaders(token),
+        headers,
         data: body,
     });
     expect(res.status(), `org kb create body=${await res.text().catch(() => '')}`).toBe(201);
@@ -224,11 +246,11 @@ async function createOrgDoc(
 
 async function getMemory(
     request: APIRequestContext,
-    token: string,
+    headers: Record<string, string>,
     query = '',
 ): Promise<MemoryResult> {
     const res = await request.get(`${API_BASE}/api/memory${query ? `?${query}` : ''}`, {
-        headers: authedHeaders(token),
+        headers,
     });
     expect(res.status(), `memory body=${await res.text().catch(() => '')}`).toBe(200);
     return res.json();
@@ -236,11 +258,11 @@ async function getMemory(
 
 async function consolidate(
     request: APIRequestContext,
-    token: string,
+    headers: Record<string, string>,
     apply?: boolean,
 ): Promise<ConsolReport> {
     const res = await request.post(`${API_BASE}/api/memory/consolidate`, {
-        headers: authedHeaders(token),
+        headers,
         data: apply === undefined ? {} : { apply },
     });
     expect(res.status(), `consolidate body=${await res.text().catch(() => '')}`).toBe(200);
@@ -253,12 +275,12 @@ function itemById(result: MemoryResult, id: string): MemoryItem | undefined {
 
 async function getWorkDocRaw(
     request: APIRequestContext,
-    token: string,
+    headers: Record<string, string>,
     workId: string,
     docId: string,
 ): Promise<{ status: number; body: Record<string, unknown> }> {
     const res = await request.get(`${API_BASE}/api/works/${workId}/kb/documents/${docId}`, {
-        headers: authedHeaders(token),
+        headers,
     });
     const body = res.status() === 200 ? ((await res.json()) as Record<string, unknown>) : {};
     return { status: res.status(), body };
@@ -273,8 +295,8 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
     test('a per-Work KB doc surfaces in org Memory with a coherent id and the aggregation-only projection (no body / no locked)', async ({
         request,
     }) => {
-        const { token, orgId, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, orgId, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/notes.md',
             title: `Research Notes ${stamp()}`,
             class: 'research',
@@ -290,7 +312,7 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
         expect(typeof doc.body).toBe('string');
 
         // The org Memory item is the SAME row, projected as an aggregation item.
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         const item = itemById(mem, doc.id);
         expect(item, 'the Work KB doc must surface in org Memory').toBeTruthy();
         expect(item!.title).toBe(doc.title);
@@ -317,8 +339,8 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
     test('an org-level inheritable doc is DUAL-projected: Memory (workId null) + the Work inheritable resolution; a non-inheritable org class is rejected and never surfaces', async ({
         request,
     }) => {
-        const { token, orgId, workId } = await buildChain(request);
-        const orgDoc = await createOrgDoc(request, token, orgId, {
+        const { headers, orgId, workId } = await buildChain(request);
+        const orgDoc = await createOrgDoc(request, headers, orgId, {
             path: 'legal/privacy.md',
             title: `Privacy ${stamp()}`,
             class: 'legal',
@@ -328,7 +350,7 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
         expect(orgDoc.organizationId).toBe(orgId);
 
         // Projection 1: the org doc appears in Memory with a null Work.
-        const mem = await getMemory(request, token, 'type=legal');
+        const mem = await getMemory(request, headers, 'type=legal');
         const memItem = itemById(mem, orgDoc.id);
         expect(memItem, 'org doc must surface in Memory').toBeTruthy();
         expect(memItem!.workId).toBeNull();
@@ -339,7 +361,7 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
         // the Work in that org (full KbDocumentDto array).
         const inh = await request.get(
             `${API_BASE}/api/works/${workId}/kb/inheritable?orgId=${orgId}`,
-            { headers: authedHeaders(token) },
+            { headers },
         );
         expect(inh.status()).toBe(200);
         const inherited = (await inh.json()) as Array<{
@@ -356,31 +378,31 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
         // A foreign orgId on the inheritable route is walled off (403).
         const foreign = await request.get(
             `${API_BASE}/api/works/${workId}/kb/inheritable?orgId=${UNKNOWN_UUID}`,
-            { headers: authedHeaders(token) },
+            { headers },
         );
         expect(foreign.status()).toBe(403);
 
         // A non-inheritable org class is rejected outright and never surfaces.
         const bad = await request.post(`${API_BASE}/api/organizations/${orgId}/kb/documents`, {
-            headers: authedHeaders(token),
+            headers,
             data: { path: 'research/x.md', title: 'X', class: 'research', body: 'nope' },
         });
         expect(bad.status()).toBe(400);
-        const memAfter = await getMemory(request, token);
+        const memAfter = await getMemory(request, headers);
         expect(memAfter.documents.every((d) => d.class !== 'research')).toBe(true);
     });
 
     test('the ?work filter isolates the Work rows and DROPS org-level rows, while the per-Work KB list shows only that Work — the chain projected two ways', async ({
         request,
     }) => {
-        const { token, orgId, workId } = await buildChain(request);
-        const workDoc = await createKbDoc(request, token, workId, {
+        const { headers, orgId, workId } = await buildChain(request);
+        const workDoc = await createKbDoc(request, headers, workId, {
             path: 'research/w.md',
             title: `WorkDoc ${stamp()}`,
             class: 'research',
             body: 'work scoped document body with several distinct words in it here now',
         });
-        const orgDoc = await createOrgDoc(request, token, orgId, {
+        const orgDoc = await createOrgDoc(request, headers, orgId, {
             path: 'seo/meta.md',
             title: `OrgSeo ${stamp()}`,
             class: 'seo',
@@ -388,21 +410,21 @@ test.describe('KB → Memory chain — one document across surfaces', () => {
         });
 
         // Unfiltered: both the Work doc and the org doc are present.
-        const all = await getMemory(request, token);
+        const all = await getMemory(request, headers);
         expect(all.documents.map((d) => d.id)).toEqual(
             expect.arrayContaining([workDoc.id, orgDoc.id]),
         );
 
         // ?work=WORK: the org-level row is DROPPED (a Work selection is about
         // Work documents), leaving only the Work doc.
-        const byWork = await getMemory(request, token, `work=${workId}`);
+        const byWork = await getMemory(request, headers, `work=${workId}`);
         expect(byWork.documents.map((d) => d.id)).toContain(workDoc.id);
         expect(byWork.documents.map((d) => d.id)).not.toContain(orgDoc.id);
 
         // The per-Work KB list shows the Work's own doc (never the org row,
         // which has workId null).
         const list = await request.get(`${API_BASE}/api/works/${workId}/kb/documents`, {
-            headers: authedHeaders(token),
+            headers,
         });
         expect(list.status()).toBe(200);
         const listed = (await list.json()) as
@@ -419,9 +441,9 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
     test('a PATCH title on the per-Work doc relabels the Memory item (q finds the new title, misses the old)', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
+        const { headers, workId } = await buildChain(request);
         const oldTitle = `OldName ${stamp()}`;
-        const doc = await createKbDoc(request, token, workId, {
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/t.md',
             title: oldTitle,
             class: 'research',
@@ -431,7 +453,7 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
             {
-                headers: authedHeaders(token),
+                headers,
                 data: { title: newTitle },
             },
         );
@@ -441,7 +463,7 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         // The Memory feed relabels: a lexical q on the new title finds it…
         const hit = await getMemory(
             request,
-            token,
+            headers,
             `q=${encodeURIComponent(newTitle.split(' ')[0])}`,
         );
         expect(hit.documents.map((d) => d.id)).toContain(doc.id);
@@ -449,7 +471,7 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         // …and the old title no longer matches.
         const miss = await getMemory(
             request,
-            token,
+            headers,
             `q=${encodeURIComponent(oldTitle.split(' ')[0])}`,
         );
         expect(miss.documents.map((d) => d.id)).not.toContain(doc.id);
@@ -458,14 +480,14 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
     test('a PATCH class re-buckets the Memory TYPE facet and the item agrees on the new class', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/c.md',
             title: `Classy ${stamp()}`,
             class: 'research',
             body: 'a document that will be reclassified from research to glossary soon',
         });
-        expect((await getMemory(request, token)).facets.types).toContainEqual({
+        expect((await getMemory(request, headers)).facets.types).toContainEqual({
             value: 'research',
             label: 'research',
             count: 1,
@@ -474,14 +496,14 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
             {
-                headers: authedHeaders(token),
+                headers,
                 data: { class: 'glossary' },
             },
         );
         expect(patch.status()).toBe(200);
         expect((await patch.json()).class).toBe('glossary');
 
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         expect(mem.facets.types).toContainEqual({ value: 'glossary', label: 'glossary', count: 1 });
         expect(mem.facets.types.map((f) => f.value)).not.toContain('research');
         expect(itemById(mem, doc.id)!.class).toBe('glossary');
@@ -490,8 +512,8 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
     test('a PATCH status active→archived keeps the doc in the feed (no default status gate) and moves the status facet + filters', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'style/s.md',
             title: `Styleful ${stamp()}`,
             class: 'style',
@@ -500,14 +522,14 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
             {
-                headers: authedHeaders(token),
+                headers,
                 data: { status: 'archived' },
             },
         );
         expect(patch.status()).toBe(200);
 
         // Default feed has NO status gate: the archived doc still surfaces.
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         expect(itemById(mem, doc.id)!.status).toBe('archived');
         expect(mem.facets.statuses).toContainEqual({
             value: 'archived',
@@ -516,10 +538,10 @@ test.describe('Per-Work KB edits re-project into Memory', () => {
         });
         // ?status=archived finds it; ?status=draft does not.
         expect(
-            (await getMemory(request, token, 'status=archived')).documents.map((d) => d.id),
+            (await getMemory(request, headers, 'status=archived')).documents.map((d) => d.id),
         ).toContain(doc.id);
         expect(
-            (await getMemory(request, token, 'status=draft')).documents.map((d) => d.id),
+            (await getMemory(request, headers, 'status=draft')).documents.map((d) => d.id),
         ).not.toContain(doc.id);
     });
 });
@@ -529,8 +551,8 @@ test.describe('Lock / restore / history as chain hops', () => {
     test('full-lock a surfaced doc → it STILL surfaces in Memory; PATCH+DELETE gate 403; unlock reopens PATCH; the Memory item never carries a lock field', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/lock.md',
             title: `Lockable ${stamp()}`,
             class: 'research',
@@ -539,7 +561,7 @@ test.describe('Lock / restore / history as chain hops', () => {
 
         const lock = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/lock`,
-            { headers: authedHeaders(token), data: { mode: 'full' } },
+            { headers, data: { mode: 'full' } },
         );
         expect(lock.status()).toBe(200);
         const locked = (await lock.json()) as KbDoc;
@@ -547,7 +569,7 @@ test.describe('Lock / restore / history as chain hops', () => {
         expect(locked.lockMode).toBe('full');
 
         // Still in Memory (no locked facet), and the item exposes no lock field.
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         const item = itemById(mem, doc.id);
         expect(item).toBeTruthy();
         expect('locked' in item!).toBe(false);
@@ -557,26 +579,26 @@ test.describe('Lock / restore / history as chain hops', () => {
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
             {
-                headers: authedHeaders(token),
+                headers,
                 data: { body: 'blocked edit' },
             },
         );
         expect(patch.status()).toBe(403);
         const del = await request.delete(`${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`, {
-            headers: authedHeaders(token),
+            headers,
         });
         expect(del.status()).toBe(403);
 
         // Unlock reopens editing.
         const unlock = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/unlock`,
-            { headers: authedHeaders(token) },
+            { headers },
         );
         expect(unlock.status()).toBe(200);
         expect((await unlock.json()).locked).toBe(false);
         const patch2 = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
-            { headers: authedHeaders(token), data: { title: `Reopened ${stamp()}` } },
+            { headers, data: { title: `Reopened ${stamp()}` } },
         );
         expect(patch2.status()).toBe(200);
     });
@@ -584,8 +606,8 @@ test.describe('Lock / restore / history as chain hops', () => {
     test('additions-only lock still allows a body PATCH and the doc keeps surfacing; an off-enum mode → 400; a non-UUID docId → 400', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'glossary/g.md',
             title: `Additive ${stamp()}`,
             class: 'glossary',
@@ -593,7 +615,7 @@ test.describe('Lock / restore / history as chain hops', () => {
         });
         const lock = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/lock`,
-            { headers: authedHeaders(token), data: { mode: 'additions-only' } },
+            { headers, data: { mode: 'additions-only' } },
         );
         expect(lock.status()).toBe(200);
         expect((await lock.json()).lockMode).toBe('additions-only');
@@ -602,23 +624,23 @@ test.describe('Lock / restore / history as chain hops', () => {
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}`,
             {
-                headers: authedHeaders(token),
+                headers,
                 data: { body: 'appended body under additions-only lock' },
             },
         );
         expect(patch.status()).toBe(200);
-        expect((await getMemory(request, token)).documents.map((d) => d.id)).toContain(doc.id);
+        expect((await getMemory(request, headers)).documents.map((d) => d.id)).toContain(doc.id);
 
         // Off-enum lock mode → 400 with the enum message.
         const badMode = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/lock`,
-            { headers: authedHeaders(token), data: { mode: 'nonsense' } },
+            { headers, data: { mode: 'nonsense' } },
         );
         expect(badMode.status()).toBe(400);
         // Non-UUID docId is rejected at the ParseUUIDPipe.
         const badId = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/not-a-uuid/lock`,
-            { headers: authedHeaders(token), data: { mode: 'full' } },
+            { headers, data: { mode: 'full' } },
         );
         expect(badId.status()).toBe(400);
     });
@@ -626,8 +648,8 @@ test.describe('Lock / restore / history as chain hops', () => {
     test('restore + history are git-gated (repoless) → 409, yet the doc + its Memory surfacing survive; a non-hex commitSha → 400 before the git hop', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/r.md',
             title: `Restorable ${stamp()}`,
             class: 'research',
@@ -638,7 +660,7 @@ test.describe('Lock / restore / history as chain hops', () => {
         // account → NoGitCredentials 409 (tolerate the repoless failure band).
         const restore = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/restore`,
-            { headers: authedHeaders(token), data: { commitSha: 'abc1234' } },
+            { headers, data: { commitSha: 'abc1234' } },
         );
         expect([409, 400, 404, 500, 503]).toContain(restore.status());
         expect(restore.status()).toBe(409);
@@ -646,22 +668,22 @@ test.describe('Lock / restore / history as chain hops', () => {
         // The history read is git-gated the same way.
         const history = await request.get(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/history`,
-            { headers: authedHeaders(token) },
+            { headers },
         );
         expect([409, 400, 404, 500, 503]).toContain(history.status());
 
         // A symbolic / non-hex ref is rejected at the DTO BEFORE the git hop.
         const badSha = await request.post(
             `${API_BASE}/api/works/${workId}/kb/documents/${doc.id}/restore`,
-            { headers: authedHeaders(token), data: { commitSha: 'HEAD~1' } },
+            { headers, data: { commitSha: 'HEAD~1' } },
         );
         expect(badSha.status()).toBe(400);
 
         // The failed git hops changed nothing: the doc still reads (200) and
         // still surfaces in Memory.
-        const read = await getWorkDocRaw(request, token, workId, doc.id);
+        const read = await getWorkDocRaw(request, headers, workId, doc.id);
         expect(read.status).toBe(200);
-        expect((await getMemory(request, token)).documents.map((d) => d.id)).toContain(doc.id);
+        expect((await getMemory(request, headers)).documents.map((d) => d.id)).toContain(doc.id);
     });
 });
 
@@ -670,21 +692,21 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
     test('a bare POST is a dry-run: it COMPUTES the supersede pair it would create, yet writes NOTHING (every feed marker stays null)', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const a = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const a = await createKbDoc(request, headers, workId, {
             path: 'research/d1.md',
             title: `Twin ${stamp()}`,
             class: 'research',
             body: DUP_BODY,
         });
-        const b = await createKbDoc(request, token, workId, {
+        const b = await createKbDoc(request, headers, workId, {
             path: 'research/d2.md',
             title: 'Twin',
             class: 'research',
             body: DUP_BODY,
         });
 
-        const report = await consolidate(request, token); // bare POST
+        const report = await consolidate(request, headers); // bare POST
         expect(report.dryRun).toBe(true);
         expect(report.scanned).toBe(2);
         expect(report.superseded).toBe(1);
@@ -697,34 +719,34 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
         expect(report.notes.some((n) => /dry run/i.test(n))).toBe(true);
 
         // …but NO marker is persisted — the feed stays clean.
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         expect(mem.documents.every((d) => d.consolidation === null)).toBe(true);
     });
 
     test('apply persists the report’s markers ONLY on the Memory item (loser superseded → survivor; survivor promoted with a numeric score); the per-Work DTO carries no marker', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        const a = await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        const a = await createKbDoc(request, headers, workId, {
             path: 'research/e1.md',
             title: `Echo ${stamp()}`,
             class: 'research',
             body: DUP_BODY,
         });
-        const b = await createKbDoc(request, token, workId, {
+        const b = await createKbDoc(request, headers, workId, {
             path: 'research/e2.md',
             title: 'Echo',
             class: 'research',
             body: DUP_BODY,
         });
 
-        const report = await consolidate(request, token, true);
+        const report = await consolidate(request, headers, true);
         expect(report.dryRun).toBe(false);
         expect(report.superseded).toBe(1);
         const [loserId, survivorId] = report.details.supersededPairs[0];
         expect(report.details.promotedIds).toContain(survivorId);
 
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         const loser = itemById(mem, loserId)!;
         const survivor = itemById(mem, survivorId)!;
 
@@ -743,8 +765,8 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
 
         // The marker lives ONLY on the aggregation projection — the per-Work
         // KB doc DTO exposes no `consolidation` key on either row.
-        const loserRaw = await getWorkDocRaw(request, token, workId, loserId);
-        const survivorRaw = await getWorkDocRaw(request, token, workId, survivorId);
+        const loserRaw = await getWorkDocRaw(request, headers, workId, loserId);
+        const survivorRaw = await getWorkDocRaw(request, headers, workId, survivorId);
         expect(loserRaw.status).toBe(200);
         expect('consolidation' in loserRaw.body).toBe(false);
         expect('consolidation' in survivorRaw.body).toBe(false);
@@ -755,39 +777,39 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
     test('the superseded loser is NEVER deleted: still in the feed (state superseded), still GET-able per-Work (200), and an unrelated edit leaves the marker intact', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        await createKbDoc(request, headers, workId, {
             path: 'research/f1.md',
             title: `Fox ${stamp()}`,
             class: 'research',
             body: DUP_BODY,
         });
-        await createKbDoc(request, token, workId, {
+        await createKbDoc(request, headers, workId, {
             path: 'research/f2.md',
             title: 'Fox',
             class: 'research',
             body: DUP_BODY,
         });
-        const report = await consolidate(request, token, true);
+        const report = await consolidate(request, headers, true);
         const [loserId] = report.details.supersededPairs[0];
 
         // Still surfaced with the superseded state.
-        const before = itemById(await getMemory(request, token), loserId)!;
+        const before = itemById(await getMemory(request, headers), loserId)!;
         expect(before.consolidation!.state).toBe('superseded');
         const runAtBefore = before.consolidation!.runAt;
 
         // Still fully readable via the per-Work route (never hard-deleted).
-        const read = await getWorkDocRaw(request, token, workId, loserId);
+        const read = await getWorkDocRaw(request, headers, workId, loserId);
         expect(read.status).toBe(200);
         expect(read.body.id).toBe(loserId);
 
         // An unrelated per-Work metadata edit does not disturb the marker.
         const patch = await request.patch(
             `${API_BASE}/api/works/${workId}/kb/documents/${loserId}`,
-            { headers: authedHeaders(token), data: { title: `Fox Renamed ${stamp()}` } },
+            { headers, data: { title: `Fox Renamed ${stamp()}` } },
         );
         expect(patch.status()).toBe(200);
-        const after = itemById(await getMemory(request, token), loserId)!;
+        const after = itemById(await getMemory(request, headers), loserId)!;
         expect(after.consolidation!.state).toBe('superseded');
         expect(after.consolidation!.supersededById).toBe(before.consolidation!.supersededById);
         expect(after.consolidation!.runAt).toBe(runAtBefore);
@@ -796,49 +818,49 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
     test('apply is idempotent (a re-run supersedes 0 and the marker is stable); distinct docs apply to all-promoted / none-superseded', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        await createKbDoc(request, headers, workId, {
             path: 'research/g1.md',
             title: `Golf ${stamp()}`,
             class: 'research',
             body: DUP_BODY,
         });
-        await createKbDoc(request, token, workId, {
+        await createKbDoc(request, headers, workId, {
             path: 'research/g2.md',
             title: 'Golf',
             class: 'research',
             body: DUP_BODY,
         });
-        const first = await consolidate(request, token, true);
+        const first = await consolidate(request, headers, true);
         expect(first.superseded).toBe(1);
         const [loserId, survivorId] = first.details.supersededPairs[0];
 
         // Re-apply: the already-superseded loser is left alone (0 new
         // supersedes), the survivor stays promoted.
-        const second = await consolidate(request, token, true);
+        const second = await consolidate(request, headers, true);
         expect(second.superseded).toBe(0);
-        const after = itemById(await getMemory(request, token), loserId)!;
+        const after = itemById(await getMemory(request, headers), loserId)!;
         expect(after.consolidation!.state).toBe('superseded');
         expect(after.consolidation!.supersededById).toBe(survivorId);
 
         // A chain of two DISTINCT docs → both promoted, none superseded.
         const distinct = await buildChain(request);
-        await createKbDoc(request, distinct.token, distinct.workId, {
+        await createKbDoc(request, distinct.headers, distinct.workId, {
             path: 'research/h1.md',
             title: `Alpha ${stamp()}`,
             class: 'research',
             body: 'astronomy and stars in the deep night sky above the quiet ocean',
         });
-        await createKbDoc(request, distinct.token, distinct.workId, {
+        await createKbDoc(request, distinct.headers, distinct.workId, {
             path: 'glossary/h2.md',
             title: `Beta ${stamp()}`,
             class: 'glossary',
             body: 'geology and tectonic plates shifting beneath the vast continents',
         });
-        const distinctReport = await consolidate(request, distinct.token, true);
+        const distinctReport = await consolidate(request, distinct.headers, true);
         expect(distinctReport.superseded).toBe(0);
         expect(distinctReport.promoted).toBe(2);
-        const distinctMem = await getMemory(request, distinct.token);
+        const distinctMem = await getMemory(request, distinct.headers);
         expect(distinctMem.documents.every((d) => d.consolidation?.state === 'promoted')).toBe(
             true,
         );
@@ -847,16 +869,16 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
     test('a 3-cluster of a non-inheritable class supersedes 2 with an “inheritable classes” note and synthesized:0 (keyless-safe)', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
+        const { headers, workId } = await buildChain(request);
         for (const n of ['x1', 'x2', 'x3']) {
-            await createKbDoc(request, token, workId, {
+            await createKbDoc(request, headers, workId, {
                 path: `research/${n}.md`,
                 title: `Cluster ${stamp()}`,
                 class: 'research',
                 body: DUP_BODY,
             });
         }
-        const report = await consolidate(request, token); // dry-run is enough
+        const report = await consolidate(request, headers); // dry-run is enough
         expect(report.scanned).toBe(3);
         // survivor + 2 losers → 2 supersede pairs sharing one survivor.
         expect(report.superseded).toBe(2);
@@ -875,13 +897,13 @@ test.describe('Consolidation markers project onto Memory, not the per-Work DTO',
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
 
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, authedHeaders(token));
         expect(mem.documents).toEqual([]);
         expect(mem.counts).toEqual({ documents: 0, indexed: 0 });
         expect(mem.facets).toEqual({ types: [], works: [], statuses: [], sources: [] });
 
         for (const apply of [undefined, false, true] as const) {
-            const report = await consolidate(request, token, apply);
+            const report = await consolidate(request, authedHeaders(token), apply);
             expect(report.scanned).toBe(0);
             expect(report.promoted).toBe(0);
             expect(report.superseded).toBe(0);
@@ -897,46 +919,46 @@ test.describe('Cross-surface isolation + scope stability', () => {
         request,
     }) => {
         const owner = await buildChain(request);
-        const ownerDoc = await createKbDoc(request, owner.token, owner.workId, {
+        const ownerDoc = await createKbDoc(request, owner.headers, owner.workId, {
             path: 'research/secret.md',
             title: `Secret ${stamp()}`,
             class: 'research',
             body: 'confidential research the stranger must never see in their feed',
         });
         // Owner applies markers.
-        await createKbDoc(request, owner.token, owner.workId, {
+        await createKbDoc(request, owner.headers, owner.workId, {
             path: 'research/secret2.md',
             title: 'Secret',
             class: 'research',
             body: DUP_BODY,
         });
-        await createKbDoc(request, owner.token, owner.workId, {
+        await createKbDoc(request, owner.headers, owner.workId, {
             path: 'research/secret3.md',
             title: 'Secret',
             class: 'research',
             body: DUP_BODY,
         });
-        await consolidate(request, owner.token, true);
+        await consolidate(request, owner.headers, true);
 
         // A stranger with their own org sees NONE of it.
         const stranger = await buildChain(request);
-        const strangerMem = await getMemory(request, stranger.token);
+        const strangerMem = await getMemory(request, stranger.headers);
         expect(strangerMem.documents.map((d) => d.id)).not.toContain(ownerDoc.id);
 
         // The stranger's consolidate is bounded to their own (single-doc,
         // no-dup) org — it never touches the owner's chain.
-        await createKbDoc(request, stranger.token, stranger.workId, {
+        await createKbDoc(request, stranger.headers, stranger.workId, {
             path: 'research/mine.md',
             title: `Mine ${stamp()}`,
             class: 'research',
             body: 'the strangers own solitary document with unique content here',
         });
-        const strangerReport = await consolidate(request, stranger.token, true);
+        const strangerReport = await consolidate(request, stranger.headers, true);
         expect(strangerReport.superseded).toBe(0);
         expect(strangerReport.details.supersededPairs).toEqual([]);
 
         // The owner's markers are untouched by the stranger's run.
-        const ownerMem = await getMemory(request, owner.token);
+        const ownerMem = await getMemory(request, owner.headers);
         expect(ownerMem.documents.some((d) => d.consolidation?.state === 'superseded')).toBe(true);
     });
 
@@ -944,7 +966,7 @@ test.describe('Cross-surface isolation + scope stability', () => {
         request,
     }) => {
         const owner = await buildChain(request);
-        await createKbDoc(request, owner.token, owner.workId, {
+        await createKbDoc(request, owner.headers, owner.workId, {
             path: 'research/o.md',
             title: `Owned ${stamp()}`,
             class: 'research',
@@ -975,7 +997,7 @@ test.describe('Cross-surface isolation + scope stability', () => {
 
         // Cross-tenant Memory is EMPTY, not an error (the stranger with no org
         // gets the zeroed aggregation — never the owner's rows).
-        const mem = await getMemory(request, stranger.access_token);
+        const mem = await getMemory(request, authedHeaders(stranger.access_token));
         expect(mem.documents).toEqual([]);
     });
 
@@ -983,7 +1005,7 @@ test.describe('Cross-surface isolation + scope stability', () => {
         request,
     }) => {
         const owner = await buildChain(request);
-        const ownerDoc = await createKbDoc(request, owner.token, owner.workId, {
+        const ownerDoc = await createKbDoc(request, owner.headers, owner.workId, {
             path: 'research/p.md',
             title: `Peer ${stamp()}`,
             class: 'research',
@@ -993,13 +1015,13 @@ test.describe('Cross-surface isolation + scope stability', () => {
         // A different user filters THEIR memory by the owner's Work id → the
         // intersect drops it (never widens beyond the caller's own org).
         const other = await buildChain(request);
-        await createKbDoc(request, other.token, other.workId, {
+        await createKbDoc(request, other.headers, other.workId, {
             path: 'research/mine.md',
             title: `OtherOwn ${stamp()}`,
             class: 'research',
             body: 'the other users own doc which is the only thing they may see here',
         });
-        const filtered = await getMemory(request, other.token, `work=${owner.workId}`);
+        const filtered = await getMemory(request, other.headers, `work=${owner.workId}`);
         expect(filtered.documents.map((d) => d.id)).not.toContain(ownerDoc.id);
         expect(filtered.documents).toEqual([]);
 
@@ -1014,23 +1036,23 @@ test.describe('Cross-surface isolation + scope stability', () => {
         ).toBe(401);
     });
 
-    test('creating a SECOND Organization does not flip the active Memory scope — the feed keeps surfacing the first org’s chain', async ({
+    test('creating a SECOND Organization does not alter an explicitly pinned Memory scope — the feed keeps surfacing the first org’s chain', async ({
         request,
     }) => {
-        const { token, orgId, workId } = await buildChain(request);
-        const doc = await createKbDoc(request, token, workId, {
+        const { token, headers, orgId, workId } = await buildChain(request);
+        const doc = await createKbDoc(request, headers, workId, {
             path: 'research/first.md',
             title: `FirstOrg ${stamp()}`,
             class: 'research',
             body: 'a document authored in the first organization that must stay visible',
         });
-        expect((await getMemory(request, token)).documents.map((d) => d.id)).toContain(doc.id);
+        expect((await getMemory(request, headers)).documents.map((d) => d.id)).toContain(doc.id);
 
-        // Mint a SECOND org (no docs). The active scope is the validated
-        // last-active org (org #1), not the newest — so the feed is unchanged.
+        // Mint a SECOND org (no docs). The explicit header remains pinned to
+        // org #1, so mutable navigation preference cannot change this request.
         const second = await createOrganizationViaAPI(request, token, `Second Org ${stamp()}`);
         expect(second.id).not.toBe(orgId);
-        const mem = await getMemory(request, token);
+        const mem = await getMemory(request, headers);
         expect(mem.documents.map((d) => d.id)).toContain(doc.id);
         expect(mem.counts.documents).toBeGreaterThanOrEqual(1);
     });
@@ -1041,14 +1063,14 @@ test.describe('Validation guards along the chain', () => {
     test('Memory query guards: unknown type/status/source enum → 400; limit 0 and limit 201 → 400; a valid limit caps the page while counts.documents holds', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
-        await createKbDoc(request, token, workId, {
+        const { headers, workId } = await buildChain(request);
+        await createKbDoc(request, headers, workId, {
             path: 'research/v1.md',
             title: `V1 ${stamp()}`,
             class: 'research',
             body: 'first document of two used to prove the limit caps the page not the count',
         });
-        await createKbDoc(request, token, workId, {
+        await createKbDoc(request, headers, workId, {
             path: 'glossary/v2.md',
             title: `V2 ${stamp()}`,
             class: 'glossary',
@@ -1063,14 +1085,14 @@ test.describe('Validation guards along the chain', () => {
             'limit=201',
         ]) {
             const res = await request.get(`${API_BASE}/api/memory?${bad}`, {
-                headers: authedHeaders(token),
+                headers,
             });
             expect(res.status(), `expected 400 for ?${bad}`).toBe(400);
         }
 
         // A valid limit caps the returned page while counts.documents stays
         // the TRUE match total (2), not the page length (1).
-        const capped = await getMemory(request, token, 'limit=1');
+        const capped = await getMemory(request, headers, 'limit=1');
         expect(capped.documents).toHaveLength(1);
         expect(capped.counts.documents).toBe(2);
     });
@@ -1078,11 +1100,11 @@ test.describe('Validation guards along the chain', () => {
     test('Consolidate + KB body guards: apply string/number → 400, unknown property → 400, malformed workId → 400, unknown docId → 404', async ({
         request,
     }) => {
-        const { token, workId } = await buildChain(request);
+        const { headers, workId } = await buildChain(request);
 
         for (const bad of [{ apply: 'yes' }, { apply: 1 }, { bogusField: true }]) {
             const res = await request.post(`${API_BASE}/api/memory/consolidate`, {
-                headers: authedHeaders(token),
+                headers,
                 data: bad,
             });
             expect(res.status(), `expected 400 for ${JSON.stringify(bad)}`).toBe(400);
@@ -1090,20 +1112,20 @@ test.describe('Validation guards along the chain', () => {
 
         // Malformed workId in a KB route → 400 at the ParseUUIDPipe.
         const malformed = await request.get(`${API_BASE}/api/works/not-a-uuid/kb/documents`, {
-            headers: authedHeaders(token),
+            headers,
         });
         expect(malformed.status()).toBe(400);
 
         // A well-formed but unknown docId → 404.
         const unknown = await request.get(
             `${API_BASE}/api/works/${workId}/kb/documents/${UNKNOWN_UUID}`,
-            { headers: authedHeaders(token) },
+            { headers },
         );
         expect(unknown.status()).toBe(404);
 
         // A KB path that does not start with a known class folder → 400.
         const badPath = await request.post(`${API_BASE}/api/works/${workId}/kb/documents`, {
-            headers: authedHeaders(token),
+            headers,
             data: { path: 'toplevel.md', title: 'X', class: 'research', body: 'body' },
         });
         expect(badPath.status()).toBe(400);

--- a/apps/web/src/lib/ai/tools/schedule.tools.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.ts
@@ -30,7 +30,25 @@ export const setSchedule = tool({
         const result = await updateWorkSchedule(workId, {
             enable,
             cadence: cadenceMap[cadence ?? 'weekly'],
-            billingMode: WorkScheduleBillingMode.USAGE,
+            // 🛑 SUBSCRIPTION, matching the entity default
+            // (work-schedule.entity.ts:48). This used to hardcode USAGE, so
+            // EVERY schedule the assistant created was silently pay-per-use —
+            // a billing mode the user never chose and is never shown.
+            //
+            // That is not cosmetic. `billingMode === USAGE` currently skips two
+            // entitlement gates: SubscriptionService.requiresUsageBilling
+            // returns false for it (so a cadence the plan does not allow is
+            // permitted), and WorkScheduleService.validateRunEntitlement returns
+            // true immediately (so the plan's active-schedule cap is not
+            // applied). Both are justified in-code by "assuming they can pay" —
+            // but BillingProvider.recordUsageCharge is a no-op on every
+            // provider, so nobody ever pays. Asking the assistant to set up a
+            // schedule therefore granted unmetered capacity.
+            //
+            // This restores the default only. The bypass itself is still open
+            // and is tracked separately; flipping it would pause existing
+            // usage-mode schedules, which needs an owner decision.
+            billingMode: WorkScheduleBillingMode.SUBSCRIPTION,
             maxFailureBeforePause: 3,
         });
         return { success: result.success, message: result.message, error: result.error };

--- a/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
@@ -1,10 +1,22 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { WorkScheduleBillingMode } from '@/lib/api/enums';
 
-const updateWorkSchedule = vi.fn(async () => ({ success: true, message: 'ok' }));
+type ScheduleUpdatePayload = Record<string, unknown> & {
+    billingMode: WorkScheduleBillingMode;
+};
+type UpdateWorkScheduleMock = (
+    workId: string,
+    payload: ScheduleUpdatePayload,
+) => Promise<{ success: boolean; message: string }>;
+
+const updateWorkSchedule = vi.fn<UpdateWorkScheduleMock>(async () => ({
+    success: true,
+    message: 'ok',
+}));
 
 vi.mock('@/app/actions/dashboard/work-schedule', () => ({
-    updateWorkSchedule: (...args: unknown[]) => updateWorkSchedule(...(args as [])),
+    updateWorkSchedule: (...args: Parameters<UpdateWorkScheduleMock>) =>
+        updateWorkSchedule(...args),
     runWorkSchedule: vi.fn(),
     cancelWorkSchedule: vi.fn(),
 }));
@@ -37,30 +49,30 @@ describe('setSchedule — billing mode is not silently upgraded', () => {
 
     it('sends SUBSCRIPTION, never USAGE', async () => {
         const { setSchedule } = await import('./schedule.tools');
-        await (setSchedule as unknown as {
-            execute: (a: Record<string, unknown>) => Promise<unknown>;
-        }).execute({ workId: 'w1', enable: true, cadence: 'daily' });
+        await (
+            setSchedule as unknown as {
+                execute: (a: Record<string, unknown>) => Promise<unknown>;
+            }
+        ).execute({ workId: 'w1', enable: true, cadence: 'daily' });
 
         expect(updateWorkSchedule).toHaveBeenCalledTimes(1);
-        const payload = updateWorkSchedule.mock.calls[0]![1] as {
-            billingMode: WorkScheduleBillingMode;
-        };
+        const payload = updateWorkSchedule.mock.calls[0]![1];
         expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
         expect(payload.billingMode).not.toBe(WorkScheduleBillingMode.USAGE);
     });
 
     it('holds for every cadence, including the default when none is given', async () => {
         const { setSchedule } = await import('./schedule.tools');
-        const exec = (setSchedule as unknown as {
-            execute: (a: Record<string, unknown>) => Promise<unknown>;
-        }).execute;
+        const exec = (
+            setSchedule as unknown as {
+                execute: (a: Record<string, unknown>) => Promise<unknown>;
+            }
+        ).execute;
 
         for (const cadence of ['hourly', 'daily', 'weekly', 'monthly', undefined]) {
             updateWorkSchedule.mockClear();
             await exec({ workId: 'w1', enable: true, cadence });
-            const payload = updateWorkSchedule.mock.calls[0]![1] as {
-                billingMode: WorkScheduleBillingMode;
-            };
+            const payload = updateWorkSchedule.mock.calls[0]![1];
             expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
         }
     });

--- a/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/schedule.tools.unit.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { WorkScheduleBillingMode } from '@/lib/api/enums';
+
+const updateWorkSchedule = vi.fn(async () => ({ success: true, message: 'ok' }));
+
+vi.mock('@/app/actions/dashboard/work-schedule', () => ({
+    updateWorkSchedule: (...args: unknown[]) => updateWorkSchedule(...(args as [])),
+    runWorkSchedule: vi.fn(),
+    cancelWorkSchedule: vi.fn(),
+}));
+
+/**
+ * The assistant must not pick a billing mode the user never chose.
+ *
+ * `setSchedule` hardcoded `billingMode: USAGE`, so every schedule created by
+ * asking the assistant was silently pay-per-use. That is not a cosmetic
+ * mislabel — `billingMode === USAGE` currently skips BOTH entitlement gates:
+ *
+ *   - `SubscriptionService.requiresUsageBilling` returns false for it, so a
+ *     cadence the user's plan does not allow is permitted;
+ *   - `WorkScheduleService.validateRunEntitlement` returns true immediately,
+ *     so the plan's active-schedule cap is never applied.
+ *
+ * Both are justified in-code by "assuming they can pay", but
+ * `BillingProvider.recordUsageCharge` is a no-op on every provider — nobody
+ * ever pays. So the assistant was handing out unmetered capacity.
+ *
+ * `billingMode` is REQUIRED by the action's Zod schema
+ * (`work-schedule.ts:25`), so this cannot be fixed by omitting the field; the
+ * value has to be right. This pins it to the entity default
+ * (`work-schedule.entity.ts:48`).
+ */
+describe('setSchedule — billing mode is not silently upgraded', () => {
+    beforeEach(() => {
+        updateWorkSchedule.mockClear();
+    });
+
+    it('sends SUBSCRIPTION, never USAGE', async () => {
+        const { setSchedule } = await import('./schedule.tools');
+        await (setSchedule as unknown as {
+            execute: (a: Record<string, unknown>) => Promise<unknown>;
+        }).execute({ workId: 'w1', enable: true, cadence: 'daily' });
+
+        expect(updateWorkSchedule).toHaveBeenCalledTimes(1);
+        const payload = updateWorkSchedule.mock.calls[0]![1] as {
+            billingMode: WorkScheduleBillingMode;
+        };
+        expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
+        expect(payload.billingMode).not.toBe(WorkScheduleBillingMode.USAGE);
+    });
+
+    it('holds for every cadence, including the default when none is given', async () => {
+        const { setSchedule } = await import('./schedule.tools');
+        const exec = (setSchedule as unknown as {
+            execute: (a: Record<string, unknown>) => Promise<unknown>;
+        }).execute;
+
+        for (const cadence of ['hourly', 'daily', 'weekly', 'monthly', undefined]) {
+            updateWorkSchedule.mockClear();
+            await exec({ workId: 'w1', enable: true, cadence });
+            const payload = updateWorkSchedule.mock.calls[0]![1] as {
+                billingMode: WorkScheduleBillingMode;
+            };
+            expect(payload.billingMode).toBe(WorkScheduleBillingMode.SUBSCRIPTION);
+        }
+    });
+});

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -293,6 +293,9 @@ export const authAPI = {
             data,
             method: 'POST',
             wrapInData: false,
+            // Email callbacks live under /api and intentionally bypass the
+            // workspace proxy. Authentication tokens are never org-scoped.
+            publicRouteScope: 'personal',
         });
     },
 
@@ -323,6 +326,7 @@ export const authAPI = {
     validatePasswordResetToken: async (token: string) => {
         return serverFetch<TokenValidationResponse>(
             `/auth/validate-reset-token?token=${encodeURIComponent(token)}`,
+            { publicRouteScope: 'personal' },
         );
     },
 

--- a/apps/web/src/lib/api/server-api.ts
+++ b/apps/web/src/lib/api/server-api.ts
@@ -95,6 +95,8 @@ export async function getFrontendUrl(): Promise<string> {
 
 interface ServerFetchOptions extends RequestInit {
     rawResponse?: boolean;
+    /** Public server routes outside the workspace proxy may opt into personal scope only. */
+    publicRouteScope?: 'personal';
 }
 
 export async function serverFetch<T>(
@@ -102,12 +104,13 @@ export async function serverFetch<T>(
     options: ServerFetchOptions = {},
 ): Promise<T> {
     const requestHeaders = await headers();
-    const selectedScope = parseWorkspaceSelector(
-        requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER),
-    );
+    const { rawResponse, publicRouteScope, ...fetchOptions } = options;
+    const selectedScope =
+        publicRouteScope === 'personal'
+            ? { kind: 'personal' as const }
+            : parseWorkspaceSelector(requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER));
     const frontendUrl = await getFrontendUrl();
     const t = await getTranslations('api.errors');
-    const { rawResponse, ...fetchOptions } = options;
 
     const doFetch = async (authToken?: string) => {
         const reqHeaders = new Headers(fetchOptions.headers);
@@ -242,16 +245,19 @@ export async function serverMutation<T>({
     method = 'POST',
     wrapInData = false,
     headers,
+    publicRouteScope,
 }: {
     endpoint: string;
     data: any;
     method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     wrapInData: boolean;
     headers?: Record<string, string>;
+    publicRouteScope?: 'personal';
 }): Promise<T> {
     return serverFetch<T>(endpoint, {
         method,
         headers,
         body: JSON.stringify(wrapInData ? { data } : data),
+        publicRouteScope,
     });
 }

--- a/apps/web/src/lib/api/server-api.unit.spec.ts
+++ b/apps/web/src/lib/api/server-api.unit.spec.ts
@@ -67,6 +67,20 @@ describe('serverFetch workspace scope transport', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 
+    it('allows a server-owned public auth call to select personal scope explicitly', async () => {
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+
+        await serverFetch('/auth/verify-email', {
+            method: 'POST',
+            body: '{}',
+            publicRouteScope: 'personal',
+        });
+
+        const init = vi.mocked(fetch).mock.calls[0][1];
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+        expect(init).not.toHaveProperty('publicRouteScope');
+    });
+
     it.each([
         ['ever', '/org/ever/dashboard'],
         [null, '/'],

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -612,6 +612,26 @@ describe('agent/config', () => {
             expect(config.subscriptions.isEnabled()).toBe(false);
         });
 
+        describe('bypassSeatLimitsInE2E', () => {
+            it('is off by default and requires the literal true flag outside production', () => {
+                process.env.NODE_ENV = 'test';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+
+                process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(true);
+
+                process.env.E2E_BYPASS_SEAT_LIMITS = '1';
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+            });
+
+            it('is hard-gated off in production even when the flag is set', () => {
+                process.env.NODE_ENV = 'production';
+                process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+
+                expect(config.subscriptions.bypassSeatLimitsInE2E()).toBe(false);
+            });
+        });
+
         describe('scheduledUpdatesEnabled (default-on)', () => {
             it('defaults to true when unset', () => {
                 expect(config.subscriptions.scheduledUpdatesEnabled()).toBe(true);

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -499,6 +499,23 @@ export const config = {
                 process.env.SUBSCRIPTIONS_ALLOW_SELF_SERVE_PAID === 'true'
             );
         },
+        /**
+         * E2E-only fixture escape hatch for seat-consuming setup writes.
+         *
+         * The sharded suite enables subscriptions so billing scenarios can
+         * exercise real plan behavior, but its unrelated scenarios create
+         * agents and members for fresh users. A fresh free user already uses
+         * the plan's one seat, so those fixture writes otherwise fail with a
+         * 402 before the behavior under test is reached.
+         *
+         * Production ignores this value even if it is configured by mistake.
+         */
+        bypassSeatLimitsInE2E() {
+            return (
+                process.env.NODE_ENV !== 'production' &&
+                process.env.E2E_BYPASS_SEAT_LIMITS === 'true'
+            );
+        },
         scheduledUpdatesEnabled() {
             return process.env.SCHEDULED_UPDATES_ENABLED !== 'false';
         },

--- a/packages/agent/src/subscriptions/billing/seats.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/seats.service.spec.ts
@@ -131,6 +131,7 @@ function makeHarness(
 
 afterEach(() => {
     delete process.env.SUBSCRIPTIONS_ENABLED;
+    delete process.env.E2E_BYPASS_SEAT_LIMITS;
 });
 
 describe('SeatsService.getSeats', () => {
@@ -212,6 +213,15 @@ describe('SeatsService.getSeats', () => {
 });
 
 describe('SeatsService.assertSeatAvailable', () => {
+    it('bypasses seat admission only through the non-production E2E escape hatch', async () => {
+        process.env.NODE_ENV = 'test';
+        process.env.E2E_BYPASS_SEAT_LIMITS = 'true';
+        const h = makeHarness({ members: 99, agents: 99 });
+
+        await expect(h.service.assertSeatAvailable('owner-1')).resolves.toBeUndefined();
+        expect(h.userSubscriptionRepository.findActiveByUser).not.toHaveBeenCalled();
+    });
+
     it('admits while a seat is left and refuses when the next one would exceed the allowance', async () => {
         const full = makeHarness({ members: 10, agents: 4 }); // 14 used, allowance 10
         await expect(full.service.assertSeatAvailable('owner-1')).rejects.toBeInstanceOf(

--- a/packages/agent/src/subscriptions/billing/seats.service.ts
+++ b/packages/agent/src/subscriptions/billing/seats.service.ts
@@ -132,7 +132,9 @@ export class SeatsService {
      * agent). Fail-open on every axis except a genuinely full allowance.
      */
     async assertSeatAvailable(ownerUserId: string, count = 1): Promise<void> {
-        if (!config.subscriptions.isEnabled()) return;
+        if (!config.subscriptions.isEnabled() || config.subscriptions.bypassSeatLimitsInE2E()) {
+            return;
+        }
         let seats: SeatsView;
         try {
             seats = await this.getSeats(ownerUserId);

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -333,11 +333,23 @@ export class CreditLedgerService {
 
     /**
      * Daily free-credit sweep (RPC target of the `credits-daily-grant`
-     * cron, 00:05 UTC). For every active user, on EVERY plan, tops the
-     * balance back UP TO the plan's `daily-free-credits` level (platform
-     * default 50) — non-accumulating per the PRD: a balance already at or
-     * above the level receives nothing. Idempotency key
-     * `daily:{userId}:{date}` makes cron re-runs a no-op.
+     * cron, 00:05 UTC). For every active user, on EVERY plan, GRANTS the
+     * plan's `daily-free-credits` level (platform default 50). Idempotency
+     * key `daily:{userId}:{date}` makes cron re-runs a no-op.
+     *
+     * 🛑 This is ADDITIVE and does NOT expire. It is not a top-up to a
+     * ceiling, whatever the PRD says — see the long comment in
+     * `grantDailyForPlan` for why the `maxBalanceAfter` ceiling was removed
+     * (it silently denied the advertised daily credits to paid tiers and to
+     * anyone who had BOUGHT a credit pack). An idle free user therefore
+     * accrues 50 credits/day without bound, which is a deliberate, accepted
+     * consequence and NOT an oversight.
+     *
+     * This docstring previously described the removed ceiling behaviour and
+     * claimed the grant was "non-accumulating" — the exact opposite of what
+     * the code does. Corrected 2026-08-25. Whether accrual should be bounded
+     * is EW-753; if it ever is, bound it by lot expiry or by a cap scoped to
+     * `DAILY_FREE` buckets, never by a total-balance ceiling.
      */
     async dispatchDailyGrants(now: Date = new Date()): Promise<DailyGrantSummary> {
         const summary: DailyGrantSummary = {


### PR DESCRIPTION
Promotes the complete reviewed \stage\ branch to \main\ with no cherry-picks.

Stage merge #2270 is tree-identical to \develop@349fcff7551f185adf25ffbc465150e3e1cd1f08\ and includes #2264–#2269. The 15-file content diff has no schema, migration, data, or secret change.

Per owner direction, this production promotion will not wait on queued CI/CD. Runtime verification follows the merge.