### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ Notes:
 
 - We recommend deploying to Kubernetes (k8s) for production workloads. See the `.deploy/` folder for our deployment configurations.
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/ever-works/)
+
 ## 💌 Contact Us
 
 - [Ever.co Website Contact Us page](https://ever.co/contacts)


### PR DESCRIPTION
## Summary

Adds a RepoCloud one-click deploy button to the README, providing users with a convenient VPS deployment option using Docker Compose.

## Changes

- Added a new "☁️ One-Click Deploy" section between the Kubernetes production recommendation and the Contact Us section
- Button links to `https://repocloud.io/details/ever-works/` for instant deployment

## Context

[RepoCloud](https://repocloud.io) offers affordable VPS hosting for open-source applications with Docker Compose support. The deploy button gives users a one-click path to running Ever Works on a dedicated VPS with full root access, complementing the existing Docker Compose and Kubernetes deployment options.

## Screenshot

The button renders as:

[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/ever-works/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “One-Click Deploy” section to the README.
  - Included a deployment badge and direct link for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->