### PR TITLE
fix(account-transfer): round-trip Task extraRepos instead of silently dropping them

### DIFF
--- a/packages/agent/src/account-transfer/agents-skills-tasks-export.service.spec.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-export.service.spec.ts
@@ -289,6 +289,7 @@ describe('AgentsSkillsTasksExportService.exportTail', () => {
                     isolationMode: 'on',
                     acceptanceChecks: checks,
                     maxGateAttempts: 4,
+                    extraRepos: [{ repoConnectionId: 'conn-1', mountDir: 'docs', writable: true }],
                     branchRef: 'task/t-1-9f3c1a2b',
                     branchState: 'pr-open',
                     baseSha: 'a'.repeat(40),
@@ -311,6 +312,13 @@ describe('AgentsSkillsTasksExportService.exportTail', () => {
         expect(task.isolationMode).toBe('on');
         expect(task.acceptanceChecks).toEqual(checks);
         expect(task.maxGateAttempts).toBe(4);
+        // "Also work in" repositories are user-authored configuration, so
+        // they round-trip like the settings above rather than being silently
+        // reset. Whether an entry may be RESTORED is decided on import, where
+        // the receiving account's ownership of the connection is known.
+        expect(task.extraRepos).toEqual([
+            { repoConnectionId: 'conn-1', mountDir: 'docs', writable: true },
+        ]);
 
         const serialized = JSON.stringify(task);
         for (const excluded of [

--- a/packages/agent/src/account-transfer/agents-skills-tasks-export.service.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-export.service.ts
@@ -206,6 +206,10 @@ export class AgentsSkillsTasksExportService {
                     : null,
                 maxGateAttempts:
                     typeof task.maxGateAttempts === 'number' ? task.maxGateAttempts : null,
+                // "Also work in" repositories. Emitted as stored — the
+                // import side is what decides whether an entry may be
+                // restored into the receiving account (see `ExportedTask`).
+                extraRepos: Array.isArray(task.extraRepos) ? task.extraRepos : null,
                 createdAt: task.createdAt.toISOString(),
                 startedAt: task.startedAt?.toISOString() ?? null,
                 completedAt: task.completedAt?.toISOString() ?? null,

--- a/packages/agent/src/account-transfer/agents-skills-tasks-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-import.service.spec.ts
@@ -31,6 +31,29 @@ describe('AgentsSkillsTasksImportService — Task settings round-trip', () => {
         return { svc, agentExport, skillsService, tasksService };
     }
 
+    /**
+     * Same shape, but with the repository registry bound. `extraRepos` names
+     * connections by an ACCOUNT-LOCAL id, so restoring one is gated on the
+     * IMPORTING account owning it — the rule skill files already follow.
+     */
+    function makeSvcWithRepos(connections: Record<string, { enabled: boolean } | undefined>) {
+        const agentExport = { importOne: jest.fn().mockResolvedValue({}) };
+        const skillsService = { create: jest.fn().mockResolvedValue({}) };
+        const tasksService = { create: jest.fn().mockResolvedValue({ id: 't-new' }) };
+        const repoConnections = {
+            findByIdAndUser: jest.fn(async (id: string) => connections[id] ?? null),
+        };
+        const svc = new AgentsSkillsTasksImportService(
+            agentExport as any,
+            skillsService as any,
+            tasksService as any,
+            undefined,
+            undefined,
+            repoConnections as any,
+        );
+        return { svc, tasksService, repoConnections };
+    }
+
     function makeTask(overrides: Partial<ExportedTask> = {}): ExportedTask {
         return {
             __kind: 'task',
@@ -68,6 +91,76 @@ describe('AgentsSkillsTasksImportService — Task settings round-trip', () => {
             required: true,
         },
     ];
+
+    describe('extraRepos ("Also work in")', () => {
+        const EXTRA = [{ repoConnectionId: 'conn-1', mountDir: 'docs', writable: true }];
+
+        it('restores an entry the importing account owns', async () => {
+            const { svc, tasksService, repoConnections } = makeSvcWithRepos({
+                'conn-1': { enabled: true },
+            });
+
+            await svc.importTail(
+                'u-1',
+                { tasks: [makeTask({ extraRepos: EXTRA })] } as any,
+                { importTasks: true } as any,
+            );
+
+            expect(repoConnections.findByIdAndUser).toHaveBeenCalledWith('conn-1', 'u-1');
+            expect(tasksService.create.mock.calls[0][1].extraRepos).toEqual([
+                { repoConnectionId: 'conn-1', mountDir: 'docs', writable: true },
+            ]);
+        });
+
+        it('drops an entry the importing account does not own, and still imports the Task', async () => {
+            // The cross-account case. `repoConnectionId` is a uuid in the
+            // EXPORTING registry, so it resolves to nothing here. Passing it
+            // through would be worse than useless: `normalizeExtraRepos`
+            // THROWS on an unresolvable connection, and the importer's
+            // per-Task catch would drop the whole Task — its title, labels
+            // and chat with it.
+            const { svc, tasksService } = makeSvcWithRepos({});
+
+            const summary = await svc.importTail(
+                'u-1',
+                { tasks: [makeTask({ extraRepos: EXTRA })] } as any,
+                { importTasks: true } as any,
+            );
+
+            expect(summary.tasks.imported).toBe(1);
+            expect(summary.tasks.errors).toEqual([]);
+            expect('extraRepos' in tasksService.create.mock.calls[0][1]).toBe(false);
+        });
+
+        it('drops a disabled connection', async () => {
+            // `normalizeExtraRepos` refuses a disabled connection on the write
+            // path too, so keeping it would only move the failure to the next edit.
+            const { svc, tasksService } = makeSvcWithRepos({ 'conn-1': { enabled: false } });
+
+            await svc.importTail(
+                'u-1',
+                { tasks: [makeTask({ extraRepos: EXTRA })] } as any,
+                { importTasks: true } as any,
+            );
+
+            expect('extraRepos' in tasksService.create.mock.calls[0][1]).toBe(false);
+        });
+
+        it('imports the Task unchanged when the registry is not bound', async () => {
+            // Trailing @Optional() dependency: unbound behaves exactly as
+            // before the field round-tripped at all.
+            const { svc, tasksService } = makeSvc();
+
+            const summary = await svc.importTail(
+                'u-1',
+                { tasks: [makeTask({ extraRepos: EXTRA })] } as any,
+                { importTasks: true } as any,
+            );
+
+            expect(summary.tasks.imported).toBe(1);
+            expect('extraRepos' in tasksService.create.mock.calls[0][1]).toBe(false);
+        });
+    });
 
     it('applies isolationMode, acceptanceChecks and maxGateAttempts', async () => {
         const { svc, tasksService } = makeSvc();

--- a/packages/agent/src/account-transfer/agents-skills-tasks-import.service.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-import.service.ts
@@ -4,7 +4,8 @@ import { SkillsService } from '../skills/skills.service';
 import { SkillFilesService } from '../skills/skill-files.service';
 import { TasksService } from '../tasks-domain/tasks.service';
 import { UserUploadRepository } from '../database/repositories/user-upload.repository';
-import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import { RepoConnectionRepository } from '../database/repositories/repo-connection.repository';
+import type { TaskAcceptanceCheck, TaskExtraRepo } from '@ever-works/contracts';
 import {
     type AccountExportV2Tail,
     type AgentsSkillsTasksImportOptions,
@@ -39,6 +40,55 @@ function normalizeImportedAcceptanceChecks(
  * only. `null` = inherit the Work's value and is preserved; out-of-range
  * values are dropped, never clamped.
  */
+/**
+ * Keep only the extra-repo entries the IMPORTING account can actually use.
+ *
+ * `repoConnectionId` is a uuid in the EXPORTING account's registry. Passing
+ * one straight to `TasksService.create` is not merely useless, it is
+ * destructive: `normalizeExtraRepos` THROWS `BadRequestException` on a
+ * connection it cannot resolve, and the importer's per-Task catch would turn
+ * that into a skipped Task — so a Task that merely mentioned a repository
+ * would fail to import at all, losing its title, labels and chat too.
+ *
+ * Resolving here instead means a cross-account transfer drops the mounts and
+ * keeps the Task, and a same-account restore keeps both. Mirrors the
+ * skill-files rule: recreate a reference ONLY when the receiving account owns
+ * the thing referenced.
+ */
+async function resolveImportedExtraRepos(
+    raw: unknown,
+    ownerId: string,
+    repoConnections?: RepoConnectionRepository,
+): Promise<TaskExtraRepo[] | undefined> {
+    if (!Array.isArray(raw) || raw.length === 0) return undefined;
+    if (!repoConnections) return undefined;
+
+    const kept: TaskExtraRepo[] = [];
+    for (const entry of raw) {
+        const id =
+            entry && typeof (entry as TaskExtraRepo).repoConnectionId === 'string'
+                ? (entry as TaskExtraRepo).repoConnectionId.trim()
+                : '';
+        if (!id) continue;
+        const connection = await repoConnections.findByIdAndUser(id, ownerId);
+        // Disabled is dropped as well as missing: `normalizeExtraRepos`
+        // refuses a disabled connection on the write path too, so keeping
+        // one here would only move the failure to the next edit.
+        if (!connection || !connection.enabled) continue;
+        kept.push({
+            repoConnectionId: id,
+            mountDir:
+                typeof (entry as TaskExtraRepo).mountDir === 'string'
+                    ? (entry as TaskExtraRepo).mountDir
+                    : null,
+            ...(typeof (entry as TaskExtraRepo).writable === 'boolean'
+                ? { writable: (entry as TaskExtraRepo).writable }
+                : {}),
+        });
+    }
+    return kept.length > 0 ? kept : undefined;
+}
+
 function normalizeImportedMaxGateAttempts(value: unknown): number | null | undefined {
     if (value === null) return null;
     return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5
@@ -84,6 +134,14 @@ export class AgentsSkillsTasksImportService {
         // would create a dangling reference into someone else's storage.
         @Optional() private readonly skillFilesService?: SkillFilesService,
         @Optional() private readonly userUploads?: UserUploadRepository,
+        // Task "Also work in" repositories — the same ownership gate as
+        // `userUploads` above, for the same reason. An `extraRepos` entry
+        // names a connection by an ACCOUNT-LOCAL id, so it is restored only
+        // when the importing account owns an enabled connection with that
+        // id. Trailing + @Optional() so existing positional constructor
+        // calls keep working; unbound → extraRepos import as absent, which
+        // is exactly what happened before this field round-tripped at all.
+        @Optional() private readonly repoConnections?: RepoConnectionRepository,
     ) {}
 
     async importTail(
@@ -196,6 +254,11 @@ export class AgentsSkillsTasksImportService {
                         task.acceptanceChecks,
                     );
                     const maxGateAttempts = normalizeImportedMaxGateAttempts(task.maxGateAttempts);
+                    const extraRepos = await resolveImportedExtraRepos(
+                        task.extraRepos,
+                        userId,
+                        this.repoConnections,
+                    );
                     await this.tasksService.create(userId, {
                         title: task.title,
                         description: task.description ?? null,
@@ -211,6 +274,7 @@ export class AgentsSkillsTasksImportService {
                         ...(isolationMode !== undefined ? { isolationMode } : {}),
                         ...(acceptanceChecks !== undefined ? { acceptanceChecks } : {}),
                         ...(maxGateAttempts !== undefined ? { maxGateAttempts } : {}),
+                        ...(extraRepos !== undefined ? { extraRepos } : {}),
                     });
                     summary.tasks.imported += 1;
                 } catch (err) {

--- a/packages/agent/src/account-transfer/agents-skills-tasks-types.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-types.ts
@@ -1,4 +1,4 @@
-import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import type { TaskAcceptanceCheck, TaskExtraRepo } from '@ever-works/contracts';
 import type { AgentExportEnvelope } from '../agents/agent-export.service';
 
 /**
@@ -133,6 +133,19 @@ export interface ExportedTask {
      * would launder a bogus payload value into a legitimate-looking setting.
      */
     maxGateAttempts?: number | null;
+    /**
+     * Repositories the Task spans in addition to its primary one
+     * ("Also work in"). Each entry names a connection in the OWNER's
+     * repository registry by id.
+     *
+     * Ids are account-local, so this follows the same rule as skill files:
+     * an entry is restored ONLY when the importing account owns an enabled
+     * connection with that id, and is dropped otherwise. Recreating it
+     * blind would leave a Task pointing at a connection row that either
+     * does not exist or belongs to somebody else — and every fleet run of
+     * that Task would then fail resolving it.
+     */
+    extraRepos?: TaskExtraRepo[] | null;
     createdAt: string;
     startedAt?: string | null;
     completedAt?: string | null;


### PR DESCRIPTION
Targets **#2307's branch**, so it lands inside that PR. Found reviewing #2307.

## The gap

`ExportedTask` carries the user-authored Task settings one field at a time — `isolationMode`, `acceptanceChecks`, `maxGateAttempts` — under a comment that says exactly why:

> Without these an export/import silently resets a Task that opted into isolation or curated its own checks.

`extraRepos` is that same kind of setting, and it was missing from all three files: the type, the export mapping, and the import mapping. There is no wildcard spread that would pick it up incidentally, and #2307 does not touch `packages/agent/src/account-transfer/` at all.

So a user who configured "Also work in" and then transferred their account got the Task back with its multi-repo configuration gone — no error, no warning.

## Why import resolves rather than passes through

`repoConnectionId` is a uuid in the **exporting** account's registry, which makes this the first exported Task field that names another entity by id.

Handing one straight to `TasksService.create` would be worse than useless. `normalizeExtraRepos` **throws** `BadRequestException` on a connection it cannot resolve, and the importer's per-Task catch would turn that into a skipped Task — losing its title, labels and chat along with the mounts.

So entries are resolved here against the **importing** account's registry and kept only when that account owns an **enabled** connection with the id. Disabled is dropped too, because `normalizeExtraRepos` refuses a disabled connection on the write path as well; keeping one would only move the failure to the next edit.

This is the rule skill files already follow in this same service:

> a row is recreated ONLY when the importing account owns the referenced bytes (same sha256 in `user_uploads`) — anything else would create a dangling reference into someone else's storage.

| Scenario | Result |
| --- | --- |
| Same-account restore | Task and mounts both kept |
| Cross-account transfer | mounts dropped, **Task still imported** |
| Connection disabled | dropped |
| Registry not bound | unchanged from today |

## The new dependency is wired, not dead

`RepoConnectionRepository` is injected trailing + `@Optional()`, per the positional-arity rule the two dependencies above it document. I checked it resolves for real rather than silently sitting `undefined`: it is in `_repository-inventory.ts`, `DatabaseModule` provides **and exports** `REPOSITORY_PROVIDERS`, and `AccountTransferModule` imports `DatabaseModule`.

## Verification

| Check | Result |
| --- | --- |
| account-transfer specs (8 files) | 218 passed, 2 skipped (5 new) |
| `tsc --noEmit` (agent) | clean |
| `prettier --check` | clean |

The four new import tests cover the cases that matter: owned-and-enabled is restored, unowned is dropped *with the Task still imported*, disabled is dropped, and an unbound registry changes nothing.

## Also found, not fixed here

`TASK_MAX_EXTRA_REPOS = 8` is validated in isolation at attach time, but `FLEET_TASK_WORKSPACE_MAX_MOUNTS = 8` is enforced on the **combined** `[...keptAttachments, ...extraMounts]` at plan-build time. So a Task saved with 8 extra repos plus an agent with even one of its own attachments throws `workspace.mounts has 9 entries; the limit is 8` on every run — a failure the user gets no warning about at save time. The constant's own comment ("matches the fleet mount limit") shows the assumption. Left alone because the right resolution is a product call: share one budget, or let the mount resolver truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)