### PR TITLE
fix(web): send the workspace selector from the deploy and comparison pollers

### DIFF
--- a/apps/web/src/app/api/works/[id]/comparisons/generation-status/route.unit.spec.ts
+++ b/apps/web/src/app/api/works/[id]/comparisons/generation-status/route.unit.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+const { headersMock, getAuthFromCookieMock, getAuthAccessCookieMock } = vi.hoisted(() => ({
+    headersMock: vi.fn(),
+    getAuthFromCookieMock: vi.fn(),
+    getAuthAccessCookieMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({ headers: headersMock, cookies: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ getAuthFromCookie: getAuthFromCookieMock }));
+vi.mock('@/lib/auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+vi.mock('next-intl/server', () => ({ getTranslations: async () => (key: string) => key }));
+
+import { GET } from './route';
+
+const params = Promise.resolve({ id: 'w1' });
+
+/**
+ * Polled by `ComparisonGenerationProgress`. Same contract as the deploy
+ * status route: the scope comes from the browser's per-tab selector, and
+ * without it the handler fails closed to its idle payload without calling
+ * the platform.
+ */
+describe('GET /api/works/[id]/comparisons/generation-status workspace scope', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthFromCookieMock.mockResolvedValue({ id: 'u1' });
+        getAuthAccessCookieMock.mockResolvedValue('access-token');
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(JSON.stringify({ generating: true, stage: 'researching' }), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' },
+                    }),
+            ),
+        );
+    });
+
+    it('forwards the browser selector to the platform as the API scope header', async () => {
+        headersMock.mockResolvedValue(
+            new Headers({ host: 'app.example', [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:ever' }),
+        );
+
+        const response = await GET(
+            new NextRequest('https://app.example/api/works/w1/comparisons/generation-status'),
+            { params },
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ generating: true, stage: 'researching' });
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(String(url)).toMatch(/\/works\/w1\//);
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('ever');
+    });
+
+    it('fails closed without a selector: idle payload and no upstream call', async () => {
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+
+        const response = await GET(
+            new NextRequest('https://app.example/api/works/w1/comparisons/generation-status'),
+            { params },
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ generating: false });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/works/[id]/deploy/status/route.unit.spec.ts
+++ b/apps/web/src/app/api/works/[id]/deploy/status/route.unit.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+const { headersMock, getAuthFromCookieMock, getAuthAccessCookieMock } = vi.hoisted(() => ({
+    headersMock: vi.fn(),
+    getAuthFromCookieMock: vi.fn(),
+    getAuthAccessCookieMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({ headers: headersMock, cookies: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ getAuthFromCookie: getAuthFromCookieMock }));
+vi.mock('@/lib/auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+vi.mock('next-intl/server', () => ({ getTranslations: async () => (key: string) => key }));
+
+import { GET } from './route';
+
+const params = Promise.resolve({ id: 'w1' });
+
+/**
+ * Polled by `DeployProgressPanel`. The handler reaches the platform through
+ * `serverFetch`, so the scope it forwards is the browser's per-tab
+ * `x-ever-workspace` selector, and it fails closed (generic 500, no upstream
+ * call) when that selector is absent. The client poller is what has to send
+ * it; this pins both halves of that contract.
+ */
+describe('GET /api/works/[id]/deploy/status workspace scope', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthFromCookieMock.mockResolvedValue({ id: 'u1' });
+        getAuthAccessCookieMock.mockResolvedValue('access-token');
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(
+                        JSON.stringify({
+                            work: {
+                                deploymentState: 'BUILDING',
+                                deploymentStartedAt: null,
+                                website: null,
+                                deployProvider: 'k8s',
+                            },
+                        }),
+                        { status: 200, headers: { 'content-type': 'application/json' } },
+                    ),
+            ),
+        );
+    });
+
+    it('forwards the browser selector to the platform as the API scope header', async () => {
+        headersMock.mockResolvedValue(
+            new Headers({ host: 'app.example', [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:ever' }),
+        );
+
+        const response = await GET(
+            new NextRequest('https://app.example/api/works/w1/deploy/status'),
+            { params },
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ deploymentState: 'BUILDING' });
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(String(url)).toMatch(/\/works\/w1$/);
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('ever');
+    });
+
+    it('fails closed without a selector: generic 500 and no upstream call', async () => {
+        headersMock.mockResolvedValue(new Headers({ host: 'app.example' }));
+
+        const response = await GET(
+            new NextRequest('https://app.example/api/works/w1/deploy/status'),
+            { params },
+        );
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'failed_to_load_deploy_status' });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/works/detail/comparisons/ComparisonGenerationProgress.tsx
+++ b/apps/web/src/components/works/detail/comparisons/ComparisonGenerationProgress.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 const STAGES = ['researching', 'analyzing', 'writing', 'writing_extended', 'saving'] as const;
 
@@ -40,7 +41,9 @@ export function ComparisonGenerationProgress({
                 // Use direct fetch to Route Handler instead of server action
                 // to avoid Next.js server action serialization (which would
                 // block this call while the generation server action is running)
-                const res = await fetch(`/api/works/${workId}/comparisons/generation-status`);
+                const res = await browserApiFetch(
+                    `/api/works/${workId}/comparisons/generation-status`,
+                );
                 if (res.ok) {
                     setStatus(await res.json());
                 }

--- a/apps/web/src/components/works/detail/comparisons/ComparisonGenerationProgress.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/comparisons/ComparisonGenerationProgress.unit.spec.tsx
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+import { ComparisonGenerationProgress } from './ComparisonGenerationProgress';
+
+/**
+ * Same transport contract as `DeployProgressPanel`: the generation-status
+ * route handler resolves the platform scope from the per-tab
+ * `x-ever-workspace` selector, so the poller must send it.
+ */
+describe('ComparisonGenerationProgress polling transport', () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({ generating: true, stage: 'researching' }),
+            }),
+        );
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/works/w1', 'org:ever'],
+        ['/works/w1', 'personal'],
+    ])('polls with the workspace selector derived from %s', async (pathname, selector) => {
+        window.history.replaceState({}, '', pathname);
+
+        render(<ComparisonGenerationProgress workId="w1" isGenerating />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe('/api/works/w1/comparisons/generation-status');
+        expect(new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe(selector);
+    });
+});

--- a/apps/web/src/components/works/detail/deploy/DeployProgressPanel.tsx
+++ b/apps/web/src/components/works/detail/deploy/DeployProgressPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { CheckCircle2, AlertCircle, Loader2, ExternalLink, Clock } from 'lucide-react';
 
 interface DeployStatus {
@@ -127,7 +128,7 @@ export function DeployProgressPanel({ workId, isDeploying }: DeployProgressPanel
 
         const poll = async () => {
             try {
-                const res = await fetch(`/api/works/${workId}/deploy/status`);
+                const res = await browserApiFetch(`/api/works/${workId}/deploy/status`);
                 if (res.ok) {
                     setStatus(await res.json());
                 }

--- a/apps/web/src/components/works/detail/deploy/DeployProgressPanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/deploy/DeployProgressPanel.unit.spec.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+import { DeployProgressPanel } from './DeployProgressPanel';
+
+/**
+ * `/api/works/:id/deploy/status` is a Next route handler outside the proxy
+ * matcher, and it reaches the platform through `serverFetch`, which fails
+ * closed without the per-tab `x-ever-workspace` selector. A raw `fetch()`
+ * from this poller therefore threw `Invalid workspace scope` on every tick
+ * and the panel silently never updated. The poller must go through
+ * `browserApiFetch`, which derives the selector from the visible URL.
+ */
+describe('DeployProgressPanel polling transport', () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    deploymentState: 'BUILDING',
+                    deploymentStartedAt: null,
+                    website: null,
+                    deployProvider: 'k8s',
+                }),
+            }),
+        );
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/works/w1', 'org:ever'],
+        ['/works/w1', 'personal'],
+    ])('polls with the workspace selector derived from %s', async (pathname, selector) => {
+        window.history.replaceState({}, '', pathname);
+
+        render(<DeployProgressPanel workId="w1" isDeploying />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe('/api/works/w1/deploy/status');
+        expect(new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe(selector);
+    });
+});


### PR DESCRIPTION
## What

The Deploy progress panel and the Comparison generation progress panel on a Work's detail page silently never update: every poll fails server-side and both the route handler and the client poller swallow it.

Sibling of #2299 (the OAuth login fix), deliberately kept as its own PR because the correct scope here is **not** personal.

## Root cause

- `8f28edca0` made `serverFetch` fail closed with `Invalid workspace scope` unless the request carries the per-tab `x-ever-workspace` selector.
- `/api/works/:id/deploy/status` and `/api/works/:id/comparisons/generation-status` are Next route handlers outside the proxy matcher, and both reach the platform through `serverFetch` (`workAPI.get`, `workAPI.getComparisonGenerationStatus`).
- `DeployProgressPanel` and `ComparisonGenerationProgress` polled them with a **raw `fetch()`**, which sends no selector. Every tick threw inside the handler, the handler answered its generic fallback (`500 failed_to_load_deploy_status` / `{ generating: false }`), and the poller ignored the non-ok / idle response.

## Change

- Both pollers now go through `browserApiFetch`, which derives the selector from the visible URL. An Organization-scoped Work therefore keeps its real scope; forcing `publicRouteScope: 'personal'` (the login-callback remedy) would have been wrong here.
- Route handlers are unchanged: they already forward the browser selector as the API scope header and fail closed without it.

## Tests

- `DeployProgressPanel.unit.spec.tsx`, `ComparisonGenerationProgress.unit.spec.tsx` — the poll request carries `x-ever-workspace: org:ever` under `/org/ever/works/w1` and `personal` under `/works/w1` (red before, green after).
- `deploy/status/route.unit.spec.ts`, `comparisons/generation-status/route.unit.spec.ts` — the handler forwards the selector as `x-scope-slug` to the platform, and without a selector returns its fallback without calling upstream.
- `prettier --check`, `eslint`, `tsc --noEmit` on `apps/web`.

Also checked: `/api/usage/costs/[section]` is polled the same way but proxies with a raw `fetch` to `API_URL`, so it does not hit this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
