### PR TITLE
fix(api): map upstream OAuth failures to 400/502; test(node): make model-process.spec deterministic under runner load

### DIFF
--- a/apps/api/src/auth/services/social-auth.service.spec.ts
+++ b/apps/api/src/auth/services/social-auth.service.spec.ts
@@ -26,8 +26,9 @@ afterAll(() => {
     process.env = ORIGINAL_ENV;
 });
 
-import { BadRequestException } from '@nestjs/common';
-import { of } from 'rxjs';
+import { BadGatewayException, BadRequestException, HttpException, Logger } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { AxiosError } from 'axios';
 import type { HttpService } from '@nestjs/axios';
 import { SocialAuthService } from './social-auth.service';
 import type { AuthService } from './auth.service';
@@ -678,6 +679,208 @@ describe('SocialAuthService', () => {
             expect(args.tokenType).toBeNull();
             expect(args.scope).toBeNull();
             expect(args.refreshToken).toBeNull();
+        });
+    });
+
+    // Production 2026-09-03: a bogus `code` on /api/oauth/google/callback made
+    // the API log "ExceptionsHandler AxiosError: Request failed with status
+    // code 400" and answer a raw 500. The upstream HTTP failure escaped
+    // `firstValueFrom(httpService.post(...))` as an AxiosError, which Nest
+    // treats as an unhandled error. Upstream 4xx/5xx/network failures must
+    // surface as HttpExceptions with a SAFE message (provider name only,
+    // never the upstream body).
+    describe('upstream HTTP failures are mapped to HttpExceptions (never a raw 500)', () => {
+        const axiosHttpError = (status: number, body: unknown) =>
+            new AxiosError(
+                `Request failed with status code ${status}`,
+                status >= 500 ? AxiosError.ERR_BAD_RESPONSE : AxiosError.ERR_BAD_REQUEST,
+                { headers: {} } as never,
+                {},
+                {
+                    status,
+                    statusText: 'error',
+                    data: body,
+                    headers: {},
+                    config: { headers: {} } as never,
+                },
+            );
+
+        const axiosNetworkError = (code: string) =>
+            new AxiosError(`read ${code}`, code, { headers: {} } as never);
+
+        const GOOGLE_INVALID_GRANT = {
+            error: 'invalid_grant',
+            error_description: 'Malformed auth code. SECRET-UPSTREAM-DETAIL',
+        };
+
+        let warnSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        const captureError = async (promise: Promise<unknown>) => {
+            try {
+                await promise;
+            } catch (error) {
+                return error as HttpException;
+            }
+            throw new Error('expected the promise to reject');
+        };
+
+        it('(a) token endpoint 400 invalid_grant (Google) -> BadRequestException with a safe, provider-named message', async () => {
+            httpService.post.mockReturnValueOnce(
+                throwError(() => axiosHttpError(400, GOOGLE_INVALID_GRANT)),
+            );
+
+            const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'bogus'));
+
+            expect(error).toBeInstanceOf(BadRequestException);
+            expect(error.getStatus()).toBe(400);
+            expect(error.message).toContain('Google');
+            expect(error.message).not.toContain('SECRET-UPSTREAM-DETAIL');
+            expect(error.message).not.toContain('Malformed');
+            expect(JSON.stringify(error.getResponse())).not.toContain('SECRET-UPSTREAM-DETAIL');
+            expect(error.message).not.toBe('Internal server error');
+            expect(authService.validateSocialUser).not.toHaveBeenCalled();
+
+            // Operators get provider + upstream status + the bare error code,
+            // but never the free-text description.
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            const logged = String(warnSpy.mock.calls[0][0]);
+            expect(logged).toContain('google');
+            expect(logged).toContain('400');
+            expect(logged).toContain('invalid_grant');
+            expect(logged).not.toContain('SECRET-UPSTREAM-DETAIL');
+        });
+
+        it('(a2) token endpoint 4xx from any provider maps to 400 and names that provider', async () => {
+            httpService.post.mockReturnValueOnce(
+                throwError(() => axiosHttpError(401, { error: 'invalid_client' })),
+            );
+
+            const error = await captureError(service.authenticate(AuthProvider.LINKEDIN, 'bogus'));
+
+            expect(error).toBeInstanceOf(BadRequestException);
+            expect(error.message).toContain('LinkedIn');
+        });
+
+        it.each([
+            [429, 'rate_limit_exceeded'],
+            [408, 'request_timeout'],
+        ])(
+            '(a3) token endpoint %s (%s) is a provider-side condition -> BadGatewayException (502), not a client-fault 400',
+            async (status, code) => {
+                httpService.post.mockReturnValueOnce(
+                    throwError(() => axiosHttpError(status, { error: code })),
+                );
+
+                const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
+
+                expect(error).toBeInstanceOf(BadGatewayException);
+                expect(error.getStatus()).toBe(502);
+                expect(error.message).toContain('Google');
+                expect(error.message).not.toContain('rejected');
+                expect(error.message).not.toBe('Internal server error');
+                expect(authService.validateSocialUser).not.toHaveBeenCalled();
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const logged = String(warnSpy.mock.calls[0][0]);
+                expect(logged).toContain(String(status));
+                expect(logged).toContain(code);
+            },
+        );
+
+        it('(b) token endpoint 5xx -> BadGatewayException (502), not a raw 500', async () => {
+            httpService.post.mockReturnValueOnce(
+                throwError(() => axiosHttpError(503, '<html>upstream down</html>')),
+            );
+
+            const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
+
+            expect(error).toBeInstanceOf(HttpException);
+            expect(error).toBeInstanceOf(BadGatewayException);
+            expect(error.getStatus()).toBe(502);
+            expect(error.message).toContain('Google');
+            expect(error.message).not.toContain('upstream down');
+            expect(error.message).not.toBe('Internal server error');
+            expect(String(warnSpy.mock.calls[0][0])).toContain('503');
+        });
+
+        it('(c) network error (no response, ECONNRESET) -> HttpException (502), not a crash', async () => {
+            httpService.post.mockReturnValueOnce(throwError(() => axiosNetworkError('ECONNRESET')));
+
+            const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
+
+            expect(error).toBeInstanceOf(HttpException);
+            expect(error.getStatus()).toBe(502);
+            expect(error.message).toContain('Google');
+            expect(String(warnSpy.mock.calls[0][0])).toContain('ECONNRESET');
+        });
+
+        it('(d) user-info fetch rejecting with 401 -> BadRequestException, not a raw 500', async () => {
+            httpService.post.mockReturnValueOnce(of({ data: { access_token: 'tok' } }));
+            httpService.get.mockReturnValueOnce(
+                throwError(() =>
+                    axiosHttpError(401, {
+                        error: { code: 401, message: 'Invalid Credentials SECRET-UPSTREAM-DETAIL' },
+                    }),
+                ),
+            );
+
+            const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
+
+            expect(error).toBeInstanceOf(BadRequestException);
+            expect(error.message).toContain('Google');
+            expect(error.message).not.toContain('SECRET-UPSTREAM-DETAIL');
+            expect(authService.validateSocialUser).not.toHaveBeenCalled();
+        });
+
+        it('(d2) user-info fetch 5xx -> BadGatewayException (502)', async () => {
+            httpService.post.mockReturnValueOnce(of({ data: { access_token: 'tok' } }));
+            httpService.get.mockReturnValueOnce(throwError(() => axiosHttpError(502, 'boom')));
+
+            const error = await captureError(service.authenticate(AuthProvider.FACEBOOK, 'c'));
+
+            expect(error).toBeInstanceOf(BadGatewayException);
+            expect(error.message).toContain('Facebook');
+        });
+
+        it('(e) GitHub /user/emails failing upstream (inside resolveGitHubAccountEmail) -> 502, not a raw 500', async () => {
+            httpService.post.mockReturnValueOnce(of({ data: { access_token: 'gh' } }));
+            httpService.get
+                .mockReturnValueOnce(of({ data: { id: 1, login: 'octo', email: null } }))
+                .mockReturnValueOnce(throwError(() => axiosHttpError(500, 'github down')));
+
+            const error = await captureError(service.authenticate(AuthProvider.GITHUB, 'c'));
+
+            expect(error).toBeInstanceOf(BadGatewayException);
+            expect(error.message).toContain('GitHub');
+            expect(error.message).not.toContain('github down');
+        });
+
+        it('keeps the 200-with-error-body behaviour (GitHub) -> "Missing access_token" BadRequestException', async () => {
+            httpService.post.mockReturnValueOnce(
+                of({ data: { error: 'bad_verification_code', error_description: 'x' } }),
+            );
+
+            await expect(service.authenticate(AuthProvider.GITHUB, 'bad')).rejects.toThrow(
+                'Missing access_token from OAuth provider response',
+            );
+        });
+
+        it('does not mask non-HTTP programming errors as upstream failures', async () => {
+            httpService.post.mockReturnValueOnce(
+                throwError(() => new TypeError('bug in our code')),
+            );
+
+            const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
+
+            expect(error).toBeInstanceOf(TypeError);
+            expect(error).not.toBeInstanceOf(HttpException);
         });
     });
 });

