### PR TITLE
fix: preserve trigger task ownership scope

### DIFF
--- a/apps/web/e2e/flow-agent-run-atomicity-cas.spec.ts
+++ b/apps/web/e2e/flow-agent-run-atomicity-cas.spec.ts
@@ -42,11 +42,10 @@ import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
  *     { cancelled:false, previousStatus:'failed' } — the CAS `WHERE status IN
  *     (queued,running)` matches nothing, so ZERO columns mutate (finishedAt /
  *     durationMs / errorMessage all stay put). Idempotent under repeat + burst.
- *   • Cancel scoping ASYMMETRY (a genuine, pinned quirk): cancel resolves the
- *     run by (runId, userId) only — so a same-user cancel routed through a
- *     DIFFERENT agent's :id still reaches the run and 200s, whereas GET
- *     /:id/runs/:runId is agent-scoped and 404s on the same cross-agent id.
- *   • Cancel errors: unknown runId → 404 "AgentRun <id> not found."; malformed
+ *   • Cancel and run-read are both agent-scoped: the path agent must match the
+ *     run even for two agents owned by the same user. Cross-agent and
+ *     cross-user probes share one non-enumerating 404 body.
+ *   • Cancel errors: unknown runId → 404 "AgentRun not found."; malformed
  *     runId/agentId → 400 (ParseUUIDPipe); anonymous → 401; cross-USER (agent
  *     gate) → 404 with the victim's row provably untouched.
  *
@@ -348,7 +347,7 @@ test.describe('Cancel CAS — a terminal AgentRun is an immutable no-op', () => 
         });
         expect(unknown.status()).toBe(404);
         expect(await unknown.json()).toEqual({
-            message: `AgentRun ${UNKNOWN_UUID} not found.`,
+            message: 'AgentRun not found.',
             error: 'Not Found',
             statusCode: 404,
         });
