### PR TITLE
chore(release): promote stage to main — /login guard runs before the unit suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,6 @@ jobs:
         if: steps.scope.outputs.code == 'true'
         run: pnpm build --filter=!./apps/docs
 
-      - name: run test on all packages
-        if: steps.scope.outputs.code == 'true'
-        run: pnpm test
-
       # --- Regression guard: the /login locale-rewrite defect class -----------
       #
       # On 2026-08-24 `app.ever.works/login` was down ~8.5 h. FIVE fixes were
@@ -355,6 +351,10 @@ jobs:
           pkill -f "next start -p $BITE_PORT" 2>/dev/null || true
 
           exit $rc
+
+      - name: run test on all packages
+        if: steps.scope.outputs.code == 'true'
+        run: pnpm test
 
       - name: Build Internal CLI
         if: steps.scope.outputs.code == 'true'


### PR DESCRIPTION
Whole-branch cascade (no cherry-picks). Carries #2272.

The /login regression guard added in #2246 had never executed: it sat after `run test on all packages`, and GitHub skips remaining steps once one fails — with `lint-and-test` failing on clean develop for a pre-existing fleet-spec reason, it was skipped on every run. This moves it before the unit suite.

Workflow-file change only — no source, no tests, no runtime impact on any deployed service.