### PR TITLE
fix(works): pass deploymentStartedAt as epoch millis to the bigint guard

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
@@ -331,8 +331,35 @@ describe('WorkRepository', () => {
             );
             expect(fns.andWhere).toHaveBeenCalledWith(
                 'deploymentStartedAt = :deploymentStartedAt',
-                { deploymentStartedAt: startedAt },
+                { deploymentStartedAt: startedAt.getTime() },
             );
+        });
+
+        // REGRESSION (2026-09-01): `deploymentStartedAt` is a Postgres `bigint` holding epoch
+        // millis (see `TimestampColumn` in entities/_types.ts). TypeORM applies that column
+        // transformer to entity writes and object-form conditions, but NOT to raw
+        // `andWhere('col = :p', { p })` parameters. Passing the raw `Date` therefore reaches the
+        // driver as an ISO string and Postgres rejects the whole UPDATE with
+        // `invalid input syntax for type bigint: "2026-08-23T18:47:45.019+00:00"`, so every
+        // health-probed deploy failed reconciliation and no work ever reached READY.
+        it('passes deploymentStartedAt as epoch millis so the bigint column accepts it', async () => {
+            const { chain, fns } = buildChain('execute', { affected: 1 });
+            repository.createQueryBuilder.mockReturnValueOnce(chain as never);
+            const startedAt = new Date('2026-08-22T08:00:00.000Z');
+
+            await service.markDeploymentReadyIfCurrent('w1', {
+                deploymentState: 'TIMEOUT',
+                deploymentStartedAt: startedAt,
+                lastDeployCorrelationId: 'corr-1',
+            });
+
+            const call = fns.andWhere.mock.calls.find(
+                ([sql]: [string]) => sql === 'deploymentStartedAt = :deploymentStartedAt',
+            );
+            expect(call).toBeDefined();
+            const value = call![1].deploymentStartedAt;
+            expect(typeof value).toBe('number');
+            expect(value).toBe(startedAt.getTime());
         });
 
         it('returns false when a newer deployment changed the guarded fields', async () => {

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -385,8 +385,13 @@ export class WorkRepository {
         if (expected.deploymentStartedAt == null) {
             query.andWhere('deploymentStartedAt IS NULL');
         } else {
+            // `deploymentStartedAt` is a `bigint` column of epoch millis (`TimestampColumn`).
+            // TypeORM runs that column's transformer for entity writes and object-form
+            // conditions, but NOT for raw `andWhere(sql, params)` parameters — the value goes
+            // straight to the driver, which serialises a `Date` as an ISO string and makes
+            // Postgres reject the UPDATE (`invalid input syntax for type bigint`). Convert here.
             query.andWhere('deploymentStartedAt = :deploymentStartedAt', {
-                deploymentStartedAt: expected.deploymentStartedAt,
+                deploymentStartedAt: expected.deploymentStartedAt.getTime(),
             });
         }
 


### PR DESCRIPTION
## What

`markDeploymentReadyIfCurrent` guards its reconciliation UPDATE on `deploymentStartedAt`, a Postgres **`bigint`** of epoch millis (declared via `TimestampColumn`, which carries a `Date` ⇄ `bigint` transformer).

TypeORM applies that transformer to entity writes and object-form conditions, but **not** to raw `andWhere(sql, params)` parameters. The raw `Date` therefore reached node-postgres, which serialised it as an ISO string, and Postgres rejected the statement:

```
invalid input syntax for type bigint: "2026-08-23T18:47:45.019+00:00"
```

## Impact (production)

The throw happens **after** the health probe succeeds, so every work whose site was actually up failed reconciliation:

- no work ever reached `READY`
- the `DEPLOY_READY` funnel event (step 7) never fired
- the poller retried the same works forever — **2,702 warnings/day**, ~**75% of all remaining PostHog volume** after the quota fix in #2287

Introduced by `26bf16cc6` ("guard health reconciliation races"), which added the guarded comparison.

## Controls (why this is the only broken site)

| Call site | Column | Verdict |
|---|---|---|
| `WorkScheduleRepository` `nextRunAt` | bigint | ✅ already `.getTime()` |
| `NotificationRepository.deleteExpired` `expiresAt` | bigint | ✅ already `Date.now()` (with a comment saying why) |
| `NotificationRepository.deleteOlderThan` / `WorkDeploymentRepository` `createdAt` | `@CreateDateColumn()` timestamp | ✅ `Date` is correct — untouched |

## Testing (TDD)

Added a RED test asserting the parameter is epoch millis; watched it fail with `Expected: "number" / Received: "object"` **before** writing the fix.

The pre-existing test asserted the *buggy* shape (`{ deploymentStartedAt: Date }`) and is corrected here — a `jest.fn()` query builder accepts values Postgres rejects, which is exactly why a green suite never caught this.

```
80/80 work.repository.spec.ts
90/90 incl. deploy-ready-poller.service.spec.ts
tsc --noEmit clean · prettier clean
```

Found while verifying the PostHog quota cascade (#2287 / #2288 / #2289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment readiness updates that could fail when comparing deployment start times.
  * Deployment start timestamps are now handled in the correct numeric format for reliable database updates.
  * Added regression coverage to prevent this issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->