### PR TITLE
docs(agent-plugins): correct the external spec section references + record the 1.1.0 compatibility decision

### DIFF
--- a/docs/specs/decisions/018-agent-plugins-standard-interop.md
+++ b/docs/specs/decisions/018-agent-plugins-standard-interop.md
@@ -31,7 +31,7 @@ manifests are mutually incompatible by construction:
 - Spec `name` permits dots and 1-char names; our `PLUGIN_ID_PATTERN`
   (`plugin-manifest-validator.service.ts`) forbids both and enforces a 3-char
   minimum.
-- Our validator fatally rejects non-semver `version`; spec §4.4 forbids a client
+- Our validator fatally rejects non-semver `version`; spec §5.4 forbids a client
   from rejecting exactly that.
 - Our manifest requires `id`/`name`/`version`/`category`
   (`plugin-manifest-validator.service.ts:45-48`); `id` and `category` are not
@@ -77,7 +77,7 @@ _server_, `apps/mcp`), and an export serializer.
    skills, and `mcp.json` is pure data handling and is available everywhere.
    Remote MCP transports (`streamable-http`, `sse`) are outbound network clients,
    enabled where outbound policy allows, with Ever Works-managed credentials
-   injected as client-generated headers (never stored in packages — spec §6.2.1
+   injected as client-generated headers (never stored in packages — spec §7.2.1
    forbids it). `stdio` MCP servers execute a subprocess: **disabled by
    default**, operator-enabled on self-hosted/desktop; on the managed SaaS,
    stdio stays disabled in v1 — enabling it there requires a sandboxed
@@ -91,9 +91,10 @@ _server_, `apps/mcp`), and an export serializer.
 5. **`works.ever` is our extension namespace** (reverse-domain of `ever.works`),
    for Ever Works-specific data in exported manifests (`extensions["works.ever"]`)
    and, if ever needed, a `works.ever/` package directory. We ignore all other
-   namespaces without validating them (spec §7).
+   namespaces without validating them (spec §8.1).
 
-6. **Full client conformance is the target** — spec §10.1 including the optional
+6. **Full client conformance is the target** — spec §11.1 plus the Appendix A
+   checklist, including the optional
    `sse` transport, proven by a fixture suite of valid and malformed packages
    exercising every MUST (fatal vs non-fatal manifest errors, skip-one-skill,
    disable-MCP-only, per-server skip, containment escapes, expansion rules).
@@ -118,8 +119,78 @@ _server_, `apps/mcp`), and an export serializer.
 - **Extend the native manifest to swallow the spec** — rejected: the schemas
   conflict on closed-vs-open and validation severity; merging would either
   relax our validator (regression risk for 102 plugins) or violate spec MUSTs.
-- **Skills-only conformance (§10.2)** — valid per spec, rejected by product:
+- **Skills-only conformance (spec §11.2)** — valid per spec, rejected by product:
   MCP servers are half the standard's value and the founder wants full support.
 - **Treat spec packages as a new native plugin category** — rejected: spec
   packages are data; loading them through `import()`-based machinery would grant
   them a code-execution trust class they must not have.
