### PR TITLE
fix(web): let the OAuth callbacks exchange under personal scope (restores GitHub/Google login)

### DIFF
--- a/apps/web/src/app/api/oauth/oauth-callback-handler.ts
+++ b/apps/web/src/app/api/oauth/oauth-callback-handler.ts
@@ -71,6 +71,11 @@ async function loginOauth(
             await setAuthCookies(authResponse.access_token);
         }
     } catch (error) {
+        // Surface the cause. This catch used to swallow it, and a failure thrown
+        // before the API was even called (`Invalid workspace scope`) left every
+        // social login at `/auth/error?error=oauth_callback` with no log line on
+        // either tier.
+        console.error(`OAuth login callback failed for ${provider}:`, error);
         const errorCode = getOAuthRouteErrorCode(error, 'oauth_callback');
         href = ROUTES.AUTH_ERROR + `?error=${errorCode}`;
     }

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -260,6 +260,13 @@ export const authAPI = {
         const params = new URLSearchParams({ code, state });
         return serverFetch<AuthResponse>(`/oauth/${providerId}/callback?${params.toString()}`, {
             headers: { cookie: `ew_oauth_state=${state}` },
+            // The provider redirects the browser to `/api/oauth/:p/callback` as a
+            // top-level navigation. `/api/*` sits outside the proxy matcher, so this
+            // request never carries the proxy-injected workspace selector that
+            // `serverFetch` otherwise fails closed on. A login is never
+            // Organization-scoped, so select personal scope explicitly — the same
+            // exemption the email callbacks already use.
+            publicRouteScope: 'personal',
         });
     },
 

