### PR TITLE
fix(ci): run the /login guard before the unit suite so it can actually execute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,6 @@ jobs:
         if: steps.scope.outputs.code == 'true'
         run: pnpm build --filter=!./apps/docs
 
-      - name: run test on all packages
-        if: steps.scope.outputs.code == 'true'
-        run: pnpm test
-
       # --- Regression guard: the /login locale-rewrite defect class -----------
       #
       # On 2026-08-24 `app.ever.works/login` was down ~8.5 h. FIVE fixes were
@@ -355,6 +351,10 @@ jobs:
           pkill -f "next start -p $BITE_PORT" 2>/dev/null || true
 
           exit $rc
+
+      - name: run test on all packages
+        if: steps.scope.outputs.code == 'true'
+        run: pnpm test
 
       - name: Build Internal CLI
         if: steps.scope.outputs.code == 'true'


### PR DESCRIPTION
## The guard from #2246 has never run

It was placed **after** `run test on all packages`. GitHub skips remaining steps once one fails, so any unit-test failure skips it — and `lint-and-test` currently fails on clean `develop` (`fleet-agent-task-dispatch.spec.ts`, 9 of 18, pre-existing and unrelated). Net effect: **skipped on every run.**

Confirmed on the first completed run after #2246 merged ([`32774859701`](https://github.com/ever-works/ever-works/actions/runs/32774859701)):

```
 9. success  Build all packages
10. failure  run test on all packages
11. skipped  Guard: /login renders behind a foreign authority
```

A step that cannot execute protects nothing. #2246 shipped carrying the exact defect it was written to eliminate — my error in placing it.

## The fix

Move it between `Build all packages` and the unit suite. It needs only `apps/web/.next`, which the build produces. Gating a boundary-crossing smoke check behind the whole unit suite is wrong independently of today's breakage: **an unrelated red test should not disable the check guarding an 8.5-hour outage class.**

**Pure move** — the diff is the 4-line test step relocating after the guard (4 insertions / 4 deletions). The step body is untouched, including the hardening from `11b5bb896`:

| | |
|---|---|
| `if ! code=$(curl …)` fix | PRESENT |
| `BITE_CODE = 200` bite check | PRESENT |
| `000` vacuity branch | PRESENT |
| two-port design | PRESENT |

## Verification

Extracted the step from the **new** `ci.yml` and ran it verbatim:

```
guard   (foreign authority + https) -> 200|no|yes   [want 200|no|yes]
control (no forwarded headers)      -> 200|no|yes   [want 200|no|yes]
bite    (legacy override enabled)   -> 500|no|no    bite proof OK
exit 0
```

## Note on merging

`lint-and-test` cannot go green on this PR either, for the same pre-existing fleet-spec reason. That failure is what this PR works around, not something it introduces — and after this lands the guard will execute even when the suite is red, which is the entire point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reordered continuous integration checks so the `/login` regression guard runs before the aggregate package test suite.
  * Preserved the existing conditions for running the broader test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->