+
+---
+
+## Addendum, 2026-09-03: recognising Agent Plugins 1.1.0 as compatible
+
+Recorded while implementing Phase 0 ([PR #2314](https://github.com/ever-works/ever-works/pull/2314)).
+
+### What changed upstream
+
+The `agentplugins/agent-plugins-spec` repository now publishes a **1.1.0**
+release alongside 1.0.0. Verified against the repository on 2026-09-03:
+
+- `schemas/1.1.0/plugin.schema.json` and `schemas/1.1.0/mcp.schema.json` are
+  **byte-identical** to their 1.0.0 counterparts apart from the version string
+  in `$id`, in `description`, and in the `$schema` `const`.
+- `spec/1.1.0.md` differs from `spec/1.0.0.md` only in version numbers plus
+  three editorial rewordings. Its status is **Working Draft**; 1.0.0 remains
+  **Published**.
+
+No requirement was added, removed or changed.
+
+### Decision
+
+`@ever-works/agent-plugins` registers **both** releases against the same
+validators. Spec §5.2 and §7.2.1 permit exactly this: "A client MAY map
+multiple canonical identifiers to the same implementation only when it
+explicitly recognizes those Agent Plugins versions as compatible." The
+registry in `src/versions.ts` is that explicit recognition, and it carries the
+verification note above so a future reader can re-check it.
+
+The **published conformance claim stays 1.0.0**, unchanged from the original
+decision. 1.1.0 is accepted, not advertised, because a Working Draft can still
+move; `WORKING_DRAFT_VERSIONS` marks it so.
+
+### The trap this creates
+
+Accepting two releases makes it easy to weaken a rule that must not weaken.
+Spec §10.1: "When `mcp.json` is present, the version in its `$schema` value
+MUST match the version declared by `plugin.json`."
+
+That is **string equality against the manifest's release**, not membership of
+the supported set. A 1.0.0 manifest beside a 1.1.0 `mcp.json` disables MCP for
+that package even though both releases load — and the reverse likewise.
+Compatibility governs which identifiers we _accept_, never whether a pair may
+_disagree_. `mcp.ts` implements it as an equality check and a test pins it.
+
+### Extension point
+
+AP-20's version registry is the mechanism, now exercised for the first time.
+A future 1.2.0 with real requirement changes would need its own validators
+rather than another alias — the registry maps an identifier to an
+implementation, so divergent releases simply get divergent entries.
+
+---
+
+## Addendum, 2026-09-03: specification section references
+
+The section numbers cited throughout `spec.md`, `plan.md`, `tasks.md` and this
+ADR were, until the same date, one lower than the published 1.0.0 document for
+everything from the manifest onward — the manifest was cited as §4 when it is
+§5, MCP servers as §6.2 when they are §7.2, subprocess environment as §8 when
+it is §9, and the conformance checklist as §10.1 when it is §11.1 plus
+Appendix A.
+
+They are corrected. The **AP-1…AP-23 requirement identifiers defined in
+`spec.md` §4 are unaffected** and remain the right thing for implementation
+and review to cite, since they are ours and stable. When citing the external
+document, quote the requirement sentence as well as the number: this drift went
+unnoticed through a full review pass precisely because a bare number looks
+authoritative.

--- a/docs/specs/features/agent-plugins/plan.md
+++ b/docs/specs/features/agent-plugins/plan.md
@@ -174,7 +174,7 @@ strict).
 
 - `McpClientService`: connection lifecycle per (run, binding). Lazy connect at
   tool-resolution time; disconnect at run end; per-server failure isolation per
-  spec §6.2.2 (failed connect → skip server, WARN run-log, continue — mirrors the
+  spec §7.2.2 (failed connect → skip server, WARN run-log, continue — mirrors the
   suppressed-skill WARN pattern at `agent-run.service.ts:1594-1607`).
 - `McpToolSource`: the injection seam is a **new optional token-injected source
   inside `AgentToolService.resolveAllowedTools`** — exactly the

--- a/docs/specs/features/agent-plugins/spec.md
+++ b/docs/specs/features/agent-plugins/spec.md
@@ -13,7 +13,7 @@
   canonical schemas `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json` and
   `https://agent-plugins.org/schemas/1.0.0/mcp.schema.json`.
 - **Agent Skills** — <https://agentskills.io/specification> (authoritative for `SKILL.md`
-  format, delegated to by Agent Plugins §6.1). Reference validator:
+  format, delegated to by Agent Plugins §7.1). Reference validator:
   [`skills-ref`](https://github.com/agentskills/agentskills/tree/main/skills-ref).
 - **Model Context Protocol (MCP)** — <https://modelcontextprotocol.io/specification>
   (wire behavior for the MCP servers component type).
@@ -59,10 +59,10 @@ These are different species and MUST stay separate:
 
 |              | Native Ever Works plugin                                 | Agent Plugins package                                                                              |
 | ------------ | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Manifest     | `everworks.plugin` block in `package.json` (open schema) | `plugin.json` (closed schema, spec §4)                                                             |
+| Manifest     | `everworks.plugin` block in `package.json` (open schema) | `plugin.json` (closed schema, spec §5)                                                             |
 | Content      | Executable JS/TS (`dist/index.js`)                       | Data: `skills/*/SKILL.md`, `mcp.json`, assets                                                      |
 | Loaded by    | `PluginLoaderService` (`import()`)                       | New spec-package reader (fs reads only)                                                            |
-| Validated by | `PluginManifestValidator` (unchanged)                    | New closed-schema validator (parallel, per spec §4)                                                |
+| Validated by | `PluginManifestValidator` (unchanged)                    | New closed-schema validator (parallel, per spec §5)                                                |
 | Trust        | First-party / ADR-016 allowlist; code runs in-process    | Data is safe to parse; **only** stdio MCP servers execute anything, behind an explicit gate (§4.4) |
 
 The bridge between the two worlds is a **new platform module**
@@ -76,7 +76,7 @@ tenant-scoped DB state — a plugin could neither query it nor scope it.
 The existing validator MUST NOT be reused for spec manifests and MUST NOT be relaxed:
 the two schemas disagree by design (spec `name` allows dots and 1-char names and
 requires nothing but `$schema`+`name`; ours requires `id/name/version/category` and
-rejects non-semver versions — which the spec forbids a client to reject, §4.4).
+rejects non-semver versions — which the spec forbids a client to reject, spec §5.4).
 
 ---
 