--- a/apps/web/src/lib/api/auth.unit.spec.ts
+++ b/apps/web/src/lib/api/auth.unit.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_SCOPE_HEADER } from '../workspace-scope';
+
+const { getAuthAccessCookieMock, headersMock, translationsMock } = vi.hoisted(() => ({
+    getAuthAccessCookieMock: vi.fn(),
+    headersMock: vi.fn(),
+    translationsMock: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock('next/headers', () => ({ headers: headersMock }));
+vi.mock('../auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+vi.mock('next-intl/server', () => ({ getTranslations: translationsMock }));
+vi.mock('../constants', () => ({
+    ALLOWED_REDIRECT_URLS: ['app.example'],
+    API_URL: 'https://api.example',
+    ROUTES: { DASHBOARD: '/' },
+    WEB_URL: 'https://app.example',
+}));
+
+import { authAPI } from './auth';
+import { OAuthProvider } from './enums';
+
+/**
+ * The OAuth provider redirects the browser to `/api/oauth/:p/callback` as a
+ * TOP-LEVEL navigation. `/api/*` is excluded from the proxy matcher, so the
+ * request never carries the proxy-injected `x-ever-workspace` selector that
+ * `serverFetch` otherwise fails closed on. The exchange must therefore opt
+ * into personal scope explicitly — a login is never Organization-scoped.
+ *
+ * Regression: 2026-08-23 (`8f28edca0`) made the selector mandatory and every
+ * GitHub/Google login on app.ever.works ended at
+ * `/auth/error?error=oauth_callback` without a single log line, because the
+ * throw happened before the API was called and the handler swallowed it.
+ */
+describe('authAPI.connectOAuthCallback on a top-level provider redirect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // A signed-out browser: no auth cookie, no proxy workspace selector.
+        getAuthAccessCookieMock.mockResolvedValue(undefined);
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(
+                        JSON.stringify({
+                            access_token: 'session-token',
+                            user: { id: 'u1', username: 'u', email: 'u@example.com' },
+                        }),
+                        { status: 200, headers: { 'content-type': 'application/json' } },
+                    ),
+            ),
+        );
+    });
+
+    it.each([OAuthProvider.GITHUB, OAuthProvider.GOOGLE])(
+        'exchanges the %s code under personal scope without a proxy selector',
+        async (provider) => {
+            const result = await authAPI.connectOAuthCallback(provider, 'code-1', 'state-1');
+
+            expect(result.access_token).toBe('session-token');
+            expect(fetch).toHaveBeenCalledTimes(1);
+
+            const [url, init] = vi.mocked(fetch).mock.calls[0];
+            expect(url).toBe(
+                `https://api.example/oauth/${provider}/callback?code=code-1&state=state-1`,
+            );
+
+            const sent = new Headers(init?.headers);
+            expect(sent.get(API_SCOPE_HEADER)).toBe('@personal');
+            // C-03: the API re-verifies `state` against its own cookie name.
+            expect(sent.get('cookie')).toBe('ew_oauth_state=state-1');
+            expect(sent.get('authorization')).toBeNull();
+        },
+    );
+
+    it('still fails closed for the URL-issuing call, which only runs on proxied pages (control)', async () => {
+        await expect(authAPI.getOAuthAuthUrl(OAuthProvider.GITHUB)).rejects.toThrow(
+            'Invalid workspace scope',
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/lib/api/plugins-capabilities/oauth.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/oauth.ts
@@ -64,7 +64,13 @@ export const oauthAPI = {
         if (state) params.append('state', state);
         return serverFetch<OAuthConnectionInfo>(
             `/oauth/${providerId}/callback/plugins?${params.toString()}`,
-            state ? { headers: { cookie: `ew_oauth_state=${state}` } } : undefined,
+            {
+                ...(state ? { headers: { cookie: `ew_oauth_state=${state}` } } : {}),
+                // Top-level redirect from the provider, outside the proxy matcher: no
+                // workspace selector is present. The API binds the connection to the
+                // session user, so personal scope is correct by construction.
+                publicRouteScope: 'personal',
+            },
         );
     },
 
@@ -99,7 +105,13 @@ export const oauthAPI = {
         if (state) params.append('state', state);
         return serverFetch<{ providerId: string; connected: true }>(
             `/oauth/${providerId}/callback/plugins/read-packages?${params.toString()}`,
-            state ? { headers: { cookie: `ew_oauth_state=${state}` } } : undefined,
+            {
+                ...(state ? { headers: { cookie: `ew_oauth_state=${state}` } } : {}),
+                // Top-level redirect from the provider, outside the proxy matcher: no
+                // workspace selector is present. The API binds the connection to the
+                // session user, so personal scope is correct by construction.
+                publicRouteScope: 'personal',
+            },
         );
     },
 

--- a/apps/web/src/lib/api/plugins-capabilities/oauth.unit.spec.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/oauth.unit.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_SCOPE_HEADER } from '../../workspace-scope';
+
+const { getAuthAccessCookieMock, headersMock, translationsMock } = vi.hoisted(() => ({
+    getAuthAccessCookieMock: vi.fn(),
+    headersMock: vi.fn(),
+    translationsMock: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock('next/headers', () => ({ headers: headersMock }));
+vi.mock('../../auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+vi.mock('next-intl/server', () => ({ getTranslations: translationsMock }));
+vi.mock('../../constants', () => ({
+    ALLOWED_REDIRECT_URLS: ['app.example'],
+    API_URL: 'https://api.example',
+    ROUTES: { DASHBOARD: '/' },
+    WEB_URL: 'https://app.example',
+}));
+
+import { oauthAPI } from './oauth';
+
+/**
+ * Same shape as the login callback: `/api/oauth/:p/callback/plugins[/read-packages]`
+ * is a top-level redirect from the provider, outside the proxy matcher, so no
+ * `x-ever-workspace` selector is present. The API binds the connection to
+ * `req.user.userId` — it is personal by construction.
+ */
+describe('oauthAPI provider-connect callbacks on a top-level provider redirect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Signed-in user (the connect flow requires a session) but no proxy selector.
+        getAuthAccessCookieMock.mockResolvedValue('access-token');
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(JSON.stringify({ id: 'github', connected: true }), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' },
+                    }),
+            ),
+        );
+    });
+
+    it('connectCallback exchanges the code under personal scope', async () => {
+        await oauthAPI.connectCallback('github', 'code-1', 'state-1');
+
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe(
+            'https://api.example/oauth/github/callback/plugins?code=code-1&state=state-1',
+        );
+        const sent = new Headers(init?.headers);
+        expect(sent.get(API_SCOPE_HEADER)).toBe('@personal');
+        expect(sent.get('cookie')).toBe('ew_oauth_state=state-1');
+        expect(sent.get('authorization')).toBe('Bearer access-token');
+    });
+
+    it('readPackagesCallback exchanges the code under personal scope', async () => {
+        await oauthAPI.readPackagesCallback('github', 'code-2', 'state-2');
+
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe(
+            'https://api.example/oauth/github/callback/plugins/read-packages?code=code-2&state=state-2',
+        );
+        const sent = new Headers(init?.headers);
+        expect(sent.get(API_SCOPE_HEADER)).toBe('@personal');
+        expect(sent.get('cookie')).toBe('ew_oauth_state=state-2');
+    });
+
+    it('connectCallback without a state still opts into personal scope', async () => {
+        await oauthAPI.connectCallback('github', 'code-3');
+
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe('https://api.example/oauth/github/callback/plugins?code=code-3');
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+    });
+});


### PR DESCRIPTION
## What

Every GitHub / Google login on `app.ever.works` ends at `/auth/error?error=oauth_callback`, with **no log line on either tier**. This restores social login and makes the failure visible if it ever regresses.

## Root cause (proven, not inferred)

- `8f28edca0` (2026-08-23, "fix organization scope per request") made `serverFetch` **fail closed** with `Invalid workspace scope` whenever the request lacks the proxy-injected `x-ever-workspace` selector.
- The proxy matcher in `apps/web/src/proxy.ts` **excludes `/api/*`**, and the OAuth provider redirects the browser to `/api/oauth/:provider/callback` as a top-level navigation — so that request never carries the selector.
- `handleOAuthCallback` therefore threw **before the API was called**, and its `catch` mapped the throw to `oauth_callback` without logging it.
- `8a07386ac` (2026-08-25) added the `publicRouteScope: 'personal'` exemption for the email callbacks only; the OAuth login exchange and the two plugin provider-connect exchanges were missed.

Evidence gathered on prod before touching anything:
- Fake code + **matching** `oauth_state` cookie → `307 /auth/error?error=oauth_callback` with zero web/API log lines. The same exchange sent to the API directly (with the synthesized `ew_oauth_state` cookie) returns a structured `400 Missing access_token …` that the web would have logged — so the throw happens before the fetch.
- Last `user.login.github` row in `activity_log`: **2026-08-21**, i.e. before `8f28edca0` shipped; no sessions created in the last 24 h.
- The API accepts `x-scope-slug: @personal` on the public callback (identical 400 with and without it), so this cannot trade one 400 for another.

## Change

- `apps/web/src/lib/api/auth.ts` — `connectOAuthCallback` opts into `publicRouteScope: 'personal'` (a login is never Organization-scoped).
- `apps/web/src/lib/api/plugins-capabilities/oauth.ts` — `connectCallback` and `readPackagesCallback` (same top-level-redirect shape; the API binds the connection to `req.user.userId`).
- `apps/web/src/app/api/oauth/oauth-callback-handler.ts` — the `catch` now logs the cause before mapping it to an error code.
- Unit specs pin the contract: the exchange runs under `@personal` with **no** proxy selector and still forwards the C-03 `ew_oauth_state` cookie; the URL-issuing call (which only runs on proxied pages) still fails closed as a control.

Not touched: `/api/github-app/callback` (raw fetch, unaffected), `/api/auth/verify-email` and `/api/auth/reset-password` (already exempted). A sibling defect in two dashboard polling routes (`deploy/status`, `comparisons/generation-status`, polled with a raw `fetch()` and no selector) is tracked separately and deliberately kept out of this PR.

## Verification

- `vitest`: `auth.unit.spec.ts`, `plugins-capabilities/oauth.unit.spec.ts`, `server-api.unit.spec.ts` green (red before the fix with the exact production error).
- `prettier --check`, `eslint`, `tsc --noEmit` on `apps/web`.
- After deploy: the same fake-code probe must now surface `API Error: … Missing access_token …` in the web pod logs (proves the exchange reaches the API), then a real GitHub/Google sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback handling for top-level provider redirects by applying the correct personal scope.
  * Preserved OAuth state and authentication details during callback exchanges.
  * Ensured callbacks work correctly whether or not an OAuth state value is provided.
  * Added clearer error logging for OAuth login failures.

* **Tests**
  * Added coverage for OAuth callback requests, scope handling, state cookies, and authorization headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->