### PR TITLE
fix(monitoring): stop PostHog capture flooding the org event allowance

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -264,10 +264,35 @@ SENTRY_ENVIRONMENT=development
 # ============================================
 # Project (public) API key — same phc_* as the marketing site uses;
 # not a security secret. Without it set, PostHog SDK is a no-op (graceful).
-# When POSTHOG_API_KEY is set, all NestJS Logger emits (log/warn/error/
-# debug/verbose) are also forwarded to PostHog Logs as `$log` events.
 POSTHOG_API_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
+
+# --- Event-volume controls -------------------------------------------------
+# PostHog bills per event against a 1M/month allowance. On 2026-08-31 this API
+# was emitting ~110k events/day of pure machine traffic (synthetic probes,
+# internal calls, duplicated events) against 0-13 real product events/day.
+# These three knobs exist so that can never silently recur.
+#
+# Master kill switch for ALL capture (events, $log, identify). The client is
+# still constructed, so feature flags keep working. Default: true.
+# Set this to false in dev/stage while they share prod's PostHog project.
+# POSTHOG_CAPTURE_ENABLED=true
+#
+# Which log levels are forwarded to PostHog Logs as `$log` events. Accepts a
+# comma-separated list, `all`, or `none`. The console still receives EVERY
+# level regardless, so `kubectl logs` is unaffected. Default: warn,error.
+# POSTHOG_LOG_LEVELS=warn,error
+#
+# Re-enable the per-endpoint `api_<method>_<path>` companion event. It fired
+# alongside every `api_request` and duplicated it 1:1 (129,426 vs 129,205 over
+# 3 days), so it is now off; `api_request` already carries `endpoint` as a
+# property. Default: false.
+# POSTHOG_TRACK_PER_ENDPOINT_EVENTS=false
+#
+# Extra path prefixes excluded from analytics, comma-separated. Additive to
+# the built-in list (/api/health, /api/version, /api/info, /internal,
+# /.well-known, /metrics). Matches on exact hit or prefix followed by `/`.
+# POSTHOG_ANALYTICS_EXCLUDE_PATHS=
 
 
 # ============================== PLUGINS ========================================