@@ -98,8 +98,9 @@ rejects non-semver versions — which the spec forbids a client to reject, §4.4
    Agent Plugins package (`plugin.json` + `skills/`), and the Ever Works MCP server can
    be described as a conformant package (`mcp.json`, `streamable-http`), so other
    ecosystems' agents can consume what our users build.
-4. **Full client conformance** — we target the complete §10.1 client checklist, not
-   the §10.2 skills-only subset. A conformance fixture suite (valid + malformed
+4. **Full client conformance** — we target the complete §11.1 client requirements
+   and every row of the spec's Appendix A checklist, not the §11.2
+   incremental-adoption subset. A conformance fixture suite (valid + malformed
    packages) proves every MUST.
 
 **Non-goals** (v1): hosting a public registry of Agent Plugins packages; converting
@@ -161,7 +162,7 @@ a marketplace UI beyond the sources/install surface described here.
   servers to the Agent. On the Agent's next run, the platform connects to bound servers
   (per declared transport) and exposes their tools to the model, namespaced
   `mcp__<server>__<tool>`, subject to the same allowed-tools policy that gates skills.
-- **US-8 (secrets)**: Packages cannot ship credentials (spec §6.2.1). When a server
+- **US-8 (secrets)**: Packages cannot ship credentials (spec §7.2.1). When a server
   needs auth, the user provides it in Ever Works per-server settings (encrypted at
   rest like plugin `x-secret` settings). At connect time Ever Works injects them as
   _client-generated_ headers/env — which the spec explicitly permits and gives
@@ -223,7 +224,7 @@ configuration, not code paths.
 Every requirement below is testable and MUST be covered by the conformance fixture
 suite (tasks.md). References are to Agent Plugins v1.0.0 sections.
 
-### 4.1 Manifest loading (spec §4)
+### 4.1 Manifest loading (spec §5)
 
 - **AP-1**: Load `plugin.json` from the package root; it MUST be a JSON object.
 - **AP-2**: Permitted top-level fields only: `$schema`, `name`, `version`,
@@ -243,7 +244,7 @@ suite (tasks.md). References are to Agent Plugins v1.0.0 sections.
 - **AP-6**: `extensions` namespaces we don't implement are ignored **without
   validating their contents**. We implement only `works.ever`.
 
-### 4.2 Component discovery (spec §5, §6.1 + Agent Skills spec)
+### 4.2 Component discovery (spec §6, §7.1 + Agent Skills spec)
 
 - **AP-7**: Skills discovered ONLY from `skills/`: each **immediate** child directory
   whose `SKILL.md` resolves to a regular file is one skill. No recursion. Missing
@@ -265,7 +266,7 @@ suite (tasks.md). References are to Agent Plugins v1.0.0 sections.
   `command`/`cwd` → that server invalid; any other escaped path → access denied to
   that path.
 
-### 4.3 MCP configuration (spec §6.2)
+### 4.3 MCP configuration (spec §7.2)
 
 - **AP-11**: MCP config loaded ONLY from `mcp.json` at package root. Closed schema:
   `$schema` (canonical mcp id) + `mcpServers` map, nothing else. Empty map is valid.
@@ -295,7 +296,7 @@ suite (tasks.md). References are to Agent Plugins v1.0.0 sections.
   cross-origin at all. This is runtime client behavior and MUST have its own
   implementation + test task, not just static validation.
 
-### 4.4 Subprocess environment (spec §8) — stdio only
+### 4.4 Subprocess environment (spec §9) — stdio only
 
 - **AP-16**: Every spawned server process gets `PLUGIN_ROOT` (absolute package root)
   and `PLUGIN_DATA` (absolute per-installed-package writable data dir that persists
@@ -311,10 +312,10 @@ suite (tasks.md). References are to Agent Plugins v1.0.0 sections.
 - **AP-19**: `stdio` execution is gated (US-9). When the gate is off, `stdio` entries
   are surfaced as "present but disabled by policy" and handled as skip + report +
   continue — **our interpretation**, consistent with the spec's failure-isolation
-  rules for unsupported transports (§6.2.2); the spec itself does not define a
+  rules for unsupported transports (spec §7.2.2); the spec itself does not define a
   policy-disabled state.
 
-### 4.5 Versioning & updates (spec §9)
+### 4.5 Versioning & updates (spec §10)
 
 - **AP-20**: We use the manifest `$schema` id to select the targeted spec version;
   v1.0.0 is the only supported version at launch (unknown → reject with a clear
@@ -374,7 +375,8 @@ new UI tabs/pages, new env vars, new capability interface — enumerated in plan
 ## 6. Resolved decisions (founder, 2026-08-09)
 
 1. **Both component types** — Skills AND MCP servers; all three transports; full
-   §10.1 conformance, not §10.2 skills-only.
+   §11.1 conformance plus the full Appendix A checklist, not the §11.2
+   skills-only subset.
 2. **All three source kinds** — local directory AND git AND npm, availability
    governed by deployment mode + operator policy.
 3. **Strictly additive** — nothing existing is dropped or changed in behavior.

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -191,7 +191,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       this repo). Defaults keep boot non-fatal; the wiring is still required
       for the values to be settable.
 - [ ] **T32**. Full-spec conformance run: fixture packages exercising every
-      §10.1 checklist row against the live loader; publish the checklist result
+      Appendix A checklist row against the live loader; publish the checklist result
       as a doc page.
 
 ## Phase 5 — Sidecars + export (PR-8, PR-9)
@@ -230,7 +230,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       tools or document out-of-scope.
 - [ ] **T40**. Security review pass (stdio gate, SSRF policy, containment
       fuzzing over fixture escapes); Sentry tags; rate-limit re-check.
-- [ ] **T41**. Conformance statement doc: map every §10.1 row + AP-1…AP-23 to
+- [ ] **T41**. Conformance statement doc: map every Appendix A row + AP-1…AP-23 to
       test evidence; announce "Agent Plugins v1.0.0 compatible (client: skills + MCP; producer: skills packages, plus the Ever Works MCP-server package
       descriptor)" — the single canonical claim wording, used verbatim in spec
       §1.3, the ADR, and marketing. MUST document client-side policy refusals


### PR DESCRIPTION
## What

Every citation of the external Agent Plugins specification across `spec.md`, `plan.md`, `tasks.md` and ADR-018 was **one section low**, from the manifest onward:

| Cited as | Actually is |
| -------- | ----------- |
| §4 | §5 — Manifest |
| §5 | §6 — Component discovery |
| §6.1 | §7.1 — Skills |
| §6.2, §6.2.1, §6.2.2 | §7.2, §7.2.1, §7.2.2 — MCP servers |
| §8 | §9 — Environment variables and placeholder expansion |
| §9 | §10 — Versioning |
| §10.1 / §10.2 | §11.1 + Appendix A / §11.2 — Client conformance |

21 citations corrected across the four documents.

**Only external references changed.** These documents also carry many internal cross-references — `plan.md` §2.5, `spec.md` §4.5, `plan.md` §5 and so on — which are correct and untouched. That is why this was done citation by citation rather than with a pattern: a blanket shift would have silently broken every internal link, and §4.1 (containment) happens to be right in both numberings.

The **AP-1…AP-23 requirement identifiers** defined in `spec.md` §4 are unaffected and remain the right thing to cite in implementation and review. They are ours and stable; it is the borrowed numbers that drifted.

## Why it matters more than a typo

Found while implementing Phase 0 ([#2314](https://github.com/ever-works/ever-works/pull/2314)) by reading the published specification rather than trusting the numbers — and that same reading turned up a **real conformance gap** in the containment layer (§4.1 boundary 4 was only half implemented). A reviewer following `plan.md`'s pointer to "spec §6.2" would have landed in *Component discovery* instead of *MCP servers* and had no reason to look further.

`plan.md` opens with "Every file:line reference below was verified against `develop`". The repo-side references were indeed verified; the spec-side ones were not, and the asymmetry is worth removing before five more phases are built on them.

## Two addenda to ADR-018

Both **record** decisions taken during Phase 0 rather than revising anything already agreed.

**1. Recognising Agent Plugins 1.1.0 as compatible with 1.0.0.** Upstream now publishes a 1.1.0 release. Verified against the repository on 2026-09-03:

- both 1.1.0 schemas are **byte-identical** to the 1.0.0 pair apart from the version string in `$id`, `description` and the `$schema` `const`;
- `spec/1.1.0.md` differs only in version numbers plus three editorial rewordings;
- its status is **Working Draft**; 1.0.0 remains **Published**.

No requirement was added, removed or changed. Spec §5.2 permits mapping several canonical identifiers onto one implementation "only when it explicitly recognizes those Agent Plugins versions as compatible" — the registry in `src/versions.ts` is that explicit recognition, and carries the verification note so a future reader can re-check it. The published conformance claim **stays 1.0.0**: 1.1.0 is accepted, not advertised, because a Working Draft can still move.

The addendum spells out the trap, because accepting two releases makes it easy to weaken a rule that must not weaken. §10.1 requires `mcp.json` to match `plugin.json` **exactly**, so a 1.0.0 manifest beside a 1.1.0 MCP configuration disables MCP for that package even though both releases load. Compatibility governs which identifiers we *accept*, never whether a pair may *disagree*.

**2. A note on the drift itself**, with the practical guidance that an external citation should quote the requirement sentence and not only the number — this survived a full review pass precisely because a bare section number looks authoritative.

## Scope

Docs only. No code, no behaviour, no dependency change.

`prettier --check` is clean on all four touched files. Note that `docs/specs/**/*.md` reports 15 unformatted files, but those pre-exist on `develop` (verified by stashing this change and re-running) and are deliberately left alone rather than swept into an unrelated docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
