### PR TITLE
feat(billing): shared Stripe webhook relay — one endpoint routed to 15 directories (relay phase 3)

### DIFF
--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -8,6 +8,7 @@ import { PlanCheckoutController } from './plan-checkout.controller';
 import { PaymentMethodController } from './payment-method.controller';
 import { PaygController } from './payg.controller';
 import { SeatsController } from './seats.controller';
+import { StripeRelayModule } from './stripe-relay/stripe-relay.module';
 
 /**
  * The money path (billing PRD B5) — thin API module over the agent-side
@@ -32,7 +33,15 @@ import { SeatsController } from './seats.controller';
  * read-only payment-method summary on `GET /api/billing/overview`.
  */
 @Module({
-    imports: [AuthModule, AgentSubscriptionsModule, OrganizationsModule],
+    imports: [
+        AuthModule,
+        AgentSubscriptionsModule,
+        OrganizationsModule,
+        // The SHARED Stripe webhook relay (relay phase 3) — one Stripe endpoint
+        // that routes each event to the directory that owns it. Ships dark
+        // behind STRIPE_RELAY_ENABLED; additive beside the receiver above.
+        StripeRelayModule,
+    ],
     controllers: [
         BillingController,
         CreditsCheckoutController,

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -128,6 +128,21 @@ describe('StripeRelayService', () => {
             expect(outcome).toMatchObject({ status: 'unroutable', reason: 'ssrf_blocked' });
             expect(global.fetch).not.toHaveBeenCalled();
         });
+
+        it('fails closed when NODE_ENV is missing rather than treating it as local', async () => {
+            delete process.env.NODE_ENV;
+            (isSafeWebhookUrl as jest.Mock).mockReturnValue(false);
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_missing_env', { metadata: { work_id: WORK_ID } }),
+            );
+            const { service } = makeService();
+
+            expect(await service.handle('{}', 'sig')).toMatchObject({
+                status: 'unroutable',
+                reason: 'ssrf_blocked',
+            });
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
     });
 
     describe('routing', () => {
@@ -224,7 +239,7 @@ describe('StripeRelayService', () => {
             [502, 'retry'],
             [401, 'retry'], // stale secret — a re-sync may fix it inside the window
             [409, 'unroutable'], // our routing bug; retrying repeats it
-            [503, 'unroutable'], // site up, sync never injected — needs a redeploy
+            [503, 'retry'], // can come from ingress/site outage; status alone is not a trusted permanent signal
             [400, 'unroutable'], // malformed body is not fixable by retrying
             [200, 'forwarded'],
         ])('site answers %i -> %s', async (siteStatus, expected) => {

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -50,11 +50,13 @@ function makeService(overrides?: {
     decryptThrows?: boolean;
 }) {
     const workRepository = {
-        findById: jest.fn().mockResolvedValue(
-            overrides && 'work' in overrides
-                ? overrides.work
-                : { id: WORK_ID, website: SITE, platformSyncSecretEncrypted: 'enc' },
-        ),
+        findById: jest
+            .fn()
+            .mockResolvedValue(
+                overrides && 'work' in overrides
+                    ? overrides.work
+                    : { id: WORK_ID, website: SITE, platformSyncSecretEncrypted: 'enc' },
+            ),
     };
     const secretService = {
         decryptForWork: jest.fn(() => {
@@ -62,10 +64,7 @@ function makeService(overrides?: {
             return overrides && 'secret' in overrides ? overrides.secret : SECRET;
         }),
     };
-    const service = new StripeRelayService(
-        workRepository as never,
-        secretService as never,
-    );
+    const service = new StripeRelayService(workRepository as never, secretService as never);
     return { service, workRepository, secretService };
 }
 
@@ -151,7 +150,9 @@ describe('StripeRelayService', () => {
             // over `${ts}:${sha256(body)}:${workId}` with the per-Work secret.
             const ts = init.headers['x-platform-ts'];
             const expected = createHmac('sha256', SECRET)
-                .update(`${ts}:${createHash('sha256').update(raw, 'utf8').digest('hex')}:${WORK_ID}`)
+                .update(
+                    `${ts}:${createHash('sha256').update(raw, 'utf8').digest('hex')}:${WORK_ID}`,
+                )
                 .digest('hex');
             expect(init.headers.Authorization).toBe(`Bearer ${expected}`);
         });
@@ -233,7 +234,9 @@ describe('StripeRelayService', () => {
         });
 
         it('retries a network failure rather than dropping a paid event', async () => {
-            (global.fetch as jest.Mock).mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.1'));
+            (global.fetch as jest.Mock).mockRejectedValue(
+                new Error('connect ECONNREFUSED 10.0.0.1'),
+            );
             const { service } = makeService();
             expect(await service.handle('{}', 'sig')).toMatchObject({
                 status: 'retry',

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -1,0 +1,288 @@
+import { createHash, createHmac } from 'crypto';
+import {
+    StripeRelayNotConfiguredError,
+    StripeRelayService,
+    StripeRelaySignatureError,
+    extractWorkId,
+} from '../stripe-relay.service';
+
+/**
+ * The relay's job is ROUTING and RETRY CLASSIFICATION — getting either wrong
+ * loses a customer's payment or replays it forever. These tests therefore assert
+ * the decision for each real failure shape, and lead with the cases that must be
+ * REFUSED rather than the happy path.
+ *
+ * Stripe verification itself is delegated to the official SDK and is exercised
+ * here only through the two boundaries the relay owns: fail-closed when
+ * unconfigured, and one undifferentiated error when verification fails.
+ */
+
+// The workspace barrels must be mocked BEFORE the service is imported.
+// `@ever-works/agent/services` re-exports the data generator, which imports the
+// ESM-only `p-map` — pulling it in makes the suite fail to LOAD (0 tests run,
+// which reads as 'no failures'). Same pattern as the sibling
+// `directory-website-client.service.spec.ts`.
+jest.mock('@ever-works/agent/services', () => ({
+    PlatformSyncSecretService: class {},
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    WorkRepository: class {},
+}));
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    constructStripeEvent: jest.fn(),
+}));
+jest.mock('@ever-works/agent/utils', () => ({
+    isSafeWebhookUrl: jest.fn(() => true),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { constructStripeEvent } = require('@ever-works/agent/subscriptions');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { isSafeWebhookUrl } = require('@ever-works/agent/utils');
+
+const WORK_ID = 'work-123';
+const SECRET = 'per-work-secret';
+const SITE = 'https://directory.example.com';
+
+function makeService(overrides?: {
+    work?: unknown;
+    secret?: string | null;
+    decryptThrows?: boolean;
+}) {
+    const workRepository = {
+        findById: jest.fn().mockResolvedValue(
+            overrides && 'work' in overrides
+                ? overrides.work
+                : { id: WORK_ID, website: SITE, platformSyncSecretEncrypted: 'enc' },
+        ),
+    };
+    const secretService = {
+        decryptForWork: jest.fn(() => {
+            if (overrides?.decryptThrows) throw new Error('bad key');
+            return overrides && 'secret' in overrides ? overrides.secret : SECRET;
+        }),
+    };
+    const service = new StripeRelayService(
+        workRepository as never,
+        secretService as never,
+    );
+    return { service, workRepository, secretService };
+}
+
+const event = (id: string, object: Record<string, unknown>) => ({
+    id,
+    type: 'customer.subscription.created',
+    data: { object },
+});
+
+describe('StripeRelayService', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env = { ...OLD_ENV, STRIPE_RELAY_WEBHOOK_SECRET: 'whsec_test' };
+        (isSafeWebhookUrl as jest.Mock).mockReturnValue(true);
+        global.fetch = jest.fn();
+    });
+    afterAll(() => {
+        process.env = OLD_ENV;
+    });
+
+    describe('refusals', () => {
+        it('FAILS CLOSED when no relay signing secret is configured', async () => {
+            delete process.env.STRIPE_RELAY_WEBHOOK_SECRET;
+            const { service } = makeService();
+            await expect(service.handle('{}', 'sig')).rejects.toBeInstanceOf(
+                StripeRelayNotConfiguredError,
+            );
+            // Never touched the payload or the network.
+            expect(constructStripeEvent).not.toHaveBeenCalled();
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it('rejects a delivery with no signature header', async () => {
+            const { service } = makeService();
+            await expect(service.handle('{}', undefined)).rejects.toBeInstanceOf(
+                StripeRelaySignatureError,
+            );
+            expect(constructStripeEvent).not.toHaveBeenCalled();
+        });
+
+        it('rejects a bad signature without echoing the SDK message', async () => {
+            (constructStripeEvent as jest.Mock).mockImplementation(() => {
+                throw new Error('No signatures found matching the expected signature for payload');
+            });
+            const { service } = makeService();
+            await expect(service.handle('{}', 'sig')).rejects.toThrow(
+                'Webhook signature verification failed',
+            );
+        });
+
+        it('refuses to sign for an SSRF-unsafe website, so the secret never leaves', async () => {
+            process.env.NODE_ENV = 'production';
+            (isSafeWebhookUrl as jest.Mock).mockReturnValue(false);
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_1', { metadata: { work_id: WORK_ID } }),
+            );
+            const { service } = makeService();
+            const outcome = await service.handle('{}', 'sig');
+            expect(outcome).toMatchObject({ status: 'unroutable', reason: 'ssrf_blocked' });
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('routing', () => {
+        it('forwards to the owning directory with a signature over the RAW body', async () => {
+            const raw = JSON.stringify(event('evt_2', { metadata: { work_id: WORK_ID } }));
+            (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));
+            (global.fetch as jest.Mock).mockResolvedValue({ status: 200 });
+            const { service } = makeService();
+
+            const outcome = await service.handle(raw, 'sig');
+            expect(outcome).toMatchObject({ status: 'forwarded', workId: WORK_ID });
+
+            const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+            expect(url).toBe(`${SITE}/api/stripe/platform-webhook`);
+            // Byte-for-byte: re-serialising would change the digest and 401.
+            expect(init.body).toBe(raw);
+            expect(init.redirect).toBe('manual');
+
+            // The signature must be reproducible by the directory: it is an HMAC
+            // over `${ts}:${sha256(body)}:${workId}` with the per-Work secret.
+            const ts = init.headers['x-platform-ts'];
+            const expected = createHmac('sha256', SECRET)
+                .update(`${ts}:${createHash('sha256').update(raw, 'utf8').digest('hex')}:${WORK_ID}`)
+                .digest('hex');
+            expect(init.headers.Authorization).toBe(`Bearer ${expected}`);
+        });
+
+        it('binds the signature to the work id, so it cannot be replayed elsewhere', async () => {
+            const raw = JSON.stringify(event('evt_3', { metadata: { work_id: WORK_ID } }));
+            (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));
+            (global.fetch as jest.Mock).mockResolvedValue({ status: 200 });
+            const { service } = makeService();
+            await service.handle(raw, 'sig');
+
+            const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+            const ts = init.headers['x-platform-ts'];
+            const forAnotherWork = createHmac('sha256', SECRET)
+                .update(
+                    `${ts}:${createHash('sha256').update(raw, 'utf8').digest('hex')}:another-work`,
+                )
+                .digest('hex');
+            expect(init.headers.Authorization).not.toBe(`Bearer ${forAnotherWork}`);
+        });
+
+        it.each([
+            ['no work_id at all', {}, 'no_work_id'],
+            ['a work that does not exist', { metadata: { work_id: 'ghost' } }, 'unknown_work'],
+        ])('is unroutable (not retried) for %s', async (_label, object, reason) => {
+            (constructStripeEvent as jest.Mock).mockReturnValue(event('evt_4', object));
+            const { service } = makeService(reason === 'unknown_work' ? { work: null } : undefined);
+            const outcome = await service.handle('{}', 'sig');
+            expect(outcome).toMatchObject({ status: 'unroutable', reason });
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it('is unroutable when the Work has no deployed website', async () => {
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_5', { metadata: { work_id: WORK_ID } }),
+            );
+            const { service } = makeService({ work: { id: WORK_ID, website: null } });
+            expect(await service.handle('{}', 'sig')).toMatchObject({
+                status: 'unroutable',
+                reason: 'not_deployed',
+            });
+        });
+
+        it('is unroutable when the per-Work secret is missing or undecryptable', async () => {
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_6', { metadata: { work_id: WORK_ID } }),
+            );
+            expect(await makeService({ secret: null }).service.handle('{}', 'sig')).toMatchObject({
+                reason: 'not_provisioned',
+            });
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_7', { metadata: { work_id: WORK_ID } }),
+            );
+            expect(
+                await makeService({ decryptThrows: true }).service.handle('{}', 'sig'),
+            ).toMatchObject({ reason: 'secret_undecryptable' });
+        });
+    });
+
+    describe('retry classification — what Stripe is told to do', () => {
+        beforeEach(() => {
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_8', { metadata: { work_id: WORK_ID } }),
+            );
+        });
+
+        it.each([
+            [500, 'retry'],
+            [502, 'retry'],
+            [401, 'retry'], // stale secret — a re-sync may fix it inside the window
+            [409, 'unroutable'], // our routing bug; retrying repeats it
+            [503, 'unroutable'], // site up, sync never injected — needs a redeploy
+            [400, 'unroutable'], // malformed body is not fixable by retrying
+            [200, 'forwarded'],
+        ])('site answers %i -> %s', async (siteStatus, expected) => {
+            (global.fetch as jest.Mock).mockResolvedValue({ status: siteStatus });
+            const { service } = makeService();
+            expect((await service.handle('{}', 'sig')).status).toBe(expected);
+        });
+
+        it('retries a network failure rather than dropping a paid event', async () => {
+            (global.fetch as jest.Mock).mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.1'));
+            const { service } = makeService();
+            expect(await service.handle('{}', 'sig')).toMatchObject({
+                status: 'retry',
+                reason: 'network',
+            });
+        });
+    });
+
+    describe('isEnabled', () => {
+        it('is OFF unless explicitly switched on', () => {
+            const { service } = makeService();
+            delete process.env.STRIPE_RELAY_ENABLED;
+            expect(service.isEnabled()).toBe(false);
+            process.env.STRIPE_RELAY_ENABLED = 'false';
+            expect(service.isEnabled()).toBe(false);
+            process.env.STRIPE_RELAY_ENABLED = 'true';
+            expect(service.isEnabled()).toBe(true);
+        });
+    });
+});
+
+describe('extractWorkId', () => {
+    it('reads the object metadata first', () => {
+        expect(extractWorkId({ data: { object: { metadata: { work_id: 'w1' } } } })).toBe('w1');
+    });
+
+    it('falls back to invoice subscription_details, which is where invoice.* carries it', () => {
+        expect(
+            extractWorkId({
+                data: { object: { subscription_details: { metadata: { work_id: 'w2' } } } },
+            }),
+        ).toBe('w2');
+    });
+
+    it('falls back to a line item', () => {
+        expect(
+            extractWorkId({
+                data: { object: { lines: { data: [{}, { metadata: { work_id: 'w3' } }] } } },
+            }),
+        ).toBe('w3');
+    });
+
+    it('returns null rather than guessing when nothing carries a key', () => {
+        expect(extractWorkId({ data: { object: { metadata: {} } } })).toBeNull();
+        expect(extractWorkId({})).toBeNull();
+    });
+
+    it('ignores blank and non-string values instead of routing to ""', () => {
+        expect(extractWorkId({ data: { object: { metadata: { work_id: '   ' } } } })).toBeNull();
+        expect(extractWorkId({ data: { object: { metadata: { work_id: 42 } } } })).toBeNull();
+    });
+});

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -286,6 +286,18 @@ describe('extractWorkId', () => {
         ).toBe('w2');
     });
 
+    it('reads Stripe v18 invoice parent.subscription_details metadata', () => {
+        expect(
+            extractWorkId({
+                data: {
+                    object: {
+                        parent: { subscription_details: { metadata: { work_id: 'w-v18' } } },
+                    },
+                },
+            }),
+        ).toBe('w-v18');
+    });
+
     it('falls back to a line item', () => {
         expect(
             extractWorkId({

--- a/apps/api/src/billing/stripe-relay/stripe-relay.controller.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { Public } from '../../auth/decorators/public.decorator';
+import { Public } from '@src/auth/decorators/public.decorator';
 import {
     StripeRelayNotConfiguredError,
     StripeRelayService,

--- a/apps/api/src/billing/stripe-relay/stripe-relay.controller.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.controller.ts
@@ -1,0 +1,113 @@
+import {
+    BadRequestException,
+    Controller,
+    Headers,
+    HttpCode,
+    HttpStatus,
+    Logger,
+    NotFoundException,
+    Post,
+    Req,
+    ServiceUnavailableException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../auth/decorators/public.decorator';
+import {
+    StripeRelayNotConfiguredError,
+    StripeRelayService,
+    StripeRelaySignatureError,
+} from './stripe-relay.service';
+
+/**
+ * The ONE Stripe endpoint that serves every Ever Works directory (relay phase 3).
+ *
+ * Stripe caps an account at 16 live webhook endpoints, so per-site endpoints
+ * cannot scale — three directories currently have no slot and run fail-closed.
+ * This receiver verifies Stripe's signature once, resolves the owning directory
+ * from `metadata.work_id`, and forwards the event to that site.
+ *
+ * Posture matches `BillingWebhookController` exactly:
+ *  - **@Public**, because Stripe calls it — authentication is the SIGNATURE.
+ *  - **Raw body** from the bodyParser `verify` hook in `main.ts`; a
+ *    re-serialized body would not match the digest.
+ *  - **FAIL CLOSED**: no relay signing secret configured ⇒ 401 for every
+ *    delivery, including Stripe's own test pings.
+ *  - **Constant-time comparison** inside the official SDK — not hand-rolled.
+ *
+ * Response codes are chosen for what they make Stripe DO:
+ *  - `200` — delivered, or verified-but-unroutable (a retry would deliver the
+ *    same unroutable event forever).
+ *  - `503` — the directory is down / timed out / rejected our signature, so
+ *    Stripe should RETRY (it does for up to 3 days, covering a site outage or
+ *    a secret re-sync). Silently dropping a paid event is the worse failure.
+ *
+ * Ships DARK: `STRIPE_RELAY_ENABLED` is off by default and the route 404s until
+ * it is switched on, so merging this cannot change production behaviour.
+ */
+@ApiTags('Billing')
+@Controller('api/billing')
+export class StripeRelayController {
+    private readonly logger = new Logger(StripeRelayController.name);
+
+    constructor(private readonly relayService: StripeRelayService) {}
+
+    @Public()
+    @Post('stripe-relay')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary:
+            'Shared Stripe webhook relay — verifies once, routes to the owning directory by metadata.work_id.',
+    })
+    @ApiResponse({ status: 200, description: 'Forwarded, or verified but unroutable' })
+    @ApiResponse({ status: 400, description: 'Missing raw payload' })
+    @ApiResponse({ status: 401, description: 'Unconfigured receiver or bad signature' })
+    @ApiResponse({ status: 404, description: 'Relay disabled in this environment' })
+    @ApiResponse({ status: 503, description: 'Directory unreachable — Stripe should retry' })
+    @Throttle({ long: { limit: 300, ttl: 60_000 } })
+    async receive(
+        @Req() req: { rawBody?: string },
+        @Headers('stripe-signature') signature: string | undefined,
+    ) {
+        if (!this.relayService.isEnabled()) {
+            // 404 rather than 403: a disabled relay should be indistinguishable
+            // from a route that does not exist.
+            throw new NotFoundException();
+        }
+        if (!req.rawBody) {
+            throw new BadRequestException('Missing raw request payload');
+        }
+
+        let outcome;
+        try {
+            outcome = await this.relayService.handle(req.rawBody, signature);
+        } catch (error) {
+            if (
+                error instanceof StripeRelayNotConfiguredError ||
+                error instanceof StripeRelaySignatureError
+            ) {
+                // One undifferentiated 401 (house internal-endpoint posture) so
+                // the response cannot be used to probe configuration.
+                throw new UnauthorizedException('Invalid webhook delivery');
+            }
+            throw error;
+        }
+
+        if (outcome.status === 'retry') {
+            // Make Stripe retry. The reason is safe to surface: it names our own
+            // classification, never upstream content.
+            throw new ServiceUnavailableException(`Directory unavailable (${outcome.reason})`);
+        }
+
+        // Log the event id and the routing decision only — never the payload.
+        this.logger.log(
+            outcome.status === 'forwarded'
+                ? `relay ${outcome.eventId} -> ${outcome.workId} (${outcome.siteStatus})`
+                : `relay ${outcome.eventId} unroutable (${outcome.reason})`,
+        );
+        return outcome.status === 'forwarded'
+            ? { received: true, routed: true }
+            : { received: true, routed: false, reason: outcome.reason };
+    }
+}

--- a/apps/api/src/billing/stripe-relay/stripe-relay.module.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { WorkModule } from '@ever-works/agent/services';
+import { AuthModule } from '@src/auth';
+import { StripeRelayController } from './stripe-relay.controller';
+import { StripeRelayService } from './stripe-relay.service';
+
+/**
+ * The shared Stripe webhook relay (relay phase 3).
+ *
+ * Imports mirror `ActivityFeedModule`, the other platform to site caller:
+ * `WorkModule` for `PlatformSyncSecretService` (per-Work signing secret) and
+ * `DatabaseModule` for `WorkRepository` (resolving `work_id` to a Work + its
+ * deployed website). `AuthModule` supplies the guard that `@Public()` opts out
+ * of, matching every other webhook receiver in this app.
+ *
+ * No `HttpModule`: the forwarder uses global `fetch` so it can pin
+ * `redirect: 'manual'` per request and abort on a timeout without adding a
+ * transport dependency.
+ *
+ * Additive — the existing `BillingWebhookController` (the platform's OWN Stripe
+ * receiver on `/api/billing/webhook`) is untouched and keeps its own secret.
+ */
+@Module({
+    imports: [WorkModule, DatabaseModule, AuthModule],
+    controllers: [StripeRelayController],
+    providers: [StripeRelayService],
+    exports: [StripeRelayService],
+})
+export class StripeRelayModule {}

--- a/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
@@ -233,8 +233,14 @@ export function extractWorkId(event: { data?: { object?: unknown } }): string | 
     const direct = read((obj as { metadata?: unknown }).metadata);
     if (direct) return direct;
 
-    // invoice.* — `subscription_details.metadata` carries the subscription's
-    // metadata, and line items carry their own copy.
+    // Stripe v18 invoice.* — the subscription's metadata is nested below
+    // `parent.subscription_details`; older event shapes used the top level.
+    const parentDetails = read(
+        (obj as { parent?: { subscription_details?: { metadata?: unknown } } }).parent
+            ?.subscription_details?.metadata,
+    );
+    if (parentDetails) return parentDetails;
+
     const details = read(
         (obj as { subscription_details?: { metadata?: unknown } }).subscription_details?.metadata,
     );

--- a/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
@@ -146,8 +146,7 @@ export class StripeRelayService {
         // BEFORE signing so the secret never leaves the process for an unsafe
         // target. Local dev/test may legitimately point a Work at http://localhost.
         const env = process.env.NODE_ENV;
-        const isLocalEnv =
-            env === 'development' || env === 'test' || env === undefined || env === '';
+        const isLocalEnv = env === 'development' || env === 'test';
         if (!isLocalEnv && !isSafeWebhookUrl(url)) {
             this.logger.warn(
                 `relay: forward blocked by SSRF guard for work ${workId} (host resolves to a private / loopback / link-local / metadata target)`,
@@ -193,10 +192,6 @@ export class StripeRelayService {
                 `relay: work ${workId} rejected event ${eventId} as belonging to another directory`,
             );
             return { status: 'unroutable', eventId, reason: 'work_mismatch' };
-        }
-        if (response.status === 503) {
-            // Site is up but platform sync was never injected — needs a redeploy.
-            return { status: 'unroutable', eventId, reason: 'site_not_provisioned' };
         }
         if (response.status === 401) {
             // Stale/rotated secret. Retry: a re-sync may fix it within Stripe's

--- a/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
@@ -1,0 +1,260 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, createHmac } from 'crypto';
+import { WorkRepository } from '@ever-works/agent/database';
+import { PlatformSyncSecretService } from '@ever-works/agent/services';
+import { constructStripeEvent } from '@ever-works/agent/subscriptions';
+import { isSafeWebhookUrl } from '@ever-works/agent/utils';
+
+/**
+ * The shared Stripe **webhook relay** (relay phase 3).
+ *
+ * WHY THIS EXISTS
+ *
+ * Stripe caps an account at **16 live webhook endpoints**. Ever Works runs 15
+ * directory sites on ONE shared Stripe account, alongside four platform
+ * endpoints — so per-site endpoints cannot scale, and today three directories
+ * have no slot at all and run fail-closed (they cannot charge).
+ *
+ * The platform therefore owns a SINGLE Stripe endpoint. It verifies Stripe's
+ * signature once, resolves which directory owns the event from
+ * `metadata.work_id`, and forwards the event to that directory's
+ * `/api/stripe/platform-webhook` over the platform to site HMAC channel already
+ * shipped for the activity feed.
+ *
+ * Spec: `knowledge/runbooks/EVER_WORKS_STRIPE_WEBHOOK_RELAY.md` in
+ * `ever-works/workspace`.
+ *
+ * Posture mirrors `DirectoryWebsiteClient` (the other outbound platform to site
+ * caller): SSRF guard BEFORE signing, per-Work secret, work id inside the
+ * signed payload, no redirects, bounded timeout, and never logs a payload.
+ */
+
+/** Bound on how long we wait for a directory before telling Stripe to retry. */
+const FORWARD_TIMEOUT_MS = 10_000;
+
+export type StripeRelayOutcome =
+    /** Delivered to the owning directory. Answer Stripe 200. */
+    | { status: 'forwarded'; eventId: string; workId: string; siteStatus: number }
+    /**
+     * Verified, but we can never route it (no `work_id`, unknown Work, Work has
+     * no deployed site, or the site rejected it as belonging to someone else).
+     * Answer Stripe 200 — a retry would deliver the same unroutable event.
+     */
+    | { status: 'unroutable'; eventId: string; reason: string }
+    /**
+     * Transient: the directory is down, timed out, or rejected our signature.
+     * Answer Stripe 5xx so Stripe RETRIES (it does so for up to 3 days, which
+     * covers a site outage or a secret re-sync).
+     */
+    | { status: 'retry'; eventId: string; reason: string };
+
+export class StripeRelayNotConfiguredError extends Error {}
+export class StripeRelaySignatureError extends Error {}
+
+@Injectable()
+export class StripeRelayService {
+    private readonly logger = new Logger(StripeRelayService.name);
+
+    constructor(
+        private readonly workRepository: WorkRepository,
+        private readonly secretService: PlatformSyncSecretService,
+    ) {}
+
+    /** Off by default — the relay ships dark and is switched on per environment. */
+    isEnabled(): boolean {
+        return process.env.STRIPE_RELAY_ENABLED === 'true';
+    }
+
+    /**
+     * Verify Stripe's signature, resolve the owning directory, and forward.
+     *
+     * @throws StripeRelayNotConfiguredError when no relay signing secret is set
+     *         (FAIL CLOSED — an unconfigured receiver rejects rather than trusts).
+     * @throws StripeRelaySignatureError when verification fails.
+     */
+    async handle(rawBody: string, signature: string | undefined): Promise<StripeRelayOutcome> {
+        const webhookSecret = process.env.STRIPE_RELAY_WEBHOOK_SECRET;
+        if (!webhookSecret) {
+            throw new StripeRelayNotConfiguredError('Relay receiver is not configured');
+        }
+        if (!signature) {
+            throw new StripeRelaySignatureError('Missing webhook signature header');
+        }
+
+        let event: { id: string; type: string; data?: { object?: unknown } };
+        try {
+            event = constructStripeEvent(rawBody, signature, webhookSecret);
+        } catch {
+            // The SDK message can quote header content — never echo it.
+            throw new StripeRelaySignatureError('Webhook signature verification failed');
+        }
+
+        const workId = extractWorkId(event);
+        if (!workId) {
+            // Not an error: platform-owned events (and Stripe's own test pings)
+            // legitimately carry no directory routing key.
+            this.logger.warn(`relay: event ${event.id} (${event.type}) carries no work_id`);
+            return { status: 'unroutable', eventId: event.id, reason: 'no_work_id' };
+        }
+
+        const work = await this.workRepository.findById(workId);
+        if (!work) {
+            this.logger.warn(`relay: event ${event.id} names unknown work ${workId}`);
+            return { status: 'unroutable', eventId: event.id, reason: 'unknown_work' };
+        }
+        if (!work.website) {
+            this.logger.warn(`relay: work ${workId} has no deployed website`);
+            return { status: 'unroutable', eventId: event.id, reason: 'not_deployed' };
+        }
+
+        let secret: string | null;
+        try {
+            secret = this.secretService.decryptForWork(work);
+        } catch (err) {
+            this.logger.warn(
+                `relay: decryptForWork failed for work ${workId}: ${(err as Error).message}`,
+            );
+            return { status: 'unroutable', eventId: event.id, reason: 'secret_undecryptable' };
+        }
+        if (!secret) {
+            // The site was never provisioned with PLATFORM_SYNC_SECRET, so it
+            // would answer 503. Retrying cannot fix that without a redeploy.
+            return { status: 'unroutable', eventId: event.id, reason: 'not_provisioned' };
+        }
+
+        return this.forward(work.id, work.website, secret, rawBody, event.id);
+    }
+
+    /**
+     * POST the VERBATIM raw body to the directory, signed with the per-Work
+     * secret. The body must not be re-serialised: the signature covers a digest
+     * of these exact bytes, and the site recomputes it byte-for-byte.
+     */
+    private async forward(
+        workId: string,
+        website: string,
+        secret: string,
+        rawBody: string,
+        eventId: string,
+    ): Promise<StripeRelayOutcome> {
+        const url = `${stripTrailingSlash(website)}/api/stripe/platform-webhook`;
+
+        // Security (SSRF + signed-bearer leak) — identical reasoning to
+        // DirectoryWebsiteClient: `work.website` is attacker-influenceable (a
+        // tenant's verified custom domain is promoted into it), and the request
+        // below carries an HMAC Bearer header bound to the per-Work secret. Refuse
+        // BEFORE signing so the secret never leaves the process for an unsafe
+        // target. Local dev/test may legitimately point a Work at http://localhost.
+        const env = process.env.NODE_ENV;
+        const isLocalEnv =
+            env === 'development' || env === 'test' || env === undefined || env === '';
+        if (!isLocalEnv && !isSafeWebhookUrl(url)) {
+            this.logger.warn(
+                `relay: forward blocked by SSRF guard for work ${workId} (host resolves to a private / loopback / link-local / metadata target)`,
+            );
+            return { status: 'unroutable', eventId, reason: 'ssrf_blocked' };
+        }
+
+        const timestamp = new Date().toISOString();
+        const bodyDigest = createHash('sha256').update(rawBody, 'utf8').digest('hex');
+        // Same formula the activity feed uses, with the body digest in the slot
+        // the feed fills with its canonical query — so the directory verifies it
+        // with `verifyPlatformSignature` unchanged. The work id is inside the
+        // signed payload, so a signature leaked from one directory cannot be
+        // replayed against another.
+        const hmac = createHmac('sha256', secret)
+            .update(`${timestamp}:${bodyDigest}:${workId}`)
+            .digest('hex');
+
+        let response: Response;
+        try {
+            response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${hmac}`,
+                    'x-platform-ts': timestamp,
+                    'User-Agent': 'ever-works-platform/stripe-relay',
+                },
+                body: rawBody,
+                redirect: 'manual',
+                signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+            });
+        } catch (err) {
+            // Raw messages embed internal IPs/hostnames — keep them server-side.
+            this.logger.warn(`relay: forward to work ${workId} failed: ${(err as Error).message}`);
+            return { status: 'retry', eventId, reason: 'network' };
+        }
+
+        if (response.status === 409) {
+            // The directory says this event's work_id names a DIFFERENT
+            // directory. That is a routing bug on our side; retrying repeats it.
+            this.logger.error(
+                `relay: work ${workId} rejected event ${eventId} as belonging to another directory`,
+            );
+            return { status: 'unroutable', eventId, reason: 'work_mismatch' };
+        }
+        if (response.status === 503) {
+            // Site is up but platform sync was never injected — needs a redeploy.
+            return { status: 'unroutable', eventId, reason: 'site_not_provisioned' };
+        }
+        if (response.status === 401) {
+            // Stale/rotated secret. Retry: a re-sync may fix it within Stripe's
+            // retry window, and silently dropping a paid event is worse.
+            this.logger.error(`relay: work ${workId} rejected our signature for event ${eventId}`);
+            return { status: 'retry', eventId, reason: 'unauthorized' };
+        }
+        if (response.status >= 500) {
+            return { status: 'retry', eventId, reason: `site_${response.status}` };
+        }
+        if (response.status >= 400) {
+            // A malformed body is not fixable by retrying.
+            return { status: 'unroutable', eventId, reason: `site_${response.status}` };
+        }
+
+        this.logger.log(`relay: event ${eventId} -> work ${workId} (site ${response.status})`);
+        return { status: 'forwarded', eventId, workId, siteStatus: response.status };
+    }
+}
+
+/**
+ * Resolve the owning directory from the event.
+ *
+ * 🛑 Stripe does NOT copy a Checkout Session's metadata onto the Subscription or
+ * PaymentIntent it creates, which is why the template stamps
+ * `subscription_data.metadata` / `payment_intent_data.metadata` explicitly
+ * (relay phase 1). The fallbacks below cover invoice shapes, where the routing
+ * key rides on the subscription details or the line items rather than the
+ * invoice itself.
+ */
+export function extractWorkId(event: { data?: { object?: unknown } }): string | null {
+    const obj = (event.data?.object ?? {}) as Record<string, unknown>;
+
+    const read = (bag: unknown): string | null => {
+        const value = (bag as { work_id?: unknown } | undefined)?.work_id;
+        return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+    };
+
+    const direct = read((obj as { metadata?: unknown }).metadata);
+    if (direct) return direct;
+
+    // invoice.* — `subscription_details.metadata` carries the subscription's
+    // metadata, and line items carry their own copy.
+    const details = read(
+        (obj as { subscription_details?: { metadata?: unknown } }).subscription_details?.metadata,
+    );
+    if (details) return details;
+
+    const lines = (obj as { lines?: { data?: Array<{ metadata?: unknown }> } }).lines?.data;
+    if (Array.isArray(lines)) {
+        for (const line of lines) {
+            const fromLine = read(line?.metadata);
+            if (fromLine) return fromLine;
+        }
+    }
+    return null;
+}
+
+function stripTrailingSlash(url: string): string {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+}

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
@@ -98,8 +98,8 @@ describe('fleet agent-task dispatch (AUDIT A46/A24 producer wiring)', () => {
                     Promise.resolve({
                         id,
                         userId,
-                        tenantId: scope.tenantId,
-                        organizationId: scope.organizationId,
+                        tenantId: scope?.tenantId ?? null,
+                        organizationId: scope?.organizationId ?? null,
                     }),
                 ),
             } as never,

--- a/apps/node/src/core/external-uptime-monitor.contract.spec.ts
+++ b/apps/node/src/core/external-uptime-monitor.contract.spec.ts
@@ -23,11 +23,19 @@ async function summaryBlock(): Promise<string> {
 function exerciseSummary(block: string, failingUrls: string) {
 	const shellLiteral = failingUrls.replace(/'/g, `'"'"'`);
 	const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : 'bash';
-	const cleanEnv = { ...process.env };
-	delete cleanEnv.BASH_ENV;
+	// The self-hosted runners may inject Bash startup hooks through either
+	// BASH_ENV or ENV. Give this contract only the OS variables it needs so a
+	// runner profile cannot change the shell semantics under test.
+	const cleanEnv = Object.fromEntries(
+		['PATH', 'HOME', 'SYSTEMROOT', 'COMSPEC', 'PATHEXT', 'TMPDIR', 'TMP', 'TEMP']
+			.map((key) => [key, process.env[key]])
+			.filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+	);
 	return spawnSync(
 		bash,
 		[
+			'--noprofile',
+			'--norc',
 			'-euo',
 			'pipefail',
 			'-c',

--- a/apps/node/src/core/external-uptime-monitor.contract.spec.ts
+++ b/apps/node/src/core/external-uptime-monitor.contract.spec.ts
@@ -23,6 +23,8 @@ async function summaryBlock(): Promise<string> {
 function exerciseSummary(block: string, failingUrls: string) {
 	const shellLiteral = failingUrls.replace(/'/g, `'"'"'`);
 	const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : 'bash';
+	const cleanEnv = { ...process.env };
+	delete cleanEnv.BASH_ENV;
 	return spawnSync(
 		bash,
 		[
@@ -33,7 +35,7 @@ function exerciseSummary(block: string, failingUrls: string) {
 		],
 		{
 			encoding: 'utf8',
-			env: process.env
+			env: cleanEnv
 		}
 	);
 }

--- a/packages/agent/src/subscriptions/billing/stripe-webhook-verify.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-webhook-verify.ts
@@ -1,0 +1,30 @@
+import Stripe from 'stripe';
+
+/**
+ * Verifies a Stripe webhook signature against an ARBITRARY signing secret.
+ *
+ * `StripeBillingProvider.verifyWebhook` exists already, but it is hard-bound to
+ * the platform's own receiver secret (`config.billing.stripe.getWebhookSecret()`).
+ * The shared **relay** endpoint has its own, separate signing secret, so it needs
+ * the same verification with a different key.
+ *
+ * 🛑 Deliberately delegates to the official SDK. `constructEvent` performs the
+ * constant-time HMAC comparison (`secureCompare`) AND the delivery-timestamp
+ * tolerance check. We do not hand-roll the scheme — see the posture notes on
+ * `BillingWebhookController`.
+ *
+ * The API key passed to the constructor is irrelevant here: `constructEvent` is
+ * pure crypto over the raw body and never performs a network call. A placeholder
+ * keeps the relay receiver working on a deployment that verifies-and-forwards
+ * without holding a Stripe secret key of its own.
+ */
+export function constructStripeEvent(
+    rawBody: string | Buffer,
+    signature: string,
+    webhookSecret: string,
+): Stripe.Event {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || 'sk_relay_verification_only');
+    // Throws on any mismatch; callers translate that into one undifferentiated
+    // 401 so the response cannot be used to probe configuration.
+    return stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -10,6 +10,9 @@ export * from './billing/credits-pricing';
 export { estimatePaygCents, getPaygCatalog, paygLookupKey } from './billing/stripe-catalog';
 export type { CatalogPayg, CatalogPaygTier } from './billing/stripe-catalog';
 export * from './billing/stripe-billing.provider';
+// Signature verification against an arbitrary secret — the shared Stripe
+// webhook RELAY has its own signing secret, separate from the platform receiver.
+export * from './billing/stripe-webhook-verify';
 export * from './billing/billing.service';
 export * from './billing/auto-recharge.service';
 // Paid-plan purchase: checkout, return-route sync, activation (audit B24)

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -180,6 +180,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'UsageLedgerService',
                     'BillingProvider',
                     'BillingProviderError',
+                    'BILLING_PROVIDER_ERROR_CODES',
                     'BillingProviderNotConfiguredError',
                     'ManualBillingProvider',
                     // The money path (billing PRD B5)
@@ -191,6 +192,7 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'defaultAutoRechargePack',
                     'estimatePaygCents',
                     'StripeBillingProvider',
+                    'constructStripeEvent',
                     'STRIPE_METADATA_KEYS',
                     'STRIPE_PERPETUAL_LICENCE',
                     'STRIPE_PURCHASE_KINDS',


### PR DESCRIPTION
Stripe caps an account at **16 live webhook endpoints**. Ever Works runs 15 directory sites on one shared Stripe account alongside 4 platform endpoints — so per-site endpoints cannot scale. Measured today: **16/16, 0 free**, and three directories (`sustainable-fashion`, `react-components-hub`, `awesome-rust-tools-and-frameworks`) hold `DISABLED_BY_OPS` placeholders and **cannot charge at all**.

This is the platform side: **one** receiver that verifies Stripe's signature once, resolves the owning directory from `metadata.work_id` (stamped by the template in [phase 1](https://github.com/ever-works/directory-web-template/pull/1033)), and forwards the **verbatim** raw body to that site's `/api/stripe/platform-webhook`.

```
POST /api/billing/stripe-relay
```

## Posture is copied, not invented

| concern | precedent followed |
|---|---|
| receiver | `BillingWebhookController` — `@Public`, raw body, **fail closed** when unconfigured, constant-time compare inside the official SDK |
| forwarder | `DirectoryWebsiteClient` — **SSRF guard before signing** (so the per-Work secret never leaves the process for an unsafe host), work id inside the signed payload, `redirect: 'manual'`, bounded timeout, no payload logged |

## The part worth reviewing: retry classification

The response decides what Stripe **does**:

| directory answers | relay returns | why |
|---|---|---|
| 5xx / timeout / 401 | **503** → Stripe retries | up to 3 days, which covers a site outage or a secret re-sync |
| 409 / 503 / 4xx / unroutable | **200** | retrying redelivers the same unroutable event forever |

Silently dropping a paid event is the worse failure, so ambiguity resolves to **retry**.

## Ships dark

`STRIPE_RELAY_ENABLED` is off by default and the route **404s** until switched on — merging cannot change production behaviour. Nothing removed: the existing `/api/billing/webhook` receiver keeps its own secret and is untouched.

`constructStripeEvent` was added to `packages/agent` because the relay has its **own** signing secret, separate from the platform receiver's, and `stripe` is a dependency of `packages/agent` but not `apps/api`. It delegates to the SDK — nothing hand-rolled.

## Tests: 24, and proven to bite

Inverting the `401 -> retry` decision (a real money-losing bug) turns the suite **red**; reverting turns it green again. The suite also had to be made to **run**: importing the agent services barrel pulls in ESM-only `p-map`, which made it fail to *load* with "0 tests" — the failure mode that reads as success.

## ⚠️ Do not start phase 4 on the strength of this merge

The live account has **0 free slots**, so creating the relay endpoint means **disabling an existing one** — and a directory whose endpoint is disabled has no fulfilment path until the relay actually serves it. Order: merge → deploy → enable → prove in **test mode** → then take **one** live slot at a time. Merged is not deployed, and deployed is not enabled.

Spec: `knowledge/runbooks/EVER_WORKS_STRIPE_WEBHOOK_RELAY.md` in `ever-works/workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared Stripe webhook relay endpoint for securely verifying and forwarding events.
  * Webhooks are routed using work metadata and signed for delivery to the appropriate destination.
  * Added support for configurable signature verification, including modern invoice metadata formats.
  * Added clear handling for invalid, unroutable, unavailable, and retryable webhook deliveries.

* **Bug Fixes**
  * Added safeguards against unsafe destinations and malformed work identifiers.
  * Improved retry handling for temporary forwarding failures, including server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->