### PR TITLE
test(e2e): align conversation and steering contracts

### DIFF
--- a/apps/web/e2e/flow-conversations-crud-deep.spec.ts
+++ b/apps/web/e2e/flow-conversations-crud-deep.spec.ts
@@ -201,20 +201,17 @@ test.describe('Conversations CRUD deep — create-body validation (DTO caps + wh
 });
 
 test.describe('Conversations CRUD deep — PATCH body validation', () => {
-    test('PATCH requires title: {} → 400; over-length → 400; valid → 204', async ({ request }) => {
+    test('PATCH accepts an empty no-op; over-length → 400; valid → 204', async ({ request }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const conv = await createConversation(request, token, { title: 'original' });
 
-        // UpdateConversationDto.title has NO @IsOptional → an empty PATCH body is a 400.
+        // Both update fields are optional so an empty PATCH is a valid no-op.
         const missing = await request.patch(`${API_BASE}/api/conversations/${conv.id}`, {
             headers: authedHeaders(token),
             data: {},
         });
-        expect(missing.status(), 'PATCH {} → 400 (title required)').toBe(400);
-        expect(messageText(await missing.json()), 'title must be a string').toContain(
-            'title must be a string',
-        );
+        expect(missing.status(), 'PATCH {} → 204 (no-op)').toBe(204);
 
         // Over-length rename trips the @MaxLength(200) cap.
         const tooLong = await request.patch(`${API_BASE}/api/conversations/${conv.id}`, {
@@ -223,14 +220,14 @@ test.describe('Conversations CRUD deep — PATCH body validation', () => {
         });
         expect(tooLong.status(), 'PATCH 201-char title → 400').toBe(400);
 
-        // Both failed PATCHes left the original title intact (no partial write).
+        // The empty no-op and failed over-length PATCH left the title intact.
         const stillOriginal = await request.get(`${API_BASE}/api/conversations/${conv.id}`, {
             headers: authedHeaders(token),
         });
         expect(stillOriginal.status()).toBe(200);
         expect(
             ((await stillOriginal.json()) as ConversationRow).title,
-            'failed PATCHes did not mutate the title',
+            'empty/failed PATCHes did not mutate the title',
         ).toBe('original');
 
         // A within-cap rename succeeds with 204 No Content and persists.
@@ -319,25 +316,23 @@ test.describe('Conversations CRUD deep — ParseUUIDPipe on :id routes', () => {
         expect(append.status(), 'append bad-uuid → 400').toBe(400);
     });
 
-    test('PATCH validates the body before the id pipe: bad body wins, valid body surfaces the uuid 400', async ({
+    test('PATCH validates the id before either an empty or populated optional body', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
 
-        // PATCH bad-uuid + EMPTY body → the body DTO validation fires first, so the
-        // response is the title error, NOT the uuid error (pins NestJS pipe ordering).
+        // An empty body is valid, so the malformed id is the failing boundary.
         const badBody = await request.patch(`${API_BASE}/api/conversations/${MALFORMED_ID}`, {
             headers: authedHeaders(token),
             data: {},
         });
         expect(badBody.status(), 'PATCH bad-uuid + bad-body → 400').toBe(400);
-        expect(messageText(await badBody.json()), 'body error wins over the uuid pipe').toContain(
-            'title must be a string',
+        expect(messageText(await badBody.json()), 'uuid pipe surfaces for an empty body').toContain(
+            'uuid is expected',
         );
 
-        // PATCH bad-uuid + VALID body → now the param pipe is the only failing gate
-        // → the uuid-expected error surfaces.
+        // A populated valid body reaches the same id boundary.
         const validBody = await request.patch(`${API_BASE}/api/conversations/${MALFORMED_ID}`, {
             headers: authedHeaders(token),
             data: { title: 'valid title' },

--- a/apps/web/e2e/flow-conversations-list-pagination.spec.ts
+++ b/apps/web/e2e/flow-conversations-list-pagination.spec.ts
@@ -93,7 +93,7 @@ interface ConvListBody {
 async function createConversation(
     request: APIRequestContext,
     token: string,
-    body: { title?: string; providerId?: string } = {},
+    body: { title?: string; providerId?: string; model?: string } = {},
     expectStatus = 201,
 ): Promise<ConvSummary> {
     const res = await request.post(CONV_URL, {

--- a/apps/web/e2e/flow-conversations-list-pagination.spec.ts
+++ b/apps/web/e2e/flow-conversations-list-pagination.spec.ts
@@ -219,28 +219,24 @@ test.describe('Conversations list — shape & projection', () => {
         expect(row!.updatedAt).toMatch(ISO_RE);
     });
 
-    test('a titleless conversation lists with title:null / providerId:null; model is always null (create rejects it)', async ({
+    test('a titleless conversation lists with null defaults; a create-time model pin is projected', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
-        // `model` is NOT whitelisted on CreateConversationDto → forbidNonWhitelisted 400.
         await createConversation(request, token, { title: 't', providerId: 'p' }, 201);
-        const rejected = await request.post(CONV_URL, {
-            headers: { ...authedHeaders(token), 'content-type': 'application/json' },
-            data: { title: 't2', model: 'gpt-4' },
+        const modelled = await createConversation(request, token, {
+            title: 't2',
+            model: 'gpt-4',
         });
-        expect(rejected.status(), 'model is not an accepted create field').toBe(400);
 
         const conv = await createConversation(request, token, {}); // empty body allowed
         const body = await listConversations(request, token);
         const row = body.conversations.find((c) => c.id === conv.id)!;
         expect(row.title).toBeNull();
         expect(row.providerId).toBeNull();
-        expect(
-            row.model,
-            'model can never be set via the public create path → always null',
-        ).toBeNull();
+        expect(row.model).toBeNull();
+        expect(body.conversations.find((c) => c.id === modelled.id)!.model).toBe('gpt-4');
     });
 });
 

--- a/apps/web/e2e/flow-conversations-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-conversations-validation-authz-matrix.spec.ts
@@ -544,24 +544,25 @@ test.describe('append › pipeline ordering and create whitelist', () => {
         expect(msg, 'the uuid-pipe error is NOT what surfaced').not.toContain('uuid is expected');
     });
 
-    test('conversation create rejects entity columns absent from the DTO (model, metadata)', async ({
+    test('conversation create accepts a model pin but rejects server-owned metadata', async ({
         request,
     }) => {
         const { access_token } = await registerUserViaAPI(request);
 
-        // `model` and `metadata` are real (nullable) columns on the Conversation
-        // entity but are NOT part of CreateConversationDto — they are message-/
-        // server-owned and must not be client-settable at create time.
-        for (const field of ['model', 'metadata'] as const) {
-            const res = await request.post(`${API_BASE}/api/conversations`, {
-                headers: authedHeaders(access_token),
-                data: { title: 'x', [field]: field === 'metadata' ? { a: 1 } : 'gpt-4' },
-            });
-            expect(res.status(), `create with ${field} → 400 (forbidNonWhitelisted)`).toBe(400);
-            const json = (await res.json()) as Record<string, unknown>;
-            expect(errText(json), `names the forbidden ${field} property`).toContain(
-                `property ${field} should not exist`,
-            );
-        }
+        const accepted = await request.post(`${API_BASE}/api/conversations`, {
+            headers: authedHeaders(access_token),
+            data: { title: 'x', model: 'gpt-4' },
+        });
+        expect(accepted.status(), 'model is a whitelisted create-time pin').toBe(201);
+        expect(((await accepted.json()) as Record<string, unknown>).model).toBe('gpt-4');
+
+        const rejected = await request.post(`${API_BASE}/api/conversations`, {
+            headers: authedHeaders(access_token),
+            data: { title: 'x', metadata: { a: 1 } },
+        });
+        expect(rejected.status(), 'metadata remains server-owned').toBe(400);
+        expect(errText((await rejected.json()) as Record<string, unknown>)).toContain(
+            'property metadata should not exist',
+        );
     });
 });

--- a/apps/web/e2e/flow-run-sessions-steering-contract.spec.ts
+++ b/apps/web/e2e/flow-run-sessions-steering-contract.spec.ts
@@ -301,7 +301,7 @@ test.describe('GET /api/works/:id/runs-summary', () => {
 });
 
 test.describe('run steering — steer / interrupt / resume', () => {
-    test('steer: empty message is a DTO 400, whitespace-only is a 409, oversized is rejected', async ({
+    test('steer: empty/oversized messages are DTO 400s; an unknown run stays a 404', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -315,11 +315,11 @@ test.describe('run steering — steer / interrupt / resume', () => {
         expect(empty.status()).toBe(400);
         expect(errText(await empty.json())).toContain('message');
 
-        // Whitespace passes the DTO; the service's own trim guard rejects
-        // it — and does so BEFORE the run lookup, so this is 409 not 404.
+        // Whitespace passes the DTO, but the controller scopes the run before
+        // invoking the service. An unknown run therefore remains a 404 and
+        // does not expose the service's trim guard ordering.
         const whitespace = await post(request, u.access_token, path, { message: '   ' });
-        expect(whitespace.status()).toBe(409);
-        expect(errText(await whitespace.json())).toContain('steering message is required');
+        expect(whitespace.status()).toBe(404);
 
         const oversized = await post(request, u.access_token, path, {
             message: 'a'.repeat(16_385),


### PR DESCRIPTION
## What changed
- update four stale E2E contract specs to match the implemented DTO/controller boundaries
- preserve every suite and assertion path; no production code or workflow is changed
- pin model-at-create, optional conversation PATCH fields, UUID-pipe ordering, and scoped-run-before-steering behavior

## Runtime evidence
Stage exact SHA b90dd468c3cc5befa37b920b68f6e85ac2aafe67 exposed the drift in E2E run 32950358018:
- shard 9: conversation create/PATCH assertions expected the pre-model-pin contract
- shard 18: unknown-run whitespace steering expected the service 409 before the controller's scoped lookup

The current source contract explicitly accepts create-time model, makes both PATCH fields optional, and scopes the run before invoking steering.

## Verification
- Prettier: 4/4 files clean
- ESLint: 4/4 files clean
- affected Playwright specs: 77/77 passed against the isolated local API/web stack

No schema, storage, runtime, or customer-data change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conversation updates now allow empty PATCH requests as no-ops while preserving title validation.
  - Conversation creation and listings now support the `model` field, while server-managed metadata remains restricted.
  - Invalid conversation and run identifiers return clearer validation errors.
  - Steering requests consistently validate message content and return not-found responses for unknown runs.
- **Tests**
  - Expanded coverage for conversation updates, model handling, pagination, authorization, and run steering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->