@@ -701,10 +700,10 @@ test.describe('Reconciled-run detail shape', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Run scoping asymmetry: cancel is user-scoped, run-read is agent-scoped.
+// Run scoping symmetry: cancel and run-read are both agent-scoped.
 // ─────────────────────────────────────────────────────────────────────────────
-test.describe('Run scoping asymmetry — cancel is user-scoped, run-read is agent-scoped', () => {
-    test("same user, cross-agent: getRun 404s (agent-scoped) but cancel 200-no-ops (user-scoped); the run's own agent is untouched", async ({
+test.describe('Run scoping symmetry — cancel and run-read are agent-scoped', () => {
+    test("same user, cross-agent: getRun and cancel both 404 without mutating the run's own agent", async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -726,12 +725,10 @@ test.describe('Run scoping asymmetry — cancel is user-scoped, run-read is agen
         });
         expect(crossRead.status(), 'cross-agent run READ is agent-scoped 404').toBe(404);
 
-        // cancel resolves the run by (runId, userId) ONLY — the :id agent is not
-        // matched — so the same cross-agent cancel REACHES the run and 200-no-ops.
+        // Cancel enforces the same run.agentId === :id relation as read.
         const crossCancel = await cancel(request, u.access_token, other.id, run.id);
-        expect(crossCancel.status, 'cross-agent (same-user) cancel is user-scoped 200').toBe(200);
-        expect(crossCancel.body.cancelled).toBe(false);
-        expect(crossCancel.body.previousStatus).toBe('failed');
+        expect(crossCancel.status, 'cross-agent (same-user) cancel is agent-scoped 404').toBe(404);
+        expect(crossCancel.body).toMatchObject({ message: 'AgentRun not found.', statusCode: 404 });
 
         // The run is still readable + terminal under its OWN agent, untouched.
         const readBack = await getRunDetail(request, u.access_token, owner.id, run.id);
@@ -756,13 +753,13 @@ test.describe('Run scoping asymmetry — cancel is user-scoped, run-read is agen
             await getRunDetail(request, owner.access_token, agent.id, run.id),
         );
 
-        // The intruder holds BOTH real ids but the service.getOne agent gate fires
-        // first → 404 "Agent <id> not found." (no existence leak).
+        // The intruder holds BOTH real ids but receives the same non-enumerating
+        // run-scoped 404 as every other ownership mismatch.
         const res = await request.post(`${AGENTS}/${agent.id}/runs/${run.id}/cancel`, {
             headers: authedHeaders(intruder.access_token),
         });
         expect(res.status()).toBe(404);
-        expect((await res.json()).message).toBe(`Agent ${agent.id} not found.`);
+        expect((await res.json()).message).toBe('AgentRun not found.');
 
         // Cross-user run READ is likewise a 404 (never an empty 200).
         const read = await request.get(`${AGENTS}/${agent.id}/runs/${run.id}`, {

--- a/apps/web/e2e/flow-agent-run-cancellation.spec.ts
+++ b/apps/web/e2e/flow-agent-run-cancellation.spec.ts
@@ -26,10 +26,9 @@
  *     inside the cradle-to-grave journey.
  * The NEW, un-pinned angles here: the Trigger.dev-independence contrast
  * (cancel 200 while assign/run-now 500), CAS terminal-row INTEGRITY proved via
- * the getRun detail before/after, guard-ORDERING (agent-gate 404 vs run 404
- * carry different messages), the 'manual' (run-now) trigger-kind cancel, the
- * same-user CROSS-AGENT-path asymmetry (cancel is not agentId-scoped whereas
- * getRun is), cancel ISOLATION across sibling runs + sibling agents, the events
+ * the getRun detail before/after, non-enumerating 404s across ownership
+ * mismatches, the 'manual' (run-now) trigger-kind cancel, same-user
+ * CROSS-AGENT-path rejection, cancel ISOLATION across sibling runs + sibling agents, the events
  * feed staying inert on a no-op cancel, and the exact 2-key response envelope.
  *
  * PROBED LIVE (http://127.0.0.1:3100, sqlite in-memory, NO LLM key, NO
@@ -43,12 +42,12 @@
  *     { cancelled:false, previousStatus:'failed' } — deterministic, never 500;
  *     the row STAYS 'failed' (getRun detail unchanged: status/errorMessage/
  *     finishedAt/durationMs identical), and re-cancel repeats verbatim.
- *   - cross-user cancel (real ids) → 404 { message:"Agent <id> not found.", … }.
- *   - real agent + unknown runId → 404 { message:"AgentRun <id> not found.", … }.
- *   - unknown agentId + real runId → 404 "Agent <id> not found." (gate first).
+ *   - cross-user cancel (real ids) → 404 { message:"AgentRun not found.", … }.
+ *   - real agent + unknown runId → the same non-enumerating 404 body.
+ *   - unknown agentId + real runId → the same non-enumerating 404 body.
  *   - malformed run/agent id → 400 "Validation failed (uuid is expected)".
- *   - same-user cross-agent path (A's run under agent B) → 200 no-op (cancel is
- *     userId-scoped, not agentId-scoped) — while GET :B/runs/:runIdOfA → 404.
+ *   - same-user cross-agent path (A's run under agent B) → 404; cancel and GET
+ *     enforce the same agentId/run relation.
  *   - anonymous cancel → 401 { message:"Unauthorized", statusCode:401 }.
  *
  * Isolation: every test registers a FRESH owner via registerUserViaAPI() with a
@@ -352,25 +351,24 @@ test.describe('agent-run cancellation — guard ordering + id validation matrix'
         expect((await badAgent.json()).message).toBe('Validation failed (uuid is expected)');
     });
 
-    test('the agent-ownership gate fires BEFORE the run lookup — the two 404s carry DIFFERENT messages', async ({
+    test('agent and run ownership mismatches share one non-enumerating 404 body', async ({
         request,
     }) => {
         const s = await seedAgentWithTaskRun(request, 'GuardOrder');
 
-        // Unknown AGENT + a real run id → the gate answers "Agent … not found."
+        // Unknown agent + a real run id must not reveal which identifier missed.
         const unknownAgent = await cancel(request, s.token, UNKNOWN_AGENT_UUID, s.run.id);
         expect(unknownAgent.status).toBe(404);
         const uaBody = unknownAgent.body as unknown as ErrorBody;
-        expect(uaBody.message).toBe(`Agent ${UNKNOWN_AGENT_UUID} not found.`);
+        expect(uaBody.message).toBe('AgentRun not found.');
 
-        // Real agent + unknown RUN id → the gate passes; the run lookup answers.
+        // Real agent + unknown run id returns the same body.
         const unknownRun = await cancel(request, s.token, s.agentId, UNKNOWN_RUN_UUID);
         expect(unknownRun.status).toBe(404);
         const urBody = unknownRun.body as unknown as ErrorBody;
-        expect(urBody.message).toBe(`AgentRun ${UNKNOWN_RUN_UUID} not found.`);
+        expect(urBody.message).toBe('AgentRun not found.');
 
-        // The distinct messages prove the ordering (agent gate → run CAS).
-        expect(uaBody.message).not.toBe(urBody.message);
+        expect(uaBody).toEqual(urBody);
     });
 
     test('unknown runId under the OWNER agent returns the AgentRun-scoped 404 body', async ({
@@ -383,7 +381,7 @@ test.describe('agent-run cancellation — guard ordering + id validation matrix'
         expect(res.status()).toBe(404);
         const body = (await res.json()) as ErrorBody;
         expect(body).toEqual({
-            message: `AgentRun ${UNKNOWN_RUN_UUID} not found.`,
+            message: 'AgentRun not found.',
             error: 'Not Found',
             statusCode: 404,
         });
@@ -407,18 +405,18 @@ test.describe('agent-run cancellation — guard ordering + id validation matrix'
 
 // ───────────────────────────────────────────────────────────────────────────
 test.describe('agent-run cancellation — cross-user vs cross-agent scoping', () => {
-    test('a stranger holding BOTH real ids still 404s at the agent gate and cannot mutate the run', async ({
+    test('a stranger holding BOTH real ids receives a non-enumerating 404 and cannot mutate the run', async ({
         request,
     }) => {
         const s = await seedAgentWithTaskRun(request, 'CrossUser');
         const intruder = await registerUserViaAPI(request);
 
-        // Cancel with the victim's real agent + run ids → agent-gate 404.
+        // Cancel with the victim's real agent + run ids → generic run 404.
         const res = await request.post(`${AGENTS}/${s.agentId}/runs/${s.run.id}/cancel`, {
             headers: authedHeaders(intruder.access_token),
         });
         expect(res.status()).toBe(404);
-        expect((await res.json()).message).toBe(`Agent ${s.agentId} not found.`);
+        expect((await res.json()).message).toBe('AgentRun not found.');
 
         // The intruder cannot even read the run detail (same 404 gate).
         const peek = await request.get(`${AGENTS}/${s.agentId}/runs/${s.run.id}`, {
@@ -432,13 +430,11 @@ test.describe('agent-run cancellation — cross-user vs cross-agent scoping', ()
         expect(after.id).toBe(s.run.id);
     });
 
-    test('cancel is userId-scoped, NOT agentId-scoped: an owner may cancel their run through a DIFFERENT owned agent path', async ({
+    test('cancel is agentId-scoped: an owner cannot cancel a run through a different owned agent path', async ({
         request,
     }) => {
-        // NOVEL: agentRuns.cancel(runId, userId) is not keyed on the path agentId,
-        // so run-of-A cancelled via agent-B's path succeeds (as a no-op) — unlike
-        // GET :id/runs/:runId which enforces run.agentId === id. Both agents are
-        // owned by the SAME user, so no cross-user boundary is crossed.
+        // Both agents are owned by the same user, but run.agentId must still
+        // match the path agent before cancellation reaches the repository.
         const s = await seedAgentWithTaskRun(request, 'CrossAgent');
         const agentB = await createAgentViaAPI(request, s.token, {
             name: `CrossAgentB ${stamp()}`,
@@ -450,19 +446,12 @@ test.describe('agent-run cancellation — cross-user vs cross-agent scoping', ()
         });
         expect(detailUnderB.status()).toBe(404);
 
-        // cancel is NOT agentId-scoped → observed 200 no-op. Tolerate a future
-        // hardening to 404; assert the exact shape in whichever branch is live.
+        // Cancel is intentionally agent-scoped too.
         const viaB = await request.post(`${AGENTS}/${agentB.id}/runs/${s.run.id}/cancel`, {
             headers: authedHeaders(s.token),
         });
-        expect([200, 404]).toContain(viaB.status());
-        if (viaB.status() === 200) {
-            const body = (await viaB.json()) as CancelBody;
-            expect(body.cancelled).toBe(false);
-            expect(body.previousStatus).toBe(s.run.status);
-        } else {
-            expect((await viaB.json()).message).toContain('not found');
-        }
+        expect(viaB.status()).toBe(404);
+        expect((await viaB.json()).message).toBe('AgentRun not found.');
 
         // Either way the run is unchanged and still lives under agent A.
         const underA = await getRun(request, s.token, s.agentId, s.run.id);
@@ -471,16 +460,14 @@ test.describe('agent-run cancellation — cross-user vs cross-agent scoping', ()
         expect((await listRunsPage(request, s.token, agentB.id)).meta.total).toBe(0);
     });
 
-    test('an unknown (well-formed) agentId with a real run id resolves at the agent gate, not the run lookup', async ({
+    test('an unknown (well-formed) agentId with a real run id returns the shared non-enumerating body', async ({
         request,
     }) => {
         const s = await seedAgentWithTaskRun(request, 'PhantomAgent');
         const res = await cancel(request, s.token, UNKNOWN_AGENT_UUID, s.run.id);
         expect(res.status).toBe(404);
         const body = res.body as unknown as ErrorBody;
-        // Names the AGENT (gate), never the run — no cross-agent existence leak.
-        expect(body.message).toBe(`Agent ${UNKNOWN_AGENT_UUID} not found.`);
-        expect(String(body.message)).not.toContain('AgentRun');
+        expect(body.message).toBe('AgentRun not found.');
     });
 });
 

--- a/apps/web/e2e/flow-agents-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-agents-validation-authz-matrix.spec.ts
@@ -498,7 +498,7 @@ test.describe('Agent create DTO — field validation matrix', () => {
         expect(perms.canEditSkills).toBe(false);
     });
 
-    test('targets: array of typed entries — non-array, bad type, missing type, and bad id all 400; a wildcard entry round-trips', async ({
+    test('targets: invalid shapes 400; wildcard round-trips; a well-formed but unreachable work id 404s', async ({
         request,
     }) => {
         const token = await freshToken(request);
@@ -541,12 +541,15 @@ test.describe('Agent create DTO — field validation matrix', () => {
         });
         expect(wildcard.targets).toEqual([{ type: 'wildcard' }]);
 
-        // A well-formed uuid id passes DTO validation (existence is not checked here).
-        const withId = await createOk(request, token, {
+        // DTO validation passes, then the ownership check rejects a target that
+        // is not reachable in this caller's scope.
+        const withId = await rawCreate(request, token, {
+            scope: 'tenant',
             name: `Tgt WithId ${stamp()}`,
             targets: [{ type: 'work', id: SOME_UUID }],
         });
-        expect(Array.isArray(withId.targets)).toBe(true);
+        expect(withId.status()).toBe(404);
+        expect(messageText(await withId.json())).toBe(`Work ${SOME_UUID} not found.`);
     });
 
     test('avatar cluster: avatarMode enum, avatarIcon <=64, avatarImageUploadId IsUUID', async ({

--- a/apps/web/e2e/flow-concurrency-tasks-matrix.spec.ts
+++ b/apps/web/e2e/flow-concurrency-tasks-matrix.spec.ts
@@ -67,7 +67,7 @@
  *       peer stays client-level (<500).
  *
  *   ISOLATION / GATES  cross-user transition + assignee-add against another user's
- *     Task → 404 (no existence leak); an unowned-agent assignee → 400 "not reachable"
+ *     Task → 404 (no existence leak); an out-of-scope actor → one generic 400
  *     (never 5xx). The approver gate blocks `→done` (409) until force overrides it,
  *     and under a force burst the CAS still elects exactly one winner.
  *
@@ -84,7 +84,7 @@
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
 import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
-import { createTaskViaAPI, transitionTaskViaAPI } from './helpers/agents-tasks';
+import { createAgentViaAPI, createTaskViaAPI, transitionTaskViaAPI } from './helpers/agents-tasks';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const TASKS = `${API_BASE}/api/tasks`;
@@ -99,8 +99,7 @@ function H(token: string): Record<string, string> {
     return { ...authedHeaders(token), 'content-type': 'application/json' };
 }
 
-/** A synthetic user-actor id (assigneeId column is a uuid; a random one is a valid
- *  "user" actor — the service only existence-checks agent-type actors). */
+/** A well-formed unknown UUID for negative-path and missing-resource probes. */
 function actorUuid(): string {
     const hex = () => Math.floor(Math.random() * 16).toString(16);
     const s = Array.from({ length: 12 }, hex).join('');
@@ -333,7 +332,7 @@ test.describe('Tasks — parallel duplicate roster adds → exactly one 201 + th
         const task = await createTaskViaAPI(request, u.access_token, {
             title: `Assignee CAS ${stamp()}`,
         });
-        const assigneeId = actorUuid();
+        const assigneeId = u.user.id;
         const BURST = 5;
 
         const results = await Promise.all(
@@ -390,7 +389,7 @@ test.describe('Tasks — parallel duplicate roster adds → exactly one 201 + th
         const task = await createTaskViaAPI(request, u.access_token, {
             title: `Reviewer CAS ${stamp()}`,
         });
-        const reviewerId = actorUuid();
+        const reviewerId = u.user.id;
         const BURST = 4;
 
         const results = await Promise.all(
@@ -417,7 +416,7 @@ test.describe('Tasks — parallel duplicate roster adds → exactly one 201 + th
         const task = await createTaskViaAPI(request, u.access_token, {
             title: `Approver CAS ${stamp()}`,
         });
-        const approverId = actorUuid();
+        const approverId = u.user.id;
         const BURST = 4;
 
         const results = await Promise.all(
@@ -498,7 +497,7 @@ test.describe('Tasks — parallel duplicate roster adds → exactly one 201 + th
         expect((await loser.json()).message).toMatch(/already has a relation/i);
     });
 
-    test('DISTINCT assignees added in parallel → ALL 201 with distinct row ids (no false conflict)', async ({
+    test('DISTINCT scoped agent assignees added in parallel → ALL 201 with distinct row ids (no false conflict)', async ({
         request,
     }) => {
         test.setTimeout(90_000);
@@ -506,13 +505,21 @@ test.describe('Tasks — parallel duplicate roster adds → exactly one 201 + th
         const task = await createTaskViaAPI(request, u.access_token, {
             title: `Fanout ${stamp()}`,
         });
-        const ids = [actorUuid(), actorUuid(), actorUuid(), actorUuid()];
+        const agents = await Promise.all(
+            Array.from({ length: 4 }, (_, i) =>
+                createAgentViaAPI(request, u.access_token, {
+                    name: `Fanout Agent ${i} ${stamp()}`,
+                    scope: 'tenant',
+                }),
+            ),
+        );
+        const ids = agents.map((agent) => agent.id);
 
         const results = await Promise.all(
             ids.map((assigneeId) =>
                 request.post(`${TASKS}/${task.id}/assignees`, {
                     headers: H(u.access_token),
-                    data: { assigneeType: 'user', assigneeId },
+                    data: { assigneeType: 'agent', assigneeId },
                     timeout: T,
                 }),
             ),
@@ -771,7 +778,7 @@ test.describe('Tasks — delete races resolve to a gone row (no double-remove, n
         });
         const add = await request.post(`${TASKS}/${task.id}/assignees`, {
             headers: H(u.access_token),
-            data: { assigneeType: 'user', assigneeId: actorUuid() },
+            data: { assigneeType: 'user', assigneeId: u.user.id },
         });
         expect(add.status()).toBe(201);
         const rowId = (await add.json()).id;
@@ -886,7 +893,7 @@ test.describe('Tasks — gate/force interplay, isolation, and bad-input robustne
         // Configure a PENDING approver so requireAllApprovers gates →done.
         const addApprover = await request.post(`${TASKS}/${task.id}/approvers`, {
             headers: H(u.access_token),
-            data: { approverType: 'user', approverId: actorUuid() },
+            data: { approverType: 'user', approverId: u.user.id },
         });
         expect(addApprover.status()).toBe(201);
         await walkTo(request, u.access_token, task.id, ['todo', 'in_progress']);
@@ -988,7 +995,7 @@ test.describe('Tasks — gate/force interplay, isolation, and bad-input robustne
         const task = await createTaskViaAPI(request, u.access_token, {
             title: `Bad Actor ${stamp()}`,
         });
-        const userAssignee = actorUuid();
+        const userAssignee = u.user.id;
 
         const [good, bad] = await Promise.all([
             request.post(`${TASKS}/${task.id}/assignees`, {
@@ -1003,9 +1010,9 @@ test.describe('Tasks — gate/force interplay, isolation, and bad-input robustne
             }),
         ]);
         expect(good.status(), 'the valid user assignee lands').toBe(201);
-        // An agent that doesn't belong to the user is a clean 400 — never a 5xx.
+        // An agent outside the Task scope is a clean, non-enumerating 400.
         expect(bad.status(), 'the unowned agent is rejected 400').toBe(400);
-        expect((await bad.json()).message).toMatch(/not reachable for this user/i);
+        expect((await bad.json()).message).toBe('Task actor is not reachable in this Task scope.');
     });
 
     test('concurrent invalid transition inputs never 5xx: garbage targets → 400 validation; a missing task → 404; the row is untouched', async ({

--- a/apps/web/e2e/flow-goals-lifecycle-deep.spec.ts
+++ b/apps/web/e2e/flow-goals-lifecycle-deep.spec.ts
@@ -131,10 +131,11 @@ test.describe('Goals — create & read', () => {
         expect(body.outcome).toBeNull();
         expect(typeof body.createdAt).toBe('string');
         expect(typeof body.updatedAt).toBe('string');
-        // Pure projection — internal ownership/scope columns are NOT on the wire.
+        // The internal user id stays private. Nullable tenant/organization scope
+        // is explicit on the DTO so callers can distinguish a personal Goal.
         expect(body.userId).toBeUndefined();
-        expect(body.tenantId).toBeUndefined();
-        expect(body.organizationId).toBeUndefined();
+        expect(body.tenantId).toBeNull();
+        expect(body.organizationId).toBeNull();
     });
 
     test('create normalizes input: trims title, blanks description → null, keeps params, allows 0/negative/float targets', async ({

--- a/apps/web/e2e/flow-goals-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-goals-ui-journey.spec.ts
@@ -679,9 +679,9 @@ test.describe('Goals — /goals/new create form (UI)', () => {
         await expect(page.getByRole('heading', { name: title, level: 1 })).toBeVisible({
             timeout: 30_000,
         });
-        // Fresh draft: the metric value + comparator we entered are shown. The
-        // `/goals/[id]` detail is another first-hit compile, so give the target
-        // value line a generous window (the default expect timeout is only 5s).
+        // Fresh draft: the metric value + comparator we entered are shown under
+        // the Progress tab. The detail page defaults to Definition of Done.
+        await page.getByRole('tab', { name: 'Progress log' }).click();
         await expect(page.getByText('2,500 usd').first()).toBeVisible({ timeout: 30_000 });
 
         // And it now appears back in the catalog.

--- a/apps/web/e2e/flow-idor-resource-access.spec.ts
+++ b/apps/web/e2e/flow-idor-resource-access.spec.ts
@@ -63,8 +63,8 @@ import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
  *               :id / :id/runs cross-user → 404 "Agent <id> not found." (uuid
  *               pipe → non-uuid 400).
  *   Assignees   POST /api/tasks/:id/assignees {assigneeType:'agent'|'user',
- *               assigneeId} on YOUR task but a FOREIGN agent child → 400 "Agent
- *               <id> is not reachable for this user — cannot assign." (== the body
+ *               assigneeId} on YOUR task but a FOREIGN agent child → 400 "Task
+ *               actor is not reachable in this Task scope." (== the body
  *               for a never-existed agent: child-existence non-disclosure).
  *   AssignTask  POST /api/agents/:id/assign-task {taskId} on YOUR agent but a
  *               FOREIGN task child → 404 "Task <id> not found.".
@@ -504,7 +504,7 @@ test.describe('IDOR — guessable ids, sub-resource-requires-parent, cross-user 
         const bobAgent = await createAgentViaAPI(request, bob.token, { name: `Bob Ag ${sfx}` });
 
         // (a) Alice adds BOB's agent as an assignee to her OWN task → 400
-        //     "not reachable for this user". The body for a FOREIGN agent must
+        //     with the generic Task-scope response. The body for a FOREIGN agent must
         //     equal the body for a NEVER-EXISTED agent (child non-disclosure).
         const foreignAgentAssign = await request.post(
             `${API_BASE}/api/tasks/${aliceTask.id}/assignees`,

--- a/apps/web/e2e/flow-inbound-trigger-task-agent-chain.spec.ts
+++ b/apps/web/e2e/flow-inbound-trigger-task-agent-chain.spec.ts
@@ -61,6 +61,13 @@ const TASK_SLUG_RE = /^T-\d+$/;
 const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
 const AGENTS = `${API_BASE}/api/agents`;
 
+function triggerScopeHeaders(token: string) {
+    // createTriggerViaAPI intentionally uses the unprefixed management route,
+    // which creates this fixture in personal scope. List under that same
+    // explicit scope rather than the user's separately remembered org scope.
+    return { ...authedHeaders(token), 'x-scope-slug': '@personal' };
+}
+
 function stamp(): string {
     return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
@@ -522,8 +529,8 @@ test.describe('Trigger fire counters + spawned-Task lifecycle', () => {
         );
 
         // The owner's task list holds exactly the three spawned Tasks (fresh user).
-        const list = await request.get(`${API_BASE}/api/tasks?limit=200`, {
-            headers: authedHeaders(token),
+        const list = await request.get(`${API_BASE}/api/tasks?limit=200&includeHidden=true`, {
+            headers: triggerScopeHeaders(token),
         });
         expect(list.status()).toBe(200);
         const ids = ((await list.json()).data as { id: string }[]).map((t) => t.id);
@@ -573,8 +580,8 @@ test.describe('Trigger fire counters + spawned-Task lifecycle', () => {
         // A fire against a paused trigger is a 409 with NO spawned Task.
         const paused = await fireTrigger(request, trigger.id, secret, '{"e":1}');
         expect(paused.status()).toBe(409);
-        const emptyList = await request.get(`${API_BASE}/api/tasks?limit=200`, {
-            headers: authedHeaders(token),
+        const emptyList = await request.get(`${API_BASE}/api/tasks?limit=200&includeHidden=true`, {
+            headers: triggerScopeHeaders(token),
         });
         expect((await emptyList.json()).data.length).toBe(0);
 
@@ -587,8 +594,8 @@ test.describe('Trigger fire counters + spawned-Task lifecycle', () => {
             ).status(),
         ).toBe(200);
         const { taskId } = await fireAndSpawn(request, trigger.id, secret, '{"e":2}');
-        const afterList = await request.get(`${API_BASE}/api/tasks?limit=200`, {
-            headers: authedHeaders(token),
+        const afterList = await request.get(`${API_BASE}/api/tasks?limit=200&includeHidden=true`, {
+            headers: triggerScopeHeaders(token),
         });
         const ids = ((await afterList.json()).data as { id: string }[]).map((t) => t.id);
         expect(ids).toContain(taskId);

--- a/apps/web/e2e/flow-inbound-triggers-deep.spec.ts
+++ b/apps/web/e2e/flow-inbound-triggers-deep.spec.ts
@@ -180,8 +180,13 @@ test.describe('Inbound Triggers — the PUBLIC HMAC fire endpoint', () => {
         expect(typeof result.taskSlug).toBe('string');
 
         // The spawned Task is real: it shows up in the owner's task list with the templated title.
-        const tasks = await request.get(`${API_BASE}/api/tasks?limit=100`, {
-            headers: authedHeaders(user.access_token),
+        const tasks = await request.get(`${API_BASE}/api/tasks?limit=100&includeHidden=true`, {
+            headers: {
+                ...authedHeaders(user.access_token),
+                // The unprefixed trigger-management route creates the
+                // trigger in personal scope; query the spawned Task there.
+                'x-scope-slug': '@personal',
+            },
         });
         expect(tasks.status()).toBe(200);
         const rows = (await tasks.json()).data as Array<{ id: string; title: string }>;

--- a/apps/web/e2e/flow-prebuilt-companies-import-deep.spec.ts
+++ b/apps/web/e2e/flow-prebuilt-companies-import-deep.spec.ts
@@ -552,7 +552,10 @@ test.describe('Prebuilt Companies — materialized org structure', () => {
         test.skip(report.created.agents === 0, 'template created no agents in this run');
 
         const agentsRes = await request.get(`${API_BASE}/api/agents`, {
-            headers: authedHeaders(token),
+            headers: {
+                ...authedHeaders(token),
+                'x-scope-slug': report.organization.slug,
+            },
         });
         expect(agentsRes.status()).toBe(200);
         const agents = (await agentsRes.json()).data as Array<{

--- a/apps/web/e2e/flow-subscriptions-validation-matrix.spec.ts
+++ b/apps/web/e2e/flow-subscriptions-validation-matrix.spec.ts
@@ -279,7 +279,7 @@ test.describe('Subscriptions plan — POST happy path, self-serve gate, transiti
             const gated = body.plan.allowedCadences.filter((c: { allowed: boolean }) => !c.allowed);
             for (const c of gated) {
                 expect(c.payPerUse).toBe(true);
-                expect(String(c.reason)).toContain('Upgrade to Premium');
+                expect(String(c.reason)).toContain('Upgrade to Enterprise');
             }
         } else {
             expect(/billing|self-assigned/i.test(JSON.stringify(body.message))).toBe(true);

--- a/apps/web/e2e/flow-task-approvers-gate.spec.ts
+++ b/apps/web/e2e/flow-task-approvers-gate.spec.ts
@@ -413,13 +413,27 @@ test.describe('Task approver gate — requireAllApprovers on → done (API)', ()
         // class-validator returns `message` as a string[]; coerce before matching.
         expect(String((await badType.json()).message)).toMatch(/one of the following values/i);
 
-        // (b) Agent approver outside the persisted Task scope → generic 400.
+        // (b) A real persisted Agent from another tenant/organization is
+        // outside the Task scope → generic 400. A separate missing-actor
+        // probe keeps the not-found repository outcome covered too.
+        const bob = await registerUserViaAPI(request);
+        const foreignAgent = await createAgentViaAPI(request, bob.access_token, {
+            name: `Foreign Approver Bot ${stamp}`,
+        });
         const unownedAgent = await rawAddApprover(request, token, task.id, {
             approverType: 'agent',
-            approverId: '00000000-0000-0000-0000-000000000000',
+            approverId: foreignAgent.id,
         });
         expect(unownedAgent.status()).toBe(400);
         expect((await unownedAgent.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
+        const missingAgent = await rawAddApprover(request, token, task.id, {
+            approverType: 'agent',
+            approverId: '00000000-0000-0000-0000-000000000000',
+        });
+        expect(missingAgent.status()).toBe(400);
+        expect((await missingAgent.json()).message).toBe(
             'Task actor is not reachable in this Task scope.',
         );
 
@@ -451,7 +465,6 @@ test.describe('Task approver gate — requireAllApprovers on → done (API)', ()
 
         // (f) Cross-user isolation — a stranger adding an approver to my task
         // gets a 404 (no existence leak), not a 403.
-        const bob = await registerUserViaAPI(request);
         const stranger = await rawAddApprover(request, bob.access_token, task.id, {
             approverType: 'user',
             approverId: bob.user.id,

--- a/apps/web/e2e/flow-task-approvers-gate.spec.ts
+++ b/apps/web/e2e/flow-task-approvers-gate.spec.ts
@@ -39,8 +39,8 @@ import { createTaskViaAPI, transitionTaskViaAPI, createAgentViaAPI } from './hel
  *         first with the class-validator array message "approverType must be
  *         one of the following values: user, agent" (NOT the controller's
  *         "Invalid actor type" string, which the pipe never reaches).
- *       · approverType:'agent' with a non-owned/unknown agent id → 400
- *         "Agent <id> is not reachable for this user — cannot assign."
+ *       · an actor outside the persisted Task scope → 400 with the generic
+ *         non-enumerating "Task actor is not reachable in this Task scope."
  *       · DUPLICATE (same taskId+type+id) → 409 (uq_task_approver unique idx,
  *         mapped to a clean Conflict instead of an unmapped 500).
  *       · cross-user (stranger adds approver to my task) → 404
@@ -413,14 +413,15 @@ test.describe('Task approver gate — requireAllApprovers on → done (API)', ()
         // class-validator returns `message` as a string[]; coerce before matching.
         expect(String((await badType.json()).message)).toMatch(/one of the following values/i);
 
-        // (b) Agent approver pointing at an unknown / non-owned agent → 400
-        // "Agent <id> is not reachable for this user — cannot assign."
+        // (b) Agent approver outside the persisted Task scope → generic 400.
         const unownedAgent = await rawAddApprover(request, token, task.id, {
             approverType: 'agent',
             approverId: '00000000-0000-0000-0000-000000000000',
         });
         expect(unownedAgent.status()).toBe(400);
-        expect((await unownedAgent.json()).message).toMatch(/not reachable for this user/i);
+        expect((await unownedAgent.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
 
         // (c) First valid add → 201, pending.
         const first = await rawAddApprover(request, token, task.id, {

--- a/apps/web/e2e/flow-task-assignees-deep.spec.ts
+++ b/apps/web/e2e/flow-task-assignees-deep.spec.ts
@@ -26,12 +26,10 @@ import {
  *   POST /api/tasks/:id/assignees { assigneeType:'user'|'agent', assigneeId }
  *     → 201 { id, taskId, assigneeType, assigneeId, tenantId, organizationId,
  *             createdAt }
- *     - user-type: assigneeId is NOT validated against the users table — ANY
- *       uuid (incl. one that is not a real user) is accepted with 201. Only
- *       the task ownership is enforced (`getOne(userId, taskId)`).
- *     - agent-type: assigneeId IS validated — the agent must be reachable for
- *       the caller (`agents.findByIdAndUser`). Unknown/unreachable agent →
- *       400 "Agent <id> is not reachable for this user — cannot assign."
+ *     - both actor types are validated against the persisted Task scope. A
+ *       user must be active in the same Tenant (or own a personal Task), and
+ *       an agent must be reachable in that exact scope. Any mismatch returns
+ *       the same non-enumerating 400 response.
  *     - empty assigneeId → 400 "<type> id is required."
  *     - assigneeType not 'user'|'agent' → 400 "Invalid actor type: <value>"
  *       (controller guard `assertActorType`, runs before the service).
@@ -79,11 +77,10 @@ import {
  * (the shared in-memory DB / per-user `T-n` slug counter must stay clean for
  * sibling specs). Assertions tolerate pre-existing rows (toContain / >=) and
  * never assert exact global counts. UUID literals below are deliberately NOT
- * real users — exercising the "user-type is not validated" contract.
+ * real actors and exercise the scope-validation rejection path.
  */
 
 const A_UUID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
-const B_UUID = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
 const C_UUID = 'cccccccc-cccc-4ccc-cccc-cccccccccccc';
 const MALFORMED_UUID = 'not-a-uuid';
 
@@ -142,20 +139,20 @@ test.describe('Task assignees — deep integration', () => {
         // First add → clean 201, full row shape echoed back.
         const first = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: user.user.id,
         });
         expect(first.status(), `first add body=${await first.text()}`).toBe(201);
         const firstRow = await first.json();
         expect(firstRow.id).toBeTruthy();
         expect(firstRow.taskId).toBe(task.id);
         expect(firstRow.assigneeType).toBe('user');
-        expect(firstRow.assigneeId).toBe(A_UUID);
+        expect(firstRow.assigneeId).toBe(user.user.id);
 
-        // Duplicate of the LIVE (taskId,user,A_UUID) triple → 409 (uq index;
+        // Duplicate of the live owner-user triple → 409 (uq index;
         // the repo save()s with no pre-check). Never assert it is a 4xx.
         const dup = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: user.user.id,
         });
         expect(dup.status(), `dup body=${await dup.text()}`).toBe(409);
 
@@ -168,29 +165,29 @@ test.describe('Task assignees — deep integration', () => {
         // removal yields a brand-new 201 with a fresh id.
         const reAdd = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: user.user.id,
         });
         expect(reAdd.status(), `re-add body=${await reAdd.text()}`).toBe(201);
         const reRow = await reAdd.json();
-        expect(reRow.assigneeId).toBe(A_UUID);
+        expect(reRow.assigneeId).toBe(user.user.id);
         expect(reRow.id).not.toBe(firstRow.id);
 
         // And the recovered row is itself live again → a second duplicate 409s.
         const dup2 = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: user.user.id,
         });
         expect(dup2.status()).toBe(409);
     });
 
-    test('polymorphic assignee key: same uuid as both user and agent are distinct rows', async ({
+    test('validated user and agent actors have independent live rows and uniqueness', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const task = await createTaskViaAPI(request, token, { title: 'polymorphic key' });
 
-        // A real, reachable agent — its id is what we reuse across both types.
+        // A real, reachable agent shares the Task scope with the active owner.
         const agent = await createAgentViaAPI(request, token, {
             name: `Poly Agent ${Date.now().toString(36)}`,
             scope: 'tenant',
@@ -205,17 +202,16 @@ test.describe('Task assignees — deep integration', () => {
         const agentRow = await asAgent.json();
         expect(agentRow.assigneeType).toBe('agent');
 
-        // Add the SAME id as a USER assignee. uq is on the (task,type,id) triple,
-        // so a different type is a different row — and user-type isn't validated,
-        // so the id need not be a real user. → 201, distinct row id.
+        // Add the active owner as a USER assignee. Both actor kinds are now
+        // validated before insert and produce distinct join rows.
         const asUser = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: agent.id,
+            assigneeId: user.user.id,
         });
         expect(asUser.status(), `user add=${await asUser.text()}`).toBe(201);
         const userRow = await asUser.json();
         expect(userRow.assigneeType).toBe('user');
-        expect(userRow.assigneeId).toBe(agent.id);
+        expect(userRow.assigneeId).toBe(user.user.id);
         expect(userRow.id).not.toBe(agentRow.id);
 
         // Each (type,id) pair is independently unique: re-adding the agent-type
@@ -227,12 +223,12 @@ test.describe('Task assignees — deep integration', () => {
         expect(dupAgent.status()).toBe(409);
         const dupUser = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: agent.id,
+            assigneeId: user.user.id,
         });
         expect(dupUser.status()).toBe(409);
 
-        // Removing ONLY the agent-type row frees just that pair: agent-type can
-        // be re-added (201) while the user-type duplicate still 409s.
+        // Removing ONLY the agent row frees just that pair: the agent can be
+        // re-added while the independent owner-user row remains live.
         const delAgent = await deleteAssignee(request, token, task.id, agentRow.id);
         expect(delAgent.status()).toBe(200);
         const reAddAgent = await postAssignee(request, token, task.id, {
@@ -242,7 +238,7 @@ test.describe('Task assignees — deep integration', () => {
         expect(reAddAgent.status(), `re-add agent=${await reAddAgent.text()}`).toBe(201);
         const stillDupUser = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: agent.id,
+            assigneeId: user.user.id,
         });
         expect(stillDupUser.status()).toBe(409);
     });
@@ -264,14 +260,10 @@ test.describe('Task assignees — deep integration', () => {
             scope: 'tenant',
         });
 
-        // Build a heterogeneous crew: 2 distinct users + 2 distinct agents.
+        // Build a heterogeneous crew: the active owner + 2 distinct agents.
         const u1 = await addTaskAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
-        });
-        const u2 = await addTaskAssignee(request, token, task.id, {
-            assigneeType: 'user',
-            assigneeId: B_UUID,
+            assigneeId: user.user.id,
         });
         const ag1 = await addTaskAssignee(request, token, task.id, {
             assigneeType: 'agent',
@@ -281,13 +273,12 @@ test.describe('Task assignees — deep integration', () => {
             assigneeType: 'agent',
             assigneeId: agent2.id,
         });
-        const created = [u1.id, u2.id, ag1.id, ag2.id];
-        expect(new Set(created).size, 'all four rows have distinct ids').toBe(4);
+        const created = [u1.id, ag1.id, ag2.id];
+        expect(new Set(created).size, 'all three rows have distinct ids').toBe(3);
 
-        // All four are independently live: each duplicate 409s.
+        // All three are independently live: each duplicate 409s.
         for (const a of [
-            { assigneeType: 'user' as const, assigneeId: A_UUID },
-            { assigneeType: 'user' as const, assigneeId: B_UUID },
+            { assigneeType: 'user' as const, assigneeId: user.user.id },
             { assigneeType: 'agent' as const, assigneeId: agent1.id },
             { assigneeType: 'agent' as const, assigneeId: agent2.id },
         ]) {
@@ -302,8 +293,7 @@ test.describe('Task assignees — deep integration', () => {
             const addedIds = afterAdds
                 .filter((r) => r.actionType === 'task_assignee_added')
                 .map((r) => r.details?.assigneeId);
-            expect(addedIds).toContain(A_UUID);
-            expect(addedIds).toContain(B_UUID);
+            expect(addedIds).toContain(user.user.id);
             expect(addedIds).toContain(agent1.id);
             expect(addedIds).toContain(agent2.id);
         } else {
@@ -314,7 +304,7 @@ test.describe('Task assignees — deep integration', () => {
         }
 
         // Remove one agent from the crew → frees just that pair (re-addable),
-        // the other three remain live (still 409 on duplicate).
+        // the other two remain live (still 409 on duplicate).
         const delAg1 = await deleteAssignee(request, token, task.id, ag1.id);
         expect(delAg1.status()).toBe(200);
         const reAg1 = await postAssignee(request, token, task.id, {
@@ -324,9 +314,9 @@ test.describe('Task assignees — deep integration', () => {
         expect(reAg1.status(), `re-add freed agent1=${await reAg1.text()}`).toBe(201);
         const stillLiveUserA = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: user.user.id,
         });
-        expect(stillLiveUserA.status(), 'untouched user A still live').toBe(409);
+        expect(stillLiveUserA.status(), 'untouched owner-user row still live').toBe(409);
 
         // And the remove is audited too.
         const afterRemove = await taskActivity(request, token, task.id);
@@ -360,13 +350,23 @@ test.describe('Task assignees — deep integration', () => {
         expect(emptyId.status()).toBe(400);
         expect((await emptyId.json()).message).toContain('id is required');
 
-        // Agent-type assignee that is not reachable for this user → 400.
+        // Either actor type outside the Task scope gets the same generic 400.
         const unreachableAgent = await postAssignee(request, token, task.id, {
             assigneeType: 'agent',
             assigneeId: C_UUID,
         });
         expect(unreachableAgent.status()).toBe(400);
-        expect((await unreachableAgent.json()).message).toContain('not reachable');
+        expect((await unreachableAgent.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
+        const unreachableUser = await postAssignee(request, token, task.id, {
+            assigneeType: 'user',
+            assigneeId: C_UUID,
+        });
+        expect(unreachableUser.status()).toBe(400);
+        expect((await unreachableUser.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
 
         // Malformed task uuid → 400 ParseUUIDPipe.
         const badTaskUuid = await postAssignee(request, token, MALFORMED_UUID, {
@@ -395,11 +395,11 @@ test.describe('Task assignees — deep integration', () => {
         });
         expect(strangerAssign.status()).toBe(404);
 
-        // After every rejected attempt the task still has NO live A_UUID row, so
-        // a fresh add succeeds (none of the 4xx/401/404 above leaked a row).
+        // After every rejected attempt the task still has no owner-assignee row,
+        // so a valid add succeeds (none of the failures leaked a row).
         const cleanAdd = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: owner.user.id,
         });
         expect(cleanAdd.status(), `clean add after matrix=${await cleanAdd.text()}`).toBe(201);
     });
@@ -415,7 +415,7 @@ test.describe('Task assignees — deep integration', () => {
         // Assignee row attached to task A.
         const rowA = await addTaskAssignee(request, token, taskA.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: owner.user.id,
         });
 
         // Removing an UNKNOWN id (never existed) under task A removes nothing →
@@ -423,13 +423,13 @@ test.describe('Task assignees — deep integration', () => {
         // (taskId,id) key; 0 rows affected → NotFound, NOT an idempotent 200).
         const ghost = await deleteAssignee(request, token, taskA.id, C_UUID);
         expect(ghost.status(), `ghost delete=${await ghost.text()}`).toBe(404);
-        // A_UUID is still live on task A → duplicate add 409s (ghost delete
+        // The owner actor is still live on task A → duplicate add 409s (ghost delete
         // touched nothing).
         const stillLive = await postAssignee(request, token, taskA.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: owner.user.id,
         });
-        expect(stillLive.status(), 'A still live after ghost delete').toBe(409);
+        expect(stillLive.status(), 'owner still live after ghost delete').toBe(409);
 
         // The :id is BOTH an ownership gate AND part of the delete key
         // (removeForTask deletes the (taskId,id) pair — IDOR hardening). So
@@ -439,15 +439,16 @@ test.describe('Task assignees — deep integration', () => {
         expect(crossTaskDelete.status(), `cross-task delete=${await crossTaskDelete.text()}`).toBe(
             404,
         );
-        // Proof the cross-task delete did NOT touch A's row: A_UUID is still
+        // Proof the cross-task delete did NOT touch A's row: the owner is still
         // live on task A, so a duplicate add still 409s.
         const stillLiveAfterCross = await postAssignee(request, token, taskA.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: owner.user.id,
         });
-        expect(stillLiveAfterCross.status(), 'A still live after cross-task delete attempt').toBe(
-            409,
-        );
+        expect(
+            stillLiveAfterCross.status(),
+            'owner still live after cross-task delete attempt',
+        ).toBe(409);
 
         // A correct remove (right task + right id) succeeds → 200 { deleted:true }.
         const goodDelete = await deleteAssignee(request, token, taskA.id, rowA.id);
@@ -456,7 +457,7 @@ test.describe('Task assignees — deep integration', () => {
         // After a successful remove the same (type,id) re-adds cleanly → 201.
         const reAddA = await postAssignee(request, token, taskA.id, {
             assigneeType: 'user',
-            assigneeId: A_UUID,
+            assigneeId: owner.user.id,
         });
         expect(reAddA.status(), `re-add after delete=${await reAddA.text()}`).toBe(201);
 
@@ -474,7 +475,7 @@ test.describe('Task assignees — deep integration', () => {
         // row to task A first so the gate (not a missing row) is what blocks.
         const rowA2 = await addTaskAssignee(request, token, taskA.id, {
             assigneeType: 'user',
-            assigneeId: B_UUID,
+            assigneeId: owner.user.id,
         });
         const stranger = await registerUserViaAPI(request);
         const strangerRemove = await deleteAssignee(

--- a/apps/web/e2e/flow-task-assignees-deep.spec.ts
+++ b/apps/web/e2e/flow-task-assignees-deep.spec.ts
@@ -350,10 +350,17 @@ test.describe('Task assignees — deep integration', () => {
         expect(emptyId.status()).toBe(400);
         expect((await emptyId.json()).message).toContain('id is required');
 
-        // Either actor type outside the Task scope gets the same generic 400.
+        // A real persisted actor from another tenant/organization is not
+        // reachable from the owner's Task scope. Keep this distinct from the
+        // missing-actor probes below: both must fail closed, but they exercise
+        // different repository outcomes.
+        const foreign = await registerUserViaAPI(request);
+        const foreignAgent = await createAgentViaAPI(request, foreign.access_token, {
+            name: 'Foreign validation agent',
+        });
         const unreachableAgent = await postAssignee(request, token, task.id, {
             assigneeType: 'agent',
-            assigneeId: C_UUID,
+            assigneeId: foreignAgent.id,
         });
         expect(unreachableAgent.status()).toBe(400);
         expect((await unreachableAgent.json()).message).toBe(
@@ -361,12 +368,23 @@ test.describe('Task assignees — deep integration', () => {
         );
         const unreachableUser = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
-            assigneeId: C_UUID,
+            assigneeId: foreign.user.id,
         });
         expect(unreachableUser.status()).toBe(400);
         expect((await unreachableUser.json()).message).toBe(
             'Task actor is not reachable in this Task scope.',
         );
+
+        for (const assigneeType of ['agent', 'user'] as const) {
+            const missingActor = await postAssignee(request, token, task.id, {
+                assigneeType,
+                assigneeId: C_UUID,
+            });
+            expect(missingActor.status()).toBe(400);
+            expect((await missingActor.json()).message).toBe(
+                'Task actor is not reachable in this Task scope.',
+            );
+        }
 
         // Malformed task uuid → 400 ParseUUIDPipe.
         const badTaskUuid = await postAssignee(request, token, MALFORMED_UUID, {
@@ -388,7 +406,7 @@ test.describe('Task assignees — deep integration', () => {
 
         // A stranger cannot see — let alone assign on — my task: scoped-resolve
         // reads as 404 (not 403). The owner's task is untouched.
-        const stranger: RegisteredUser = await registerUserViaAPI(request);
+        const stranger: RegisteredUser = foreign;
         const strangerAssign = await postAssignee(request, stranger.access_token, task.id, {
             assigneeType: 'user',
             assigneeId: stranger.user.id,

--- a/apps/web/e2e/flow-task-full-multistep.spec.ts
+++ b/apps/web/e2e/flow-task-full-multistep.spec.ts
@@ -44,8 +44,8 @@
  *       is an escape hatch (→200 without force); zero approvers pass vacuously.
  *   POST   /api/tasks/:id/assignees { assigneeType:'user'|'agent', assigneeId }
  *     → 201 { taskId, assigneeType, assigneeId, id, createdAt, … }
- *     - agent-type must be an OWNED agent (foreign/unknown → 400); user-type
- *       id is NOT validated; duplicate → 409; DELETE is BY ROW id (the add
+ *     - every actor must be reachable in the persisted Task scope; foreign or
+ *       unknown user/agent ids share one generic 400; duplicate → 409; DELETE is BY ROW id (the add
  *       response `id`, not the actor id) → { deleted:true }, re-delete → 404.
  *   POST   /api/tasks/:id/reviewers { reviewerType, reviewerId }
  *     → 201 { …, reviewState:'pending', reviewedAt:null }
@@ -102,7 +102,6 @@ async function createTask(
     request: APIRequestContext,
     ctx: OwnerCtx,
     body: Record<string, unknown>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
     const res = await request.post(`${API_BASE}/api/tasks`, { headers: ctx.headers, data: body });
     expect(res.status(), `createTask body=${await res.text().catch(() => '')}`).toBe(201);
@@ -421,7 +420,7 @@ test.describe('Task full lifecycle — reviewers + assignee sub-resource lifecyc
         expect(readd.assigneeId).toBe(ctx.userId);
     });
 
-    test('agent assignee must be an OWNED agent (foreign → 400); user-type ids are not validated', async ({
+    test('agent and user assignees must both be reachable in the persisted Task scope', async ({
         request,
     }) => {
         const ctx = await boot(request);
@@ -434,13 +433,15 @@ test.describe('Task full lifecycle — reviewers + assignee sub-resource lifecyc
         });
         expect(foreignAgent.status()).toBe(400);
 
-        // A user-type assignee id is taken as-is (no users-table lookup in this graph).
+        // The same non-enumerating rejection applies to an unknown user id.
         const anyUser = await request.post(`${tasksBase()}/${task.id}/assignees`, {
             headers: ctx.headers,
             data: { assigneeType: 'user', assigneeId: UNKNOWN_UUID },
         });
-        expect(anyUser.status()).toBe(201);
-        expect((await anyUser.json()).assigneeId).toBe(UNKNOWN_UUID);
+        expect(anyUser.status()).toBe(400);
+        expect((await anyUser.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
     });
 });
 

--- a/apps/web/e2e/flow-tasks-advanced-deep.spec.ts
+++ b/apps/web/e2e/flow-tasks-advanced-deep.spec.ts
@@ -41,7 +41,7 @@ import { createAgentViaAPI, createTaskViaAPI, transitionTaskViaAPI } from './hel
  *         "reviewerType must be one of the following values: user, agent"
  *         (the @IsIn pipe fires before the controller's assertActorType).
  *       · reviewerType:'agent' + unknown/unowned id → 400
- *         "Agent <id> is not reachable for this user — cannot assign."
+ *         "Task actor is not reachable in this Task scope."
  *       · missing reviewerId → 400 (@IsString/@MaxLength).
  *       · DUPLICATE (same taskId+type+id) → 500 (unique index).
  *       · cross-user (stranger on my task) → 404 "Task <id> not found."
@@ -212,7 +212,9 @@ test.describe('Task reviewers — add lifecycle (API)', () => {
             reviewerId: NIL_UUID,
         });
         expect(unownedAgent.status()).toBe(400);
-        expect((await unownedAgent.json()).message).toMatch(/not reachable for this user/i);
+        expect((await unownedAgent.json()).message).toBe(
+            'Task actor is not reachable in this Task scope.',
+        );
 
         // (c) Missing reviewerId → 400 (DTO @IsString/@MaxLength).
         const missingId = await addReviewer(request, token, task.id, { reviewerType: 'user' });

--- a/apps/web/e2e/flow-tasks-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-tasks-validation-authz-matrix.spec.ts
@@ -72,7 +72,7 @@ import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from '.
  *       missing/bad type → 400 ["<x>Type must be one of the following values: user, agent"]
  *       missing id       → 400 ["<x>Id must be a string", …]
  *       id 129 chars     → 400 ["<x>Id must be shorter than or equal to 128 characters"]
- *       agent-type + unknown agent id → 400 "Agent … is not reachable for this user — cannot assign."
+ *       agent-type + unknown agent id → 400 "Task actor is not reachable in this Task scope."
  *       user-type happy  → 201;  duplicate → 409;  cross-user task → 404;  no auth → 401
  *     DELETE assignees/:assigneeId — unknown → 404; malformed → 400
  *
@@ -639,7 +639,7 @@ test.describe('POST assignees/reviewers/approvers — actor DTO symmetric matrix
             assigneeId: UNKNOWN_UUID,
         });
         expect(res.status()).toBe(400);
-        expect(errText(await res.json())).toContain('is not reachable for this user');
+        expect(errText(await res.json())).toBe('Task actor is not reachable in this Task scope.');
     });
 
     test('user-type assignee happy path → 201, exact duplicate → 409 conflict', async ({

--- a/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
+++ b/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
@@ -595,7 +595,7 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
         expect(filedBody.mimeType).toBe('image/png');
     });
 
-    test('serve a valid-shape but never-stored filename (owner) -> 404 "Upload not found"; malformed filename -> 400 InvalidFilename', async ({
+    test('serve a never-stored canonical filename as 404; malformed shape is the same opaque 404', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
@@ -616,8 +616,8 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
             `${API_BASE}/api/uploads/${owner.user.id}/not-a-valid-name.txt`,
             { headers: authedHeaders(owner.access_token) },
         );
-        expect(bad.status(), 'malformed filename -> 400').toBe(400);
+        expect(bad.status(), 'malformed filename -> opaque 404').toBe(404);
         const badBody = (await bad.json()) as Record<string, unknown>;
-        expect(badBody.code).toBe('InvalidFilename');
+        expect(badBody).toEqual({ status: 'error', message: 'Not found' });
     });
 });

--- a/apps/web/e2e/flow-uploads-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-uploads-validation-authz-matrix.spec.ts
@@ -23,7 +23,7 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *      the `auth.userId !== :userId` short-circuit fired with NO stored file
  *      (pure path-segment mismatch → 404 "Not found"), a canonical-shape
  *      filename with an out-of-allow-list extension (<hex64>.exe → 400
- *      InvalidFilename), and a too-short hash (63 chars → 400 InvalidFilename).
+ *      InvalidFilename), and a too-short hash (63 chars → opaque 404).
  *   4. The ANONYMOUS upload routes' VALIDATION (rejects, not the happy mint
  *      sec-pin already owns): image-only allow-list, magic-byte mismatch,
  *      empty/missing file on `/anonymous`, the broader allow-list + reject on
@@ -526,7 +526,7 @@ test.describe('FLOW: uploads authz — serve-route filename + ownership edges', 
         expect(body.message).toBe('Invalid filename');
     });
 
-    test('a too-short hash (63 hex chars) with a valid extension → 400 InvalidFilename', async ({
+    test('a too-short hash (63 hex chars) with a valid extension → opaque 404', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -534,8 +534,8 @@ test.describe('FLOW: uploads authz — serve-route filename + ownership edges', 
             `${API_BASE}/api/uploads/${user.user.id}/${'a'.repeat(63)}.png`,
             { headers: authedHeaders(user.access_token) },
         );
-        expect(res.status()).toBe(400);
-        expect((await res.json()).code).toBe('InvalidFilename');
+        expect(res.status()).toBe(404);
+        expect(await res.json()).toEqual({ status: 'error', message: 'Not found' });
     });
 });
 

--- a/apps/web/e2e/helpers/agents-tasks.ts
+++ b/apps/web/e2e/helpers/agents-tasks.ts
@@ -1,6 +1,12 @@
 import { type APIRequestContext, expect } from '@playwright/test';
 import { API_BASE, authedHeaders } from './api';
 
+function scopedHeaders(token: string, scopeSlug?: string) {
+    return scopeSlug
+        ? { ...authedHeaders(token), 'x-scope-slug': scopeSlug }
+        : authedHeaders(token);
+}
+
 /**
  * Agents + Tasks helpers.
  *
@@ -51,9 +57,10 @@ export async function createAgentViaAPI(
     request: APIRequestContext,
     token: string,
     body: { name: string; scope?: string; missionId?: string; ideaId?: string; workId?: string },
+    scopeSlug?: string,
 ): Promise<Agent> {
     const res = await request.post(`${API_BASE}/api/agents`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
         data: { scope: 'tenant', ...body },
     });
     expect(res.status(), `createAgent body=${await res.text().catch(() => '')}`).toBe(201);
@@ -72,9 +79,10 @@ export async function createTaskViaAPI(
         missionId?: string;
         ideaId?: string;
     },
+    scopeSlug?: string,
 ): Promise<Task> {
     const res = await request.post(`${API_BASE}/api/tasks`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
         data: body,
     });
     expect(res.status(), `createTask body=${await res.text().catch(() => '')}`).toBe(201);
@@ -87,9 +95,10 @@ export async function addTaskAssignee(
     token: string,
     taskId: string,
     assignee: { assigneeType: 'agent' | 'user'; assigneeId: string },
+    scopeSlug?: string,
 ): Promise<{ id: string; taskId: string; assigneeType: string; assigneeId: string }> {
     const res = await request.post(`${API_BASE}/api/tasks/${taskId}/assignees`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
         data: assignee,
     });
     expect(res.status(), `addAssignee body=${await res.text().catch(() => '')}`).toBe(201);
@@ -102,9 +111,10 @@ export async function transitionTaskViaAPI(
     taskId: string,
     to: string,
     force = false,
+    scopeSlug?: string,
 ): Promise<Task> {
     const res = await request.post(`${API_BASE}/api/tasks/${taskId}/transition`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
         data: { to, force },
     });
     expect(res.status(), `transition body=${await res.text().catch(() => '')}`).toBeLessThan(300);
@@ -122,9 +132,10 @@ export async function assignTaskToAgent(
     token: string,
     agentId: string,
     taskId: string,
+    scopeSlug?: string,
 ): Promise<{ runId?: string } | null> {
     const res = await request.post(`${API_BASE}/api/agents/${agentId}/assign-task`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
         data: { taskId },
     });
     if (res.ok()) return res.json();
@@ -135,9 +146,10 @@ export async function listAgentRuns(
     request: APIRequestContext,
     token: string,
     agentId: string,
+    scopeSlug?: string,
 ): Promise<AgentRun[]> {
     const res = await request.get(`${API_BASE}/api/agents/${agentId}/runs`, {
-        headers: authedHeaders(token),
+        headers: scopedHeaders(token, scopeSlug),
     });
     expect(res.status()).toBe(200);
     const body = await res.json();

--- a/apps/web/e2e/sec-pin-agent-run-scoping.spec.ts
+++ b/apps/web/e2e/sec-pin-agent-run-scoping.spec.ts
@@ -258,7 +258,7 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
         );
         expect(res.status()).toBe(404);
         const body = (await res.json()) as ErrorBody;
-        expect(body.message).toBe(`Agent ${a.agent.id} not found.`);
+        expect(body.message).toBe('AgentRun not found.');
 
         // The victim's history is provably untouched: same total, same row,
         // same terminal status (a cancel would have flipped/echoed state).

--- a/packages/agent/src/triggers/__tests__/inbound-triggers-events.spec.ts
+++ b/packages/agent/src/triggers/__tests__/inbound-triggers-events.spec.ts
@@ -288,6 +288,7 @@ describe('InboundTriggersService — event-sourced triggers', () => {
                     title: 'Push on acme/widgets',
                     description: 'By ada — Pushed 3 commits',
                 }),
+                { tenantId: null, organizationId: null },
             );
             const row = repo._rows.get(trigger.id) as InboundTrigger;
             expect(row.fireCount).toBe(1);
@@ -422,6 +423,7 @@ describe('InboundTriggersService — event-sourced triggers', () => {
                     title: 'From template: github.push',
                     description: 'Templated body',
                 }),
+                { tenantId: null, organizationId: null },
             );
         });
 
@@ -444,6 +446,7 @@ describe('InboundTriggersService — event-sourced triggers', () => {
             expect(tasks.create).toHaveBeenCalledWith(
                 'user-1',
                 expect.objectContaining({ title: 'Own title' }),
+                { tenantId: null, organizationId: null },
             );
         });
     });
@@ -466,6 +469,7 @@ describe('InboundTriggersService — event-sourced triggers', () => {
             expect(tasks.create).toHaveBeenCalledWith(
                 'user-1',
                 expect.objectContaining({ labels: [TRIGGER_TEST_LABEL] }),
+                { tenantId: null, organizationId: null },
             );
             const row = repo._rows.get(trigger.id) as InboundTrigger;
             expect(row.fireCount).toBe(0);

--- a/packages/agent/src/triggers/__tests__/inbound-triggers.service.spec.ts
+++ b/packages/agent/src/triggers/__tests__/inbound-triggers.service.spec.ts
@@ -180,11 +180,33 @@ describe('InboundTriggersService', () => {
                     createdById: 'user-1',
                     description: expect.stringContaining('ada@example.com'),
                 }),
+                { tenantId: null, organizationId: null },
             );
             expect(tasks.addAssignee).toHaveBeenCalledWith('user-1', 'task-1', 'agent', 'agent-1');
             const row = repo._rows.get(trigger.id) as InboundTrigger;
             expect(row.fireCount).toBe(1);
             expect(row.lastFiredAt).toBeInstanceOf(Date);
+        });
+
+        it('propagates the persisted trigger tenant and organization scope to the spawned Task', async () => {
+            const { service, repo, tasks } = makeService();
+            const { trigger, secret } = await service.create(ORG_SCOPE, { name: 'Scoped hook' });
+            const row = repo._rows.get(trigger.id) as InboundTrigger;
+            row.tenantId = 'tenant-1';
+
+            const body = '{}';
+            const ts = nowSeconds();
+            await service.fire(trigger.id, {
+                rawBody: body,
+                signatureHeader: sign(secret, ts, body),
+                timestampHeader: ts,
+                contentType: 'application/json',
+            });
+
+            expect(tasks.create).toHaveBeenCalledWith('user-1', expect.any(Object), {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+            });
         });
 
         it('accepts a sha256=-prefixed signature and defaults the task title template', async () => {
@@ -202,6 +224,7 @@ describe('InboundTriggersService', () => {
             expect(tasks.create).toHaveBeenCalledWith(
                 'user-1',
                 expect.objectContaining({ title: 'Trigger: Plain hook' }),
+                { tenantId: null, organizationId: null },
             );
         });
 

--- a/packages/agent/src/triggers/inbound-triggers.service.ts
+++ b/packages/agent/src/triggers/inbound-triggers.service.ts
@@ -561,14 +561,21 @@ export class InboundTriggersService {
                     '```',
                 ].join('\n'),
         );
-        const task = await this.tasks.create(row.userId, {
-            title,
-            description,
-            labels: [TRIGGER_TEST_LABEL],
-            hiddenFromBoard: !row.showOnBoard,
-            createdByType: 'user',
-            createdById: row.userId,
-        });
+        const task = await this.tasks.create(
+            row.userId,
+            {
+                title,
+                description,
+                labels: [TRIGGER_TEST_LABEL],
+                hiddenFromBoard: !row.showOnBoard,
+                createdByType: 'user',
+                createdById: row.userId,
+            },
+            {
+                tenantId: row.tenantId ?? null,
+                organizationId: row.organizationId ?? null,
+            },
+        );
         await this.tryAssignAgent(row, task.id);
         // Rehearsals appear in the fire log (that is where the owner looks
         // to see what happened) but never dedupe against anything and never
@@ -638,16 +645,23 @@ export class InboundTriggersService {
 
         let task: { id: string; slug: string; title: string };
         try {
-            task = await this.tasks.create(row.userId, {
-                title,
-                description,
-                workId: ctx.workId ?? null,
-                // Automated work stays off the human board unless the
-                // trigger's owner opted it in.
-                hiddenFromBoard: !row.showOnBoard,
-                createdByType: 'user',
-                createdById: row.userId,
-            });
+            task = await this.tasks.create(
+                row.userId,
+                {
+                    title,
+                    description,
+                    workId: ctx.workId ?? null,
+                    // Automated work stays off the human board unless the
+                    // trigger's owner opted it in.
+                    hiddenFromBoard: !row.showOnBoard,
+                    createdByType: 'user',
+                    createdById: row.userId,
+                },
+                {
+                    tenantId: row.tenantId ?? null,
+                    organizationId: row.organizationId ?? null,
+                },
+            );
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             await this.closeFire(ctx.fire, 'failed', { reason: message });


### PR DESCRIPTION
## What changed

- update the stage E2E contracts for tenant/organization ownership hardening, hidden trigger tasks, and the current subscription response
- preserve tenant and organization scope when public HMAC trigger fires create tasks
- keep the test-fire path on the same persisted ownership contract

## Why

The July browser contracts still assumed pre-hardening personal-scope behavior. While correcting them, the anonymous inbound-trigger flow exposed a real source defect: tasks created by both public fire paths omitted the trigger row's persisted tenant and organization scope.

## Verification

- 363/363 touched browser tests passed against the CI-shaped isolated API/web stack
- 41/41 inbound-trigger unit tests passed after rebase onto exact develop `9755ee975c0bdf3577c2c0bbe48a1746a87354c1`
- changed web ESLint and web/agent type-check passed
- API and agent builds passed; monorepo build passed
- regression test was proven red before the source repair

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access scoping for agent runs, tasks, assignments, reviewers, and approvers.
  - Standardized not-found responses to avoid exposing inaccessible resources.
  - Improved upload error handling for malformed or unavailable filenames.
  - Inbound-triggered tasks now retain their tenant, organization, and work context.
  - Corrected goal detail navigation and displayed scope fields.
  - Updated subscription validation messaging to say “Upgrade to Enterprise.”

- **Tests**
  - Expanded coverage for authorization, scoping, task workflows, triggers, uploads, and agent-run cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->