### PR TITLE
fix(workflows): stop a dead worker stranding a workflow run forever

### DIFF
--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -973,6 +973,15 @@ describe('agent/config', () => {
                 'terminal',
                 'trigger',
                 'websiteTemplate',
+                // Judgment layer G5 — `workflows.*` group adds the
+                // `workflow_runs` stuck-row sweeper knobs
+                // (WORKFLOW_RUN_SWEEPER_ENABLED,
+                // WORKFLOW_RUN_STUCK_TIMEOUT_MINUTES,
+                // WORKFLOW_RUN_SWEEPER_MAX_BATCH). The cutoff is clamped
+                // above the `workflow-run` task's own 60-minute
+                // `maxDuration`, so a misconfigured value cannot reap a
+                // healthy walk. Pinned alphabetically, last.
+                'workflows',
             ]);
         });
     });

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -1173,6 +1173,53 @@ export const config = {
      */
 
     /**
+     * Saved workflow graphs (judgment layer G5) — the `workflow_runs`
+     * stuck-row sweep.
+     *
+     * `POST /api/workflows/:id/run` inserts the row `queued` and the
+     * Trigger.dev `workflow-run` task owns it from `markStarted` onward.
+     * That task runs `maxAttempts: 1`, so if its machine dies without
+     * reaching a terminal write — OOM, node eviction, a
+     * `release-trigger-prod` deploy, or `maxDuration` expiry — nothing
+     * re-delivers it and the row stays `queued`/`running` forever. A
+     * `queued` row is equally strandable: an enqueue that parks in
+     * `PENDING_VERSION` across an API/worker deploy skew may never run.
+     */
+    workflows: {
+        /** Kill switch for the `workflow_runs` stuck-row sweeper. Default on. */
+        getRunSweeperEnabled() {
+            return process.env.WORKFLOW_RUN_SWEEPER_ENABLED !== 'false';
+        },
+        /**
+         * Age past which a `queued`/`running` workflow run is considered
+         * abandoned, measured from `COALESCE(startedAt, createdAt)`.
+         *
+         * The two error costs are asymmetric in the same way
+         * `agents.getStuckTimeoutMinutes` documents, so this is deliberately
+         * generous. Sweeping LATE leaves a status field wrong for a few extra
+         * hours. Sweeping EARLY marks a LIVE walk `failed`; the worker's own
+         * `markCompleted` then no-ops against the terminal CAS and the real
+         * result is lost, which is unrecoverable.
+         *
+         * The floor is the task's own ceiling: `workflow-run.task.ts` pins
+         * `maxDuration: 60 * 60`, so a legitimate walk can occupy 60 minutes.
+         * 90 leaves half an hour of margin. A value at or below 60 would reap
+         * healthy long walks, so it is clamped up.
+         */
+        getRunStuckTimeoutMinutes() {
+            const raw = parseInt(process.env.WORKFLOW_RUN_STUCK_TIMEOUT_MINUTES || '90', 10);
+            const minutes = Number.isFinite(raw) && raw > 0 ? raw : 90;
+            // `maxDuration` is 60 minutes; never reap inside a walk's own budget.
+            return Math.max(minutes, 61);
+        },
+        /** Upper bound on rows reaped per sweep tick. */
+        getRunSweeperMaxBatch() {
+            const raw = parseInt(process.env.WORKFLOW_RUN_SWEEPER_MAX_BATCH || '100', 10);
+            return Number.isFinite(raw) && raw > 0 ? raw : 100;
+        },
+    },
+
+    /**
      * Streaming-terminal M9 / founder decision D1 — persisted terminal
      * transcripts.
      *

--- a/packages/agent/src/database/repositories/workflow-run.repository.ts
+++ b/packages/agent/src/database/repositories/workflow-run.repository.ts
@@ -8,6 +8,13 @@ const NON_TERMINAL: WorkflowRunStatus[] = ['queued', 'running'];
 /** Narrower source set for a dispatch rollback — see `markDispatchFailed`. */
 const QUEUED_ONLY: WorkflowRunStatus[] = ['queued'];
 
+/**
+ * `failureCode` stamped on a run reaped by the stuck-row sweep, so it is
+ * distinguishable from a graph that genuinely failed. Short machine string,
+ * never free text — the same convention as the `agent_runs` attention tokens.
+ */
+export const WORKFLOW_RUN_SWEPT_FAILURE_CODE = 'stuck-swept' as const;
+
 export interface CreateWorkflowRunInput {
     workflowId: string;
     userId: string;
@@ -203,6 +210,86 @@ export class WorkflowRunRepository {
             .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
             .execute();
         return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Rows abandoned by a worker that died without reaching a terminal write
+     * — OOM, node eviction, a `release-trigger-prod` deploy, Trigger.dev
+     * teardown, or `maxDuration` expiry. Nothing else reaps them.
+     *
+     * `workflow-run.task.ts` runs `maxAttempts: 1` (a graph walk is not
+     * safely re-runnable: `ai.ask` nodes are already paid for and delegate
+     * nodes spawn real child runs), so there is no runtime redelivery to fall
+     * back on. Without this the row reads `running` forever, `finishedAt` and
+     * `durationMs` stay NULL, and the user has no signal that the walk died.
+     *
+     * `COALESCE("startedAt", "createdAt")` covers BOTH non-terminal statuses
+     * in one predicate. `startedAt` is NULL while `queued`, and `markStarted`
+     * is the only writer of `status='running'` and sets both in one atomic
+     * UPDATE, so `running` implies `startedAt IS NOT NULL` with no torn
+     * window. Sweeping `queued` matters on its own: an enqueue that parks in
+     * `PENDING_VERSION` across an API/worker deploy skew may never execute.
+     *
+     * Bounded by `limit` on purpose — see {@link markStuckFailed}.
+     */
+    async findStuckNonTerminal(
+        cutoff: Date,
+        limit: number,
+    ): Promise<
+        Pick<WorkflowRun, 'id' | 'workflowId' | 'userId' | 'status' | 'startedAt' | 'createdAt'>[]
+    > {
+        return this.repository
+            .createQueryBuilder('run')
+            .select([
+                'run.id',
+                'run.workflowId',
+                'run.userId',
+                'run.status',
+                'run.startedAt',
+                'run.createdAt',
+            ])
+            .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .andWhere('COALESCE(run."startedAt", run."createdAt") < :cutoff', { cutoff })
+            .orderBy('COALESCE(run."startedAt", run."createdAt")', 'ASC')
+            .limit(limit)
+            .getMany();
+    }
+
+    /**
+     * Bulk `queued | running → failed` for a batch from
+     * {@link findStuckNonTerminal}.
+     *
+     * Guarded on `NON_TERMINAL` in the same statement, so a worker that
+     * reached its own terminal write between the scan and this update keeps
+     * its result — the sweep simply is not counted for that row. Returns
+     * `affected`, NOT `runIds.length`: reporting the input size would
+     * overstate the sweep every time that race is lost.
+     *
+     * `durationMs` is deliberately left NULL. It cannot be computed in a bulk
+     * statement, and NULL is the honest value for "we do not know when this
+     * died". Nothing branches on it — it is a reporting field.
+     *
+     * `failureCode` is stamped so an operator (and any future `on_failure`
+     * routing) can tell a swept run apart from a graph that genuinely failed.
+     */
+    async markStuckFailed(runIds: string[], errorMessage: string): Promise<number> {
+        // TypeORM renders `IN (:...ids)` as invalid SQL for an empty array.
+        if (runIds.length === 0) return 0;
+
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set({
+                status: 'failed',
+                finishedAt: new Date(),
+                errorMessage,
+                failureCode: WORKFLOW_RUN_SWEPT_FAILURE_CODE,
+            })
+            .where('id IN (:...runIds)', { runIds })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+
+        return result.affected ?? 0;
     }
 
     /**

--- a/packages/agent/src/services/__tests__/workflow-run-sweeper.service.spec.ts
+++ b/packages/agent/src/services/__tests__/workflow-run-sweeper.service.spec.ts
@@ -1,0 +1,199 @@
+import { DataSource } from 'typeorm';
+import type { WorkflowGraph, WorkflowNode } from '@ever-works/contracts';
+import { Workflow, WorkflowStatus } from '../../entities/workflow.entity';
+import { WorkflowRun } from '../../entities/workflow-run.entity';
+import { WorkflowRepository } from '../../database/repositories/workflow.repository';
+import {
+    WORKFLOW_RUN_SWEPT_FAILURE_CODE,
+    WorkflowRunRepository,
+} from '../../database/repositories/workflow-run.repository';
+import { WorkflowRunSweeperService } from '../workflow-run-sweeper.service';
+
+/**
+ * The backstop for `workflow_runs` rows abandoned by a dead worker.
+ *
+ * `workflow-run.task.ts` runs `maxAttempts: 1`, so nothing re-enters the task
+ * to finish a row whose machine was OOM-killed, evicted, or rolled by a
+ * deploy. Before this sweep such a row read `queued`/`running` forever, with
+ * `finishedAt` and `durationMs` NULL, and there is still no cancel route to
+ * clear it by hand.
+ *
+ * Runs against a real in-memory DataSource rather than a mocked repository:
+ * the whole mechanism is a `COALESCE(startedAt, createdAt) < cutoff` predicate
+ * plus a status-guarded bulk CAS, and a mock would only assert the SQL I wrote
+ * rather than the rows it actually selects.
+ */
+describe('WorkflowRunSweeperService', () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    let dataSource: DataSource;
+    let workflows: WorkflowRepository;
+    let runs: WorkflowRunRepository;
+    let sweeper: WorkflowRunSweeperService;
+
+    const graph: WorkflowGraph = {
+        id: 'g-1',
+        entryNodeId: 'a',
+        nodes: [{ id: 'a', kind: 'noop' } as WorkflowNode],
+        edges: [],
+    } as WorkflowGraph;
+
+    /** Backdate a row's clock columns so the cutoff predicate can see it. */
+    const backdate = async (
+        runId: string,
+        minutesAgo: number,
+        column: 'startedAt' | 'createdAt',
+    ) => {
+        const when = new Date(Date.now() - minutesAgo * 60 * 1000);
+        await dataSource
+            .getRepository(WorkflowRun)
+            .createQueryBuilder()
+            .update(WorkflowRun)
+            .set({ [column]: when })
+            .where('id = :runId', { runId })
+            .execute();
+    };
+
+    beforeEach(async () => {
+        process.env = { ...ORIGINAL_ENV };
+        delete process.env.WORKFLOW_RUN_SWEEPER_ENABLED;
+        delete process.env.WORKFLOW_RUN_STUCK_TIMEOUT_MINUTES;
+        delete process.env.WORKFLOW_RUN_SWEEPER_MAX_BATCH;
+
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [Workflow, WorkflowRun],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        workflows = new WorkflowRepository(dataSource.getRepository(Workflow));
+        runs = new WorkflowRunRepository(dataSource.getRepository(WorkflowRun));
+        sweeper = new WorkflowRunSweeperService(runs);
+    });
+
+    afterEach(async () => {
+        process.env = { ...ORIGINAL_ENV };
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    const seedRun = async () => {
+        const workflow = await workflows.create({
+            userId: 'user-1',
+            name: 'Nightly digest',
+            graph,
+            status: WorkflowStatus.ACTIVE,
+        } as Parameters<WorkflowRepository['create']>[0]);
+        return runs.createQueued({ workflowId: workflow.id, userId: 'user-1' });
+    };
+
+    it('reaps a running row whose startedAt is past the cutoff', async () => {
+        const run = await seedRun();
+        await runs.markStarted(run.id, 'run_abc');
+        await backdate(run.id, 200, 'startedAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.swept).toEqual([run.id]);
+        expect(summary.scanned).toBe(1);
+
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('failed');
+        expect(row?.failureCode).toBe(WORKFLOW_RUN_SWEPT_FAILURE_CODE);
+        expect(row?.finishedAt).not.toBeNull();
+        expect(row?.errorMessage).toContain('abandoned');
+    });
+
+    it('reaps a queued row too — an enqueue can park across a deploy skew and never run', async () => {
+        const run = await seedRun();
+        // Never started, so `startedAt` is NULL and only the COALESCE onto
+        // `createdAt` can see this row. A predicate written against
+        // `startedAt` alone would leave it stranded forever.
+        await backdate(run.id, 200, 'createdAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.swept).toEqual([run.id]);
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('failed');
+    });
+
+    it('does NOT touch a long-running walk inside its own time budget', async () => {
+        const run = await seedRun();
+        await runs.markStarted(run.id);
+        // 45 minutes in. The task pins `maxDuration: 60 * 60`, so this is a
+        // healthy walk. Reaping it would be the unrecoverable error: the row
+        // reads `failed`, the worker's own `markCompleted` then no-ops against
+        // the terminal CAS, and the real result is gone.
+        await backdate(run.id, 45, 'startedAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.swept).toEqual([]);
+        expect(summary.scanned).toBe(0);
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('running');
+    });
+
+    it('clamps a misconfigured cutoff up above the task maxDuration', async () => {
+        // An operator setting 5 minutes would otherwise reap every healthy
+        // walk. The floor is 61 minutes.
+        process.env.WORKFLOW_RUN_STUCK_TIMEOUT_MINUTES = '5';
+        const run = await seedRun();
+        await runs.markStarted(run.id);
+        await backdate(run.id, 30, 'startedAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.cutoffMinutes).toBeGreaterThan(60);
+        expect(summary.swept).toEqual([]);
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('running');
+    });
+
+    it('leaves a row that reached its own terminal status alone', async () => {
+        const run = await seedRun();
+        await runs.markStarted(run.id);
+        await runs.markCompleted(run.id, { stepCount: 3 });
+        await backdate(run.id, 500, 'startedAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.swept).toEqual([]);
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('completed');
+        expect(row?.failureCode ?? null).toBeNull();
+    });
+
+    it('honours the kill switch without scanning', async () => {
+        process.env.WORKFLOW_RUN_SWEEPER_ENABLED = 'false';
+        const run = await seedRun();
+        await runs.markStarted(run.id);
+        await backdate(run.id, 500, 'startedAt');
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.enabled).toBe(false);
+        expect(summary.swept).toEqual([]);
+        const row = await runs.findByIdAndUser(run.id, 'user-1');
+        expect(row?.status).toBe('running');
+    });
+
+    it('bounds one tick by the max batch', async () => {
+        process.env.WORKFLOW_RUN_SWEEPER_MAX_BATCH = '2';
+        for (let i = 0; i < 3; i++) {
+            const run = await seedRun();
+            await runs.markStarted(run.id);
+            await backdate(run.id, 300 + i, 'startedAt');
+        }
+
+        const summary = await sweeper.sweepStuckRuns();
+
+        expect(summary.scanned).toBe(2);
+    });
+
+    it('markStuckFailed no-ops on an empty batch rather than emitting invalid SQL', async () => {
+        // TypeORM renders `IN (:...ids)` as invalid SQL for an empty array.
+        await expect(runs.markStuckFailed([], 'nothing')).resolves.toBe(0);
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -65,6 +65,7 @@ export * from './workflows.module';
 // (the walk). Split so the API cannot reach an executor.
 export * from './workflow-runs.service';
 export * from './workflow-run-executor.service';
+export * from './workflow-run-sweeper.service';
 // Repository registry (Feature G) — registry CRUD + agent grants + resolver.
 export * from './repo-registry.service';
 // Memory Files — folder tree + unified file list + manual git sync

--- a/packages/agent/src/services/workflow-run-sweeper.service.ts
+++ b/packages/agent/src/services/workflow-run-sweeper.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { config } from '../config';
+import {
+    WORKFLOW_RUN_SWEPT_FAILURE_CODE,
+    WorkflowRunRepository,
+} from '../database/repositories/workflow-run.repository';
+
+/** What one sweep tick did, for the caller to log. */
+export interface WorkflowRunSweepSummary {
+    /** Ids that this sweep actually transitioned to `failed`. */
+    swept: string[];
+    /** Rows the scan matched — may exceed `swept` when a worker won the race. */
+    scanned: number;
+    /** The cutoff age applied, echoed so a log line is self-describing. */
+    cutoffMinutes: number;
+    /** False when the kill switch is off; nothing was scanned. */
+    enabled: boolean;
+}
+
+/**
+ * Stuck-row sweep for `workflow_runs` (judgment layer G5).
+ *
+ * ## Why this exists at all
+ *
+ * `POST /api/workflows/:id/run` inserts the row `queued`, and the Trigger.dev
+ * `workflow-run` task owns it from `markStarted` onward. That task declares
+ * `retry: { maxAttempts: 1 }` — deliberately, because a graph walk is not
+ * safely re-runnable — so if its machine dies before a terminal write there is
+ * no redelivery. The row then reads `queued`/`running` forever, with
+ * `finishedAt` and `durationMs` NULL, and there is no cancel route to clear it.
+ *
+ * The task's `onFailure` hook is the PRIMARY recovery path and covers every
+ * failure the runtime reports. This sweep is the backstop for the failures it
+ * cannot report: a hard OOM, a node eviction, a `release-trigger-prod` deploy
+ * mid-walk, or `maxDuration` expiry. `agent_runs` has had exactly this pair
+ * since the sweeper was added for it; `workflow_runs` shipped with neither.
+ *
+ * This is the repo's stated rule, from `agent-heartbeat.task.ts`: "the
+ * stuck-row sweep in the dispatcher is a backstop, not a primary path."
+ *
+ * ## What it deliberately does NOT do
+ *
+ * It does not touch a row inside the walk's own time budget. The cutoff is
+ * clamped above the task's `maxDuration` (60 minutes) by
+ * `config.workflows.getRunStuckTimeoutMinutes`, because sweeping early is the
+ * unrecoverable error: the row would read `failed`, the worker's own
+ * `markCompleted` would then no-op against the terminal CAS, and the real
+ * result would be gone.
+ */
+@Injectable()
+export class WorkflowRunSweeperService {
+    private readonly logger = new Logger(WorkflowRunSweeperService.name);
+
+    constructor(private readonly runs: WorkflowRunRepository) {}
+
+    async sweepStuckRuns(): Promise<WorkflowRunSweepSummary> {
+        const cutoffMinutes = config.workflows.getRunStuckTimeoutMinutes();
+
+        if (!config.workflows.getRunSweeperEnabled()) {
+            return { swept: [], scanned: 0, cutoffMinutes, enabled: false };
+        }
+
+        const cutoff = new Date(Date.now() - cutoffMinutes * 60 * 1000);
+        const limit = config.workflows.getRunSweeperMaxBatch();
+
+        const candidates = await this.runs.findStuckNonTerminal(cutoff, limit);
+        if (candidates.length === 0) {
+            return { swept: [], scanned: 0, cutoffMinutes, enabled: true };
+        }
+
+        const ids = candidates.map((c) => c.id);
+        const affected = await this.runs.markStuckFailed(
+            ids,
+            `Workflow run abandoned: no terminal write within ${cutoffMinutes} minutes. ` +
+                `The worker executing the graph died without reporting a failure ` +
+                `(code: ${WORKFLOW_RUN_SWEPT_FAILURE_CODE}).`,
+        );
+
+        // `affected` can be lower than `ids.length`: a worker that reached its
+        // own terminal write between the scan and the CAS keeps its result.
+        // Report the scan and the transition separately rather than conflating
+        // them — a persistent gap between the two is itself a signal.
+        this.logger.warn(
+            `workflow-run sweep reaped ${affected}/${ids.length} abandoned runs ` +
+                `(cutoff ${cutoffMinutes}m): ${ids.join(', ')}`,
+        );
+
+        return {
+            swept: affected > 0 ? ids : [],
+            scanned: ids.length,
+            cutoffMinutes,
+            enabled: true,
+        };
+    }
+}

--- a/packages/agent/src/services/workflows.module.ts
+++ b/packages/agent/src/services/workflows.module.ts
@@ -6,6 +6,7 @@ import { WorkflowRepository } from '../database/repositories/workflow.repository
 import { WorkflowRunRepository } from '../database/repositories/workflow-run.repository';
 import { WorkflowsService } from './workflows.service';
 import { WorkflowRunsService } from './workflow-runs.service';
+import { WorkflowRunSweeperService } from './workflow-run-sweeper.service';
 
 /**
  * Saved workflow graphs (judgment layer G5).
@@ -34,7 +35,22 @@ import { WorkflowRunsService } from './workflow-runs.service';
  */
 @Module({
     imports: [TypeOrmModule.forFeature([Workflow, WorkflowRun])],
-    providers: [WorkflowRepository, WorkflowRunRepository, WorkflowsService, WorkflowRunsService],
-    exports: [WorkflowRepository, WorkflowRunRepository, WorkflowsService, WorkflowRunsService],
+    providers: [
+        WorkflowRepository,
+        WorkflowRunRepository,
+        WorkflowsService,
+        WorkflowRunsService,
+        // Backstop for runs abandoned by a dead worker. Cheap to provide
+        // here — it needs only `WorkflowRunRepository` — and doing so keeps
+        // the sweeper's worker module lean.
+        WorkflowRunSweeperService,
+    ],
+    exports: [
+        WorkflowRepository,
+        WorkflowRunRepository,
+        WorkflowsService,
+        WorkflowRunsService,
+        WorkflowRunSweeperService,
+    ],
 })
 export class WorkflowsModule {}

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -7,6 +7,10 @@ export * from './kb-mirror-document.task';
 export * from './kb-org-overlay-fanout.task';
 export * from './kb-reconcile.task';
 export * from './agent-run-sweeper.task';
+// Judgment layer G5 — backstop for `workflow_runs` rows abandoned by a
+// worker that died without reaching a terminal write. Paired with the
+// `onFailure` hook on `workflow-run.task.ts`, which is the primary path.
+export * from './workflow-run-sweeper.task';
 export * from './terminal-session.task';
 // Streaming-terminal M9 / D1 — nightly plan-tier retention sweep over
 // persisted terminal transcripts.

--- a/packages/tasks/src/tasks/trigger/workflow-run-sweeper.task.ts
+++ b/packages/tasks/src/tasks/trigger/workflow-run-sweeper.task.ts
@@ -1,0 +1,68 @@
+import { logger, schedules } from '@trigger.dev/sdk';
+import { WorkflowRunSweeperService } from '@ever-works/agent/services';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerWorkflowRunSweeperModule } from '../../trigger/worker/modules/trigger-workflow-run-sweeper.module';
+
+/**
+ * Stuck-row sweep for `workflow_runs` (judgment layer G5).
+ *
+ * The `workflow-run` task's `onFailure` hook is the PRIMARY recovery path and
+ * handles every failure the runtime can report. This is the backstop for the
+ * ones it cannot: a hard OOM, a node eviction, a `release-trigger-prod` deploy
+ * landing mid-walk, or `maxDuration` expiry. In each of those the process is
+ * gone before `onFailure` can run, and because the task declares
+ * `maxAttempts: 1` there is no redelivery either — so without this the row
+ * reads `queued`/`running` forever, with `finishedAt` and `durationMs` NULL
+ * and no cancel route to clear it.
+ *
+ * `agent_runs` has had this pair (an `onFailure` write plus
+ * `agent-run-sweeper`) since the sweeper was added for it, and
+ * `agent-run.repository.ts` records why: those rows are "abandoned by a worker
+ * that died without reaching any checkpoint — OOM, node eviction, deploy,
+ * Trigger.dev teardown. Nothing else reaps them." `workflow_runs` shipped with
+ * neither half.
+ *
+ * Its own schedule rather than a pass inside another task, per the
+ * `agent-run-sweeper` / `kb-reconcile` rationale: a reap is a signal that
+ * something upstream died, and buried inside another task's run history it is
+ * invisible. Cron offset off the hour so it does not collide with the
+ * per-minute dispatchers or the other sweeps — `agent-run-sweeper` runs at
+ * minute 23 of every second hour, `task-branch-gc` daily at 04:41. Hourly
+ * against a 90-minute cutoff bounds detection lag to `cutoff + 1h`.
+ */
+export const workflowRunSweeperTask = schedules.task({
+    id: 'workflow-run-sweeper',
+    cron: '37 * * * *',
+    run: async () => {
+        // NOTE the third argument. `withWorkerContext` defaults to
+        // `TriggerWorkerModule`, which provides neither
+        // `WorkflowRunSweeperService` nor `WorkflowRunRepository` — omitting it
+        // fails at runtime, on every fire, silently, forever.
+        return withWorkerContext(
+            'WorkflowRunSweeper',
+            async (appContext) => {
+                const sweeper = appContext.get(WorkflowRunSweeperService);
+                const summary = await sweeper.sweepStuckRuns();
+
+                if (!summary.enabled) {
+                    logger.log('workflow-run-sweeper disabled by kill switch');
+                    return summary;
+                }
+
+                // Only speak when something was reaped. A reap means a worker
+                // died; an empty tick is the normal case and logging it hourly
+                // would bury the signal.
+                if (summary.swept.length > 0) {
+                    logger.warn('workflow-run-sweeper reaped abandoned runs', {
+                        runIds: summary.swept,
+                        scanned: summary.scanned,
+                        cutoffMinutes: summary.cutoffMinutes,
+                    });
+                }
+
+                return summary;
+            },
+            TriggerWorkflowRunSweeperModule,
+        );
+    },
+});

--- a/packages/tasks/src/tasks/trigger/workflow-run.task.ts
+++ b/packages/tasks/src/tasks/trigger/workflow-run.task.ts
@@ -1,8 +1,10 @@
 import { logger, task } from '@trigger.dev/sdk';
 import type { WorkflowRunPayload } from '@ever-works/agent/tasks';
+import { WorkflowRunRepository } from '@ever-works/agent/database';
 import { WorkflowRunExecutorService } from '@ever-works/agent/services';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 import { TriggerWorkflowRunModule } from '../../trigger/worker/modules/trigger-workflow-run.module';
+import { TriggerWorkflowRunSweeperModule } from '../../trigger/worker/modules/trigger-workflow-run-sweeper.module';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
 // Security: validate payload ids before any DB access (defence in depth,
 // mirrors every other task that takes ids off a queue payload).
@@ -52,6 +54,26 @@ import { assertUuid } from '../../trigger/worker/utils/task-context.utils';
  * understands the graph. `WorkflowRunExecutorService` is nonetheless
  * idempotent — it returns early on a row already in a terminal state —
  * so a runtime-level redelivery cannot double-walk.
+ *
+ * ## Who lands the row when the walk does not
+ *
+ * Because there is no retry, nothing re-enters `run` to finish the row. The
+ * executor writes the terminal status on both of its own outcomes, but a
+ * failure BEFORE or AROUND it — `assertUuid` rejecting a payload id, the Nest
+ * context failing to boot, `TriggerPluginHydratorService.initialize()`
+ * throwing, an unexpected error out of the executor, or `maxDuration` expiry
+ * — left the row `queued`/`running` forever, with `finishedAt` and
+ * `durationMs` NULL and no cancel route to clear it.
+ *
+ * Two layers now cover that, the same pair `agent_runs` has:
+ *
+ *   1. `onFailure` below — the PRIMARY path, for every failure the runtime
+ *      reports.
+ *   2. `workflow-run-sweeper.task.ts` — the BACKSTOP, for the failures it
+ *      cannot report: a hard OOM, a node eviction, a deploy landing mid-walk.
+ *
+ * In that order deliberately. `agent-heartbeat.task.ts` states the rule: "the
+ * stuck-row sweep in the dispatcher is a backstop, not a primary path."
  */
 export const workflowRunTask = task<'workflow-run', WorkflowRunPayload>({
     id: 'workflow-run',
@@ -59,6 +81,44 @@ export const workflowRunTask = task<'workflow-run', WorkflowRunPayload>({
     // the 10-minute ceiling), with room for the AI calls between them.
     maxDuration: 60 * 60,
     retry: { maxAttempts: 1 },
+    /**
+     * Land the row when the run did not.
+     *
+     * `markFailed` CASes on `queued | running`, so this cannot stomp a walk
+     * that already wrote its own terminal status — the normal `failed` path
+     * keeps its `failureCode` and `failedNodeId`, and this no-ops.
+     *
+     * Boots `TriggerWorkflowRunSweeperModule`, NOT the task's own module: this
+     * hook runs after the task has already failed, sometimes because the
+     * machine is out of memory, and the walk module hydrates the plugin
+     * registry over the network. A recovery path must not be able to fail for
+     * the same reason as the thing it is recovering.
+     *
+     * Best-effort by design. If even this cannot run, the row is still
+     * reachable by `workflow-run-sweeper`.
+     */
+    onFailure: async ({ payload, error }: { payload?: WorkflowRunPayload; error?: unknown }) => {
+        if (!payload?.workflowRunId) return;
+        try {
+            // Security: validate the id before any DB access, mirroring `run`.
+            assertUuid(payload.workflowRunId, 'payload.workflowRunId');
+            await withWorkerContext(
+                'WorkflowRun:Failure',
+                async (appContext) => {
+                    const runs = appContext.get(WorkflowRunRepository);
+                    const message = error instanceof Error ? error.message : String(error);
+                    await runs.markFailed(
+                        payload.workflowRunId,
+                        `workflow-run task failed before the walk could record an outcome: ${message}`,
+                        { failureCode: 'task-failed' },
+                    );
+                },
+                TriggerWorkflowRunSweeperModule,
+            );
+        } catch {
+            // Best-effort — `workflow-run-sweeper` is the backstop.
+        }
+    },
     run: async (payload: WorkflowRunPayload, { ctx }: { ctx?: { run?: { id?: string } } } = {}) => {
         assertUuid(payload.workflowRunId, 'payload.workflowRunId');
         assertUuid(payload.workflowId, 'payload.workflowId');

--- a/packages/tasks/src/trigger/worker/modules/trigger-workflow-run-sweeper.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-workflow-run-sweeper.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { WorkflowsModule } from '@ever-works/agent/services';
+
+/**
+ * Lean Nest module for the two `workflow_runs` recovery paths: the
+ * `workflow-run` task's `onFailure` hook and the `workflow-run-sweeper`
+ * schedule.
+ *
+ * # Why not `TriggerWorkflowRunModule`
+ *
+ * That module boots the plugin registry, the AI facade and six knowledge-base
+ * providers, because the WALK needs them. Neither recovery path executes a
+ * node — both only need `WorkflowRunRepository` to move a row to `failed`. On
+ * the `onFailure` path the cost is not merely cold-start latency: that hook
+ * runs after the task has already failed, sometimes because the machine is out
+ * of memory, and `TriggerPluginHydratorService` reaches over the network. A
+ * recovery path must not be able to fail for the same reason as the thing it
+ * is recovering.
+ *
+ * # Why not `TriggerInternalModule`
+ *
+ * That module reaches the API over `TriggerInternalApiClient` remote proxies.
+ * Same rationale `TriggerWorkflowRunModule` documents for going DB-direct: the
+ * worker already shares the API's database — it must, since it writes the
+ * `workflow_runs` row — so an RPC hop adds a failure mode with no correctness
+ * benefit. That matters more on a recovery path, where the API being
+ * unreachable is a plausible reason the run died in the first place.
+ *
+ * `WorkflowsModule` supplies `WorkflowRunRepository` and
+ * `WorkflowRunSweeperService`; both of its other services construct from a
+ * single repository each, and its `WORKFLOW_RUN_DISPATCHER` injection is
+ * `@Optional()`, so nothing here needs the api-side binding.
+ */
+@Module({
+    imports: [DatabaseModule, WorkflowsModule],
+    exports: [WorkflowsModule],
+})
+export class TriggerWorkflowRunSweeperModule {}


### PR DESCRIPTION
## The defect

`POST /api/workflows/:id/run` inserts the `workflow_runs` row `queued`, and the Trigger.dev `workflow-run` task owns it from `markStarted` onward. That task declares `retry: { maxAttempts: 1 }` — correctly, since a graph walk is not safely re-runnable — so nothing re-enters `run` to finish the row.

It shipped with **neither** of the two recovery layers `agent_runs` has:

- **No `onFailure` hook.** `withWorkerContext` only closes the context in a `finally`; it has no `catch`. So anything thrown left the row untouched: `assertUuid` rejecting a payload id, the Nest context failing to boot, `TriggerPluginHydratorService.initialize()` throwing, an unexpected error out of the executor, or `maxDuration` expiry.
- **No sweeper.** `WorkflowRunRepository` had no stuck-row query at all, and `markCancelled` has no caller — so no automatic recovery and no manual one either. There is still no cancel route.

The row then read `queued`/`running` forever, with `finishedAt` and `durationMs` NULL. `agent-run.repository.ts` already records why this matters: rows *"abandoned by a worker that died without reaching any checkpoint — OOM, node eviction, deploy, Trigger.dev teardown. Nothing else reaps them."*

Every sibling task has the pair: `agent-task-execute`, `agent-heartbeat`, `agent-chat-reply` and `work-generation` all implement `onFailure`, and `agent-run-sweeper` is the backstop.

## The fix

Both layers, in the order `agent-heartbeat.task.ts` prescribes — *"the stuck-row sweep in the dispatcher is a backstop, not a primary path."*

1. **`onFailure` on `workflow-run.task.ts`** marks the row `failed` with `failureCode: 'task-failed'`. It CASes on `queued | running`, so it cannot stomp a walk that already wrote its own terminal status — the normal `failed` path keeps its `failureCode` and `failedNodeId`.
2. **`workflow-run-sweeper.task.ts`**, hourly at minute 37, reaps rows whose `COALESCE(startedAt, createdAt)` is past the cutoff.

### Three decisions worth reviewing

**`COALESCE`, not `startedAt`.** A `queued` row is equally strandable: an enqueue that parks in `PENDING_VERSION` across an API/worker deploy skew may never execute, and `startedAt` is NULL there. A predicate on `startedAt` alone would leave those stranded forever. There is a test for it.

**A new lean `TriggerWorkflowRunSweeperModule`, not the task's own module.** The walk module hydrates the plugin registry over the network. `onFailure` runs *after* the task has already failed, sometimes because the machine is out of memory. A recovery path must not be able to fail for the same reason as the thing it is recovering. It also goes DB-direct rather than through `TriggerInternalModule`'s RPC proxies, for the same reason the walk module does — plus the API being unreachable is a plausible cause of the death being recovered from.

**The cutoff has a 61-minute floor.** Sweeping late costs a wrong status field for a few hours. Sweeping early marks a *live* walk `failed`; the worker's `markCompleted` then no-ops against the terminal CAS and the real result is gone — unrecoverable. The task pins `maxDuration: 60 * 60`, so any value at or under 60 would reap healthy walks. `WORKFLOW_RUN_STUCK_TIMEOUT_MINUTES=5` is clamped up, and there is a test for that too.

## Not fixed here

`markCancelled` still has no caller. Giving users a cancel route is a feature, not a bug fix, so it is out of scope — but it is the other half of this gap and worth its own issue.

## Verification

| Check | Result |
| --- | --- |
| new `workflow-run-sweeper.service.spec.ts` | 8 passed (real in-memory DataSource, not mocks) |
| existing workflow specs (runs, executor, workflows service) | 36 passed |
| `config.spec.ts` | 176 passed |
| `trigger-workflow-run.module.spec.ts` | 5 passed |
| `tsc --noEmit` (agent, tasks) | clean |
| `prettier --check` on changed files | clean |

`config.spec.ts` pins the top-level config groups by exact list, so `workflows` is added there.

## Provenance

Found by an adversarial multi-agent review of PR #1989 and confirmed by an independent verifier against live `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)