### PR TITLE
fix(billing): stop a retried schedule completion from billing twice

### DIFF
--- a/packages/agent/src/services/work-schedule.service.ts
+++ b/packages/agent/src/services/work-schedule.service.ts
@@ -272,7 +272,14 @@ export class WorkScheduleService {
 
     /**
      * Single entry point for finalizing a schedule run.
-     * Idempotent — safe to call multiple times for the same run.
+     *
+     * NOT idempotent on the `completed` branch. `markRunFailed` and
+     * `markRunSkipped` both carry an `isAlreadyMarkedFailed` guard, but
+     * `markRunCompleted` appends a usage-ledger row and charges the billing
+     * provider on EVERY call (see its own doc comment). Call it once per run.
+     * `WorkScheduleService.markRunCompleted` is therefore excluded from
+     * `RETRY_SAFE_REMOTE_METHODS` in
+     * `packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts`.
      */
     async finalizeScheduleRun(scheduleId: string, outcome: ScheduleRunOutcome): Promise<void> {
         switch (outcome.status) {
@@ -292,6 +299,24 @@ export class WorkScheduleService {
         }
     }
 
+    /**
+     * Finalize a SUCCESSFUL schedule run: advance `nextRunAt` off the anchor,
+     * clear the dispatch marker, and record the run for billing.
+     *
+     * ## This method is not safe to call twice for one run
+     *
+     * The tail of it is `usageLedgerService.recordUsage(...)`, which for a
+     * `billingMode: USAGE` schedule performs a plain INSERT into
+     * `usage_ledger_entry` and then calls `BillingProvider.recordUsageCharge`.
+     * There is no already-completed guard here (`isAlreadyMarkedFailed` serves
+     * `markRunFailed` only), no pre-read on `generationHistoryId`, and no
+     * UNIQUE constraint on that column — so a second call bills a second time.
+     *
+     * The schedule columns themselves are an absolute SET and would tolerate a
+     * replay; the ledger write is what does not. Any transport that might
+     * re-issue this call must treat it as unsafe: that is why it is absent
+     * from `RETRY_SAFE_REMOTE_METHODS`.
+     */
     async markRunCompleted(options: {
         scheduleId: string;
         historyId?: string;

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -354,6 +354,56 @@ describe('TriggerInternalApiClient', () => {
             expect(fetchSpy).toHaveBeenCalledTimes(4);
         });
 
+        // ── Billing safety of the retry allow-list ──────────────────────
+        //
+        // `RETRY_SAFE_REMOTE_METHODS` is a default-DENY list, and the cost of a
+        // wrong entry is asymmetric: a missing entry loses one retry, a wrong
+        // entry silently doubles a charge. `WorkScheduleService.markRunCompleted`
+        // ends in `UsageLedgerService.recordUsage`, which INSERTs a ledger row
+        // and calls `BillingProvider.recordUsageCharge` with no dedup and no
+        // UNIQUE constraint on `generationHistoryId` — so re-issuing it bills a
+        // `billingMode: USAGE` customer twice. These two tests pin the split, so
+        // re-adding it to the allow-list turns red here instead of on an invoice.
+        const remoteArgs = superjson.serialize([{ scheduleId: 's-1' }]) as {
+            json: unknown;
+            meta?: unknown;
+        };
+
+        it('does NOT retry WorkScheduleService.markRunCompleted — it bills on every call', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(500, 'down'));
+
+            const promise = client.callRemote(
+                'WorkScheduleService',
+                'markRunCompleted',
+                remoteArgs,
+            );
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request failed (500): down',
+            );
+            // Exactly one attempt: a 504 after the API already ran the write
+            // must NOT re-issue it. No retries, no second ledger row.
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('DOES retry WorkScheduleService.markRunFailed — it carries an already-marked guard', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(500, 'down'));
+
+            const promise = client.callRemote('WorkScheduleService', 'markRunFailed', remoteArgs);
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request failed (500): down',
+            );
+            // initial + 3 retries = 4
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+        });
+
         it('uses exponential backoff (500ms, 1000ms, 2000ms) between retries', async () => {
             const client = new TriggerInternalApiClient();
             fetchSpy

--- a/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
+++ b/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
@@ -65,9 +65,31 @@ const RETRY_SAFE_REMOTE_METHODS: ReadonlySet<string> = new Set<string>([
     'CreditsSweepService.runDailySweep',
     // Each row is sent once (`markSent`), and the provider de-duplicates on the identifier.
     'PaygService.flushPending',
-    // Explicit already-marked guard / absolute SET recomputed from the anchor.
-    'WorkScheduleService.markRunCompleted',
+    // Explicit already-marked guard (`isAlreadyMarkedFailed`) inside the method,
+    // plus an absolute SET recomputed from the anchor. Nothing accumulates.
     'WorkScheduleService.markRunFailed',
+
+    // ── DELIBERATELY ABSENT ─────────────────────────────────────────
+    // `WorkScheduleService.markRunCompleted` was listed here until it was
+    // found to be a re-billing hazard. It is NOT idempotent:
+    //
+    //   markRunCompleted -> UsageLedgerService.recordUsage
+    //                    -> UsageLedgerRepository.record()      (plain INSERT)
+    //                    -> BillingProvider.recordUsageCharge() (real charge)
+    //
+    // There is no already-completed guard (`isAlreadyMarkedFailed` is called
+    // only from `markRunFailed`), no pre-read on `generationHistoryId`, and no
+    // UNIQUE constraint on that column. So a 504 raised AFTER the API pod ran
+    // the write — precisely the case a retry exists for, since nginx answers
+    // 504 while the work continues server-side — inserted a SECOND ledger row
+    // and charged a `billingMode: USAGE` customer twice for one generation.
+    //
+    // Per this file's own rule ("Omitting a method costs at most one lost
+    // retry; adding the wrong one silently doubles a charge"), it is omitted.
+    // A lost retry only leaves `nextRunAt` unadvanced, which the existing
+    // schedule sweep (`SCHEDULE_STUCK_TIMEOUT_MINUTES`, default 180) already
+    // recovers. Re-list it only once `recordUsage` deduplicates on
+    // `generationHistoryId` behind a UNIQUE index.
 ]);
 
 @Injectable()


### PR DESCRIPTION
## The defect

`RETRY_SAFE_REMOTE_METHODS` in the Trigger worker's internal-API client listed `WorkScheduleService.markRunCompleted` as safe to re-issue, annotated:

> Explicit already-marked guard / absolute SET recomputed from the anchor.

There is no such guard. `isAlreadyMarkedFailed` is called only from `markRunFailed` (`work-schedule.service.ts:348`). `markRunCompleted` ends in:

```
UsageLedgerService.recordUsage
  -> UsageLedgerRepository.record()      plain INSERT, always a new row
  -> BillingProvider.recordUsageCharge() real charge
```

with no pre-read on `generationHistoryId` and no UNIQUE constraint on that column.

So the exact case the retry exists for — nginx answering 504 while the API pod keeps running the work, which this file documents as the reason `retryable` gates the loop rather than the status code — re-issued the call, inserted a second `usage_ledger_entry` row, and charged a `billingMode: USAGE` customer twice for one generation.

`finalizeScheduleRun` also documented itself as *"Idempotent — safe to call multiple times for the same run"* while routing the `completed` branch straight into that method.

**Exposure:** only schedules with `billingMode: USAGE` and subscriptions enabled. Subscription-mode schedules return early from `recordUsage`.

## The fix

Removes the allow-list entry rather than adding a guard. This file states the rule itself:

> Omitting a method costs at most one lost retry; adding the wrong one silently doubles a charge.

A lost retry only leaves `nextRunAt` unadvanced, which the existing schedule sweep already recovers (`SCHEDULE_STUCK_TIMEOUT_MINUTES`, default 180).

I deliberately did **not** add an `isAlreadyMarkedCompleted` guard keyed on `lastRunStatus` + the 5-minute idempotency window. It would risk the opposite error — skipping a genuine completion and *under*-billing — because a manual run can reach `markRunCompleted` with `scheduledFor` already NULL. The correct durable fix is a ledger dedup on `generationHistoryId` behind a UNIQUE index, which is a migration and a separate change. The code comment records that as the precondition for re-listing.

`markRunFailed` stays on the list: its guard is real.

## Also

- Corrects both docstrings that claimed the idempotency.
- Two tests pin the split, so re-adding the entry fails in CI instead of on an invoice.

## Verification

| Check | Result |
| --- | --- |
| `trigger-internal-api.client.spec.ts` | 55 passed |
| `tsc --noEmit` (agent, tasks) | clean |
| `prettier --check` on changed files | clean |

## Provenance

Found by an adversarial multi-agent review of PR #1990 and confirmed by an independent verifier against live `develop`. Not introduced by #1990 — that PR built the allow-list and this entry was wrong from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic retries for schedule completions that could result in duplicate usage charges.
  * Enabled safe retries for failed schedule updates, improving recovery after transient request failures.

* **Tests**
  * Added coverage confirming retry behavior for completed and failed schedule runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->