### PR TITLE
chore(cascade): develop → stage — deploy-ready poller bigint fix

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
@@ -331,8 +331,35 @@ describe('WorkRepository', () => {
             );
             expect(fns.andWhere).toHaveBeenCalledWith(
                 'deploymentStartedAt = :deploymentStartedAt',
-                { deploymentStartedAt: startedAt },
+                { deploymentStartedAt: startedAt.getTime() },
             );
+        });
+
+        // REGRESSION (2026-09-01): `deploymentStartedAt` is a Postgres `bigint` holding epoch
+        // millis (see `TimestampColumn` in entities/_types.ts). TypeORM applies that column
+        // transformer to entity writes and object-form conditions, but NOT to raw
+        // `andWhere('col = :p', { p })` parameters. Passing the raw `Date` therefore reaches the
+        // driver as an ISO string and Postgres rejects the whole UPDATE with
+        // `invalid input syntax for type bigint: "2026-08-23T18:47:45.019+00:00"`, so every
+        // health-probed deploy failed reconciliation and no work ever reached READY.
+        it('passes deploymentStartedAt as epoch millis so the bigint column accepts it', async () => {
+            const { chain, fns } = buildChain('execute', { affected: 1 });
+            repository.createQueryBuilder.mockReturnValueOnce(chain as never);
+            const startedAt = new Date('2026-08-22T08:00:00.000Z');
+
+            await service.markDeploymentReadyIfCurrent('w1', {
+                deploymentState: 'TIMEOUT',
+                deploymentStartedAt: startedAt,
+                lastDeployCorrelationId: 'corr-1',
+            });
+
+            const call = fns.andWhere.mock.calls.find(
+                ([sql]: [string]) => sql === 'deploymentStartedAt = :deploymentStartedAt',
+            );
+            expect(call).toBeDefined();
+            const value = call![1].deploymentStartedAt;
+            expect(typeof value).toBe('number');
+            expect(value).toBe(startedAt.getTime());
         });
 
         it('returns false when a newer deployment changed the guarded fields', async () => {

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -385,8 +385,13 @@ export class WorkRepository {
         if (expected.deploymentStartedAt == null) {
             query.andWhere('deploymentStartedAt IS NULL');
         } else {
+            // `deploymentStartedAt` is a `bigint` column of epoch millis (`TimestampColumn`).
+            // TypeORM runs that column's transformer for entity writes and object-form
+            // conditions, but NOT for raw `andWhere(sql, params)` parameters — the value goes
+            // straight to the driver, which serialises a `Date` as an ISO string and makes
+            // Postgres reject the UPDATE (`invalid input syntax for type bigint`). Convert here.
             query.andWhere('deploymentStartedAt = :deploymentStartedAt', {
-                deploymentStartedAt: expected.deploymentStartedAt,
+                deploymentStartedAt: expected.deploymentStartedAt.getTime(),
             });
         }
 


### PR DESCRIPTION
Cascade `develop → stage`. Carries **exactly one commit**: `4cd796e30` (PR #2290), 2 files, +34/-2.

## What it fixes

`markDeploymentReadyIfCurrent` compared the `deploymentStartedAt` **`bigint`** column (epoch millis, via the `TimestampColumn` transformer) against a raw JS `Date`. TypeORM does not apply column transformers to raw `andWhere(sql, params)` parameters, so Postgres rejected every reconciliation UPDATE:

```
invalid input syntax for type bigint: "2026-08-23T18:47:45.019+00:00"
```

The throw is **downstream of a successful health probe**, so works whose sites were genuinely up never reached `READY` and the `DEPLOY_READY` funnel event never fired. Measured in prod: **5 stuck works, ~550 retries each per day** — 2,702 warnings/day, ~75% of all remaining PostHog volume after #2287.

## Checks on `develop`

`lint-and-test (22.x)` **pass** — all 19 steps `success` (formatting, build, and full test suite genuinely ran; nothing skipped). 13 checks pass, CodeRabbit pass with no findings.

`dependency-audit` is **red and pre-existing** — it passed on develop head `55791224f` yesterday and fails today with zero dependency changes in this diff. New advisories: `browserslist <=4.28.6` (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g) via `@nestjs-modules/mailer > mjml`, and `mysql2 <3.22.0` (GHSA-3f6p-5ww8-9rcr). Not a required check, and it runs in its own job so it no longer skips build/test. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)