### PR TITLE
fix(api): map an upstream OAuth 401 to 502, not 400 — it is our credential, not the user's

### DIFF
--- a/apps/api/src/auth/services/social-auth.service.spec.ts
+++ b/apps/api/src/auth/services/social-auth.service.spec.ts
@@ -758,9 +758,14 @@ describe('SocialAuthService', () => {
             expect(logged).not.toContain('SECRET-UPSTREAM-DETAIL');
         });
 
-        it('(a2) token endpoint 4xx from any provider maps to 400 and names that provider', async () => {
+        it('(a2) a client-fault 4xx from any provider maps to 400 and names that provider', async () => {
+            // `invalid_grant` — the authorization code we presented was
+            // rejected, which the user CAN fix by restarting the flow. This
+            // deliberately no longer uses 401 `invalid_client`: that is the
+            // platform's own credential being refused, and it now maps to 502
+            // (see the `(a3)` cases).
             httpService.post.mockReturnValueOnce(
-                throwError(() => axiosHttpError(401, { error: 'invalid_client' })),
+                throwError(() => axiosHttpError(400, { error: 'invalid_grant' })),
             );
 
             const error = await captureError(service.authenticate(AuthProvider.LINKEDIN, 'bogus'));
@@ -772,6 +777,11 @@ describe('SocialAuthService', () => {
         it.each([
             [429, 'rate_limit_exceeded'],
             [408, 'request_timeout'],
+            // 401 is OUR client credentials, not the user's grant: a rejected
+            // authorization code comes back 400 `invalid_grant`. Mapped to 400
+            // it was counted as a client error, so a revoked or expired client
+            // secret took every sign-in down without raising a single 5xx.
+            [401, 'invalid_client'],
         ])(
             '(a3) token endpoint %s (%s) is a provider-side condition -> BadGatewayException (502), not a client-fault 400',
             async (status, code) => {
@@ -821,7 +831,7 @@ describe('SocialAuthService', () => {
             expect(String(warnSpy.mock.calls[0][0])).toContain('ECONNRESET');
         });
 
-        it('(d) user-info fetch rejecting with 401 -> BadRequestException, not a raw 500', async () => {
+        it('(d) user-info fetch rejecting with 401 -> BadGatewayException, not a raw 500', async () => {
             httpService.post.mockReturnValueOnce(of({ data: { access_token: 'tok' } }));
             httpService.get.mockReturnValueOnce(
                 throwError(() =>
@@ -833,7 +843,12 @@ describe('SocialAuthService', () => {
 
             const error = await captureError(service.authenticate(AuthProvider.GOOGLE, 'c'));
 
-            expect(error).toBeInstanceOf(BadRequestException);
+            // The token we present here is the one WE just obtained, so a 401
+            // means our exchange produced a token the provider will not honour
+            // — a platform/provider condition. There is nothing for the user
+            // to correct, and 5xx-keyed alerting should see it.
+            expect(error).toBeInstanceOf(BadGatewayException);
+            expect(error.getStatus()).toBe(502);
             expect(error.message).toContain('Google');
             expect(error.message).not.toContain('SECRET-UPSTREAM-DETAIL');
             expect(authService.validateSocialUser).not.toHaveBeenCalled();

--- a/apps/api/src/auth/services/social-auth.service.ts
+++ b/apps/api/src/auth/services/social-auth.service.ts
@@ -70,11 +70,24 @@ interface LinkedInUserInfo {
 type UpstreamStep = 'token exchange' | 'user profile request';
 
 /**
- * Upstream 4xx statuses that are NOT the client's fault: 408 Request Timeout
- * and 429 Too Many Requests are provider-side / quota conditions and are mapped
- * like a provider outage (502) rather than a rejected code (400).
+ * Upstream 4xx statuses that are NOT the end user's fault. These map like a
+ * provider outage (502) rather than a rejected code (400).
+ *
+ *  - 408 Request Timeout / 429 Too Many Requests — provider-side or quota
+ *    conditions. Telling the user to restart a flow that would fail again is
+ *    the wrong advice.
+ *  - 401 Unauthorized — OUR client credentials, not the user's grant. A
+ *    rejected authorization code comes back 400 `invalid_grant`; 401 is
+ *    `invalid_client`, meaning the platform's own client id/secret is wrong,
+ *    revoked or expired (and on the userinfo step, that the token WE just
+ *    obtained was refused). Both are platform misconfiguration.
+ *
+ *    401 matters beyond the status code the user sees. Mapped to 400 it was
+ *    counted as a client error, so a total sign-in outage — every user of
+ *    that provider failing — raised no 5xx alert at all and looked like a
+ *    crowd of people mistyping something.
  */
-const UPSTREAM_THROTTLE_STATUSES: ReadonlySet<number> = new Set([408, 429]);
+const UPSTREAM_NOT_USER_FAULT_STATUSES: ReadonlySet<number> = new Set([401, 408, 429]);
 
 @Injectable()
 export class SocialAuthService {
@@ -393,12 +406,14 @@ export class SocialAuthService {
      * a BadRequestException.
      *
      * Mapping:
-     *  - upstream 4xx other than 408/429 -> 400 BadRequestException (the
+     *  - upstream 4xx other than 401/408/429 -> 400 BadRequestException (the
      *    code / token we presented was rejected; the user has to restart the
      *    flow)
-     *  - upstream 408 / 429 (provider timeout or rate limit — our app or the
-     *    provider is throttled, the user did nothing wrong), upstream 5xx, or
-     *    no response at all (ECONNRESET, timeout, DNS) -> 502
+     *  - upstream 401 (OUR client credentials, not the user's grant — a
+     *    rejected code is 400 `invalid_grant`, while 401 is `invalid_client`),
+     *    408 / 429 (provider timeout or rate limit — our app or the provider
+     *    is throttled, the user did nothing wrong), upstream 5xx, or no
+     *    response at all (ECONNRESET, timeout, DNS) -> 502
      *    BadGatewayException (the identity provider is the problem, the user
      *    should simply retry; 5xx-keyed alerting keeps seeing the outage)
      *
@@ -453,7 +468,7 @@ export class SocialAuthService {
             typeof status === 'number' &&
             status >= 400 &&
             status < 500 &&
-            !UPSTREAM_THROTTLE_STATUSES.has(status)
+            !UPSTREAM_NOT_USER_FAULT_STATUSES.has(status)
         );
     }
 


### PR DESCRIPTION
**Re-targets a fix that got stranded by a merge race.** I opened #2318 against `fix/oauth-upstream-4xx-and-model-process-flake`, but #2310 had already merged that branch to develop at 15:52 UTC — hours earlier. So #2318 merged into a branch whose PR was already closed, and the fix never reached develop. This is the same commit, cherry-picked onto current develop and re-verified.

## The gap

`isClientFaultStatus` returns true for every upstream 4xx except 408 and 429, which sweeps in **401**.

401 is not the user's grant being refused. A rejected authorization code comes back **400 `invalid_grant`**. 401 is **`invalid_client`** — the platform's own OAuth client id or secret is wrong, revoked, or expired. On the user-info step it means the access token *we* just obtained was refused, which is the same class of problem: the user has nothing to correct.

The status the user sees is the smaller half. Counted as a client error, a revoked client secret takes **every sign-in for that provider** down while raising no 5xx at all — an outage that looks, to alerting, like a crowd of people mistyping something.

The merged code's own rationale for 408/429 makes the argument: the 502 mapping exists so "5xx-keyed alerting keeps seeing the outage." 401 belongs on that side of the line for the same reason.

## The change

One status added to the set, which is renamed to `UPSTREAM_NOT_USER_FAULT_STATUSES` since "throttle" no longer describes what it holds. The mapping doc comment is updated to match.

## Two existing tests asserted the old behaviour

Updated rather than deleted, because both were testing something real:

| Test | Before | After |
| --- | --- | --- |
| `(a2)` "4xx from any provider maps to 400" | used 401 `invalid_client` | uses 400 `invalid_grant`, a genuine client fault, so it still proves provider naming without pinning the mapping this change corrects |
| `(d)` user-info 401 | expected `BadRequestException` | expects `BadGatewayException` (502), with the reasoning recorded inline |

`(a3)`, the parameterised provider-side list, gains `401 / invalid_client` next to 429 and 408, so the corrected mapping is pinned going forward.

## Verification

| Check | Result |
| --- | --- |
| `social-auth.service.spec.ts` against current develop | 49 passed |
| `prettier --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)