### PR TITLE
fix(billing): route legacy managed directory hosts

### DIFF
--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -219,6 +219,29 @@ describe('StripeRelayService', () => {
             );
         });
 
+        it('ignores a stale Vercel placeholder for a managed k8s Work', async () => {
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_placeholder', { metadata: { work_id: WORK_ID } }),
+            );
+            (global.fetch as jest.Mock).mockResolvedValue({ status: 200 });
+            const { service } = makeService({
+                work: {
+                    id: WORK_ID,
+                    slug: 'awesome-rust-tools-and-frameworks',
+                    deployProvider: 'k8s',
+                    website: 'https://awesome-rust-tools-and-frameworks-w.vercel.app',
+                    managedSubdomain: null,
+                    platformSyncSecretEncrypted: 'enc',
+                },
+            });
+
+            expect(await service.handle('{}', 'sig')).toMatchObject({ status: 'forwarded' });
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://awesome-rust-tools-and-frameworks.ever.works/api/stripe/platform-webhook',
+                expect.any(Object),
+            );
+        });
+
         it('binds the signature to the work id, so it cannot be replayed elsewhere', async () => {
             const raw = JSON.stringify(event('evt_3', { metadata: { work_id: WORK_ID } }));
             (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -172,6 +172,53 @@ describe('StripeRelayService', () => {
             expect(init.headers.Authorization).toBe(`Bearer ${expected}`);
         });
 
+        it('routes a legacy managed k8s Work through its canonical slug host when website is null', async () => {
+            delete process.env.EVER_WORKS_DOMAIN;
+            const raw = JSON.stringify(event('evt_legacy', { metadata: { work_id: WORK_ID } }));
+            (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));
+            (global.fetch as jest.Mock).mockResolvedValue({ status: 200 });
+            const { service } = makeService({
+                work: {
+                    id: WORK_ID,
+                    slug: 'awesome-rust-ai-libraries',
+                    deployProvider: 'k8s',
+                    website: null,
+                    managedSubdomain: null,
+                    platformSyncSecretEncrypted: 'enc',
+                },
+            });
+
+            expect(await service.handle(raw, 'sig')).toMatchObject({ status: 'forwarded' });
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://awesome-rust-ai-libraries.ever.works/api/stripe/platform-webhook',
+                expect.objectContaining({ body: raw }),
+            );
+        });
+
+        it('prefers an allocated managed subdomain and respects the configured root domain', async () => {
+            process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
+            (constructStripeEvent as jest.Mock).mockReturnValue(
+                event('evt_managed', { metadata: { work_id: WORK_ID } }),
+            );
+            (global.fetch as jest.Mock).mockResolvedValue({ status: 200 });
+            const { service } = makeService({
+                work: {
+                    id: WORK_ID,
+                    slug: 'legacy-slug',
+                    deployProvider: 'k8s',
+                    website: null,
+                    managedSubdomain: 'Allocated-Name',
+                    platformSyncSecretEncrypted: 'enc',
+                },
+            });
+
+            expect(await service.handle('{}', 'sig')).toMatchObject({ status: 'forwarded' });
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://allocated-name.preview.ever.works/api/stripe/platform-webhook',
+                expect.any(Object),
+            );
+        });
+
         it('binds the signature to the work id, so it cannot be replayed elsewhere', async () => {
             const raw = JSON.stringify(event('evt_3', { metadata: { work_id: WORK_ID } }));
             (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));

--- a/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
+++ b/apps/api/src/billing/stripe-relay/__tests__/stripe-relay.service.spec.ts
@@ -172,7 +172,7 @@ describe('StripeRelayService', () => {
             expect(init.headers.Authorization).toBe(`Bearer ${expected}`);
         });
 
-        it('routes a legacy managed k8s Work through its canonical slug host when website is null', async () => {
+        it('routes a legacy managed k8s Work by slug when website is null', async () => {
             delete process.env.EVER_WORKS_DOMAIN;
             const raw = JSON.stringify(event('evt_legacy', { metadata: { work_id: WORK_ID } }));
             (constructStripeEvent as jest.Mock).mockReturnValue(JSON.parse(raw));
@@ -195,7 +195,7 @@ describe('StripeRelayService', () => {
             );
         });
 
-        it('prefers an allocated managed subdomain and respects the configured root domain', async () => {
+        it('prefers a managed subdomain and respects the configured root domain', async () => {
             process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
             (constructStripeEvent as jest.Mock).mockReturnValue(
                 event('evt_managed', { metadata: { work_id: WORK_ID } }),

--- a/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
@@ -102,7 +102,8 @@ export class StripeRelayService {
             this.logger.warn(`relay: event ${event.id} names unknown work ${workId}`);
             return { status: 'unroutable', eventId: event.id, reason: 'unknown_work' };
         }
-        if (!work.website) {
+        const website = resolveDirectoryWebsite(work);
+        if (!website) {
             this.logger.warn(`relay: work ${workId} has no deployed website`);
             return { status: 'unroutable', eventId: event.id, reason: 'not_deployed' };
         }
@@ -122,7 +123,7 @@ export class StripeRelayService {
             return { status: 'unroutable', eventId: event.id, reason: 'not_provisioned' };
         }
 
-        return this.forward(work.id, work.website, secret, rawBody, event.id);
+        return this.forward(work.id, website, secret, rawBody, event.id);
     }
 
     /**
@@ -140,8 +141,8 @@ export class StripeRelayService {
         const url = `${stripTrailingSlash(website)}/api/stripe/platform-webhook`;
 
         // Security (SSRF + signed-bearer leak) — identical reasoning to
-        // DirectoryWebsiteClient: `work.website` is attacker-influenceable (a
-        // tenant's verified custom domain is promoted into it), and the request
+        // DirectoryWebsiteClient: the resolved website is attacker-influenceable
+        // (a tenant's verified custom domain may be promoted into it), and the request
         // below carries an HMAC Bearer header bound to the per-Work secret. Refuse
         // BEFORE signing so the secret never leaves the process for an unsafe
         // target. Local dev/test may legitimately point a Work at http://localhost.
@@ -210,6 +211,43 @@ export class StripeRelayService {
         this.logger.log(`relay: event ${eventId} -> work ${workId} (site ${response.status})`);
         return { status: 'forwarded', eventId, workId, siteStatus: response.status };
     }
+}
+
+/**
+ * Resolve the directory's public base URL without requiring a data migration.
+ *
+ * Older managed k8s Works predate `managedSubdomain` and several have a null
+ * `website` even though their canonical `${slug}.ever.works` deployment is
+ * live. The deploy pipeline deliberately preserves that legacy derivation;
+ * the relay must use the same address or it will classify paid events as
+ * permanently unroutable. Explicit website URLs still win, and unmanaged
+ * providers never get a guessed destination.
+ */
+function resolveDirectoryWebsite(work: {
+    website?: string | null;
+    deployProvider?: string | null;
+    managedSubdomain?: string | null;
+    slug?: string | null;
+}): string | null {
+    const explicit = work.website?.trim();
+    if (explicit) return explicit;
+
+    if (work.deployProvider !== 'k8s' && work.deployProvider !== 'ever-works') {
+        return null;
+    }
+
+    const isDnsLabel = (value: string) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(value);
+    const subdomainCandidates = [work.managedSubdomain, work.slug]
+        .map((value) => value?.trim().toLowerCase() ?? '')
+        .filter((value) => isDnsLabel(value));
+    const subdomain = subdomainCandidates[0];
+    if (!subdomain) return null;
+
+    const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim().toLowerCase() || 'ever.works';
+    if (!rootDomain.split('.').every((label) => isDnsLabel(label))) {
+        return null;
+    }
+    return `https://${subdomain}.${rootDomain}`;
 }
 
 /**

--- a/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
+++ b/apps/api/src/billing/stripe-relay/stripe-relay.service.ts
@@ -218,10 +218,11 @@ export class StripeRelayService {
  *
  * Older managed k8s Works predate `managedSubdomain` and several have a null
  * `website` even though their canonical `${slug}.ever.works` deployment is
- * live. The deploy pipeline deliberately preserves that legacy derivation;
- * the relay must use the same address or it will classify paid events as
- * permanently unroutable. Explicit website URLs still win, and unmanaged
- * providers never get a guessed destination.
+ * live. The deploy pipeline deliberately preserves that legacy derivation and
+ * ignores stale `*.vercel.app` placeholders for managed k8s Works; the relay
+ * must do the same or it will classify paid events as permanently unroutable.
+ * Real explicit website URLs still win, and unmanaged providers never get a
+ * guessed destination.
  */
 function resolveDirectoryWebsite(work: {
     website?: string | null;
@@ -229,10 +230,21 @@ function resolveDirectoryWebsite(work: {
     managedSubdomain?: string | null;
     slug?: string | null;
 }): string | null {
+    const isManagedProvider = work.deployProvider === 'k8s' || work.deployProvider === 'ever-works';
     const explicit = work.website?.trim();
-    if (explicit) return explicit;
+    if (explicit) {
+        let isVercelPlaceholder = false;
+        try {
+            const parsed = new URL(explicit.includes('://') ? explicit : `https://${explicit}`);
+            isVercelPlaceholder = parsed.hostname.toLowerCase().endsWith('.vercel.app');
+        } catch {
+            // Preserve the existing explicit-target behavior; the forwarder's
+            // SSRF/URL checks remain the authority for malformed values.
+        }
+        if (!isManagedProvider || !isVercelPlaceholder) return explicit;
+    }
 
-    if (work.deployProvider !== 'k8s' && work.deployProvider !== 'ever-works') {
+    if (!isManagedProvider) {
         return null;
     }
 


### PR DESCRIPTION
Live-data verification before relay cutover exposed a fixture gap in #2275:

- Five deployed k8s directories have a live <slug>.ever.works host and a provisioned platform-sync secret, but legacy rows have both website = null and managedSubdomain = null.
- The relay therefore classified their paid events as permanently not_deployed.
- The intended low-risk cutover candidate, awesome-rust-ai-libraries, is one of those five.

This repair makes relay target resolution match the deploy pipeline's preserved legacy behavior:

- Explicit work.website still wins.
- Managed k8s / ever-works Works fall back to allocated managedSubdomain, then their validated slug under EVER_WORKS_DOMAIN (default ever.works).
- Unmanaged providers never get a guessed destination.
- Existing SSRF validation still runs before HMAC signing and network I/O.

TDD evidence:
- New live-shape case failed first: expected forwarded, received unroutable.
- After implementation: relay suite 28/28 green.
- Added managed-subdomain precedence and root-domain override coverage.
- Prettier and git diff --check green.

No live flag, secret, Stripe endpoint, or routing state was changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved routing for managed Kubernetes Works that do not have a public website.
  * Supports configured managed subdomains and canonical slug-based fallback URLs.
  * Respects the configurable Works domain and normalizes hostnames consistently.

* **Bug Fixes**
  * Prevents forwarding to invalid or unsupported website destinations.
  * Uses the validated resolved website URL when routing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->