--- a/apps/api/src/auth/services/social-auth.service.ts
+++ b/apps/api/src/auth/services/social-auth.service.ts
@@ -1,6 +1,13 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+    BadGatewayException,
+    BadRequestException,
+    HttpException,
+    Injectable,
+    Logger,
+} from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { createGitHubOAuthHeaders } from '@ever-works/agent/utils';
+import { isAxiosError } from 'axios';
 import { firstValueFrom } from 'rxjs';
 import { AuthProvider } from '../../config/constants';
 import { AuthService } from './auth.service';
@@ -59,8 +66,20 @@ interface LinkedInUserInfo {
     locale?: string;
 }
 
+/** Which upstream OAuth call failed — surfaced in the safe client message. */
+type UpstreamStep = 'token exchange' | 'user profile request';
+
+/**
+ * Upstream 4xx statuses that are NOT the client's fault: 408 Request Timeout
+ * and 429 Too Many Requests are provider-side / quota conditions and are mapped
+ * like a provider outage (502) rather than a rejected code (400).
+ */
+const UPSTREAM_THROTTLE_STATUSES: ReadonlySet<number> = new Set([408, 429]);
+
 @Injectable()
 export class SocialAuthService {
+    private readonly logger = new Logger(SocialAuthService.name);
+
     constructor(
         private readonly httpService: HttpService,
         private readonly authService: AuthService,
@@ -137,13 +156,19 @@ export class SocialAuthService {
             params.set('grant_type', 'authorization_code');
         }
 
-        const { data } = await firstValueFrom(
-            this.httpService.post<Record<string, unknown>>(provider.tokenUrl, params.toString(), {
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-            }),
+        const { data } = await this.callUpstream(providerId, 'token exchange', () =>
+            firstValueFrom(
+                this.httpService.post<Record<string, unknown>>(
+                    provider.tokenUrl,
+                    params.toString(),
+                    {
+                        headers: {
+                            Accept: 'application/json',
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                    },
+                ),
+            ),
         );
 
         const accessToken = this.readString(data, 'access_token');
@@ -182,14 +207,19 @@ export class SocialAuthService {
     private async getGitHubUser(accessToken: string) {
         const headers = createGitHubOAuthHeaders(accessToken);
 
-        const { data } = await firstValueFrom(
-            this.httpService.get<GitHubUser>('https://api.github.com/user', { headers }),
+        const { data } = await this.callUpstream(AuthProvider.GITHUB, 'user profile request', () =>
+            firstValueFrom(
+                this.httpService.get<GitHubUser>('https://api.github.com/user', { headers }),
+            ),
         );
 
-        const { email, emailVerified } = await resolveGitHubAccountEmail(
-            this.httpService,
-            accessToken,
-            data.email || null,
+        // `resolveGitHubAccountEmail` (shared with the GitHub App integration)
+        // performs its own `/user/emails` request — wrap the call site so an
+        // upstream failure there is mapped exactly like the ones above.
+        const { email, emailVerified } = await this.callUpstream(
+            AuthProvider.GITHUB,
+            'user profile request',
+            () => resolveGitHubAccountEmail(this.httpService, accessToken, data.email || null),
         );
 
         if (!email) {
@@ -214,14 +244,16 @@ export class SocialAuthService {
     }
 
     private async getGoogleUser(accessToken: string) {
-        const { data } = await firstValueFrom(
-            this.httpService.get<GoogleUserInfo>(
-                'https://openidconnect.googleapis.com/v1/userinfo',
-                {
-                    headers: {
-                        Authorization: `Bearer ${accessToken}`,
+        const { data } = await this.callUpstream(AuthProvider.GOOGLE, 'user profile request', () =>
+            firstValueFrom(
+                this.httpService.get<GoogleUserInfo>(
+                    'https://openidconnect.googleapis.com/v1/userinfo',
+                    {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                        },
                     },
-                },
+                ),
             ),
         );
 
@@ -245,15 +277,20 @@ export class SocialAuthService {
     }
 
     private async getFacebookUser(accessToken: string) {
-        const { data } = await firstValueFrom(
-            this.httpService.get<FacebookUser>('https://graph.facebook.com/me', {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-                params: {
-                    fields: 'id,name,email,picture.type(large)',
-                },
-            }),
+        const { data } = await this.callUpstream(
+            AuthProvider.FACEBOOK,
+            'user profile request',
+            () =>
+                firstValueFrom(
+                    this.httpService.get<FacebookUser>('https://graph.facebook.com/me', {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                        },
+                        params: {
+                            fields: 'id,name,email,picture.type(large)',
+                        },
+                    }),
+                ),
         );
 
         if (!data.email) {
@@ -276,12 +313,17 @@ export class SocialAuthService {
     }
 
     private async getLinkedInUser(accessToken: string) {
-        const { data } = await firstValueFrom(
-            this.httpService.get<LinkedInUserInfo>('https://api.linkedin.com/v2/userinfo', {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            }),
+        const { data } = await this.callUpstream(
+            AuthProvider.LINKEDIN,
+            'user profile request',
+            () =>
+                firstValueFrom(
+                    this.httpService.get<LinkedInUserInfo>('https://api.linkedin.com/v2/userinfo', {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                        },
+                    }),
+                ),
         );
 
         if (!data.email) {
@@ -337,5 +379,95 @@ export class SocialAuthService {
     private readNumber(data: Record<string, unknown>, key: string) {
         const value = data[key];
         return typeof value === 'number' ? value : null;
+    }
+
+    /**
+     * Runs one upstream OAuth call and converts transport / HTTP failures
+     * into HttpExceptions.
+     *
+     * Before this, an AxiosError — e.g. Google answering 400 `invalid_grant`
+     * to a bogus `code` on `/api/oauth/google/callback` — escaped straight to
+     * Nest's ExceptionsHandler and became a 500 "Internal server error"
+     * (production, 2026-09-03). GitHub never hit it only because github.com
+     * answers 200 with an error body, which `readString` already turns into
+     * a BadRequestException.
+     *
+     * Mapping:
+     *  - upstream 4xx other than 408/429 -> 400 BadRequestException (the
+     *    code / token we presented was rejected; the user has to restart the
+     *    flow)
+     *  - upstream 408 / 429 (provider timeout or rate limit — our app or the
+     *    provider is throttled, the user did nothing wrong), upstream 5xx, or
+     *    no response at all (ECONNRESET, timeout, DNS) -> 502
+     *    BadGatewayException (the identity provider is the problem, the user
+     *    should simply retry; 5xx-keyed alerting keeps seeing the outage)
+     *
+     * The thrown message names only the provider and the step. The upstream
+     * status and a regex-validated bare error code (e.g. `invalid_grant`) are
+     * logged at warn level; the free-text body / `error_description` is
+     * never logged nor echoed to the client.
+     *
+     * HttpExceptions raised inside `run` pass through untouched, and non-HTTP
+     * errors are rethrown as-is so genuine bugs still surface as 500s.
+     */
+    private async callUpstream<T>(
+        providerId: SocialAuthProviderId,
+        step: UpstreamStep,
+        run: () => Promise<T>,
+    ): Promise<T> {
+        try {
+            return await run();
+        } catch (error) {
+            if (error instanceof HttpException || !isAxiosError(error)) {
+                throw error;
+            }
+
+            const { displayName } = SOCIAL_AUTH_PROVIDERS[providerId];
+            const status = error.response?.status;
+            const errorCode = this.readUpstreamErrorCode(error.response?.data) ?? error.code;
+
+            this.logger.warn(
+                `${providerId} OAuth ${step} failed upstream ` +
+                    `(status=${status ?? 'none'}, code=${errorCode ?? 'unknown'})`,
+            );
+
+            if (this.isClientFaultStatus(status)) {
+                throw new BadRequestException(`${displayName} rejected the OAuth ${step}`);
+            }
+
+            throw new BadGatewayException(
+                `${displayName} did not complete the OAuth ${step} (upstream error)`,
+            );
+        }
+    }
+
+    /**
+     * True only for upstream statuses that mean "what we presented was
+     * rejected". 408 (provider timed out reading our request) and 429 (our
+     * app / the provider is rate-limited) are provider-side conditions, so
+     * they deliberately fall through to the 502 branch instead of telling the
+     * user to restart a flow that would fail again.
+     */
+    private isClientFaultStatus(status: number | undefined): boolean {
+        return (
+            typeof status === 'number' &&
+            status >= 400 &&
+            status < 500 &&
+            !UPSTREAM_THROTTLE_STATUSES.has(status)
+        );
+    }
+
+    /**
+     * Extracts the bare OAuth error code (`invalid_grant`, `bad_verification_code`,
+     * ...) from an upstream error body, or null. Only a short `[A-Za-z0-9_]`
+     * token is accepted so nothing attacker-influenced or multi-line ever
+     * reaches the log line.
+     */
+    private readUpstreamErrorCode(data: unknown): string | null {
+        if (!data || typeof data !== 'object') {
+            return null;
+        }
+        const code = (data as Record<string, unknown>).error;
+        return typeof code === 'string' && /^[A-Za-z0-9_]{1,64}$/.test(code) ? code : null;
     }
 }

--- a/apps/node/src/core/model-execution/model-process.internal.ts
+++ b/apps/node/src/core/model-execution/model-process.internal.ts
@@ -120,6 +120,13 @@ export interface ModelExecutionIo {
 	/** Test-only cleanup seam; never exported by the production model-process API. */
 	readonly removeRunRoot?: (path: string) => Promise<void>;
 	/**
+	 * Test-only bound for a containment close that never settles; never exported
+	 * by the production model-process API. A test may shorten the production
+	 * termination-safety deadline so it controls the clock instead of racing the
+	 * real scheduler, but it can never extend that deadline.
+	 */
+	readonly terminationSettleMs?: number;
+	/**
 	 * Internal containment integration seam. Production supplies it only for a
 	 * configured trusted Windows launcher that assigns the suspended child to a
 	 * kill-on-close Job Object before resuming it.
@@ -164,7 +171,11 @@ export const MODEL_CLI_COMPATIBILITY = {
 	codex: { minimumVersion: '0.120.0', accessTokenMinimumVersion: '0.146.0' }
 } as const;
 
-const TERMINATION_SETTLE_MS = 2500;
+/**
+ * @internal Production termination-safety deadline for a containment close.
+ * The test-only `terminationSettleMs` seam may shorten it but never extend it.
+ */
+export const TERMINATION_SETTLE_MS = 2500;
 const WINDOWS_TREE_KILL_TIMEOUT_MS = 2000;
 const MODEL_RUN_ROOT_CLEANUP_ATTEMPTS = 3;
 const MODEL_RUN_ROOT_CLEANUP_ATTEMPT_TIMEOUT_MS = 250;
@@ -289,6 +300,7 @@ export async function executeModelProcessInternal(
 	const now = io.now ?? Date.now;
 	const monotonicNow = io.monotonicNow ?? (() => performance.now());
 	const platform = io.platform ?? process.platform;
+	const terminationSettleMs = resolveTerminationSettleMs(io);
 	if (request.signal?.aborted) {
 		return terminalResult(request.provider, 'cancelled', 0);
 	}
@@ -365,6 +377,7 @@ export async function executeModelProcessInternal(
 					io.spawnFn ?? spawn,
 					deadlineAt,
 					monotonicNow,
+					terminationSettleMs,
 					request.signal
 				);
 			} catch (error) {
@@ -418,6 +431,7 @@ export async function executeModelProcessInternal(
 					io.spawnFn ?? spawn,
 					deadlineAt,
 					monotonicNow,
+					terminationSettleMs,
 					request.signal
 				);
 			} catch (error) {
@@ -567,6 +581,7 @@ async function acquireModelProcessContainment(
 	spawnFn: typeof spawn,
 	deadlineAt: number,
 	monotonicNow: () => number,
+	terminationSettleMs: number,
 	signal?: AbortSignal
 ): Promise<ModelProcessContainment> {
 	const ownership: {
@@ -589,7 +604,7 @@ async function acquireModelProcessContainment(
 		if (!ownership.transferred && ownership.acquisition) {
 			void ownership.acquisition.then(
 				(containment) => {
-					void boundedProcessTreeTermination(() => containment.close());
+					void boundedProcessTreeTermination(() => containment.close(), terminationSettleMs);
 				},
 				() => undefined
 			);
@@ -1115,11 +1130,12 @@ async function runProcess(
 ): Promise<RawProcessResult> {
 	const spawnFn = io.spawnFn ?? spawn;
 	const platform = io.platform ?? process.platform;
+	const terminationSettleMs = resolveTerminationSettleMs(io);
 	let child: ChildProcess;
 	let processTimeoutMs: number;
 	const closeBeforeSpawn = async (raw: RawProcessResult): Promise<RawProcessResult> => {
 		if (!containment) return raw;
-		const outcome = await boundedProcessTreeTermination(() => containment.close());
+		const outcome = await boundedProcessTreeTermination(() => containment.close(), terminationSettleMs);
 		return outcome.verified
 			? raw
 			: {
@@ -1224,16 +1240,18 @@ async function runProcess(
 
 		const startTreeSafety = (): Promise<ProcessTreeTermination> => {
 			if (!terminationAttempt) {
-				terminationAttempt = boundedProcessTreeTermination(() =>
-					containment
-						? containment.close()
-						: terminateProcessTree(
-								child,
-								platform,
-								spawnFn,
-								io.processKill ?? process.kill,
-								withoutProviderCredentials(options.env)
-							)
+				terminationAttempt = boundedProcessTreeTermination(
+					() =>
+						containment
+							? containment.close()
+							: terminateProcessTree(
+									child,
+									platform,
+									spawnFn,
+									io.processKill ?? process.kill,
+									withoutProviderCredentials(options.env)
+								),
+					terminationSettleMs
 				);
 			}
 			return terminationAttempt;
@@ -1299,8 +1317,22 @@ async function runProcess(
 	});
 }
 
+/**
+ * The production termination-safety deadline, unless a test shortened it. An
+ * absent, non-finite, non-positive, or larger value keeps the production bound
+ * so the seam can only ever make the safety deadline stricter.
+ */
+function resolveTerminationSettleMs(io: ModelExecutionIo): number {
+	const requested = io.terminationSettleMs;
+	if (typeof requested !== 'number' || !Number.isFinite(requested) || requested <= 0) {
+		return TERMINATION_SETTLE_MS;
+	}
+	return Math.min(Math.ceil(requested), TERMINATION_SETTLE_MS);
+}
+
 function boundedProcessTreeTermination(
-	operation: () => Promise<ProcessTreeTermination>
+	operation: () => Promise<ProcessTreeTermination>,
+	settleMs: number
 ): Promise<ProcessTreeTermination> {
 	return new Promise<ProcessTreeTermination>((resolvePromise) => {
 		let settled = false;
@@ -1316,7 +1348,7 @@ function boundedProcessTreeTermination(
 					verified: false,
 					detail: 'The process containment close did not settle before its safety deadline'
 				}),
-			TERMINATION_SETTLE_MS
+			settleMs
 		);
 		Promise.resolve()
 			.then(operation)

--- a/apps/node/src/core/model-execution/model-process.spec.ts
+++ b/apps/node/src/core/model-execution/model-process.spec.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { performance } from 'node:perf_hooks';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { PassThrough } from 'node:stream';
 
@@ -14,7 +15,11 @@ import {
 	type ModelExecutionProvider,
 	type ModelExecutionRequest
 } from './model-process';
-import { ModelProcessContainmentUnavailableError, executeModelProcessInternal } from './model-process.internal';
+import {
+	ModelProcessContainmentUnavailableError,
+	TERMINATION_SETTLE_MS,
+	executeModelProcessInternal
+} from './model-process.internal';
 
 const executeModelProcess = executeModelProcessInternal;
 type ModelExecutionIo = NonNullable<Parameters<typeof executeModelProcessInternal>[1]>;
@@ -23,6 +28,33 @@ type TestContainment = Awaited<ReturnType<NonNullable<ModelExecutionIo['createMo
 const FAKE_CLAUDE_CREDENTIAL = 'claude-oauth-test-value-123456789';
 const FAKE_CODEX_CREDENTIAL = 'codex-access-test-value-123456789';
 const PINNED_CLI_FIXTURE = join(__dirname, '__fixtures__', 'pinned-cli.cjs');
+/**
+ * Shortened termination-safety deadline injected wherever a test asserts
+ * hung-vs-result for a containment close that never settles. The production
+ * 2.5 s bound stays covered by the version-probe closure test, which only
+ * awaits the result; a hung-vs-result race must control the bound instead of
+ * racing the real scheduler and disk against it with a sub-second margin.
+ */
+const TEST_TERMINATION_SETTLE_MS = 100;
+/**
+ * Hang detector for a shortened settle. This is still a wall-clock race: the
+ * detector starts before the trusted-command realpath calls, the run-root
+ * mkdtemp and its eight mkdir calls, and the real settle setTimeout, so the
+ * in-race margin (detector minus settle, ~7.9 s) must dwarf the ~3.8 s of
+ * non-settle overhead a 33-shard E2E storm produced on CI. Tests that use it
+ * must also seam out `directoryExists` and `removeRunRoot` so the stat and the
+ * up-to-750 ms bounded run-root removal never sit inside the race.
+ */
+const HUNG_CLOSE_DETECTION_MS = 8_000;
+/** Per-test budget for a hung-close race: the detector plus room for harness setup and teardown. */
+const HUNG_CLOSE_TEST_BUDGET_MS = HUNG_CLOSE_DETECTION_MS + 4_000;
+/**
+ * Wall-clock budget for a real two-subprocess success path (version probe +
+ * model) on a saturated CI runner. Applied to the request deadline so a
+ * starved runner reports the executor's own `timed-out` diagnosis, and the
+ * vitest budget stays above it so that diagnosis is what the failure shows.
+ */
+const REAL_PROCESS_RUN_BUDGET_MS = 15_000;
 
 const STUB_SOURCE = String.raw`
 const fs = require('node:fs');
@@ -318,7 +350,10 @@ function request(
 		instructions: 'Edit the project and report the verified result.',
 		model: provider === 'claude-code' ? 'sonnet' : 'gpt-5.6-codex',
 		authentication: { kind: 'local-session' as const },
-		timeoutMs: 5_000
+		// Every real-process test that does not override this runs two real
+		// Node subprocesses against it; the old 5 s default turned any 5 s
+		// runner stall into a `timed-out` result under a green-looking test.
+		timeoutMs: REAL_PROCESS_RUN_BUDGET_MS
 	};
 	return { ...base, ...overrides, provider } as ModelExecutionRequest;
 }
@@ -432,10 +467,14 @@ function closedProcess(stdoutText: string): ChildProcess {
 		stdin: new PassThrough(),
 		kill: () => true
 	}) as unknown as ChildProcess;
-	queueMicrotask(() => {
+	// Close on a later macrotask, not a microtask: `runProcess` awaits the
+	// (synchronous) containment spawn before it attaches its listeners, and a
+	// microtask queued inside the spawn call would emit 'close' into nobody.
+	// A real child also closes only after its stdio has ended.
+	setImmediate(() => {
 		stdout.end(stdoutText);
 		stderr.end();
-		child.emit('close', 0, null);
+		setImmediate(() => child.emit('close', 0, null));
 	});
 	return child;
 }
@@ -450,6 +489,20 @@ function isWithin(root: string, candidate: string): boolean {
 	return child === '' || (!child.startsWith('..') && !isAbsolute(child));
 }
 
+// Residual wall-clock sensitivity (documented, deliberately NOT loosened):
+// the real-taskkill tests — three it.runIf(win32) ones plus two plain tests
+// whose expected status is platform-conditional — keep a REAL taskkill inside
+// the 2.5 s production settle: 'closes version-probe
+// containment on output limit/timeout/AbortSignal', 'kills the whole spawned
+// process tree on timeout', 'fails closed when the containment boundary
+// cannot verify descendant termination', 'terminates and reports output
+// that exceeds the hard byte bound' and 'redacts a credential fragment cut
+// by the raw output ceiling' — can still flip to termination-failed when a
+// taskkill spawn stalls > 2.5 s. They run on CI via
+// .github/workflows/windows-job-launcher.yml (windows-2022) and all passed in
+// isolation; the real kill path IS their subject, so stubbing it would remove
+// what they prove. Everything else in this describe now runs against the
+// REAL_PROCESS_RUN_BUDGET_MS request budget and the 30 s vitest budget.
 describe('executeModelProcess — real process boundary', () => {
 	it.each(['claude-code', 'codex'] as const)(
 		'refuses raw %s provider credentials before any model process can inherit them',
@@ -587,10 +640,10 @@ describe('executeModelProcess — real process boundary', () => {
 			await expect(access(harness.capturePath)).rejects.toThrow();
 		},
 		// The never-settling branch deliberately consumes the 2.5 s production
-		// termination-safety deadline. Leave enough runner headroom for the two
-		// real subprocesses and temp-directory cleanup while keeping the test
-		// itself bounded.
-		10_000
+		// termination-safety deadline on top of a real version-probe subprocess
+		// and temp-directory cleanup, so it gets the real-process budget plus
+		// headroom rather than a 10 s figure a 5 s runner stall could exhaust.
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
 	);
 
 	it.runIf(process.platform === 'win32')(
@@ -1011,7 +1064,10 @@ if (process.argv.includes('--version')) {
 				OPENAI_API_KEY: 'ambient-openai-must-not-win'
 			});
 
-			const result = await executeModelProcess(request(provider, harness.workspacePath), harness.io);
+			const result = await executeModelProcess(
+				request(provider, harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+				harness.io
+			);
 
 			expect(result).toMatchObject({ status: 'succeeded', provider, exitCode: 0, summary: 'done' });
 			const capture = await readCapture(harness);
@@ -1025,7 +1081,11 @@ if (process.argv.includes('--version')) {
 			expect(capture.env.DATABASE_PASSWORD).toBeUndefined();
 			expect(capture.env.GH_TOKEN).toBeUndefined();
 			expect(capture.env.NODE_OPTIONS).toBeUndefined();
-		}
+		},
+		// Two real Node subprocesses plus temp-directory work: pure runner
+		// starvation (a 33-shard E2E storm stalled this at >9 s) is the only
+		// thing that can slow it, so the budget is derived from that mechanism.
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
 	);
 
 	it.each(['claude-code', 'codex'] as const)(
@@ -1109,7 +1169,10 @@ if (process.argv.includes('--version')) {
 			expect(envValue(modelEnv, name)).toBeUndefined();
 			expect(envValue(versionEnv, name)).toBeUndefined();
 		},
-		10_000
+		// Two real subprocesses on the real-process request budget: the vitest
+		// budget stays above it so a starved runner shows `timed-out`, not an
+		// opaque vitest timeout.
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
 	);
 
 	it('builds the supported non-interactive Claude Code argv with zero provider credential injection', async () => {
@@ -1374,7 +1437,7 @@ if (process.argv.includes('--version')) {
 			expect(result.status).toBe('containment-unavailable');
 			await expect(access(harness.capturePath)).rejects.toThrow();
 		},
-		5_000
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
 	);
 
 	it.runIf(process.platform === 'win32')(
@@ -1388,6 +1451,12 @@ if (process.argv.includes('--version')) {
 				execution = executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
 					...harness.io,
 					platform: 'win32',
+					// Wall-clock race: the 1 s model budget, the settle timer, and
+					// the real run-root removal (up to 3 x 250 ms, kept real so the
+					// isolated run root never leaks) all sit inside the detector
+					// below, so the test owns the settle bound and the detector
+					// keeps a multi-second margin over that mechanism.
+					terminationSettleMs: TEST_TERMINATION_SETTLE_MS,
 					createModelProcessContainment: async (spawnFn) => {
 						containmentIndex += 1;
 						const containment = await createBaseContainment(spawnFn);
@@ -1399,12 +1468,15 @@ if (process.argv.includes('--version')) {
 				const outcome = await Promise.race([
 					execution.then((result) => ({ kind: 'result' as const, result })),
 					new Promise<{ kind: 'deadline' }>((resolve) =>
-						setTimeout(() => resolve({ kind: 'deadline' }), 4_000)
+						setTimeout(() => resolve({ kind: 'deadline' }), HUNG_CLOSE_DETECTION_MS)
 					)
 				]);
 
 				expect(outcome.kind).toBe('result');
-				if (outcome.kind === 'result') expect(outcome.result.status).toBe('termination-failed');
+				if (outcome.kind === 'result') {
+					expect(outcome.result.status).toBe('termination-failed');
+					expect(outcome.result.summary).toMatch(/did not settle before its safety deadline/);
+				}
 			} finally {
 				await forceKillCapturedTree(harness);
 				if (execution) {
@@ -1412,7 +1484,7 @@ if (process.argv.includes('--version')) {
 				}
 			}
 		},
-		10_000
+		HUNG_CLOSE_TEST_BUDGET_MS
 	);
 
 	it.runIf(process.platform === 'win32')(
@@ -1451,7 +1523,7 @@ if (process.argv.includes('--version')) {
 				await forceKillCapturedTree(harness);
 			}
 		},
-		10_000
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
 	);
 
 	it.runIf(process.platform === 'win32')(
@@ -1545,37 +1617,45 @@ if (process.argv.includes('--version')) {
 		}
 	});
 
-	it('does not hang when isolated run-directory cleanup never settles', async () => {
-		const harness = await createHarness('success');
-		let cleanupPath: string | null = null;
-		try {
-			const execution = executeModelProcess(request('codex', harness.workspacePath), {
-				...harness.io,
-				removeRunRoot: (path) => {
-					cleanupPath = path;
-					return new Promise<void>(() => undefined);
-				}
-			});
-			const outcome = await Promise.race([
-				execution.then(
-					(result) => ({ kind: 'resolved' as const, result }),
-					(error: unknown) => ({ kind: 'rejected' as const, error })
-				),
-				// The cleanup itself is bounded to 3 x 250 ms, but this race
-				// covers the complete real-process execution as well. Keep enough
-				// headroom for process startup on loaded/Windows CI runners while
-				// still proving that a never-settling cleanup cannot hang forever.
-				new Promise<{ kind: 'hung' }>((resolve) => setTimeout(() => resolve({ kind: 'hung' }), 4_000))
-			]);
+	it(
+		'does not hang when isolated run-directory cleanup never settles',
+		async () => {
+			const harness = await createHarness('success');
+			let cleanupPath: string | null = null;
+			try {
+				const execution = executeModelProcess(request('codex', harness.workspacePath), {
+					...harness.io,
+					removeRunRoot: (path) => {
+						cleanupPath = path;
+						return new Promise<void>(() => undefined);
+					}
+				});
+				const outcome = await Promise.race([
+					execution.then(
+						(result) => ({ kind: 'resolved' as const, result }),
+						(error: unknown) => ({ kind: 'rejected' as const, error })
+					),
+					// The cleanup itself is bounded to 3 x 250 ms, but this race
+					// covers the complete real two-subprocess execution as well, so
+					// the detector sits above the real-process request budget (plus
+					// the bounded cleanup): a starved runner surfaces the executor
+					// 'timed-out' diagnosis, while an unbounded cleanup still trips
+					// the detector.
+					new Promise<{ kind: 'hung' }>((resolve) =>
+						setTimeout(() => resolve({ kind: 'hung' }), REAL_PROCESS_RUN_BUDGET_MS + 2_000)
+					)
+				]);
 
-			expect(outcome.kind).toBe('resolved');
-			if (outcome.kind === 'resolved') {
-				expect(outcome.result).toMatchObject({ status: 'succeeded', cleanupFailed: true });
+				expect(outcome.kind).toBe('resolved');
+				if (outcome.kind === 'resolved') {
+					expect(outcome.result).toMatchObject({ status: 'succeeded', cleanupFailed: true });
+				}
+			} finally {
+				if (cleanupPath) await rm(cleanupPath, { recursive: true, force: true });
 			}
-		} finally {
-			if (cleanupPath) await rm(cleanupPath, { recursive: true, force: true });
-		}
-	}, 8_000);
+		},
+		REAL_PROCESS_RUN_BUDGET_MS + 5_000
+	);
 });
 
 describe('executeModelProcess — request refusal', () => {
@@ -1756,25 +1836,45 @@ describe('executeModelProcess — request refusal', () => {
 	it('makes the absolute deadline win when containment close consumes the remaining budget', async () => {
 		const harness = await createHarness('success');
 		let monotonicTime = 0;
+		const spawnPurposes: string[] = [];
 		const baseCreateContainment = harness.io.createModelProcessContainment!;
-		const result = await executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-			...harness.io,
-			monotonicNow: () => monotonicTime,
-			createModelProcessContainment: async (spawnFn) => {
-				const containment = await baseCreateContainment(spawnFn);
-				return {
-					...containment,
-					close: async () => {
-						const outcome = await containment.close();
-						monotonicTime = 1_001;
-						return outcome;
-					}
-				};
+		const result = await executeModelProcess(
+			request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+			{
+				...harness.io,
+				monotonicNow: () => monotonicTime,
+				beforeSpawn: (purpose) => spawnPurposes.push(purpose),
+				// The clock under test is the injected monotonic one, but the
+				// version probe's own timer and the pre-spawn deadline timers are
+				// real. A real probe subprocess inside a real 1 s budget flipped
+				// this to termination-failed under CPU load (2 of 7 runs): the
+				// probe timer fired first and its taskkill then overran the
+				// settle bound. So the probe is a stub that closes without a
+				// subprocess, and the request budget is the real-process one so
+				// the remaining real timers around trusted-command and run-root
+				// preparation are not sub-second either.
+				spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+				createModelProcessContainment: async (spawnFn) => {
+					const containment = await baseCreateContainment(spawnFn);
+					return {
+						...containment,
+						close: async () => {
+							const outcome = await containment.close();
+							monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+							return outcome;
+						}
+					};
+				}
 			}
-		});
+		);
 
 		expect(result.status).toBe('timed-out');
 		expect(result.summary).toMatch(/wall-clock/i);
+		// The probe closed normally (exit 0) and only the close moved the clock
+		// past the deadline; a probe that timed out on its own real timer would
+		// carry a null exit code, and the model must never have been spawned.
+		expect(result.exitCode).toBe(0);
+		expect(spawnPurposes).toEqual(['version-probe']);
 	});
 
 	it('closes containment acquired exactly as the absolute budget expires before model spawn', async () => {
@@ -1906,32 +2006,144 @@ describe('executeModelProcess — request refusal', () => {
 							closeCalls += 1;
 							return new Promise(() => undefined);
 						};
-			const execution = executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-				...harness.io,
-				monotonicNow: () => monotonicTime,
-				spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
-				createModelProcessContainment: async () => {
-					monotonicTime = 1_001;
-					return {
-						spawn: (() => {
-							throw new Error('model must not spawn after the deadline');
-						}) as typeof spawn,
-						close
-					};
-				}
-			});
-			const outcome = await Promise.race([
-				execution.then((result) => ({ kind: 'result' as const, result })),
-				new Promise<{ kind: 'hung' }>((resolvePromise) =>
-					setTimeout(() => resolvePromise({ kind: 'hung' }), 3_500)
-				)
-			]);
+			let deferredRunRoot: string | undefined;
+			try {
+				const execution = executeModelProcess(
+					request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+					{
+						...harness.io,
+						monotonicNow: () => monotonicTime,
+						// The hang detector below starts before the trusted-command
+						// and run-root filesystem preparation, while the settle timer
+						// only starts after it. Racing the production 2.5 s bound
+						// against a 3.5 s detector left <1 s for that I/O and failed
+						// on a saturated runner (CI job 100564258206: 6285 ms). The
+						// test owns the bound and keeps the workspace stat and the
+						// bounded run-root removal (up to 3 x 250 ms) out of the
+						// race; what still races is the realpath/mkdtemp/mkdir
+						// preparation and the real settle timer.
+						terminationSettleMs: TEST_TERMINATION_SETTLE_MS,
+						directoryExists: async () => true,
+						removeRunRoot: async (path) => {
+							deferredRunRoot = path;
+						},
+						spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+						createModelProcessContainment: async () => {
+							monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+							return {
+								spawn: (() => {
+									throw new Error('model must not spawn after the deadline');
+								}) as typeof spawn,
+								close
+							};
+						}
+					}
+				);
+				let hangDetector: NodeJS.Timeout | undefined;
+				const outcome = await Promise.race([
+					execution.then((result) => ({ kind: 'result' as const, result })),
+					new Promise<{ kind: 'hung' }>((resolvePromise) => {
+						hangDetector = setTimeout(() => resolvePromise({ kind: 'hung' }), HUNG_CLOSE_DETECTION_MS);
+					})
+				]).finally(() => clearTimeout(hangDetector));
 
-			expect(outcome.kind).toBe('result');
-			if (outcome.kind === 'result') expect(outcome.result.status).toBe('termination-failed');
-			expect(closeCalls).toBe(1);
+				expect(outcome.kind).toBe('result');
+				if (outcome.kind === 'result') {
+					expect(outcome.result.status).toBe('termination-failed');
+					expect(outcome.result.summary).toMatch(
+						closeMode === 'rejects'
+							? /close failed: unused containment close rejected/
+							: /did not settle before its safety deadline/
+					);
+				}
+				expect(closeCalls).toBe(1);
+				expect(deferredRunRoot).toBeDefined();
+			} finally {
+				if (deferredRunRoot) await rm(deferredRunRoot, { recursive: true, force: true });
+			}
 		},
-		6_000
+		HUNG_CLOSE_TEST_BUDGET_MS
+	);
+
+	it.each([
+		['larger than the production bound', 60_000],
+		['NaN', Number.NaN],
+		['negative', -1],
+		['Infinity', Number.POSITIVE_INFINITY]
+	])(
+		'never lets a %s terminationSettleMs seam value extend the production safety deadline',
+		async (_shape, requestedSettleMs) => {
+			const harness = await createHarness('success');
+			let monotonicTime = 0;
+			let closeCalls = 0;
+			const closeTiming: { startedAt?: number } = {};
+			let deferredRunRoot: string | undefined;
+			try {
+				const execution = executeModelProcess(
+					request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+					{
+						...harness.io,
+						monotonicNow: () => monotonicTime,
+						// The seam's only safety property: it may shorten the production
+						// termination-safety deadline but can never extend it. Unclamped,
+						// 60 s would extend it and NaN / -1 / Infinity would arm a
+						// degenerate ~1 ms timer, so the same never-settling close must
+						// be abandoned at exactly the production bound in every row.
+						terminationSettleMs: requestedSettleMs,
+						directoryExists: async () => true,
+						removeRunRoot: async (path) => {
+							deferredRunRoot = path;
+						},
+						spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+						createModelProcessContainment: async () => {
+							monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+							return {
+								spawn: (() => {
+									throw new Error('model must not spawn after the deadline');
+								}) as typeof spawn,
+								close: () => {
+									closeCalls += 1;
+									closeTiming.startedAt = performance.now();
+									return new Promise(() => undefined);
+								}
+							};
+						}
+					}
+				);
+				let hangDetector: NodeJS.Timeout | undefined;
+				const outcome = await Promise.race([
+					execution.then((result) => ({ kind: 'result' as const, result })),
+					new Promise<{ kind: 'hung' }>((resolvePromise) => {
+						hangDetector = setTimeout(() => resolvePromise({ kind: 'hung' }), HUNG_CLOSE_DETECTION_MS);
+					})
+				]).finally(() => clearTimeout(hangDetector));
+				const settledAt = performance.now();
+
+				expect(outcome.kind).toBe('result');
+				if (outcome.kind === 'result') {
+					expect(outcome.result.status).toBe('termination-failed');
+					expect(outcome.result.summary).toMatch(/did not settle before its safety deadline/);
+				}
+				expect(closeCalls).toBe(1);
+				expect(closeTiming.startedAt).toBeDefined();
+				// Measured from the close call (the settle timer is armed in the
+				// same tick, immediately before it) to the result. That window
+				// holds only the settle timer and microtasks - the workspace stat
+				// and the run-root removal are seamed out above - so it is the
+				// production bound itself: the lower edge tolerates Node firing a
+				// timer up to ~1 ms early, and the upper edge leaves 1.5 s for
+				// event-loop delay on a loaded runner (no I/O sits in the window).
+				// An unclamped 60 s timer or a degenerate 1 ms timer both land far
+				// outside it.
+				const settleWindowMs = settledAt - (closeTiming.startedAt ?? settledAt);
+				expect(settleWindowMs).toBeGreaterThanOrEqual(TERMINATION_SETTLE_MS - 50);
+				expect(settleWindowMs).toBeLessThan(4_000);
+				expect(deferredRunRoot).toBeDefined();
+			} finally {
+				if (deferredRunRoot) await rm(deferredRunRoot, { recursive: true, force: true });
+			}
+		},
+		HUNG_CLOSE_TEST_BUDGET_MS
 	);
 
 	it('makes cancellation win when the trusted async launcher rejects after observing abort', async () => {

--- a/apps/node/vitest.config.ts
+++ b/apps/node/vitest.config.ts
@@ -1,11 +1,23 @@
 import { defineConfig } from 'vitest/config';
 
-// The headless node is pure Node logic — every test injects its own fetch, fs,
-// clock and command-runner fakes, so no network, no real filesystem and no
-// real timers are ever touched.
+// The headless node is pure Node logic. Almost every spec injects its own
+// fetch, fs, clock and command-runner fakes, so no network and no real timers
+// are touched. The one exception is
+// `src/core/model-execution/model-process.spec.ts`: its "real process
+// boundary" describe spawns real Node child processes and writes real temp
+// directories on purpose, because the process boundary is what it proves.
 export default defineConfig({
 	test: {
 		environment: 'node',
-		include: ['src/**/*.spec.ts']
+		include: ['src/**/*.spec.ts'],
+		// CI-load resilience: the real-process specs above spawn child
+		// processes on a saturated runner and drifted past vitest's 5 s default
+		// (CI job 100617108924: "Test timed out in 5000ms" on a test that had
+		// no timing assertion of its own). Matches the 30000 ms that
+		// apps/web/vitest.config.ts, packages/tasks/vitest.config.ts and the
+		// apps/api jest config already use for the same reason. Tests that assert
+		// their own wall-clock bounds keep their explicit, smaller per-test budgets.
+		testTimeout: 30_000,
+		hookTimeout: 30_000
 	}
 });


### PR DESCRIPTION
## What

The two follow-ups from the social-login fix (#2299 / #2309), owner-requested ("fix it"). Two commits, disjoint packages.

### 1. API — a rejected OAuth code no longer becomes a 500 (`be0148efc`)

`GET /api/oauth/:provider/callback` with a bogus/reused code answered `500 Internal server error` for Google (seen on prod 2026-09-03): `SocialAuthService` awaited the axios calls with no error handling, so the `AxiosError` from a non-2xx provider answer escaped to Nest's `ExceptionsHandler`. GitHub was immune only because github.com answers 200 with an error body.

Every upstream call (token exchange, the four user-info requests, GitHub `/user/emails`) now runs through one `callUpstream` helper:
- upstream 4xx other than 408/429 → **400** `"<Provider> rejected the OAuth <step>"` (the code/token we presented was refused; restart the flow)
- 408/429, 5xx or no response → **502** `"<Provider> did not complete the OAuth <step> (upstream error)"` (provider-side; retry; stays visible to 5xx-keyed alerting)

The client message names only the provider and step; a warn log carries the upstream status and a regex-validated bare error code (`invalid_grant`); the free-text body is never logged or echoed. `HttpException`s pass through; non-axios errors still surface as 500s. The 200-with-error-body path and the C-03 state check are unchanged. **9 new unit tests, 7 red against the previous service** (an independent reviewer reproduced the red with `Received constructor: AxiosError`).

### 2. `apps/node` — `model-process.spec.ts` no longer races the runner (`2988c60a6`)

Three distinct tests failed three consecutive CI runs on 2026-09-03 while 33 E2E shards saturated the pool (`33728950905` attempts 1+2, `33745565559`): `expected 'hung' to be 'result'`, a real-process-boundary run, and a plain `Test timed out in 5000ms`. The identical tree passed on quieter runners.

Root causes and remedies (details in the commit message):
- disk I/O and the real run-root `rm` sat inside a 3.5 s hang detector with ~1 s of margin → I/O seamed out via injected `directoryExists`/`removeRunRoot`, detector 8 s with a 12 s budget;
- one test kept a real version-probe subprocess inside a real 1 s timer while faking the clock → `closedProcess` stub + budget from `REAL_PROCESS_RUN_BUDGET_MS`, two mechanism assertions added; same 1 s → budget change on the two hung-close `it.each` tests;
- the new `terminationSettleMs` seam's clamp had no test → new `it.each` (60 000 / NaN / −1 / ∞) proves it can never extend the 2.5 s production deadline (red without the clamp);
- `apps/node/vitest.config.ts` had no `testTimeout`, so real child processes ran against the 5 s default → 30 s like `apps/web`, `packages/tasks` and the `apps/api` jest config; harness `request()` default and the remaining explicit 5 s / 10 s figures now derive from the run budget;
- latent stub defect: `closedProcess` emitted `close` on a microtask before `runProcess` attached listeners → `setImmediate`.

**No assertion weakened, skipped or retried**; every changed test keeps or gains assertions. The real-taskkill tests that remain load-sensitive on windows-2022 (`.github/workflows/windows-job-launcher.yml` runs this describe on every PR touching it) are documented above the describe, not loosened — the real kill path is their subject.

## Verification

- API: jest on `social-auth.service.spec.ts` + `oauth.controller.spec.ts` → 61/61.
- node: full `model-process.spec.ts` green on 7+ consecutive local runs (Windows, so the win32-gated tests ran too); inverted-knob proofs reproduce the exact CI assertion text deterministically.
- Each lane: TDD, then two adversarial reviewers with distinct lenses (correctness/security; test quality/honesty) and fix-up rounds until both accepted; a final independent re-verification of the last round.
- `prettier --check`, byte-level LF check, eslint, `tsc --noEmit` for `apps/api` and `apps/node` (against freshly built workspace packages).

Out of scope, reported for a ticket: the **plugin-connect** OAuth path (`apps/api/src/plugins-capabilities/oauth/oauth.service.ts` → `packages/agent/src/facades/oauth.facade.ts` → `packages/plugins/github/src/github.plugin.ts`, which uses global `fetch` and never checks `response.ok`) still answers 500 on an upstream rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
