### PR TITLE
fix(fleet): a cancelled run must not open a pull request, and a cancelled job must not be re-leased

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
@@ -365,6 +365,60 @@ describe('FleetAgentTaskReconcilerService', () => {
         expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
     });
 
+    // Cancellation reaches a node as a REFUSED HEARTBEAT, and
+    // `FleetJobService.completeJob` deliberately does not check the flag —
+    // the row settles with the node's own verdict. So a node that finished
+    // and pushed before its next heartbeat reports SUCCESS, and the event
+    // arrives as an ordinary `node-report`, not the synthetic `cancelled`
+    // one. Before the guard, that fell through to the full success path and
+    // opened a real pull request for a Task the user had cancelled.
+    //
+    // `markCompleted` was never the problem: it CASes against NON_TERMINAL
+    // and no-ops on the cancelled row. The pull request, the chat message
+    // and the inbox notice are not CAS-guarded and cannot be undone.
+    it('opens no pull request when the AgentRun is already cancelled', async () => {
+        runs.findById.mockResolvedValue({
+            id: RUN,
+            userId: USER,
+            agentId: AGENT,
+            workId: 'work-1',
+            status: 'cancelled',
+        });
+
+        await build().onCompleted(
+            new FleetJobCompletedEvent(
+                job(),
+                USER,
+                'node-report',
+                NODE,
+                successResult as unknown as Record<string, unknown>,
+            ),
+        );
+
+        expect(taskWorkspace.finalizeRemotePush).not.toHaveBeenCalled();
+        expect(runs.markCompleted).not.toHaveBeenCalled();
+        expect(inbox.notice).not.toHaveBeenCalled();
+        expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
+    });
+
+    it('opens no pull request when the job carries cancelRequestedAt', async () => {
+        // The run row may not have flipped yet — the flag on the job is an
+        // independent signal that a cancel is in flight.
+        await build().onCompleted(
+            new FleetJobCompletedEvent(
+                job({ cancelRequestedAt: new Date().toISOString() }),
+                USER,
+                'node-report',
+                NODE,
+                successResult as unknown as Record<string, unknown>,
+            ),
+        );
+
+        expect(taskWorkspace.finalizeRemotePush).not.toHaveBeenCalled();
+        expect(runs.markCompleted).not.toHaveBeenCalled();
+        expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
+    });
+
     it('ignores a run that belongs to another owner, and non-agent jobs', async () => {
         runs.findById.mockResolvedValue({ id: RUN, userId: 'someone-else' });
         await build().onCompleted(

--- a/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
@@ -145,9 +145,40 @@ export class FleetAgentTaskReconcilerService {
             return;
         }
 
-        if (event.source === 'cancelled') {
-            // The operator path already flipped the run to `cancelled`
-            // (that is what triggered the job cancel); mirror the board.
+        // A cancelled run gets the board mirror and NOTHING else.
+        //
+        // Three different arrivals mean "this run was cancelled", and only
+        // the first is a synthetic event:
+        //
+        //   1. `source === 'cancelled'` — the operator cancelled a job no
+        //      node had claimed yet, so the service failed it outright.
+        //   2. `run.status === 'cancelled'` — the operator path flipped the
+        //      AgentRun first (that is what triggers the job cancel).
+        //   3. `event.job.cancelRequestedAt` — the job carries the flag but
+        //      the node got its report in first.
+        //
+        // Case 3 is the one that bit. Cancellation reaches a node as a
+        // REFUSED HEARTBEAT, and `FleetJobService.completeJob` deliberately
+        // does not check the flag ("the row settles with the node's own
+        // verdict"). So a node that had already finished and pushed before
+        // its next heartbeat reports success, `completeJob` accepts it, and
+        // the event arrives as an ordinary `node-report`.
+        //
+        // Falling through from there ran the whole success path:
+        // `finalizeRemotePush` OPENED A PULL REQUEST — and can auto-merge it
+        // — for a Task the user had explicitly cancelled, then posted a
+        // "run finished" chat message contradicting the cancellation.
+        //
+        // The terminal write itself was always safe: `markCompleted` CASes
+        // against NON_TERMINAL and no-ops on an already-cancelled row. What
+        // was never guarded is the side effects — the pull request, the chat
+        // message, the inbox notice — none of which are CAS-guarded and none
+        // of which can be undone once they have happened.
+        if (
+            event.source === 'cancelled' ||
+            run.status === 'cancelled' ||
+            event.job.cancelRequestedAt
+        ) {
             await this.bestEffort('board denorm', () =>
                 this.runDenorm.recordTerminal(ctx.taskId, ctx.runId, 'failed'),
             );

--- a/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
@@ -180,6 +180,39 @@ describe('FleetJobService — cancel + lifecycle events', () => {
         expect(event.error).toMatch(/attempt budget exhausted/);
     });
 
+    // A cancelled job must never go back in the pool. `reclaim()` resets
+    // status/nodeId/leaseExpiresAt but leaves `cancelRequestedAt` set, and
+    // `claim()` CASed on `{ id, status: 'queued' }` only — so a cancelled job
+    // whose node aborted on the refused heartbeat WITHOUT calling complete()
+    // was requeued still flagged, re-leased to a fresh node, and started
+    // re-executing the cancelled Task for real until the attempt budget ran
+    // out. It is settled instead, well inside the attempt budget.
+    it('settles a cancelled job instead of requeuing it when its lease lapses', async () => {
+        await leaseIt();
+        await service.cancel(job.id);
+        emitter.emit.mockClear();
+
+        // Attempts deliberately BELOW maxAttempts: without the cancel check
+        // this row takes the requeue branch, not the exhausted one.
+        job.attempts = 0;
+        job.leaseExpiresAt = new Date(Date.now() - 60_000);
+        jobs.findExpiredLeases.mockResolvedValue([job]);
+
+        const summary = await service.reclaimExpired(USER);
+
+        expect(summary.requeued).toBe(0);
+        expect(summary.failed).toBe(1);
+        expect(jobs.reclaim).not.toHaveBeenCalled();
+
+        const [name, event] = emitter.emit.mock.calls[0];
+        expect(name).toBe(FleetJobCompletedEvent.EVENT_NAME);
+        // `cancelled` routes the reconciler to its board-mirror branch —
+        // nothing was produced that anyone should act on.
+        expect(event.source).toBe('cancelled');
+        expect(event.succeeded).toBe(false);
+        expect(event.error).toMatch(/stopped reporting/);
+    });
+
     it('never fails the lease protocol when a listener throws', async () => {
         emitter.emit.mockImplementation(() => {
             throw new Error('listener exploded');

--- a/packages/agent/src/fleet/fleet-job.repository.ts
+++ b/packages/agent/src/fleet/fleet-job.repository.ts
@@ -115,9 +115,21 @@ export class FleetJobRepository {
      * CAS-claim one queued job for a node. The row must STILL be
      * `queued` — a raced second lease matches zero rows and returns
      * false, so exactly one node ever wins a given job.
+     *
+     * `cancelRequestedAt IS NULL` is part of the same predicate, not a
+     * separate read. A cancelled job must never be leased, and the status
+     * column alone cannot express that: `reclaim()` returns a lapsed claim
+     * to `queued` without clearing the flag, so a flagged row can legally
+     * BE `queued`. `FleetJobService.reclaimExpired` now settles those
+     * instead of requeuing them, but this is the invariant itself rather
+     * than one caller remembering it — any future path that queues a
+     * flagged row is refused here.
      */
     async claim(id: string, patch: ClaimJobPatch): Promise<boolean> {
-        const result = await this.repository.update({ id, status: 'queued' }, patch);
+        const result = await this.repository.update(
+            { id, status: 'queued', cancelRequestedAt: IsNull() },
+            patch,
+        );
         return (result.affected ?? 0) === 1;
     }
 

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -71,6 +71,14 @@ export interface ReclaimSummary {
 /** Error text a job settles with when an operator cancels it before any node claimed it. */
 export const FLEET_JOB_CANCELLED_ERROR = 'Cancelled by the operator before a node claimed it';
 
+/**
+ * Settled reason for an ACTIVE job that was cancelled and whose node then
+ * died without reporting. Distinct from {@link FLEET_JOB_CANCELLED_ERROR},
+ * which only covers a job no node had claimed yet.
+ */
+export const FLEET_JOB_CANCELLED_LEASE_LAPSED_ERROR =
+    'Cancelled by the operator; the node holding it stopped reporting';
+
 /** What `cancel` did (or could not do) — see {@link FleetJobService.cancel}. */
 export interface CancelFleetJobOutcome {
     /** True when the request changed the job's course (dropped, or flagged for the node). */
@@ -487,6 +495,48 @@ export class FleetJobService {
                     nodeId: job.nodeId,
                     leaseExpiresAt: job.leaseExpiresAt,
                 };
+                // A cancelled job must never go back in the pool.
+                //
+                // `reclaim()` resets status / nodeId / leaseExpiresAt /
+                // queuedReason but leaves `cancelRequestedAt` set, and
+                // `claim()` CASes on `{ id, status: 'queued' }` only — it does
+                // not exclude a flagged row. So a job the operator cancelled,
+                // whose node then aborted on the refused heartbeat without
+                // calling `complete()` (or simply crashed), was requeued still
+                // carrying the flag and re-leased to a fresh node, which began
+                // re-executing the cancelled Task for real — CLI work, git
+                // work — until the attempt budget ran out.
+                //
+                // Settle it instead, with the same observed-lease CAS the
+                // exhausted path uses so a heartbeat landing between the scan
+                // and this write still wins. `source: 'cancelled'` routes the
+                // reconciler to its board-mirror branch, which is exactly
+                // right: nothing was produced that anyone should act on.
+                if (job.cancelRequestedAt) {
+                    const error = FLEET_JOB_CANCELLED_LEASE_LAPSED_ERROR;
+                    const settled = await this.jobs.failExhausted(job.id, observed, error, now);
+                    if (settled) {
+                        summary.failed += 1;
+                        this.emit(
+                            FleetJobCompletedEvent.EVENT_NAME,
+                            new FleetJobCompletedEvent(
+                                toJobView({
+                                    ...job,
+                                    status: 'failed',
+                                    error,
+                                    completedAt: now,
+                                    leaseExpiresAt: null,
+                                } as FleetJob),
+                                job.userId,
+                                'cancelled',
+                                job.nodeId ?? null,
+                                null,
+                                error,
+                            ),
+                        );
+                    }
+                    continue;
+                }
                 if ((job.attempts ?? 0) >= (job.maxAttempts ?? 1)) {
                     const error = `Lease expired ${job.attempts} time(s) without a result; attempt budget exhausted`;
                     const failed = await this.jobs.failExhausted(job.id, observed, error, now);


### PR DESCRIPTION
Targets **#2298's branch**, not develop, so it lands inside that PR before the stack merges. Both defects were found reviewing #2298 and verified against its code.

## 1. A cancelled run still opened a pull request — blocker

Cancellation reaches a node as a **refused heartbeat**: the node reads "lease lost" and aborts, exactly as it would for a dead server. `FleetJobService.completeJob` deliberately does not check `cancelRequestedAt`, and says so:

> Its report is still accepted below (`completeJob` does not check the flag), so the row settles with the node's own verdict.

Settling the row is fine. The problem is what happens next.

A node that had already finished and pushed before its next heartbeat reports **success**. `completeJob` accepts it, so the event arrives as an ordinary `node-report`, not the synthetic `cancelled` one. The reconciler's only cancellation early-return tested `event.source`, so execution fell through to the full success path:

- `finalizeRemotePush` **opened a real pull request** for a Task the user had explicitly cancelled — and can auto-merge it where `allowAgentMerge` is on
- a "run finished" chat message was posted, contradicting the cancellation
- an inbox notice was raised

The terminal write was never the issue. `markCompleted` CASes against `NON_TERMINAL` and no-ops on the already-cancelled row, which is what the branch notes mean by "a duplicate event is a no-op." That holds for `agent_runs.status`. It does not hold for the side effects — the pull request, the chat message and the inbox notice are not CAS-guarded, and none of them can be undone.

The guard now covers all three ways "this run was cancelled" can arrive, and routes every one to the board-mirror branch that already existed:

| Signal | When it fires |
| --- | --- |
| `event.source === 'cancelled'` | operator cancelled a job no node had claimed |
| `run.status === 'cancelled'` | the operator path flipped the AgentRun first |
| `event.job.cancelRequestedAt` | flag is set, but the node's report won the race |

## 2. A cancelled job was requeued and re-executed — medium

`reclaim()` returns a lapsed claim to `queued` but leaves `cancelRequestedAt` set, `reclaimExpired` never consulted it, and `claim()` CASed on `{ id, status: 'queued' }` alone.

So a cancelled job whose node aborted on the refused heartbeat **without** calling `complete()`, or simply crashed, was requeued still flagged and re-leased to a fresh node, which began re-executing the cancelled Task for real — CLI work, git work — until the attempt budget ran out. Bounded, not stranded, but the cancellation was not honoured.

`reclaimExpired` now settles those, using the same observed-lease CAS the exhausted path uses so a heartbeat landing between the scan and the write still wins. It emits `source: 'cancelled'`, which routes the reconciler to the board-mirror branch — nothing was produced that anyone should act on.

`claim()` additionally gains `cancelRequestedAt: IsNull()` in its CAS predicate. That is the invariant itself rather than one caller remembering it, and it is the same predicate `heartbeat` already uses one method away — `claim` was the outlier.

## Verification

| Check | Result |
| --- | --- |
| `fleet-agent-task-reconciler.spec.ts` | 16 passed (2 new) |
| `fleet-job.cancel-and-events.spec.ts` | 11 passed (1 new) |
| `fleet-job.service.spec.ts` | 39 passed |
| `tsc --noEmit` (agent, api) | clean for the changed files |
| `prettier --check` | clean |

The new reclaim test pins `attempts` **below** `maxAttempts` deliberately: without the cancel check that row takes the requeue branch, not the exhausted one, so the test fails if the guard is removed.

## Not addressed here

The review also found that auto-merge eligibility is driven by the node's unverified self-report: `toGateStatus` accepts the node's own string and `isCheckResult` only checks that `id` and `status` are strings, so a node reporting `gateStatus: 'green'` satisfies `requireGreenGate` with no acceptance checks having run. That is a design decision about whether to re-verify server-side or cross-check the provider's CI status, not a bug fix, so I left it for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)