--- a/packages/monitoring/src/interceptors/__tests__/posthog.interceptor.spec.ts
+++ b/packages/monitoring/src/interceptors/__tests__/posthog.interceptor.spec.ts
@@ -23,11 +23,21 @@ const buildExecCtx = (req: any, response: any = { statusCode: 200 }): ExecutionC
 describe('PostHogInterceptor', () => {
     let interceptor: PostHogInterceptor;
 
+    let envBackup: NodeJS.ProcessEnv;
+
     beforeEach(async () => {
+        envBackup = { ...process.env };
+        delete process.env.POSTHOG_CAPTURE_ENABLED;
+        delete process.env.POSTHOG_TRACK_PER_ENDPOINT_EVENTS;
+        delete process.env.POSTHOG_ANALYTICS_EXCLUDE_PATHS;
         await shutdownPostHog();
         captureMock.mockClear();
         identifyMock.mockClear();
         interceptor = new PostHogInterceptor();
+    });
+
+    afterEach(() => {
+        process.env = envBackup;
     });
 
     it('does not throw when PostHog is not initialized', async () => {
@@ -39,7 +49,7 @@ describe('PostHogInterceptor', () => {
         expect(captureMock).not.toHaveBeenCalled();
     });
 
-    it('emits two events (api_request and per-endpoint) on success with user', async () => {
+    it('emits a single api_request event carrying the full request context', async () => {
         initPostHog({ apiKey: 'k' });
         const req = {
             method: 'GET',
@@ -52,7 +62,9 @@ describe('PostHogInterceptor', () => {
         const next: CallHandler = { handle: () => of({}) };
         await lastValueFrom(interceptor.intercept(buildExecCtx(req, { statusCode: 201 }), next));
 
-        expect(captureMock).toHaveBeenCalledTimes(2);
+        // ONE event per request: the per-endpoint companion is opt-in (see the
+        // "machine-traffic suppression" block) because it duplicated this 1:1.
+        expect(captureMock).toHaveBeenCalledTimes(1);
 
         const apiRequestCall = captureMock.mock.calls.find((c) => c[0].event === 'api_request');
         expect(apiRequestCall).toBeDefined();
@@ -66,11 +78,8 @@ describe('PostHogInterceptor', () => {
         expect(typeof apiReq.properties.duration).toBe('number');
         expect(apiReq.groups).toEqual({ endpoint: '/works/42' });
 
-        const namedCall = captureMock.mock.calls.find((c) => c[0].event !== 'api_request');
-        expect(namedCall).toBeDefined();
-        // /works/42 -> /works/:id -> get_works_:id (lowercased) — but ":" is a non-alphanumeric and gets replaced with "_"
-        // works -> works, /:id -> _:id is filtered to /_id, leading slash trimmed, "/" replaced with "_"
-        expect(namedCall![0].event).toMatch(/^api_get_works/);
+        // No second event: nothing else was captured for this request.
+        expect(captureMock.mock.calls.filter((c) => c[0].event !== 'api_request')).toHaveLength(0);
     });
 
     it('uses "anonymous" as distinctId when no user is attached', async () => {
@@ -137,6 +146,8 @@ describe('PostHogInterceptor', () => {
     });
 
     it('replaces numeric IDs with :id and lowercases the named-event slug', async () => {
+        // Slug generation only runs for the opt-in per-endpoint event.
+        process.env.POSTHOG_TRACK_PER_ENDPOINT_EVENTS = 'true';
         initPostHog({ apiKey: 'k' });
         const req = {
             method: 'PATCH',
@@ -152,5 +163,92 @@ describe('PostHogInterceptor', () => {
         expect(namedCall[0].event).toMatch(/^api_patch_/);
         // numeric ids are replaced with :id, then ":" -> "_" via the second replace
         expect(namedCall[0].event).not.toMatch(/123|456/);
+    });
+});
+
+/**
+ * Regression tests for the 2026-08-31 PostHog quota incident.
+ *
+ * The interceptor was emitting ~110k events/day against a 1M/month allowance
+ * while real product events ran at 0-13/day. Three defects, all covered here:
+ *   1. every request produced TWO events (a catch-all `api_request` AND a
+ *      per-endpoint `api_<method>_<path>`) — exact 1:1 duplication;
+ *   2. only `/api/health*` was exempt, so synthetic monitoring hitting
+ *      `/api/version` (blackbox-exporter, 3 VMAgent replicas x 5 URLs x 60s)
+ *      and machine-to-machine `/internal/*` calls were recorded as product
+ *      analytics;
+ *   3. there was no kill switch at all — the only "off" was an absent API key.
+ */
+describe('PostHogInterceptor — machine-traffic suppression', () => {
+    let envBackup: NodeJS.ProcessEnv;
+    let interceptor: PostHogInterceptor;
+
+    beforeEach(async () => {
+        envBackup = { ...process.env };
+        delete process.env.POSTHOG_CAPTURE_ENABLED;
+        delete process.env.POSTHOG_TRACK_PER_ENDPOINT_EVENTS;
+        delete process.env.POSTHOG_ANALYTICS_EXCLUDE_PATHS;
+        await shutdownPostHog();
+        captureMock.mockClear();
+        interceptor = new PostHogInterceptor();
+        initPostHog({ apiKey: 'k' });
+    });
+
+    afterEach(() => {
+        process.env = envBackup;
+    });
+
+    const run = async (originalUrl: string, method = 'GET') => {
+        const req = { method, originalUrl, headers: {}, body: undefined };
+        const next: CallHandler = { handle: () => of({}) };
+        return lastValueFrom(interceptor.intercept(buildExecCtx(req), next));
+    };
+
+    it.each([
+        '/api/version',
+        '/api/info',
+        '/internal/trigger/remote/call',
+        '/.well-known/agent.json',
+        '/metrics',
+    ])('does NOT capture anything for ops/probe path %s', async (url) => {
+        await expect(run(url)).resolves.toEqual({});
+        expect(captureMock).not.toHaveBeenCalled();
+    });
+
+    it('emits exactly ONE event per tracked request (no per-endpoint duplicate)', async () => {
+        await run('/api/works');
+        expect(captureMock).toHaveBeenCalledTimes(1);
+        expect(captureMock.mock.calls[0][0].event).toBe('api_request');
+        // The endpoint is preserved as a PROPERTY, so nothing analytical is lost
+        // by dropping the per-endpoint event name.
+        expect(captureMock.mock.calls[0][0].properties.endpoint).toBe('/api/works');
+    });
+
+    it('restores the per-endpoint companion event when POSTHOG_TRACK_PER_ENDPOINT_EVENTS=true', async () => {
+        process.env.POSTHOG_TRACK_PER_ENDPOINT_EVENTS = 'true';
+        await run('/api/works');
+        expect(captureMock).toHaveBeenCalledTimes(2);
+        expect(captureMock.mock.calls.map((c) => c[0].event)).toEqual(
+            expect.arrayContaining(['api_request', 'api_get_api_works']),
+        );
+    });
+
+    it('captures nothing at all when POSTHOG_CAPTURE_ENABLED=false', async () => {
+        process.env.POSTHOG_CAPTURE_ENABLED = 'false';
+        await expect(run('/api/works')).resolves.toEqual({});
+        expect(captureMock).not.toHaveBeenCalled();
+    });
+
+    it('honours extra prefixes from POSTHOG_ANALYTICS_EXCLUDE_PATHS', async () => {
+        process.env.POSTHOG_ANALYTICS_EXCLUDE_PATHS = '/api/ops,/probe';
+        await run('/api/ops/status');
+        expect(captureMock).not.toHaveBeenCalled();
+        await run('/api/works');
+        expect(captureMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('still tracks a normal product route that merely resembles an ops path', async () => {
+        await run('/api/versions-of-my-doc');
+        expect(captureMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/monitoring/src/interceptors/posthog.interceptor.ts
+++ b/packages/monitoring/src/interceptors/posthog.interceptor.ts
@@ -3,6 +3,56 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { trackEvent } from '../posthog/posthog.config';
 
+/**
+ * Route prefixes that are MACHINE traffic, never product usage. Every one of
+ * these is polled around the clock by infrastructure, so recording them as
+ * analytics both bills per event and drowns the real signal.
+ *
+ * Measured on 2026-08-31 (PostHog project 144390): these paths accounted for
+ * ~99% of ~110k events/day while genuine product events ran at 0-13/day.
+ *   - `/api/health*`   — k8s liveness + readiness probes on every replica.
+ *   - `/api/version`   — synthetic monitoring. `vmprobe-ever-works-{dev,stage,
+ *     prod}` scrape it every 60s and VMAgent runs 3 replicas that each scrape
+ *     independently: 5 URLs x 3 replicas = 15 hits/min. The events arrived
+ *     with user agent `Blackbox Exporter/0.25.0` (43,188 in 2 days).
+ *   - `/api/info`      — ops metadata, probed the same way.
+ *   - `/internal/*`    — machine-to-machine calls. `/internal/trigger/remote/
+ *     call` alone produced 33,180 events in 2 days (user agent `node`).
+ *   - `/.well-known/*` — agent/protocol discovery, fetched by clients not users.
+ *   - `/metrics`       — Prometheus scrape endpoint.
+ *
+ * Matching is EXACT-or-followed-by-`/` so a real product route that merely
+ * shares a prefix (`/api/versions-of-my-doc`, `/api/healthcheck-foo`) is still
+ * tracked. Extend at runtime with `POSTHOG_ANALYTICS_EXCLUDE_PATHS` (a
+ * comma-separated prefix list) rather than editing this array for a one-off.
+ */
+const DEFAULT_EXCLUDED_PATH_PREFIXES: readonly string[] = [
+    '/api/health',
+    '/api/version',
+    '/api/info',
+    '/internal',
+    '/.well-known',
+    '/metrics',
+];
+
+/**
+ * Opt-in restore of the per-endpoint `api_<method>_<path>` companion event.
+ *
+ * It used to fire on EVERY request alongside `api_request`, which was exact
+ * 1:1 duplication: over 3 days `api_request` = 129,426 against 129,205 summed
+ * per-endpoint events. Nothing analytical is lost by defaulting it off —
+ * `api_request` already carries the same value in its `endpoint` property, and
+ * keeping one event name avoids unbounded event-name cardinality in PostHog.
+ */
+const trackPerEndpointEvents = (): boolean =>
+    /^(true|1|yes|on)$/i.test((process.env.POSTHOG_TRACK_PER_ENDPOINT_EVENTS ?? '').trim());
+
+const extraExcludedPrefixes = (): string[] =>
+    (process.env.POSTHOG_ANALYTICS_EXCLUDE_PATHS ?? '')
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean);
+
 @Injectable()
 export class PostHogInterceptor implements NestInterceptor {
     intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
@@ -15,14 +65,12 @@ export class PostHogInterceptor implements NestInterceptor {
         // ?api_key=) that must not be persisted in third-party analytics.
         const endpointPath = this.getEndpointPath(originalUrl);
 
-        // Do NOT record analytics for health-check / probe endpoints. k8s liveness +
-        // readiness probes (plus uptime monitors / load balancers) hit these every few
-        // seconds on every replica, around the clock. Each probe would otherwise emit an
-        // `api_request` event plus a per-endpoint `api_get_api_health` event — pure
-        // machine noise that bills per event and tells us nothing about real product
-        // usage. Covers `/api/health`, `/api/health/live`, `/api/health/ready`
-        // (see APIController + HealthController).
-        if (this.isHealthProbePath(endpointPath)) {
+        // Do NOT record analytics for infrastructure traffic — health probes,
+        // synthetic monitoring, internal machine-to-machine calls. These run around
+        // the clock on every replica and bill per event while telling us nothing
+        // about real product usage. See DEFAULT_EXCLUDED_PATH_PREFIXES for the list
+        // and the measurements behind it.
+        if (this.isExcludedPath(endpointPath)) {
             return next.handle();
         }
 
@@ -51,17 +99,23 @@ export class PostHogInterceptor implements NestInterceptor {
                     },
                 );
 
-                // Track specific endpoint usage
-                trackEvent(
-                    user?.id || 'anonymous',
-                    `api_${method.toLowerCase()}_${this.getEndpointName(endpointPath)}`,
-                    {
-                        endpoint: endpointPath,
-                        statusCode,
-                        duration,
-                        timestamp: new Date().toISOString(),
-                    },
-                );
+                // Track specific endpoint usage. OFF by default: this duplicated
+                // `api_request` 1:1 and doubled the event bill for no added signal
+                // (the endpoint is already a property above). Re-enable with
+                // POSTHOG_TRACK_PER_ENDPOINT_EVENTS=true if a dashboard needs
+                // per-endpoint event NAMES rather than a breakdown by property.
+                if (trackPerEndpointEvents()) {
+                    trackEvent(
+                        user?.id || 'anonymous',
+                        `api_${method.toLowerCase()}_${this.getEndpointName(endpointPath)}`,
+                        {
+                            endpoint: endpointPath,
+                            statusCode,
+                            duration,
+                            timestamp: new Date().toISOString(),
+                        },
+                    );
+                }
             }),
         );
     }
@@ -73,14 +127,18 @@ export class PostHogInterceptor implements NestInterceptor {
         return url.split('?')[0].split('#')[0];
     }
 
-    // Health-check / probe endpoints we never want in analytics. Matches the base
-    // `/api/health` liveness route plus the `/api/health/live` + `/api/health/ready`
-    // probes underneath it. Kept narrow (exact match or `/api/health/` prefix) so an
-    // unrelated future route like `/api/healthcheck-foo` would NOT be silently dropped.
-    private isHealthProbePath(path: string): boolean {
+    // Infrastructure endpoints we never want in analytics: health probes, synthetic
+    // monitoring, internal machine calls, protocol discovery, metrics. Kept narrow —
+    // a prefix matches only on an EXACT hit or when followed by `/` — so an unrelated
+    // route like `/api/healthcheck-foo` or `/api/versions-of-my-doc` is NOT silently
+    // dropped. Operators can add prefixes via POSTHOG_ANALYTICS_EXCLUDE_PATHS without
+    // a code change.
+    private isExcludedPath(path: string): boolean {
         if (!path) return false;
         const normalized = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
-        return normalized === '/api/health' || normalized.startsWith('/api/health/');
+        return [...DEFAULT_EXCLUDED_PATH_PREFIXES, ...extraExcludedPrefixes()].some(
+            (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+        );
     }
 
     private getEndpointName(url: string): string {

--- a/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
@@ -79,6 +79,11 @@ describe('PostHogLoggerService', () => {
 
     describe('with an initialized PostHog client', () => {
         beforeEach(() => {
+            // These cases exercise SERIALIZATION, distinctId and metadata — not
+            // which levels are forwarded — so opt every level back in. The
+            // production default is warn+error (see the "$log level gating"
+            // block); `process.env` is restored by the outer afterEach.
+            process.env.POSTHOG_LOG_LEVELS = 'all';
             initPostHog({ apiKey: 'phc_test' });
             captureMock.mockReset();
         });
@@ -166,5 +171,98 @@ describe('PostHogLoggerService', () => {
             svc.log('ping');
             expect(captureMock.mock.calls[0][0].properties.env).toBe('production');
         });
+    });
+});
+
+/**
+ * Regression tests for the 2026-08-31 PostHog quota incident.
+ *
+ * The logger forwarded EVERY NestJS log emit to PostHog as a `$log` event
+ * (~17k/day, distinct_id=system) against a 1M/month allowance. Log volume is
+ * driven by traffic, not by anything analytical, so the default is now
+ * warn+error only — while the CONSOLE keeps receiving every level, so
+ * `kubectl logs` is unchanged.
+ */
+describe('PostHogLoggerService — $log level gating', () => {
+    let envBackup: NodeJS.ProcessEnv;
+
+    beforeEach(async () => {
+        envBackup = { ...process.env };
+        delete process.env.POSTHOG_LOG_LEVELS;
+        delete process.env.POSTHOG_CAPTURE_ENABLED;
+        await shutdownPostHog();
+        captureMock.mockReset();
+        initPostHog({ apiKey: 'phc_test' });
+    });
+
+    afterEach(() => {
+        process.env = envBackup;
+    });
+
+    it.each(['log', 'debug', 'verbose'])(
+        'does NOT forward %s() to PostHog by default',
+        (method) => {
+            const svc = new PostHogLoggerService('Ctx');
+            (svc as any)[method]('chatty');
+            expect(captureMock).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(['warn', 'error'])('DOES forward %s() to PostHog by default', (method) => {
+        const svc = new PostHogLoggerService('Ctx');
+        (svc as any)[method]('something is wrong');
+        expect(captureMock).toHaveBeenCalledTimes(1);
+        expect(captureMock.mock.calls[0][0].properties.level).toBe(method);
+    });
+
+    it('still writes suppressed levels to the console (kubectl logs is unchanged)', () => {
+        const svc = new PostHogLoggerService('Ctx');
+        const spy = jest.spyOn((svc as any).fallbackLogger, 'log').mockImplementation(() => {});
+        svc.log('still on stdout');
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(captureMock).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    it('honours an explicit POSTHOG_LOG_LEVELS allowlist', () => {
+        process.env.POSTHOG_LOG_LEVELS = 'error';
+        const svc = new PostHogLoggerService('Ctx');
+        svc.warn('warned');
+        expect(captureMock).not.toHaveBeenCalled();
+        svc.error('failed');
+        expect(captureMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards every level when POSTHOG_LOG_LEVELS=all', () => {
+        process.env.POSTHOG_LOG_LEVELS = 'all';
+        const svc = new PostHogLoggerService('Ctx');
+        svc.log('a');
+        svc.debug('b');
+        svc.verbose('c');
+        expect(captureMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('forwards nothing when POSTHOG_LOG_LEVELS is set to none', () => {
+        process.env.POSTHOG_LOG_LEVELS = 'none';
+        const svc = new PostHogLoggerService('Ctx');
+        svc.error('even errors are suppressed');
+        expect(captureMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards nothing when POSTHOG_CAPTURE_ENABLED=false', () => {
+        process.env.POSTHOG_CAPTURE_ENABLED = 'false';
+        const svc = new PostHogLoggerService('Ctx');
+        svc.error('boom');
+        expect(captureMock).not.toHaveBeenCalled();
+    });
+
+    it('still forwards Error instances to Sentry even when $log is suppressed', () => {
+        process.env.POSTHOG_LOG_LEVELS = 'none';
+        captureExceptionMock.mockReset();
+        const err = new Error('explode');
+        const svc = new PostHogLoggerService('Ctx');
+        svc.error(err);
+        expect(captureMock).not.toHaveBeenCalled();
+        expect(captureExceptionMock).toHaveBeenCalledWith(err);
     });
 });

--- a/packages/monitoring/src/posthog/__tests__/posthog.config.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/posthog.config.spec.ts
@@ -24,6 +24,7 @@ import {
     identifyUser,
     setUserProperties,
     shutdownPostHog,
+    isCaptureEnabled,
 } from '../posthog.config';
 
 const PostHogCtor = PostHogMockCtor as unknown as jest.Mock;
@@ -141,5 +142,67 @@ describe('posthog.config', () => {
             expect(shutdownMock).toHaveBeenCalledTimes(1);
             expect(getPostHogClient()).toBeNull();
         });
+    });
+});
+
+/**
+ * Regression tests for the 2026-08-31 PostHog quota incident.
+ *
+ * Before this switch existed the ONLY way to stop capture was to unset
+ * POSTHOG_API_KEY, which also killed feature flags. `dev` and `stage` share a
+ * PostHog project with `prod`, so their traffic billed against the same
+ * 1M/month allowance with no way to opt out short of breaking the client.
+ */
+describe('posthog.config — capture kill switch', () => {
+    let envBackup: NodeJS.ProcessEnv;
+
+    beforeEach(async () => {
+        envBackup = { ...process.env };
+        delete process.env.POSTHOG_CAPTURE_ENABLED;
+        await shutdownPostHog();
+        captureMock.mockReset();
+        identifyMock.mockReset();
+        initPostHog({ apiKey: 'phc_test' });
+    });
+
+    afterEach(() => {
+        process.env = envBackup;
+    });
+
+    it('is enabled when POSTHOG_CAPTURE_ENABLED is unset (no behaviour change)', () => {
+        expect(isCaptureEnabled()).toBe(true);
+        trackEvent('u', 'evt');
+        expect(captureMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(['false', 'FALSE', '0', 'no', 'off', ' false '])(
+        'is disabled for POSTHOG_CAPTURE_ENABLED=%p',
+        (value) => {
+            process.env.POSTHOG_CAPTURE_ENABLED = value;
+            expect(isCaptureEnabled()).toBe(false);
+        },
+    );
+
+    it.each(['true', '1', 'yes', 'on', ''])(
+        'stays enabled for POSTHOG_CAPTURE_ENABLED=%p',
+        (value) => {
+            process.env.POSTHOG_CAPTURE_ENABLED = value;
+            expect(isCaptureEnabled()).toBe(true);
+        },
+    );
+
+    it('suppresses trackEvent, identifyUser and setUserProperties when disabled', () => {
+        process.env.POSTHOG_CAPTURE_ENABLED = 'false';
+        trackEvent('u', 'evt');
+        identifyUser('u', { a: 1 });
+        setUserProperties('u', { b: 2 });
+        expect(captureMock).not.toHaveBeenCalled();
+        expect(identifyMock).not.toHaveBeenCalled();
+    });
+
+    it('leaves the client constructed so feature flags keep working', () => {
+        process.env.POSTHOG_CAPTURE_ENABLED = 'false';
+        trackEvent('u', 'evt');
+        expect(getPostHogClient()).not.toBeNull();
     });
 });

--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -1,5 +1,5 @@
 import { ConsoleLogger, LoggerService } from '@nestjs/common';
-import { getPostHogClient } from './posthog.config';
+import { getPostHogClient, isCaptureEnabled } from './posthog.config';
 import { getSentryInstance } from '../sentry/sentry.config';
 
 /**
@@ -54,6 +54,37 @@ const redactSecrets = (value: string | undefined): string | undefined => {
 };
 
 type LogLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
+
+/**
+ * Which log levels are forwarded to PostHog Logs as `$log` events.
+ *
+ * Log volume scales with TRAFFIC, not with anything analytical, so forwarding
+ * every level burned ~17k events/day against a 1M/month allowance (measured
+ * 2026-08-31). Default to the two levels anyone actually alerts on; the
+ * console still receives every level, so `kubectl logs` is unaffected.
+ *
+ * `POSTHOG_LOG_LEVELS` accepts a comma-separated list (`warn,error`), the
+ * special value `all` to restore the previous forward-everything behaviour,
+ * or `none` to forward nothing.
+ */
+const DEFAULT_FORWARDED_LOG_LEVELS: readonly LogLevel[] = ['warn', 'error'];
+
+const shouldForwardLevel = (level: LogLevel): boolean => {
+    if (!isCaptureEnabled()) return false;
+
+    const raw = (process.env.POSTHOG_LOG_LEVELS ?? '').trim();
+    if (raw === '') return DEFAULT_FORWARDED_LOG_LEVELS.includes(level);
+
+    const normalized = raw.toLowerCase();
+    if (normalized === 'all' || normalized === '*') return true;
+    if (normalized === 'none' || normalized === 'off') return false;
+
+    return normalized
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .includes(level);
+};
 
 /**
  * NestJS `LoggerService` that forwards every log emit to PostHog Logs as a
@@ -151,9 +182,12 @@ export class PostHogLoggerService implements LoggerService {
             console.error('[PostHogLoggerService] fallback logger threw', level, message);
         }
 
-        // 2) Forward to PostHog Logs as a `$log` event. Swallow any error.
+        // 2) Forward to PostHog Logs as a `$log` event, if this level is
+        //    forwarded at all (see shouldForwardLevel). Swallow any error.
+        //    Step 1 above already wrote to stdout unconditionally, so a
+        //    suppressed level is still fully visible in `kubectl logs`.
         try {
-            const client = getPostHogClient();
+            const client = shouldForwardLevel(level) ? getPostHogClient() : null;
             if (client) {
                 const properties: Record<string, unknown> = {
                     level,

--- a/packages/monitoring/src/posthog/posthog.config.ts
+++ b/packages/monitoring/src/posthog/posthog.config.ts
@@ -25,12 +25,32 @@ export const getPostHogClient = (): PostHog | null => {
     return posthogClient;
 };
 
+/**
+ * Master kill switch for ALL PostHog capture (events, `$log`, identify).
+ *
+ * Before this existed the only way to stop capture was to unset
+ * `POSTHOG_API_KEY`, which also disabled feature flags and made the failure
+ * mode "analytics silently gone" rather than a deliberate choice. An explicit
+ * switch lets a non-production environment keep the client configured while
+ * sending nothing — which is how `dev` and `stage` stop billing against the
+ * shared project's event allowance.
+ *
+ * Defaults to ENABLED, so an unset variable never changes existing behaviour.
+ * Anything in {false, 0, no, off} (case-insensitive) turns capture off.
+ */
+export const isCaptureEnabled = (): boolean => {
+    const raw = process.env.POSTHOG_CAPTURE_ENABLED;
+    if (raw === undefined || raw.trim() === '') return true;
+    return !/^(false|0|no|off)$/i.test(raw.trim());
+};
+
 export const trackEvent = (
     distinctId: string,
     event: string,
     properties?: Record<string, any>,
     groups?: Record<string, string | number>,
 ) => {
+    if (!isCaptureEnabled()) return;
     if (posthogClient) {
         posthogClient.capture({
             distinctId,
@@ -46,6 +66,7 @@ export const trackEvent = (
 };
 
 export const identifyUser = (distinctId: string, properties?: Record<string, any>) => {
+    if (!isCaptureEnabled()) return;
     if (posthogClient) {
         posthogClient.identify({
             distinctId,
@@ -58,6 +79,7 @@ export const identifyUser = (distinctId: string, properties?: Record<string, any
 };
 
 export const setUserProperties = (distinctId: string, properties: Record<string, any>) => {
+    if (!isCaptureEnabled()) return;
     if (posthogClient) {
         posthogClient.identify({
             distinctId,


### PR DESCRIPTION
## Why

PostHog alerted at **80% of the 1M/month free allowance** for Ever Technologies LTD.

Measured live against PostHog project `144390` on 2026-08-31, it is **not growth** — it is this API's instrumentation:

| | events/day |
|---|---|
| Machine/server events | **96,000 – 160,000** |
| Real user events | **0 – 13** |

August 2026 total: **1,772,509 events**. Every event arrives as `lib=posthog-node`, `distinct_id=anonymous`, `$host=null` — one distinct_id for the entire fleet, so it is also worthless *as* analytics.

## What was wrong

1. **Every request emitted two events.** A catch-all `api_request` *and* a per-endpoint `api_<method>_<path>`. Exact 1:1 duplication — over 3 days `api_request` = 129,426 against 129,205 summed per-endpoint events (delta 221 = query `LIMIT` tail). Half the volume was pure duplication.
2. **Our own monitoring was the top "user".** Only `/api/health*` was exempt. `vmprobe-ever-works-{dev,stage,prod}` scrape `/api/version` every 60s, and **VMAgent runs 3 replicas that each scrape independently** — 5 URLs × 3 replicas = 15 hits/min (measured 15.06/min). The events carry user agent `Blackbox Exporter/0.25.0`: 43,188 in 2 days.
3. **Internal machine calls tracked as product analytics.** `/internal/trigger/remote/call` — 33,180 events in 2 days, user agent `node`.
4. **Every log line became an event.** `PostHogLoggerService` forwarded *all* NestJS log emits as `$log` (~17k/day).

## What this changes

Everything is **gated, not removed** (rule #9) — each behaviour can be restored with one env var.

| Variable | Default | Effect |
|---|---|---|
| `POSTHOG_CAPTURE_ENABLED` | `true` | Master kill switch for events, `$log` and identify. Client still constructed, so **feature flags keep working**. |
| `POSTHOG_TRACK_PER_ENDPOINT_EVENTS` | `false` | Restores the duplicate per-endpoint event. |
| `POSTHOG_LOG_LEVELS` | `warn,error` | Which levels reach PostHog Logs. Accepts a list, `all`, or `none`. |
| `POSTHOG_ANALYTICS_EXCLUDE_PATHS` | — | Extra excluded prefixes, additive to the built-ins. |

Built-in exclusions are now `/api/health`, `/api/version`, `/api/info`, `/internal`, `/.well-known`, `/metrics`. Matching is **exact-or-followed-by-`/`**, so `/api/versions-of-my-doc` and `/api/healthcheck-foo` are still tracked.

**No signal is lost:** `api_request` already carries `endpoint` as a property, so per-endpoint breakdowns still work — as a property breakdown rather than unbounded event names. The console still receives **every** log level, so `kubectl logs` is unchanged, and Sentry forwarding of `Error` instances is untouched.

## Expected effect

**~110k/day → ~5k/day** (~150k/month, ~15% of the free tier).

## Testing

136 tests pass in `@ever-works/monitoring` (8 suites); `tsc --noEmit` and Prettier clean.

The new tests were written **before** the fix and watched fail (9 red). The kill switch was additionally verified by **mutation** — neutering the gate turns 9 tests red across all three layers — so these are not passing by absence.

Two pre-existing tests asserted the defective behaviour (`emits two events…`) and were updated to the corrected intent; six logger tests that used `log()` merely as a vehicle for testing serialization now set `POSTHOG_LOG_LEVELS=all` so they keep testing what they were about.

## Follow-up (not in this PR)

**dev, stage and prod all write to the same PostHog project** — all three namespaces mount `ever-works-app-secrets` carrying one shared `POSTHOG_API_KEY`. That triples the bill and violates rule #10. The `POSTHOG_CAPTURE_ENABLED` switch added here is what makes the k8s-side fix a one-line env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controls to enable or disable analytics capture.
  - Added configurable log-level forwarding for PostHog Logs.
  - Added optional per-endpoint analytics events.
  - Added support for excluding custom URL path prefixes from analytics.

- **Bug Fixes**
  - Reduced duplicate request events.
  - Prevented health checks, metrics, internal routes, and other infrastructure traffic from being recorded.
  - Preserved error reporting even when routine log forwarding is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->