### PR TITLE
fix(workflows): make the workflow-run dispatch failure actually reachable in logs

### DIFF
--- a/packages/tasks/src/dispatchers/workflow-run.dispatcher.spec.ts
+++ b/packages/tasks/src/dispatchers/workflow-run.dispatcher.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `tasks` is the only SDK import this adapter should have. The mock factory
+// deliberately does NOT provide `logger`: if the adapter reaches for the SDK
+// logger again, the import resolves to `undefined` and these tests fail rather
+// than quietly writing to a `NoopTaskLogger` in production.
+vi.mock('@trigger.dev/sdk', () => ({
+    tasks: { trigger: vi.fn() },
+}));
+
+import { Logger } from '@nestjs/common';
+import { tasks } from '@trigger.dev/sdk';
+import { workflowRunTriggerAdapter } from './workflow-run.dispatcher';
+
+const PAYLOAD = {
+    workflowRunId: '11111111-1111-4111-8111-111111111111',
+    workflowId: '22222222-2222-4222-8222-222222222222',
+    userId: '33333333-3333-4333-8333-333333333333',
+};
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+    // Spy on the prototype: the adapter holds a module-scope Logger instance
+    // created at import time, so patching the instance is not an option.
+    errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
+
+describe('workflowRunTriggerAdapter', () => {
+    it('returns the Trigger.dev run handle id and keys idempotency on the run row', async () => {
+        vi.mocked(tasks.trigger).mockResolvedValue({ id: 'run_abc' } as never);
+
+        const result = await workflowRunTriggerAdapter.dispatchWorkflowRun(PAYLOAD);
+
+        expect(result).toBe('run_abc');
+        expect(tasks.trigger).toHaveBeenCalledWith('workflow-run', PAYLOAD, {
+            idempotencyKey: PAYLOAD.workflowRunId,
+        });
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('LOGS the reason through a Nest logger before collapsing a failure to null', async () => {
+        vi.mocked(tasks.trigger).mockRejectedValue(new Error('trigger unreachable'));
+
+        const result = await workflowRunTriggerAdapter.dispatchWorkflowRun(PAYLOAD);
+
+        // The contract: null, never a throw — the caller has already persisted
+        // the run row and marks it dispatch-failed.
+        expect(result).toBeNull();
+
+        // The regression this pins: the adapter used `logger` from
+        // `@trigger.dev/sdk`, whose run-scoped LoggerAPI resolves to a
+        // `NoopTaskLogger` outside a task run. This adapter only ever executes
+        // in the API process, so every dispatch failure was discarded and an
+        // auth error, a malformed payload and an unreachable Trigger.dev API
+        // all reached the operator as the same silent `null`.
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const [message] = errorSpy.mock.calls[0] as [string, string | undefined];
+        expect(message).toContain('workflow-run dispatch failed');
+        expect(message).toContain(PAYLOAD.workflowRunId);
+        expect(message).toContain(PAYLOAD.workflowId);
+        expect(message).toContain('trigger unreachable');
+    });
+
+    it('stringifies a non-Error rejection instead of losing it', async () => {
+        vi.mocked(tasks.trigger).mockRejectedValue('plain-string-failure');
+
+        const result = await workflowRunTriggerAdapter.dispatchWorkflowRun(PAYLOAD);
+
+        expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy.mock.calls[0][0]).toContain('plain-string-failure');
+    });
+});

--- a/packages/tasks/src/dispatchers/workflow-run.dispatcher.ts
+++ b/packages/tasks/src/dispatchers/workflow-run.dispatcher.ts
@@ -1,5 +1,24 @@
-import { logger, tasks } from '@trigger.dev/sdk';
+import { Logger } from '@nestjs/common';
+import { tasks } from '@trigger.dev/sdk';
 import type { WorkflowRunDispatcher, WorkflowRunPayload } from '@ever-works/agent/tasks';
+
+/**
+ * A Nest logger, NOT `logger` from `@trigger.dev/sdk`.
+ *
+ * The SDK's `logger` writes through its run-scoped `LoggerAPI` singleton,
+ * which resolves to a `NoopTaskLogger` outside a task run. This adapter is
+ * bound to `WORKFLOW_RUN_DISPATCHER` by the API-side `WorkflowsModule` and so
+ * only ever executes in the API process, where that logger discards every
+ * call. The dispatch-failure branch below was therefore silent: the whole
+ * point of catching before returning `null` is to leave an account of WHY,
+ * and it was writing to nothing.
+ *
+ * The sibling adapters in this directory (`idea-build-execute.dispatcher.ts`,
+ * `agent-task-dispatchers.ts`) import only `tasks` from the SDK and never hit
+ * this; the trigger-side tasks, which DO run inside a task, keep using the
+ * SDK logger correctly.
+ */
+const logger = new Logger('WorkflowRunDispatcher');
 
 /**
  * Judgment layer G5 — production dispatcher adapter that hands a
@@ -55,11 +74,12 @@ export const workflowRunTriggerAdapter: WorkflowRunDispatcher = {
             // and an unreachable Trigger.dev API would all reach the
             // operator as the same shrug. The row records that dispatch
             // failed; this records what actually happened.
-            logger.error('workflow-run dispatch failed', {
-                workflowRunId: payload.workflowRunId,
-                workflowId: payload.workflowId,
-                error: err instanceof Error ? err.message : String(err),
-            });
+            logger.error(
+                `workflow-run dispatch failed (workflowRunId=${payload.workflowRunId}, ` +
+                    `workflowId=${payload.workflowId}): ` +
+                    (err instanceof Error ? err.message : String(err)),
+                err instanceof Error ? err.stack : undefined,
+            );
             return null;
         }
     },


### PR DESCRIPTION
## The defect

`workflow-run.dispatcher.ts` imported `logger` from `@trigger.dev/sdk` and called `logger.error` in its catch block. That logger writes through the SDK's run-scoped `LoggerAPI` singleton, which resolves to a `NoopTaskLogger` outside a task run.

This adapter is bound to `WORKFLOW_RUN_DISPATCHER` by the **API-side** `WorkflowsModule`, so it only ever executes in the API process — where every one of those calls was discarded.

Which defeats the branch's entire purpose. Its own comment says it best:

> a bare `catch { return null }` DESTROYS the only account of why: an auth failure, a malformed payload and an unreachable Trigger.dev API would all reach the operator as the same shrug.

The log existed to keep that account, and it was going nowhere. An operator debugging "every run records dispatch-failed" had nothing to read.

Verified in the installed `@trigger.dev` 4.4.6: `sdk` re-exports `logger` from `@trigger.dev/core/v3`, which is `LoggerAPI.getInstance()`, which dispatches to a no-op when there is no active task run.

## The fix

A module-scope Nest `Logger`, matching how the rest of the API process logs. `@nestjs/common` is already a direct dependency of `packages/tasks`.

## Scope

This dispatcher is the only one affected. The siblings here (`idea-build-execute.dispatcher.ts`, `agent-task-dispatchers.ts`) import only `tasks` from the SDK and never had the problem. The trigger-side *tasks* keep the SDK logger, which is correct — they do run inside a task.

## The test guards the regression shape

The new spec's `vi.mock('@trigger.dev/sdk')` factory deliberately omits `logger`. Reaching for it again resolves to `undefined` and fails the suite, rather than going quiet in production.

## Verification

| Check | Result |
| --- | --- |
| new `workflow-run.dispatcher.spec.ts` | 3 passed |
| `agent-task-dispatchers.spec.ts` (sibling regression) | 6 passed |
| `tsc --noEmit` (tasks) | clean |
| `prettier --check` on changed files | clean |

## Provenance

Found by an adversarial multi-agent review of PR #1989 and confirmed by an independent verifier against the installed SDK source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)