### PR TITLE
feat(agent-plugins): Phase 1 — package registry, local source, and package skills in the catalog (EW-772)

### DIFF
--- a/apps/api/src/agent-plugins/agent-plugins.controller.ts
+++ b/apps/api/src/agent-plugins/agent-plugins.controller.ts
@@ -1,0 +1,131 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import {
+    AgentPluginPackageCatalogService,
+    loadedPackages,
+    rejectedPackages,
+    scanConfiguredPackages,
+} from '@ever-works/agent/agent-plugins';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ListAgentPluginPackagesQueryDto } from './dto/agent-plugin.dto';
+
+/**
+ * Read surface over installed Agent Plugins packages.
+ *
+ * The controller path starts with `api/` because there is **no**
+ * `setGlobalPrefix` in this application — every controller carries the
+ * segment itself. A path without it registers fine, compiles, passes unit
+ * tests, and 404s in production; a source-scanning guard spec exists because
+ * that once blocked every signup for two days.
+ *
+ * Authentication is global (`AuthSessionGuard` as an `APP_GUARD`), so a
+ * user-scoped controller needs no `@UseGuards` of its own.
+ *
+ * Read-only in this phase. Installing, updating and removing packages arrive
+ * with the git and npm sources; local packages are registered in place, so
+ * there is nothing yet for a write route to do that editing the directory
+ * does not already do.
+ */
+@ApiTags('agent-plugins')
+@Controller('api/agent-plugins')
+export class AgentPluginsController {
+    constructor(private readonly catalog: AgentPluginPackageCatalogService) {}
+
+    @Get()
+    @ApiOperation({
+        summary: 'List installed Agent Plugins packages',
+        description:
+            'Returns every package discovered in the configured directories, including ones that failed to load — those are reported with their findings rather than hidden, since an operator put them there deliberately.',
+    })
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async list(
+        @CurrentUser() _auth: AuthenticatedUser,
+        @Query() query: ListAgentPluginPackagesQueryDto,
+    ) {
+        const scan = await scanConfiguredPackages();
+
+        const loaded = loadedPackages(scan).map((pkg) => ({
+            name: pkg.name,
+            version: pkg.version,
+            specVersion: pkg.specVersion,
+            path: pkg.path,
+            dirName: pkg.dirName,
+            skills: pkg.skillNames,
+            mcpServers: pkg.mcpServerNames,
+            findings: pkg.findings,
+            summary: pkg.summary,
+        }));
+
+        const rejected = rejectedPackages(scan).map((pkg) => ({
+            dirName: pkg.dirName,
+            path: pkg.path,
+            findings: pkg.findings,
+            summary: pkg.summary,
+        }));
+
+        const search = query.search?.trim().toLowerCase();
+        const packages = search
+            ? loaded.filter(
+                  (pkg) =>
+                      pkg.name?.toLowerCase().includes(search) ||
+                      pkg.skills.some((skill) => skill.toLowerCase().includes(search)),
+              )
+            : loaded;
+
+        return {
+            // Distinguishes "the feature is off" from "on, and there are no
+            // packages" — without it an operator who flips the flag and sees
+            // an empty list cannot tell which they are looking at.
+            enabled: scan.enabled,
+            roots: scan.roots,
+            packages,
+            rejected,
+            shadowed: scan.shadowed.map((pkg) => ({ dirName: pkg.dirName, name: pkg.name })),
+        };
+    }
+
+    // Declared BEFORE any `:param` route. A `@Get(':id')` with a
+    // `ParseUUIDPipe` shadows every literal sibling declared after it and 400s
+    // on them, which is documented in the skills controller after it bit
+    // someone there.
+    @Get('findings')
+    @ApiOperation({
+        summary: 'Every finding across installed packages',
+        description:
+            'Flattened for an operator triaging why a skill or MCP server is missing. Findings are recorded at validation time, so they survive a package becoming unreadable.',
+    })
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async findings(@CurrentUser() _auth: AuthenticatedUser) {
+        const scan = await scanConfiguredPackages();
+        const all = scan.scans.flatMap((source) =>
+            source.candidates.flatMap((pkg) =>
+                pkg.findings.map((finding) => ({
+                    package: pkg.name ?? pkg.dirName,
+                    packageLoaded: pkg.ok,
+                    ...finding,
+                })),
+            ),
+        );
+        return { enabled: scan.enabled, findings: all };
+    }
+
+    @Get('catalog')
+    @ApiOperation({
+        summary: 'Package skills as catalog entries',
+        description:
+            'The same entries the skills catalog merges in, exposed directly so an operator can confirm what a package contributes without hunting for it among the built-in skills.',
+    })
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async catalogEntries(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: ListAgentPluginPackagesQueryDto,
+    ) {
+        const entries = await this.catalog.listEntries({
+            facadeOptions: { userId: auth.userId },
+            ...(query.search === undefined ? {} : { search: query.search }),
+        });
+        return { entries, total: entries.length };
+    }
+}

--- a/apps/api/src/agent-plugins/agent-plugins.module.ts
+++ b/apps/api/src/agent-plugins/agent-plugins.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { AgentPluginsModule as AgentSideAgentPluginsModule } from '@ever-works/agent/agent-plugins';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { AgentPluginsController } from './agent-plugins.controller';
+
+/**
+ * API-side Agent Plugins module.
+ *
+ * Imports the agent-side module rather than listing its services in
+ * `providers`. Listing them locally would create a SECOND instance with an
+ * unresolvable constructor — both sibling templates (`skills`, `mcp-connections`)
+ * import their agent-side module for exactly this reason.
+ *
+ * `DatabaseModule` is imported because the guards and repositories that
+ * later write routes will need resolve `UserRepository` through it; a module
+ * mounting an admin-guarded controller without it fails to instantiate the
+ * guard at REQUEST time, which no unit test and no `generate:openapi` run
+ * catches — that command runs in preview mode and never instantiates
+ * providers.
+ */
+@Module({
+    imports: [AgentSideAgentPluginsModule, DatabaseModule],
+    controllers: [AgentPluginsController],
+})
+export class AgentPluginsApiModule {}

--- a/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
+++ b/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * Remote sources that require an allowlist entry.
+ *
+ * `local` is absent on purpose: a local package already sits in a directory
+ * the operator configured and controls, so an allowlist entry would be asking
+ * their permission for bytes they put there themselves.
+ */
+export const AGENT_PLUGIN_ALLOWLIST_SOURCES = ['git', 'npm'] as const;
+
+/**
+ * Every DTO here is validated by the GLOBAL pipe, which runs with
+ * `whitelist: true` and `forbidNonWhitelisted: true`. Two consequences worth
+ * stating, because both fail quietly:
+ *
+ * - A property with no class-validator decorator is silently DELETED from the
+ *   body before the handler sees it. The symptom is a field that is always
+ *   `undefined`, with no error anywhere.
+ * - An unknown field is a 400, so adding a field to a request DTO is a
+ *   wire-compatibility event in both directions during a rolling deploy.
+ */
+
+export class ListAgentPluginPackagesQueryDto {
+    @ApiPropertyOptional({
+        description: 'Filter to packages whose name or a contributed skill matches this text.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    search?: string;
+}
+
+export class CreateAgentPluginAllowlistEntryDto {
+    @ApiProperty({
+        description: 'The npm package name, or git URL, this entry permits fetching.',
+    })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(2048)
+    packageName: string;
+
+    @ApiProperty({ enum: AGENT_PLUGIN_ALLOWLIST_SOURCES })
+    @IsIn(AGENT_PLUGIN_ALLOWLIST_SOURCES)
+    source: (typeof AGENT_PLUGIN_ALLOWLIST_SOURCES)[number];
+
+    @ApiPropertyOptional({
+        description: 'Permitted versions — a semver range for npm, a ref pattern for git.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    versionRange?: string;
+
+    @ApiPropertyOptional({
+        description: 'Expected sha512 (npm) or commit (git), when pinned exactly.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    integrity?: string;
+
+    @ApiPropertyOptional({
+        description: 'Why this entry exists — an audit note for the next operator.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2000)
+    notes?: string;
+}
+
+export class UpdateAgentPluginAllowlistEntryDto {
+    @ApiPropertyOptional({
+        description:
+            'Revoke permission without deleting the row, so the reason it existed stays visible.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    enabled?: boolean;
+
+    @ApiPropertyOptional()
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    versionRange?: string;
+
+    @ApiPropertyOptional()
+    @IsOptional()
+    @IsString()
+    @MaxLength(2000)
+    notes?: string;
+}

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -52,6 +52,7 @@ import { AgentsModule } from './agents/agents.module';
 import { EnvironmentsApiModule } from './environments/environments.module';
 import { AgentApprovalsModule } from './agent-approvals/agent-approvals.module';
 import { SkillsModule } from './skills/skills.module';
+import { AgentPluginsApiModule } from './agent-plugins/agent-plugins.module';
 import { McpConnectionsModule } from './mcp-connections/mcp-connections.module';
 import { RepoConnectionsModule } from './repo-connections/repo-connections.module';
 import { TasksModule } from './tasks/tasks.module';
@@ -195,6 +196,7 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // Phase 8 — Skills read-only API + SkillsFacadeService.
         // Write paths + bindings ship with Phase 9.
         SkillsModule,
+        AgentPluginsApiModule,
         // Agent Plugins MCP slice — manual external MCP connections +
         // per-agent bindings (docs/specs/features/agent-plugins §2.3).
         McpConnectionsModule,

--- a/apps/api/src/migrations/1787700000000-CreateAgentPluginPackages.ts
+++ b/apps/api/src/migrations/1787700000000-CreateAgentPluginPackages.ts
@@ -1,0 +1,160 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Agent Plugins standard interop — the package registry.
+ *
+ * Two tables, and the reason they are two is the point:
+ *
+ * - `agent_plugin_packages` records installed **data** packages in the open
+ *   Agent Plugins format. Per tenant/organization, because a package's skills
+ *   reach one owner's catalog and nobody else's.
+ * - `agent_plugin_package_allowlist` records which remote packages an
+ *   operator permits fetching. Global, and deliberately NOT the existing
+ *   `plugin_allowlist`: a row there authorises installing executable code,
+ *   and letting one table grant both powers would mean the safer decision
+ *   silently carried the more dangerous one.
+ *
+ * Both start empty and stay empty until `FEATURE_AGENT_PLUGINS` is turned on,
+ * so this migration is inert on every existing deployment.
+ *
+ * Two deliberate omissions:
+ *
+ * - **No XOR CHECK on the scope columns.** `ScopeStampingSubscriber`
+ *   populates `tenantId` AND `organizationId` on insert, so a XOR constraint
+ *   would abort on ordinary data — a bug class this repository has hit
+ *   before.
+ * - **No foreign key on the scope columns**, matching every other Tier A/C
+ *   table here; the entity carries no `@ManyToOne` for them either, to avoid
+ *   the entity-graph cycle.
+ *
+ * `down` drops both tables. They hold no financial or audit record, and a
+ * package is re-discoverable from its source, so a clean rollback is safe.
+ */
+export class CreateAgentPluginPackages1787700000000 implements MigrationInterface {
+    name = 'CreateAgentPluginPackages1787700000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('agent_plugin_packages'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'agent_plugin_packages',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'userId', type: 'uuid' },
+                        { name: 'tenantId', type: 'uuid', isNullable: true },
+                        { name: 'organizationId', type: 'uuid', isNullable: true },
+                        { name: 'name', type: 'varchar', length: '120' },
+                        { name: 'version', type: 'varchar', length: '64', isNullable: true },
+                        { name: 'specVersion', type: 'varchar', length: '16' },
+                        { name: 'source', type: 'varchar', length: '16', default: "'local'" },
+                        { name: 'sourceRef', type: 'varchar', length: '2048' },
+                        { name: 'installPath', type: 'varchar', length: '2048', isNullable: true },
+                        { name: 'integrity', type: 'varchar', length: '256', isNullable: true },
+                        // `simple-json` columns are `text` at the database
+                        // level. This codebase uses `simple-json` throughout
+                        // and has no `jsonb` column anywhere.
+                        { name: 'manifest', type: 'text', isNullable: true },
+                        { name: 'findings', type: 'text', default: "'[]'" },
+                        { name: 'skillNames', type: 'text', default: "'[]'" },
+                        { name: 'mcpServerNames', type: 'text', default: "'[]'" },
+                        {
+                            name: 'installState',
+                            type: 'varchar',
+                            length: '16',
+                            default: "'available'",
+                        },
+                        { name: 'installError', type: 'text', isNullable: true },
+                        { name: 'contentHash', type: 'varchar', length: '128', isNullable: true },
+                        { name: 'lastValidatedAt', type: 'timestamp', isNullable: true },
+                        { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                        { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                    ],
+                }),
+                true,
+            );
+
+            await queryRunner.createIndex(
+                'agent_plugin_packages',
+                new TableIndex({
+                    name: 'uq_agent_plugin_package_user_name',
+                    columnNames: ['userId', 'name'],
+                    isUnique: true,
+                }),
+            );
+            await queryRunner.createIndex(
+                'agent_plugin_packages',
+                new TableIndex({
+                    name: 'idx_agent_plugin_package_user',
+                    columnNames: ['userId'],
+                }),
+            );
+            await queryRunner.createIndex(
+                'agent_plugin_packages',
+                new TableIndex({
+                    name: 'idx_agent_plugin_package_state',
+                    columnNames: ['installState'],
+                }),
+            );
+            await queryRunner.createForeignKey(
+                'agent_plugin_packages',
+                new TableForeignKey({
+                    name: 'fk_agent_plugin_package_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasTable('agent_plugin_package_allowlist'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'agent_plugin_package_allowlist',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'packageName', type: 'varchar', length: '2048' },
+                        { name: 'source', type: 'varchar', length: '16' },
+                        { name: 'versionRange', type: 'varchar', length: '256', isNullable: true },
+                        { name: 'integrity', type: 'varchar', length: '256', isNullable: true },
+                        { name: 'enabled', type: 'boolean', default: true },
+                        { name: 'notes', type: 'text', isNullable: true },
+                        { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                        { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                    ],
+                }),
+                true,
+            );
+
+            await queryRunner.createIndex(
+                'agent_plugin_package_allowlist',
+                new TableIndex({
+                    name: 'uq_agent_plugin_allowlist_name_source',
+                    columnNames: ['packageName', 'source'],
+                    isUnique: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('agent_plugin_package_allowlist')) {
+            await queryRunner.dropTable('agent_plugin_package_allowlist', true);
+        }
+        if (await queryRunner.hasTable('agent_plugin_packages')) {
+            await queryRunner.dropTable('agent_plugin_packages', true);
+        }
+    }
+}

--- a/apps/cli/src/commands/plugins/agent-plugins.command.ts
+++ b/apps/cli/src/commands/plugins/agent-plugins.command.ts
@@ -1,0 +1,255 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { requireAuth } from '../auth';
+import { getApiService } from '../../services/api.service';
+import { handleCliError } from '../../utils/error';
+
+/**
+ * CLI over the Agent Plugins package registry.
+ *
+ *   ever-works plugins agent-plugins list       # GET /api/agent-plugins
+ *   ever-works plugins agent-plugins findings   # GET /api/agent-plugins/findings
+ *   ever-works plugins agent-plugins catalog    # GET /api/agent-plugins/catalog
+ *
+ * Mounted under the existing `plugins` command rather than as a new top-level
+ * one, because these ARE plugins from a user's point of view — just packages
+ * in the open cross-vendor format rather than native Ever Works code plugins.
+ * The nesting keeps that distinction visible without inventing a second
+ * vocabulary at the top level.
+ *
+ * Every command prints the disabled state explicitly. "The flag is off" and
+ * "the flag is on and you have no packages" look identical in a bare list,
+ * and an operator who has just switched it on needs to tell them apart.
+ */
+
+interface RawApiService {
+    get(path: string): Promise<unknown>;
+}
+
+function api(): RawApiService {
+    // The CLI's ApiService is a thin axios wrapper; casting to the raw verb
+    // signature is the established pattern here, so a new endpoint does not
+    // require a typed method on ApiService.
+    return getApiService() as unknown as RawApiService;
+}
+
+interface PackageRow {
+    name?: string;
+    version?: string;
+    specVersion?: string;
+    dirName?: string;
+    path?: string;
+    skills?: string[];
+    mcpServers?: string[];
+    summary?: { errorCount?: number; warningCount?: number };
+}
+
+interface ListResponse {
+    enabled?: boolean;
+    roots?: string[];
+    packages?: PackageRow[];
+    rejected?: Array<{ dirName?: string; path?: string; summary?: { fatalCount?: number } }>;
+    shadowed?: Array<{ dirName?: string; name?: string }>;
+}
+
+/** Prints the "feature is off" explanation, and reports whether it did. */
+function reportedDisabled(enabled: boolean | undefined): boolean {
+    if (enabled !== false) {
+        return false;
+    }
+    console.log(chalk.yellow('\nAgent Plugins support is disabled on this deployment.'));
+    console.log(
+        chalk.gray('Set FEATURE_AGENT_PLUGINS=true, and AGENT_PLUGINS_DIR if packages live'),
+    );
+    console.log(chalk.gray('somewhere other than /app/agent-plugins.'));
+    return true;
+}
+
+function buildListCommand(): Command {
+    return new Command('list')
+        .description('List installed Agent Plugins packages')
+        .option('-s, --search <text>', 'Filter by package name or contributed skill')
+        .action(async (options: { search?: string }) => {
+            try {
+                await requireAuth();
+                const spinner = ora('Reading package directories…').start();
+                const query = options.search ? `?search=${encodeURIComponent(options.search)}` : '';
+                const response = (await api().get(`/agent-plugins${query}`)) as ListResponse;
+                spinner.stop();
+
+                if (reportedDisabled(response.enabled)) {
+                    return;
+                }
+
+                const packages = response.packages ?? [];
+                const rejected = response.rejected ?? [];
+
+                console.log(
+                    chalk.cyan.bold(`\nAgent Plugins packages (${packages.length} installed)\n`),
+                );
+                if (response.roots?.length) {
+                    console.log(chalk.gray(`  Scanning: ${response.roots.join(', ')}\n`));
+                }
+
+                if (packages.length === 0 && rejected.length === 0) {
+                    console.log(chalk.gray('  No packages found.'));
+                    return;
+                }
+
+                for (const pkg of packages) {
+                    const version = pkg.version ? chalk.gray(` ${pkg.version}`) : '';
+                    const spec = pkg.specVersion ? chalk.gray(` (spec ${pkg.specVersion})`) : '';
+                    console.log(
+                        `  ${chalk.green('●')} ${chalk.bold(pkg.name ?? pkg.dirName)}${version}${spec}`,
+                    );
+                    const skills = pkg.skills ?? [];
+                    const servers = pkg.mcpServers ?? [];
+                    if (skills.length) {
+                        console.log(chalk.gray(`      skills: ${skills.join(', ')}`));
+                    }
+                    if (servers.length) {
+                        console.log(chalk.gray(`      mcp:    ${servers.join(', ')}`));
+                    }
+                    const errors = pkg.summary?.errorCount ?? 0;
+                    const warnings = pkg.summary?.warningCount ?? 0;
+                    if (errors || warnings) {
+                        console.log(
+                            chalk.yellow(
+                                `      ${errors} error(s), ${warnings} warning(s) — run "findings" for detail`,
+                            ),
+                        );
+                    }
+                }
+
+                // Rejected packages are printed too. Somebody put them in that
+                // directory on purpose, so their absence needs an explanation
+                // rather than silence.
+                for (const pkg of rejected) {
+                    console.log(
+                        `  ${chalk.red('✗')} ${chalk.bold(pkg.dirName)} ${chalk.red('rejected')}`,
+                    );
+                    console.log(chalk.gray('      run "findings" to see why'));
+                }
+
+                for (const pkg of response.shadowed ?? []) {
+                    console.log(
+                        chalk.gray(
+                            `  ○ ${pkg.dirName} shadowed — "${pkg.name}" was already provided by an earlier directory`,
+                        ),
+                    );
+                }
+            } catch (error) {
+                handleCliError(error);
+                process.exit(1);
+            }
+        });
+}
+
+function buildFindingsCommand(): Command {
+    return new Command('findings')
+        .description('Show every validation finding across installed packages')
+        .action(async () => {
+            try {
+                await requireAuth();
+                const spinner = ora('Collecting findings…').start();
+                const response = (await api().get('/agent-plugins/findings')) as {
+                    enabled?: boolean;
+                    findings?: Array<{
+                        package?: string;
+                        packageLoaded?: boolean;
+                        severity?: string;
+                        code?: string;
+                        message?: string;
+                        subject?: string;
+                    }>;
+                };
+                spinner.stop();
+
+                if (reportedDisabled(response.enabled)) {
+                    return;
+                }
+
+                const findings = response.findings ?? [];
+                if (findings.length === 0) {
+                    console.log(chalk.green('\nNo findings — every package validated cleanly.'));
+                    return;
+                }
+
+                console.log(chalk.cyan.bold(`\nFindings (${findings.length})\n`));
+                for (const finding of findings) {
+                    const tone =
+                        finding.severity === 'fatal'
+                            ? chalk.red
+                            : finding.severity === 'error'
+                              ? chalk.yellow
+                              : chalk.gray;
+                    const subject = finding.subject ? chalk.gray(` [${finding.subject}]`) : '';
+                    console.log(
+                        `  ${tone((finding.severity ?? '?').padEnd(8))} ${chalk.bold(finding.package)}${subject}`,
+                    );
+                    console.log(`      ${finding.message}`);
+                    console.log(chalk.gray(`      ${finding.code}`));
+                }
+            } catch (error) {
+                handleCliError(error);
+                process.exit(1);
+            }
+        });
+}
+
+function buildCatalogCommand(): Command {
+    return new Command('catalog')
+        .description('Show the skills these packages contribute to the catalog')
+        .option('-s, --search <text>', 'Filter entries')
+        .action(async (options: { search?: string }) => {
+            try {
+                await requireAuth();
+                const spinner = ora('Building catalog entries…').start();
+                const query = options.search ? `?search=${encodeURIComponent(options.search)}` : '';
+                const response = (await api().get(`/agent-plugins/catalog${query}`)) as {
+                    entries?: Array<{
+                        slug?: string;
+                        description?: string;
+                        packageName?: string;
+                        packageVersion?: string;
+                    }>;
+                    total?: number;
+                };
+                spinner.stop();
+
+                const entries = response.entries ?? [];
+                if (entries.length === 0) {
+                    console.log(chalk.gray('\nNo package skills in the catalog.'));
+                    return;
+                }
+
+                console.log(chalk.cyan.bold(`\nPackage skills (${entries.length})\n`));
+                for (const entry of entries) {
+                    const from = entry.packageName
+                        ? chalk.gray(
+                              ` — from ${entry.packageName}${entry.packageVersion ? ` ${entry.packageVersion}` : ''}`,
+                          )
+                        : '';
+                    console.log(`  ${chalk.green('●')} ${chalk.bold(entry.slug)}${from}`);
+                    if (entry.description) {
+                        console.log(chalk.gray(`      ${entry.description}`));
+                    }
+                }
+            } catch (error) {
+                handleCliError(error);
+                process.exit(1);
+            }
+        });
+}
+
+/** The `agent-plugins` subcommand group, for mounting on `plugins`. */
+export function buildAgentPluginsCommand(): Command {
+    const command = new Command('agent-plugins').description(
+        'Inspect Agent Plugins packages (the open cross-vendor skills + MCP format)',
+    );
+    command.addCommand(buildListCommand());
+    command.addCommand(buildFindingsCommand());
+    command.addCommand(buildCatalogCommand());
+    return command;
+}

--- a/apps/cli/src/commands/plugins/index.ts
+++ b/apps/cli/src/commands/plugins/index.ts
@@ -15,6 +15,10 @@ import {
 import type { UserPluginResponse, SettingScopeApi } from '@ever-works/plugin/api';
 // EW-693 / T36 — dynamic distribution subcommands (catalog/install/uninstall/install-status).
 import { buildDynamicSubcommands } from './dynamic.command';
+// Agent Plugins standard interop — inspect packages in the open
+// cross-vendor format. Nested under `plugins` because they ARE plugins to a
+// user, just data packages rather than native code plugins.
+import { buildAgentPluginsCommand } from './agent-plugins.command';
 
 export const pluginsCommand = new Command('plugins')
     .description('Manage plugins')
@@ -411,3 +415,5 @@ function formatCategory(category: string): string {
 for (const sub of buildDynamicSubcommands()) {
     pluginsCommand.addCommand(sub);
 }
+
+pluginsCommand.addCommand(buildAgentPluginsCommand());

--- a/apps/web/src/lib/api/skills.ts
+++ b/apps/web/src/lib/api/skills.ts
@@ -82,6 +82,21 @@ export interface SkillCatalogEntry {
     version: string;
     tags: string[];
     sourceUrl?: string;
+
+    /**
+     * Provenance for entries that came from an Agent Plugins package.
+     *
+     * This interface is a hand-maintained MIRROR of the one in
+     * `packages/plugin/src/contracts/capabilities/skills-provider.interface.ts`
+     * — the web app does not import that package's type. Adding a field there
+     * and not here is invisible: the API sends it, nothing strips it, and the
+     * UI simply never sees it. That failure shows up as "the source label
+     * never renders", not as a type error, so the two must be changed
+     * together.
+     */
+    packageName?: string;
+    packageVersion?: string;
+    sourceKind?: 'plugin' | 'local' | 'git' | 'npm';
 }
 
 export interface ListResponse<T> {

--- a/packages/agent/jest.config.js
+++ b/packages/agent/jest.config.js
@@ -9,6 +9,16 @@ module.exports = {
             {
                 diagnostics: {
                     ignoreCodes: [151002],
+                    // `@ever-works/agent-plugins` is mapped to SOURCE below, so
+                    // without this ts-jest type-checks that library using THIS
+                    // package's compiler options — and this package sets
+                    // `strictNullChecks: false`, under which the library's
+                    // discriminated result unions (`{ok: true, ...} | {ok: false, ...}`)
+                    // stop narrowing and every consumer of one fails to compile.
+                    // The library is strictly type-checked and tested in its own
+                    // package, which is the right place for it; re-checking it
+                    // here under weaker settings only produces false failures.
+                    exclude: ['**/agent-plugins/src/**'],
                 },
             },
         ],
@@ -31,8 +41,14 @@ module.exports = {
         // file (not a folder with index), separated from `helpers/index.ts` so
         // its `node:net`/`node:dns` imports stay out of the client bundle.
         // Map BEFORE the catch-all `helpers` rule below so the regex order matters.
-        '^@ever-works/plugin/helpers/ssrf-guard$': '<rootDir>/../../plugin/src/helpers/ssrf-guard.ts',
+        '^@ever-works/plugin/helpers/ssrf-guard$':
+            '<rootDir>/../../plugin/src/helpers/ssrf-guard.ts',
         '^@ever-works/plugin/(.*)$': '<rootDir>/../../plugin/src/$1/index.ts',
+        // Resolve the conformance library to SOURCE, exactly as the two
+        // siblings below do. Without this a spec importing it would load
+        // `dist/`, which only exists after a build — so the suite would
+        // pass or fail depending on whether someone had run one.
+        '^@ever-works/agent-plugins$': '<rootDir>/../../agent-plugins/src/index.ts',
         '^@ever-works/contracts$': '<rootDir>/../../contracts/src/index.ts',
         '^@ever-works/contracts/(.*)$': '<rootDir>/../../contracts/src/$1/index.ts',
         // p-map is ESM-only and ts-jest can't load it. Substitute a

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -125,6 +125,10 @@
             "types": "./dist/template-catalog/index.d.ts",
             "default": "./dist/template-catalog/index.js"
         },
+        "./agent-plugins": {
+            "types": "./dist/agent-plugins/index.d.ts",
+            "default": "./dist/agent-plugins/index.js"
+        },
         "./account-transfer": {
             "types": "./dist/account-transfer/index.d.ts",
             "default": "./dist/account-transfer/index.js"
@@ -289,6 +293,7 @@
     },
     "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",
+        "@ever-works/agent-plugins": "workspace:*",
         "@ever-works/contracts": "workspace:*",
         "@ever-works/plugin": "workspace:*",
         "@langchain/textsplitters": "^0.1.0",

--- a/packages/agent/src/agent-plugins/__tests__/catalog-integration.spec.ts
+++ b/packages/agent/src/agent-plugins/__tests__/catalog-integration.spec.ts
@@ -1,0 +1,345 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ISkillsProviderPlugin, PluginManifest, SkillCatalogEntry } from '@ever-works/plugin';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { SkillsFacadeService } from '../../facades/skills.facade';
+import { AgentPluginPackageCatalogService } from '../package-catalog.service';
+
+/**
+ * End-to-end through the real objects: a package written to a real directory,
+ * read by the real conformance library, mapped by the real catalog service,
+ * and merged by the real facade. Nothing is mocked except the plugin registry,
+ * which stands in for the provider plugins the facade would otherwise load.
+ *
+ * The unit suites each prove one link. This proves the CHAIN — which is where
+ * a wiring mistake lives: every piece can be correct while the assembled
+ * whole surfaces nothing.
+ */
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+
+const facadeOptions = { userId: 'user-1' } as never;
+const page = { limit: 50, offset: 0 } as never;
+
+async function packagesRoot(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'agent-plugins-e2e-'));
+}
+
+async function writePackage(
+    root: string,
+    dirName: string,
+    manifest: Record<string, unknown>,
+    skills: Record<string, string> = {},
+    mcp?: unknown,
+): Promise<void> {
+    const dir = join(root, dirName);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify(manifest, null, 2), 'utf8');
+    for (const [name, body] of Object.entries(skills)) {
+        await mkdir(join(dir, 'skills', name), { recursive: true });
+        await writeFile(join(dir, 'skills', name, 'SKILL.md'), body, 'utf8');
+    }
+    if (mcp !== undefined) {
+        await writeFile(join(dir, 'mcp.json'), JSON.stringify(mcp, null, 2), 'utf8');
+    }
+}
+
+const skillFile = (name: string, description: string, extra = ''): string =>
+    `---\nname: ${name}\ndescription: ${description}\n${extra}---\n\n# ${name}\n\nInstructions.\n`;
+
+function builtinProvider(entries: SkillCatalogEntry[]): RegisteredPlugin {
+    const plugin = {
+        id: 'everworks-skills',
+        name: 'Ever Works Skills',
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['skills-provider'],
+        settingsSchema: { type: 'object', properties: {} },
+        configurationMode: 'hybrid',
+        providerName: 'Ever Works Skills',
+        onLoad: jest.fn(),
+        onUnload: jest.fn(),
+        listEntries: jest
+            .fn()
+            .mockImplementation(({ limit, offset }: { limit: number; offset: number }) => ({
+                entries: entries.slice(offset, offset + limit),
+                total: entries.length,
+            })),
+        getEntry: jest
+            .fn()
+            .mockImplementation(
+                async (slug: string) => entries.find((e) => e.slug === slug) ?? null,
+            ),
+    } as unknown as ISkillsProviderPlugin;
+
+    return {
+        plugin,
+        manifest: {
+            id: 'everworks-skills',
+            name: 'Ever Works Skills',
+            version: '1.0.0',
+            description: 'Built-in catalog',
+            category: 'utility',
+            capabilities: ['skills-provider'],
+        } as PluginManifest,
+        state: 'loaded',
+        builtIn: true,
+        stateHistory: [],
+        registeredAt: 0,
+    };
+}
+
+function builtinEntry(slug: string): SkillCatalogEntry {
+    return {
+        slug,
+        title: slug,
+        description: `Built-in ${slug}`,
+        frontmatter: { name: slug, description: `Built-in ${slug}` },
+        body: 'Built-in body.',
+        version: '1.0.0',
+        tags: [],
+    };
+}
+
+function facadeWith(providers: RegisteredPlugin[], source?: AgentPluginPackageCatalogService) {
+    const registry = {
+        getByCapability: jest.fn().mockReturnValue(providers),
+        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+    } as unknown as PluginRegistryService;
+    const settings = {
+        getResolvedSettings: jest.fn().mockResolvedValue({}),
+    } as unknown as PluginSettingsService;
+    return new SkillsFacadeService(registry, settings, undefined, source);
+}
+
+describe('Agent Plugins → skills catalog (integration)', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.AGENT_PLUGINS_DIR;
+        delete process.env.FEATURE_AGENT_PLUGINS;
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('surfaces a package skill in the catalog, end to end', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'acme-tools',
+            { $schema: PLUGIN_SCHEMA, name: 'acme.tools', version: '1.4.0' },
+            {
+                'release-notes': skillFile(
+                    'release-notes',
+                    'Draft release notes from a changelog.',
+                ),
+            },
+            {
+                $schema: MCP_SCHEMA,
+                mcpServers: {
+                    api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+                },
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith(
+            [builtinProvider([builtinEntry('plan')])],
+            new AgentPluginPackageCatalogService(),
+        );
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        expect(result.entries.map((e) => e.slug)).toEqual(['plan', 'release-notes']);
+        expect(result.total).toBe(2);
+
+        const fromPackage = result.entries.find((e) => e.slug === 'release-notes');
+        expect(fromPackage).toMatchObject({
+            packageName: 'acme.tools',
+            packageVersion: '1.4.0',
+            version: '1.4.0',
+            sourceKind: 'local',
+        });
+        expect(fromPackage?.body).toContain('Instructions.');
+
+        // The install path resolves through getEntry, so it must find the same
+        // skill the card was rendered from.
+        await expect(facade.getEntry('release-notes', facadeOptions)).resolves.toMatchObject({
+            providerId: 'agent-plugins',
+            entry: { slug: 'release-notes' },
+        });
+    });
+
+    it('changes nothing at all while the flag is off', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'acme-tools',
+            { $schema: PLUGIN_SCHEMA, name: 'acme.tools' },
+            {
+                'release-notes': skillFile('release-notes', 'Draft release notes.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        // FEATURE_AGENT_PLUGINS deliberately unset.
+
+        const facade = facadeWith(
+            [builtinProvider([builtinEntry('plan')])],
+            new AgentPluginPackageCatalogService(),
+        );
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        expect(result.entries.map((e) => e.slug)).toEqual(['plan']);
+        expect(result.total).toBe(1);
+        await expect(facade.getEntry('release-notes', facadeOptions)).resolves.toBeNull();
+    });
+
+    it('never lets a package displace a built-in skill of the same slug', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'shadower',
+            { $schema: PLUGIN_SCHEMA, name: 'shadower' },
+            {
+                plan: skillFile('plan', 'A package skill claiming a built-in slug.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith(
+            [builtinProvider([builtinEntry('plan')])],
+            new AgentPluginPackageCatalogService(),
+        );
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        expect(result.entries).toHaveLength(1);
+        expect(result.entries[0]?.description).toBe('Built-in plan');
+        // And the install path agrees, or the card and the install would
+        // disagree about which skill the user is getting.
+        await expect(facade.getEntry('plan', facadeOptions)).resolves.toMatchObject({
+            providerId: 'everworks-skills',
+        });
+    });
+
+    it('surfaces package skills even with no provider plugin enabled', async () => {
+        // Only `everworks-skills` auto-enables, so a deployment with no
+        // skills-provider plugin is real — and the facade used to return early
+        // in exactly that case.
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'acme-tools',
+            { $schema: PLUGIN_SCHEMA, name: 'acme.tools' },
+            {
+                'release-notes': skillFile('release-notes', 'Draft release notes.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith([], new AgentPluginPackageCatalogService());
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        expect(result.entries.map((e) => e.slug)).toEqual(['release-notes']);
+    });
+
+    it('keeps the good skills of a package whose other skills are broken', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'mixed',
+            { $schema: PLUGIN_SCHEMA, name: 'mixed' },
+            {
+                good: skillFile('good', 'This one conforms.'),
+                mismatched: skillFile('other-name', 'Frontmatter disagrees with the directory.'),
+                'no-description': '---\nname: no-description\n---\n\nMissing its description.\n',
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith([], new AgentPluginPackageCatalogService());
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        // Per-skill failure isolation, carried all the way from the
+        // conformance library to the catalog.
+        expect(result.entries.map((e) => e.slug)).toEqual(['good']);
+    });
+
+    it('drops an entire package whose manifest is fatally invalid', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'broken',
+            { $schema: PLUGIN_SCHEMA, name: 'Bad Name' },
+            {
+                hidden: skillFile('hidden', 'Should never reach the catalog.'),
+            },
+        );
+        await writePackage(
+            root,
+            'fine',
+            { $schema: PLUGIN_SCHEMA, name: 'fine' },
+            {
+                visible: skillFile('visible', 'Should reach the catalog.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith([], new AgentPluginPackageCatalogService());
+
+        const result = await facade.listEntries(page, facadeOptions);
+
+        // A fatal manifest means discover nothing from THAT package, while its
+        // neighbour is unaffected.
+        expect(result.entries.map((e) => e.slug)).toEqual(['visible']);
+    });
+
+    it('paginates a mixed catalog consistently', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'many',
+            { $schema: PLUGIN_SCHEMA, name: 'many' },
+            {
+                'pkg-a': skillFile('pkg-a', 'Package skill A.'),
+                'pkg-b': skillFile('pkg-b', 'Package skill B.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+
+        const facade = facadeWith(
+            [builtinProvider([builtinEntry('builtin-1'), builtinEntry('builtin-2')])],
+            new AgentPluginPackageCatalogService(),
+        );
+
+        const first = await facade.listEntries({ limit: 3, offset: 0 } as never, facadeOptions);
+        const second = await facade.listEntries({ limit: 3, offset: 3 } as never, facadeOptions);
+
+        expect(first.total).toBe(4);
+        expect(second.total).toBe(4);
+        expect([...first.entries, ...second.entries].map((e) => e.slug)).toEqual([
+            'builtin-1',
+            'builtin-2',
+            'pkg-a',
+            'pkg-b',
+        ]);
+    });
+});

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -1,0 +1,43 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+import { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
+import { DatabaseModule } from '../database/database.module';
+import { AgentPluginPackageCatalogService } from './package-catalog.service';
+import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
+
+/**
+ * Agent Plugins standard interop — the agent-side module.
+ *
+ * A **leaf** module on purpose. `FacadesModule` imports it to obtain the
+ * `AGENT_PLUGIN_SKILL_SOURCE` binding, and that only works without a cycle
+ * because this module imports nothing that imports facades.
+ *
+ * Binding through a token rather than adding the service to the `FACADES`
+ * provider array is also not stylistic: `facades.module.spec.ts` asserts that
+ * array's length exactly, so a provider appended there turns it red. A
+ * module added to `imports` is asserted by containment instead.
+ *
+ * The entities are registered here for `forFeature`, and separately in
+ * `_entities-inventory.ts` — registering only here compiles, boots, and then
+ * throws `EntityMetadataNotFoundError` on the first query, because there is
+ * no `autoLoadEntities`.
+ */
+@Module({
+    imports: [
+        DatabaseModule,
+        TypeOrmModule.forFeature([AgentPluginPackage, AgentPluginPackageAllowlist]),
+    ],
+    providers: [
+        AgentPluginPackageCatalogService,
+        {
+            // The facade consumes this @Optional(), so a deployment that never
+            // imports this module keeps behaving exactly as it did before the
+            // seam existed.
+            provide: AGENT_PLUGIN_SKILL_SOURCE,
+            useExisting: AgentPluginPackageCatalogService,
+        },
+    ],
+    exports: [AgentPluginPackageCatalogService, AGENT_PLUGIN_SKILL_SOURCE],
+})
+export class AgentPluginsModule {}

--- a/packages/agent/src/agent-plugins/configured-source.spec.ts
+++ b/packages/agent/src/agent-plugins/configured-source.spec.ts
@@ -1,0 +1,141 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import {
+    configuredPackageDirs,
+    loadedPackages,
+    rejectedPackages,
+    scanConfiguredPackages,
+} from './configured-source';
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+
+async function packageDir(name: string, manifestName?: string): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'agent-plugins-cfg-'));
+    const dir = join(root, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+        join(dir, 'plugin.json'),
+        JSON.stringify({ $schema: PLUGIN_SCHEMA, name: manifestName ?? name }),
+        'utf8',
+    );
+    return root;
+}
+
+describe('agent-plugins configured source', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        delete process.env.AGENT_PLUGINS_DIR;
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    describe('when the flag is off', () => {
+        it('scans nothing at all, and says so', async () => {
+            const root = await packageDir('alpha');
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            const result = await scanConfiguredPackages();
+
+            // `enabled: false` is distinguishable from "on but empty" on
+            // purpose: an operator who turns the flag on and still sees
+            // nothing needs to know which of the two they are looking at.
+            expect(result.enabled).toBe(false);
+            expect(result.roots).toEqual([]);
+            expect(result.scans).toEqual([]);
+            expect(loadedPackages(result)).toEqual([]);
+        });
+
+        it('does not even read the configured directory', async () => {
+            // The catalog runs this on every request, so "off" must cost
+            // nothing — not one filesystem call.
+            process.env.AGENT_PLUGINS_DIR = '/definitely/not/a/real/path';
+            await expect(scanConfiguredPackages()).resolves.toEqual({
+                enabled: false,
+                roots: [],
+                scans: [],
+                shadowed: [],
+            });
+        });
+    });
+
+    describe('when the flag is on', () => {
+        beforeEach(() => {
+            process.env.FEATURE_AGENT_PLUGINS = 'true';
+        });
+
+        it('finds packages in the configured directory', async () => {
+            const root = await packageDir('alpha');
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            const result = await scanConfiguredPackages();
+
+            expect(result.enabled).toBe(true);
+            expect(result.roots).toEqual([root]);
+            expect(loadedPackages(result).map((p) => p.name)).toEqual(['alpha']);
+        });
+
+        it('reports a missing directory as empty rather than failing', async () => {
+            // Nothing creates the default directory — no Dockerfile mkdir, no
+            // volume mount — so every existing deployment hits this path the
+            // first time the flag is turned on. It must not be an error.
+            process.env.AGENT_PLUGINS_DIR = '/no/such/directory/anywhere';
+
+            const result = await scanConfiguredPackages();
+
+            expect(result.enabled).toBe(true);
+            expect(loadedPackages(result)).toEqual([]);
+            expect(result.scans[0]?.unavailable).toBe(true);
+        });
+
+        it('separates packages that loaded from packages that were rejected', async () => {
+            const root = await mkdtemp(join(tmpdir(), 'agent-plugins-cfg-'));
+            await mkdir(join(root, 'good'), { recursive: true });
+            await writeFile(
+                join(root, 'good', 'plugin.json'),
+                JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'good' }),
+                'utf8',
+            );
+            await mkdir(join(root, 'bad'), { recursive: true });
+            await writeFile(
+                join(root, 'bad', 'plugin.json'),
+                JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'Bad Name' }),
+                'utf8',
+            );
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            const result = await scanConfiguredPackages();
+
+            expect(loadedPackages(result).map((p) => p.name)).toEqual(['good']);
+            // A rejected package was put there deliberately, so its absence
+            // from the catalog needs an explanation rather than silence.
+            expect(rejectedPackages(result).map((p) => p.dirName)).toEqual(['bad']);
+        });
+
+        it('scans several configured directories, first definition winning', async () => {
+            const primary = await packageDir('one', 'shared');
+            const secondary = await packageDir('two', 'shared');
+            process.env.AGENT_PLUGINS_DIR = [primary, secondary].join(delimiter);
+
+            const result = await scanConfiguredPackages();
+
+            expect(result.roots).toEqual([primary, secondary]);
+            expect(loadedPackages(result).map((p) => p.name)).toEqual(['shared']);
+            expect(result.shadowed.map((p) => p.dirName)).toEqual(['two']);
+        });
+
+        it('uses the default directory when none is configured', () => {
+            expect(configuredPackageDirs()).toEqual(['/app/agent-plugins']);
+        });
+
+        it('treats an empty configured value as unset', () => {
+            process.env.AGENT_PLUGINS_DIR = '';
+            expect(configuredPackageDirs()).toEqual(['/app/agent-plugins']);
+        });
+    });
+});

--- a/packages/agent/src/agent-plugins/configured-source.ts
+++ b/packages/agent/src/agent-plugins/configured-source.ts
@@ -1,0 +1,84 @@
+import { config } from '../config';
+import {
+    parsePackageDirs,
+    scanLocalSources,
+    type LocalPackageCandidate,
+    type LocalSourceScan,
+    type ScanLocalPackagesOptions,
+} from './local-source';
+
+/**
+ * The configured local source — where the feature flag is actually read.
+ *
+ * Kept as a separate file from `local-source.ts` on purpose. That module is
+ * pure: give it directories, it tells you what is in them, and it can be
+ * tested against real trees with no environment at all. This one is the thin
+ * layer that decides WHICH directories, by consulting configuration — so the
+ * policy is in one small, obvious place instead of threaded through the
+ * scanner.
+ *
+ * It also ensures `FEATURE_AGENT_PLUGINS` ships with a reader. The repository
+ * already carries one flag that is defined, documented, unit-tested, and read
+ * by nothing; a flag with no reader is a dead feature that looks shipped.
+ */
+
+/** What a configured scan found, plus why it found nothing when it did. */
+export interface ConfiguredScanResult {
+    /**
+     * False when `FEATURE_AGENT_PLUGINS` is off. Distinguished from "on but
+     * empty" so an operator who turns the flag on and sees nothing can tell
+     * which of the two they are looking at.
+     */
+    readonly enabled: boolean;
+    /** Directories that were consulted, after parsing the configured value. */
+    readonly roots: readonly string[];
+    readonly scans: readonly LocalSourceScan[];
+    /** Packages skipped because an earlier directory already defined that name. */
+    readonly shadowed: readonly LocalPackageCandidate[];
+}
+
+/** The directories configured for local packages, in precedence order. */
+export function configuredPackageDirs(): string[] {
+    return parsePackageDirs(config.agentPlugins.getPackageDirs());
+}
+
+/**
+ * Scans every configured directory, or returns an empty, disabled result when
+ * the feature is off.
+ *
+ * Returning a shaped result rather than throwing or returning `null` matters
+ * for the caller this exists for: the skills catalog runs on every request,
+ * and "the feature is off" must be as cheap and as ordinary as "there are no
+ * packages".
+ */
+export async function scanConfiguredPackages(
+    options?: ScanLocalPackagesOptions,
+): Promise<ConfiguredScanResult> {
+    if (!config.agentPlugins.isEnabled()) {
+        return { enabled: false, roots: [], scans: [], shadowed: [] };
+    }
+
+    const roots = configuredPackageDirs();
+    if (roots.length === 0) {
+        return { enabled: true, roots: [], scans: [], shadowed: [] };
+    }
+
+    const { scans, shadowed } = await scanLocalSources(roots, options);
+    return { enabled: true, roots, scans, shadowed };
+}
+
+/** Every package that loaded successfully, flattened across configured directories. */
+export function loadedPackages(result: ConfiguredScanResult): LocalPackageCandidate[] {
+    return result.scans.flatMap((scan) => scan.candidates.filter((candidate) => candidate.ok));
+}
+
+/**
+ * Every package that was found but rejected.
+ *
+ * Worth surfacing separately: these are packages an operator deliberately put
+ * in the directory, so their absence from the catalog needs an explanation
+ * rather than silence.
+ */
+export function rejectedPackages(result: ConfiguredScanResult): LocalPackageCandidate[] {
+    return result.scans.flatMap((scan) => scan.candidates.filter((candidate) => !candidate.ok));
+}

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -18,6 +18,15 @@
  * This is ordinary platform code for exactly that reason.
  */
 
+export { AgentPluginPackageCatalogService } from './package-catalog.service';
+
+export {
+    AGENT_PLUGIN_PROVIDER_ID,
+    AGENT_PLUGIN_SKILL_SOURCE,
+    type AgentPluginSkillSource,
+    type AgentPluginSkillSourceOptions,
+} from './skill-source.token';
+
 export {
     configuredPackageDirs,
     loadedPackages,

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -1,3 +1,5 @@
+export { AgentPluginsModule } from './agent-plugins.module';
+
 /**
  * Agent Plugins standard interop — the platform side.
  *

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Agent Plugins standard interop — the platform side.
+ *
+ * `@ever-works/agent-plugins` knows the specification and nothing about Ever
+ * Works. This module is the other half: it knows Ever Works — tenancy,
+ * configuration, persistence, the skills catalog — and calls into that library
+ * for every judgement about what the standard permits.
+ *
+ * The split is deliberate and load-bearing. It is what lets the conformance
+ * library be tested against a fixture corpus with no database, and what keeps
+ * specification rules from being quietly re-implemented, and subtly differently,
+ * inside platform code.
+ *
+ * Note what this is NOT: a native Ever Works plugin. Native plugins are
+ * instantiated bare with no repository access, and the skills-provider
+ * capability is scope-blind — so a plugin could neither read the tenant-scoped
+ * package registry nor scope it, and package skills would leak across tenants.
+ * This is ordinary platform code for exactly that reason.
+ */
+
+export {
+    DEFAULT_MAX_LOCAL_ENTRIES,
+    parsePackageDirs,
+    scanLocalPackages,
+    scanLocalSources,
+    type LocalPackageCandidate,
+    type LocalSourceScan,
+    type ScanLocalPackagesOptions,
+} from './local-source';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -19,6 +19,14 @@
  */
 
 export {
+    configuredPackageDirs,
+    loadedPackages,
+    rejectedPackages,
+    scanConfiguredPackages,
+    type ConfiguredScanResult,
+} from './configured-source';
+
+export {
     DEFAULT_MAX_LOCAL_ENTRIES,
     parsePackageDirs,
     scanLocalPackages,

--- a/packages/agent/src/agent-plugins/local-source.spec.ts
+++ b/packages/agent/src/agent-plugins/local-source.spec.ts
@@ -1,0 +1,310 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import {
+    DEFAULT_MAX_LOCAL_ENTRIES,
+    parsePackageDirs,
+    scanLocalPackages,
+    scanLocalSources,
+} from './local-source';
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+
+async function scratch(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'agent-plugins-local-'));
+}
+
+/** Writes a package directory and returns its path. */
+async function makePackage(
+    root: string,
+    dirName: string,
+    options?: {
+        manifest?: unknown;
+        rawManifest?: string;
+        skills?: Record<string, string>;
+        mcp?: unknown;
+        omitManifest?: boolean;
+    },
+): Promise<string> {
+    const dir = join(root, dirName);
+    await mkdir(dir, { recursive: true });
+
+    if (!options?.omitManifest) {
+        const text =
+            options?.rawManifest ??
+            JSON.stringify(options?.manifest ?? { $schema: PLUGIN_SCHEMA, name: dirName }, null, 2);
+        await writeFile(join(dir, 'plugin.json'), text, 'utf8');
+    }
+
+    for (const [name, body] of Object.entries(options?.skills ?? {})) {
+        await mkdir(join(dir, 'skills', name), { recursive: true });
+        await writeFile(join(dir, 'skills', name, 'SKILL.md'), body, 'utf8');
+    }
+
+    if (options?.mcp !== undefined) {
+        await writeFile(join(dir, 'mcp.json'), JSON.stringify(options.mcp, null, 2), 'utf8');
+    }
+
+    return dir;
+}
+
+const skill = (name: string, description: string): string =>
+    `---\nname: ${name}\ndescription: ${description}\n---\n\nBody.\n`;
+
+describe('scanLocalPackages', () => {
+    it('finds every immediate child directory carrying a manifest', async () => {
+        const root = await scratch();
+        await makePackage(root, 'alpha', {
+            skills: { summarise: skill('summarise', 'Summarise a document. Use when condensing.') },
+        });
+        await makePackage(root, 'beta', {
+            mcp: {
+                $schema: MCP_SCHEMA,
+                mcpServers: { api: { type: 'streamable-http', url: 'https://x.example.com/mcp' } },
+            },
+        });
+
+        const scan = await scanLocalPackages(root);
+
+        expect(scan.unavailable).toBe(false);
+        expect(scan.candidates.map((c) => c.dirName)).toEqual(['alpha', 'beta']);
+        expect(scan.candidates.every((c) => c.ok)).toBe(true);
+        expect(scan.candidates[0]?.skillNames).toEqual(['summarise']);
+        expect(scan.candidates[1]?.mcpServerNames).toEqual(['api']);
+    });
+
+    it('ignores a directory with no manifest instead of reporting it', async () => {
+        // An operator may legitimately keep other folders alongside their
+        // packages; those are not broken packages and must not generate noise.
+        const root = await scratch();
+        await makePackage(root, 'real');
+        await mkdir(join(root, 'notes'), { recursive: true });
+        await writeFile(join(root, 'notes', 'README.md'), '# not a package\n', 'utf8');
+        await writeFile(join(root, 'loose-file.txt'), 'x', 'utf8');
+
+        const scan = await scanLocalPackages(root);
+
+        expect(scan.candidates.map((c) => c.dirName)).toEqual(['real']);
+    });
+
+    it('reports a package whose manifest is fatally invalid, rather than hiding it', async () => {
+        // This one the operator MEANT to work, so silence would be wrong.
+        const root = await scratch();
+        await makePackage(root, 'good');
+        await makePackage(root, 'broken', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'Bad Name' },
+        });
+
+        const scan = await scanLocalPackages(root);
+
+        expect(scan.candidates.map((c) => c.dirName)).toEqual(['broken', 'good']);
+        const broken = scan.candidates.find((c) => c.dirName === 'broken');
+        expect(broken?.ok).toBe(false);
+        expect(broken?.name).toBeUndefined();
+        expect(broken?.summary.fatalCount).toBeGreaterThan(0);
+        expect(scan.candidates.find((c) => c.dirName === 'good')?.ok).toBe(true);
+    });
+
+    it('carries per-package findings through without interpreting them', async () => {
+        const root = await scratch();
+        await makePackage(root, 'noisy', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'noisy', unknownField: 1 },
+            skills: {
+                good: skill('good', 'Loads fine.'),
+                mismatched: skill('other', 'Name disagrees.'),
+            },
+        });
+
+        const scan = await scanLocalPackages(root);
+        const pkg = scan.candidates[0];
+
+        expect(pkg?.ok).toBe(true);
+        expect(pkg?.skillNames).toEqual(['good']);
+        expect(pkg?.findings.map((f) => f.code)).toEqual(
+            expect.arrayContaining(['manifest.unknown-field', 'skill.name-directory-mismatch']),
+        );
+    });
+
+    it('treats a missing directory as empty rather than as an error', async () => {
+        // The feature is off by default; a packages directory that has not been
+        // created yet means zero packages, not a broken deployment, and must
+        // never be able to stop the API booting.
+        const scan = await scanLocalPackages(join(await scratch(), 'never-created'));
+
+        expect(scan.unavailable).toBe(true);
+        expect(scan.unavailableReason).toContain('does not exist');
+        expect(scan.candidates).toEqual([]);
+    });
+
+    it('refuses a relative configured path', async () => {
+        const scan = await scanLocalPackages('./packages');
+
+        expect(scan.unavailable).toBe(true);
+        expect(scan.unavailableReason).toContain('absolute');
+    });
+
+    it('caps how many entries it examines, and says so', async () => {
+        const root = await scratch();
+        for (const name of ['a', 'b', 'c']) {
+            await makePackage(root, name);
+        }
+
+        const scan = await scanLocalPackages(root, { maxEntries: 2 });
+
+        expect(scan.candidates).toHaveLength(2);
+        expect(scan.unavailable).toBe(false);
+        // Truncation is reported. A silent cap would read as "you have two
+        // packages" to an operator who installed three.
+        expect(scan.unavailableReason).toContain('only the first 2');
+    });
+
+    it('defaults the cap to a sane ceiling', () => {
+        expect(DEFAULT_MAX_LOCAL_ENTRIES).toBe(200);
+    });
+
+    it('passes component support through to the loader', async () => {
+        const root = await scratch();
+        await makePackage(root, 'both', {
+            skills: { s: skill('s', 'A skill.') },
+            mcp: {
+                $schema: MCP_SCHEMA,
+                mcpServers: { api: { type: 'streamable-http', url: 'https://x.example.com/mcp' } },
+            },
+        });
+
+        const skillsOnly = await scanLocalPackages(root, {
+            load: { components: { skills: true, mcpServers: false } },
+        });
+
+        expect(skillsOnly.candidates[0]?.skillNames).toEqual(['s']);
+        expect(skillsOnly.candidates[0]?.mcpServerNames).toEqual([]);
+    });
+
+    it('returns candidates in a stable order regardless of filesystem iteration', async () => {
+        const root = await scratch();
+        for (const name of ['zulu', 'alpha', 'mike']) {
+            await makePackage(root, name);
+        }
+
+        const first = await scanLocalPackages(root);
+        const second = await scanLocalPackages(root);
+
+        expect(first.candidates.map((c) => c.dirName)).toEqual(['alpha', 'mike', 'zulu']);
+        expect(second.candidates.map((c) => c.dirName)).toEqual(
+            first.candidates.map((c) => c.dirName),
+        );
+    });
+
+    it('records the manifest version when the package declares one', async () => {
+        const root = await scratch();
+        await makePackage(root, 'versioned', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'versioned', version: '2.1.0' },
+        });
+        await makePackage(root, 'unversioned');
+
+        const scan = await scanLocalPackages(root);
+
+        expect(scan.candidates.find((c) => c.dirName === 'versioned')?.version).toBe('2.1.0');
+        // Absent is legal: the specification forbids rejecting a package for it.
+        expect(scan.candidates.find((c) => c.dirName === 'unversioned')?.version).toBeUndefined();
+    });
+
+    it('never throws for a package an author could plausibly write', async () => {
+        const root = await scratch();
+        await makePackage(root, 'invalid-json', { rawManifest: '{ "name": "broken", }' });
+        await makePackage(root, 'array-manifest', { rawManifest: '[]' });
+        await makePackage(root, 'empty-manifest', { rawManifest: '' });
+
+        await expect(scanLocalPackages(root)).resolves.toBeDefined();
+        const scan = await scanLocalPackages(root);
+        expect(scan.candidates).toHaveLength(3);
+        expect(scan.candidates.every((c) => !c.ok)).toBe(true);
+    });
+});
+
+describe('scanLocalSources', () => {
+    it('scans directories in order and lets the first definition of a name win', async () => {
+        const primary = await scratch();
+        const secondary = await scratch();
+        await makePackage(primary, 'shared', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'shared-tools' },
+        });
+        await makePackage(secondary, 'shared-copy', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'shared-tools' },
+        });
+        await makePackage(secondary, 'unique', {
+            manifest: { $schema: PLUGIN_SCHEMA, name: 'unique' },
+        });
+
+        const { scans, shadowed } = await scanLocalSources([primary, secondary]);
+
+        expect(scans).toHaveLength(2);
+        expect(scans[0]?.candidates.map((c) => c.name)).toEqual(['shared-tools']);
+        expect(scans[1]?.candidates.map((c) => c.name)).toEqual(['unique']);
+        expect(shadowed.map((c) => c.dirName)).toEqual(['shared-copy']);
+    });
+
+    it('does not deduplicate packages that failed to load, since they have no name', async () => {
+        const a = await scratch();
+        const b = await scratch();
+        await makePackage(a, 'broken', { manifest: { $schema: PLUGIN_SCHEMA, name: 'Bad Name' } });
+        await makePackage(b, 'broken', { manifest: { $schema: PLUGIN_SCHEMA, name: 'Bad Name' } });
+
+        const { scans, shadowed } = await scanLocalSources([a, b]);
+
+        expect(shadowed).toEqual([]);
+        expect(scans[0]?.candidates).toHaveLength(1);
+        expect(scans[1]?.candidates).toHaveLength(1);
+    });
+
+    it('tolerates an unavailable directory among available ones', async () => {
+        const good = await scratch();
+        await makePackage(good, 'real');
+
+        const { scans } = await scanLocalSources([join(good, 'missing'), good]);
+
+        expect(scans[0]?.unavailable).toBe(true);
+        expect(scans[1]?.candidates.map((c) => c.dirName)).toEqual(['real']);
+    });
+
+    it('returns nothing for an empty source list', async () => {
+        const { scans, shadowed } = await scanLocalSources([]);
+        expect(scans).toEqual([]);
+        expect(shadowed).toEqual([]);
+    });
+});
+
+describe('parsePackageDirs', () => {
+    it('returns nothing for an absent or empty value', () => {
+        expect(parsePackageDirs(undefined)).toEqual([]);
+        expect(parsePackageDirs('')).toEqual([]);
+        expect(parsePackageDirs('   ')).toEqual([]);
+    });
+
+    it('splits on commas and semicolons and trims', () => {
+        expect(parsePackageDirs('/a, /b ;/c')).toEqual(['/a', '/b', '/c']);
+    });
+
+    it('splits on the platform path delimiter', () => {
+        expect(parsePackageDirs(['/one', '/two'].join(delimiter))).toEqual(['/one', '/two']);
+    });
+
+    it('never splits a Windows drive letter', () => {
+        // `C:\packages` contains a colon, which is exactly why the Windows path
+        // delimiter is `;`. Splitting on a bare colon would turn one real path
+        // into two broken ones.
+        const parsed = parsePackageDirs('C:\\packages;D:\\more');
+        if (delimiter === ';') {
+            expect(parsed).toEqual(['C:\\packages', 'D:\\more']);
+        } else {
+            // On POSIX the semicolon still separates, and the drive-letter
+            // colons are not delimiters there either.
+            expect(parsed).toEqual(['C:\\packages', 'D:\\more']);
+        }
+    });
+
+    it('drops empty segments from a trailing or doubled separator', () => {
+        expect(parsePackageDirs('/a,,/b,')).toEqual(['/a', '/b']);
+    });
+});

--- a/packages/agent/src/agent-plugins/local-source.ts
+++ b/packages/agent/src/agent-plugins/local-source.ts
@@ -1,0 +1,246 @@
+/**
+ * The local-directory package source (US-1).
+ *
+ * A self-hosted operator points `AGENT_PLUGINS_DIR` at a folder; every
+ * immediate child of it that carries a `plugin.json` is an available Agent
+ * Plugins package. Packages are registered **in place** — nothing is copied,
+ * because the operator already controls these bytes.
+ *
+ * This module is deliberately free of NestJS, TypeORM and configuration: it
+ * takes directory paths and returns what it found. Policy — which sources an
+ * operator has enabled, what gets persisted, who may see it — belongs to the
+ * service above it, and keeping that out means this can be unit-tested against
+ * a real directory tree without a container.
+ *
+ * The scan is discovery only. It never installs, never writes, and never
+ * executes anything: it reads each candidate through the conformance library
+ * and reports what that library says.
+ */
+
+import { readdir } from 'node:fs/promises';
+import { delimiter, isAbsolute, join } from 'node:path';
+import {
+    loadPluginPackage,
+    MANIFEST_FILENAME,
+    summarizeLoad,
+    type Finding,
+    type LoadPluginPackageOptions,
+    type PackageLoadSummary,
+    type SpecVersion,
+} from '@ever-works/agent-plugins';
+
+/** One package found on disk, whether or not it turned out to be valid. */
+export interface LocalPackageCandidate {
+    /** The directory name under the scanned root, which is how an operator refers to it. */
+    readonly dirName: string;
+    /** Absolute, filesystem-resolved package root. */
+    readonly path: string;
+    /** True when the package loaded; false when its manifest was fatally invalid. */
+    readonly ok: boolean;
+    /** Manifest name, when the package loaded. Absent otherwise — a rejected package has no identity. */
+    readonly name?: string;
+    readonly version?: string;
+    readonly specVersion?: SpecVersion;
+    readonly skillNames: readonly string[];
+    readonly mcpServerNames: readonly string[];
+    readonly findings: readonly Finding[];
+    readonly summary: PackageLoadSummary;
+}
+
+/** Result of scanning one configured source directory. */
+export interface LocalSourceScan {
+    /** The directory that was scanned, as configured. */
+    readonly root: string;
+    /**
+     * True when the directory does not exist or could not be listed.
+     *
+     * Deliberately NOT an error: an operator who has not created the packages
+     * directory yet has zero packages, not a broken deployment. The feature is
+     * off by default and must never be able to stop the API from booting.
+     */
+    readonly unavailable: boolean;
+    /** Why it was unavailable, for a log line. Absent when the scan succeeded. */
+    readonly unavailableReason?: string;
+    readonly candidates: readonly LocalPackageCandidate[];
+}
+
+export interface ScanLocalPackagesOptions {
+    /** Passed through to the conformance library — component types and transports this client supports. */
+    readonly load?: LoadPluginPackageOptions;
+    /**
+     * Cap on how many child directories are examined, newest-agnostic and
+     * purely defensive: a mis-set `AGENT_PLUGINS_DIR` pointing at, say, a home
+     * directory should not turn a boot into a filesystem walk of thousands of
+     * entries. Exceeding it is reported, never silent.
+     */
+    readonly maxEntries?: number;
+}
+
+/** Default ceiling on child directories examined in one scan. */
+export const DEFAULT_MAX_LOCAL_ENTRIES = 200;
+
+/**
+ * Scans one directory for Agent Plugins packages.
+ *
+ * Every immediate child directory is a candidate; a child without a
+ * `plugin.json` is not a package and is skipped silently, because an operator
+ * may legitimately keep other things alongside. A child WITH a manifest that
+ * fails to load is reported with its findings, because that is a package the
+ * operator meant to work.
+ */
+export async function scanLocalPackages(
+    root: string,
+    options?: ScanLocalPackagesOptions,
+): Promise<LocalSourceScan> {
+    if (!isAbsolute(root)) {
+        return {
+            root,
+            unavailable: true,
+            unavailableReason: 'the configured packages directory must be an absolute path',
+            candidates: [],
+        };
+    }
+
+    let entries;
+    try {
+        entries = await readdir(root, { withFileTypes: true });
+    } catch (error) {
+        const code = (error as NodeJS.ErrnoException)?.code;
+        return {
+            root,
+            unavailable: true,
+            unavailableReason:
+                code === 'ENOENT'
+                    ? 'the configured packages directory does not exist'
+                    : `the configured packages directory could not be read: ${error instanceof Error ? error.message : String(error)}`,
+            candidates: [],
+        };
+    }
+
+    const limit = options?.maxEntries ?? DEFAULT_MAX_LOCAL_ENTRIES;
+    const directories = entries.filter((entry) => entry.isDirectory() || entry.isSymbolicLink());
+    const examined = directories.slice(0, limit);
+
+    const candidates: LocalPackageCandidate[] = [];
+    for (const entry of examined) {
+        const candidatePath = join(root, entry.name);
+
+        // A directory with no manifest is not a package at all. Reading the
+        // listing is cheaper than a full load and keeps unrelated folders out
+        // of the findings an operator has to read.
+        let childNames: string[];
+        try {
+            childNames = await readdir(candidatePath);
+        } catch {
+            continue;
+        }
+        if (!childNames.includes(MANIFEST_FILENAME)) {
+            continue;
+        }
+
+        const result = await loadPluginPackage(candidatePath, options?.load);
+        const summary = summarizeLoad(result);
+
+        candidates.push(
+            result.ok
+                ? {
+                      dirName: entry.name,
+                      path: result.root,
+                      ok: true,
+                      name: result.manifest.name,
+                      ...(result.manifest.version === undefined
+                          ? {}
+                          : { version: result.manifest.version }),
+                      specVersion: result.specVersion,
+                      skillNames: result.skills.map((skill) => skill.name),
+                      mcpServerNames: result.mcpServers.map((server) => server.name),
+                      findings: result.findings,
+                      summary,
+                  }
+                : {
+                      dirName: entry.name,
+                      path: result.root,
+                      ok: false,
+                      skillNames: [],
+                      mcpServerNames: [],
+                      findings: result.findings,
+                      summary,
+                  },
+        );
+    }
+
+    // Stable ordering so a catalog built from this does not reshuffle between
+    // boots on filesystems with different directory iteration order.
+    candidates.sort((a, b) => (a.dirName < b.dirName ? -1 : a.dirName > b.dirName ? 1 : 0));
+
+    return directories.length > limit
+        ? {
+              root,
+              unavailable: false,
+              unavailableReason: `the directory holds ${directories.length} entries; only the first ${limit} were examined`,
+              candidates,
+          }
+        : { root, unavailable: false, candidates };
+}
+
+/**
+ * Scans several configured directories in order.
+ *
+ * When two directories offer a package with the same manifest `name`, the
+ * FIRST one wins and the later one is reported as shadowed. First-wins matches
+ * how the skills catalog already resolves duplicate slugs, so an operator who
+ * learns the rule once knows it everywhere.
+ */
+export async function scanLocalSources(
+    roots: readonly string[],
+    options?: ScanLocalPackagesOptions,
+): Promise<{ scans: readonly LocalSourceScan[]; shadowed: readonly LocalPackageCandidate[] }> {
+    const scans: LocalSourceScan[] = [];
+    const seen = new Set<string>();
+    const shadowed: LocalPackageCandidate[] = [];
+
+    for (const root of roots) {
+        const scan = await scanLocalPackages(root, options);
+        const kept: LocalPackageCandidate[] = [];
+        for (const candidate of scan.candidates) {
+            if (candidate.ok && candidate.name !== undefined) {
+                if (seen.has(candidate.name)) {
+                    shadowed.push(candidate);
+                    continue;
+                }
+                seen.add(candidate.name);
+            }
+            kept.push(candidate);
+        }
+        scans.push({ ...scan, candidates: kept });
+    }
+
+    return { scans, shadowed };
+}
+
+/**
+ * Splits a configured directory list into paths.
+ *
+ * Separators are a comma, a semicolon, and the platform's own path delimiter.
+ * Note what is NOT a separator on Windows: a bare colon. `delimiter` is `;`
+ * there precisely because `C:\packages` contains one, and splitting on `:`
+ * unconditionally would turn a single Windows path into two broken ones.
+ */
+export function parsePackageDirs(value: string | undefined): string[] {
+    if (!value) {
+        return [];
+    }
+    const separators = new Set([',', ';', delimiter]);
+    const parts: string[] = [];
+    let current = '';
+    for (const char of value) {
+        if (separators.has(char)) {
+            parts.push(current);
+            current = '';
+            continue;
+        }
+        current += char;
+    }
+    parts.push(current);
+    return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}

--- a/packages/agent/src/agent-plugins/local-source.ts
+++ b/packages/agent/src/agent-plugins/local-source.ts
@@ -233,11 +233,30 @@ export function parsePackageDirs(value: string | undefined): string[] {
     const separators = new Set([',', ';', delimiter]);
     const parts: string[] = [];
     let current = '';
-    for (const char of value) {
+    for (let i = 0; i < value.length; i += 1) {
+        const char = value[i];
         if (separators.has(char)) {
-            parts.push(current);
-            current = '';
-            continue;
+            // A drive-letter colon belongs to the path on EVERY platform.
+            //
+            // On Windows this never fires: `delimiter` is `;` there, so `:`
+            // is not in `separators` at all. It bites on POSIX, where
+            // `delimiter` IS `:` — a container or CI host reading a value
+            // authored on Windows would otherwise turn `C:\packages` into
+            // `C` and `\packages`, and then scan two directories that do
+            // not exist instead of reporting the one that does.
+            //
+            // Deliberately requires a BACKSLASH after the colon rather than
+            // any slash: on POSIX a list like `a:/b` is two real paths, and
+            // treating that as a drive letter would silently merge them. A
+            // Windows-authored path always uses `\`, so this keeps the
+            // POSIX meaning intact.
+            const isDriveLetterColon =
+                char === ':' && /^[A-Za-z]$/.test(current) && value[i + 1] === '\\';
+            if (!isDriveLetterColon) {
+                parts.push(current);
+                current = '';
+                continue;
+            }
         }
         current += char;
     }

--- a/packages/agent/src/agent-plugins/package-catalog.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-catalog.service.spec.ts
@@ -1,0 +1,302 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentPluginPackageCatalogService } from './package-catalog.service';
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+
+const options = { facadeOptions: { userId: 'user-1' } } as never;
+
+async function packagesRoot(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'agent-plugins-catalog-'));
+}
+
+async function writePackage(
+    root: string,
+    dirName: string,
+    manifest: Record<string, unknown>,
+    skills: Record<string, string> = {},
+): Promise<void> {
+    const dir = join(root, dirName);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify(manifest), 'utf8');
+    for (const [name, body] of Object.entries(skills)) {
+        await mkdir(join(dir, 'skills', name), { recursive: true });
+        await writeFile(join(dir, 'skills', name, 'SKILL.md'), body, 'utf8');
+    }
+}
+
+const skillFile = (name: string, description: string, extra = ''): string =>
+    `---\nname: ${name}\ndescription: ${description}\n${extra}---\n\n# ${name}\n\nBody text.\n`;
+
+describe('AgentPluginPackageCatalogService', () => {
+    const originalEnv = process.env;
+    let service: AgentPluginPackageCatalogService;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.AGENT_PLUGINS_DIR;
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+        service = new AgentPluginPackageCatalogService();
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('returns nothing at all when the feature is off', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                deploy: skillFile('deploy', 'Deploy a service.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+        process.env.FEATURE_AGENT_PLUGINS = 'false';
+
+        await expect(service.listEntries(options)).resolves.toEqual([]);
+        await expect(service.getEntry('deploy', options)).resolves.toBeNull();
+    });
+
+    it('maps a package skill into a catalog entry with provenance', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'acme.tools', version: '2.1.0' },
+            { deploy: skillFile('deploy', 'Deploy a service. Use when shipping.') },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const entries = await service.listEntries(options);
+
+        expect(entries).toHaveLength(1);
+        expect(entries[0]).toMatchObject({
+            slug: 'deploy',
+            description: 'Deploy a service. Use when shipping.',
+            version: '2.1.0',
+            packageName: 'acme.tools',
+            packageVersion: '2.1.0',
+            sourceKind: 'local',
+        });
+        expect(entries[0]?.body).toContain('Body text.');
+    });
+
+    it('keeps provenance OUT of frontmatter', async () => {
+        // `installFromCatalog` writes frontmatter verbatim into the stored
+        // Skill row, and that JSON is injected into the model's context.
+        // Provenance is for the operator reading a catalog card, not the model
+        // reading a skill.
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                deploy: skillFile('deploy', 'Deploy a service.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const [entry] = await service.listEntries(options);
+
+        expect(entry?.frontmatter).not.toHaveProperty('packageName');
+        expect(entry?.frontmatter).not.toHaveProperty('sourceKind');
+        expect(Object.keys(entry?.frontmatter ?? {}).sort()).toEqual(['description', 'name']);
+    });
+
+    it('tokenizes allowed-tools at ingest, into the platform shape', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                deploy: skillFile('deploy', 'Deploy.', 'allowed-tools: Bash(git:*) Read\n'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const [entry] = await service.listEntries(options);
+
+        // The specification's wire form is one space-separated string; the
+        // platform works in tokens.
+        expect(entry?.frontmatter.allowedTools).toEqual(['Bash(git:*)', 'Read']);
+    });
+
+    it('never emits a version longer than the storage column allows', async () => {
+        // `skills.sourceCatalogVersion` is varchar(16). A version that
+        // overflows it passes every test in this package and then throws at
+        // INSERT the first time somebody clicks Install.
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'unversioned',
+            { $schema: PLUGIN_SCHEMA, name: 'unversioned' },
+            { a: skillFile('a', 'No package version at all.') },
+        );
+        await writePackage(
+            root,
+            'overlong',
+            {
+                $schema: PLUGIN_SCHEMA,
+                name: 'overlong',
+                version: '1.0.0-rc.1+build.20260903.deadbeef',
+            },
+            { b: skillFile('b', 'A very long version string.') },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const entries = await service.listEntries(options);
+
+        expect(entries).toHaveLength(2);
+        for (const entry of entries) {
+            expect(entry.version.length).toBeLessThanOrEqual(
+                AgentPluginPackageCatalogService.MAX_VERSION_LENGTH,
+            );
+            expect(entry.version.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('synthesizes a stable version for a package that declares none', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                deploy: skillFile('deploy', 'Deploy.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const first = await service.listEntries(options);
+        const second = await service.listEntries(options);
+
+        // Absent is legal — the specification forbids rejecting a package for
+        // it — so the catalog's required version has to come from somewhere,
+        // and it must not change between two reads of the same package.
+        expect(first[0]?.version).toBe(second[0]?.version);
+    });
+
+    it('skips a package whose manifest is invalid, keeping the rest', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'good',
+            { $schema: PLUGIN_SCHEMA, name: 'good' },
+            {
+                works: skillFile('works', 'This one loads.'),
+            },
+        );
+        await writePackage(
+            root,
+            'broken',
+            { $schema: PLUGIN_SCHEMA, name: 'Bad Name' },
+            {
+                hidden: skillFile('hidden', 'Never reaches the catalog.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const entries = await service.listEntries(options);
+
+        expect(entries.map((e) => e.slug)).toEqual(['works']);
+    });
+
+    it('filters by tag and by search text', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                deploy: skillFile('deploy', 'Ship a service.', 'tags:\n  - ops\n'),
+                summarise: skillFile('summarise', 'Condense a document.', 'tags:\n  - writing\n'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const byTag = await service.listEntries({ ...(options as object), tags: ['ops'] } as never);
+        expect(byTag.map((e) => e.slug)).toEqual(['deploy']);
+
+        const bySearch = await service.listEntries({
+            ...(options as object),
+            search: 'condense',
+        } as never);
+        expect(bySearch.map((e) => e.slug)).toEqual(['summarise']);
+    });
+
+    it('returns entries in a stable order', async () => {
+        const root = await packagesRoot();
+        await writePackage(
+            root,
+            'tools',
+            { $schema: PLUGIN_SCHEMA, name: 'tools' },
+            {
+                zulu: skillFile('zulu', 'Last alphabetically.'),
+                alpha: skillFile('alpha', 'First alphabetically.'),
+            },
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const entries = await service.listEntries(options);
+
+        expect(entries.map((e) => e.slug)).toEqual(['alpha', 'zulu']);
+    });
+
+    describe('getEntry', () => {
+        it('agrees with listEntries about slugs', async () => {
+            // If the two disagreed, the catalog would show a card whose
+            // Install button 404s.
+            const root = await packagesRoot();
+            await writePackage(
+                root,
+                'tools',
+                { $schema: PLUGIN_SCHEMA, name: 'tools' },
+                {
+                    deploy: skillFile('deploy', 'Deploy a service.'),
+                },
+            );
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            const listed = await service.listEntries(options);
+            for (const entry of listed) {
+                const found = await service.getEntry(entry.slug, options);
+                expect(found?.entry.slug).toBe(entry.slug);
+                expect(found?.providerId).toBe('agent-plugins');
+            }
+        });
+
+        it('ignores the caller filters, so a filtered view can still install', async () => {
+            const root = await packagesRoot();
+            await writePackage(
+                root,
+                'tools',
+                { $schema: PLUGIN_SCHEMA, name: 'tools' },
+                {
+                    deploy: skillFile('deploy', 'Ship a service.', 'tags:\n  - ops\n'),
+                },
+            );
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            const found = await service.getEntry('deploy', {
+                ...(options as object),
+                tags: ['something-else'],
+            } as never);
+
+            expect(found?.entry.slug).toBe('deploy');
+        });
+
+        it('returns null for an unknown slug', async () => {
+            const root = await packagesRoot();
+            await writePackage(root, 'tools', { $schema: PLUGIN_SCHEMA, name: 'tools' });
+            process.env.AGENT_PLUGINS_DIR = root;
+
+            await expect(service.getEntry('nope', options)).resolves.toBeNull();
+        });
+    });
+});

--- a/packages/agent/src/agent-plugins/package-catalog.service.ts
+++ b/packages/agent/src/agent-plugins/package-catalog.service.ts
@@ -1,0 +1,182 @@
+import { createHash } from 'node:crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import type { SkillCatalogEntry, SkillFrontmatter } from '@ever-works/plugin';
+import type { DiscoveredSkill } from '@ever-works/agent-plugins';
+import { discoverSkills } from '@ever-works/agent-plugins';
+import { loadedPackages, scanConfiguredPackages } from './configured-source';
+import type { LocalPackageCandidate } from './local-source';
+import {
+    AGENT_PLUGIN_PROVIDER_ID,
+    type AgentPluginSkillSource,
+    type AgentPluginSkillSourceOptions,
+} from './skill-source.token';
+
+/**
+ * Turns installed Agent Plugins packages into skills-catalog entries.
+ *
+ * This is the bridge between two vocabularies: the specification's package
+ * of `SKILL.md` files, and Ever Works' `SkillCatalogEntry`. Everything the
+ * specification decides — what a valid skill is, which ones to skip, what
+ * `allowed-tools` means — is decided by the conformance library; this class
+ * only translates.
+ *
+ * One translation is load-bearing and easy to get wrong: `version`. The
+ * catalog requires it, packages need not declare it (the specification
+ * explicitly forbids rejecting a package for that), and the column it
+ * eventually lands in — `skills.sourceCatalogVersion` — is **varchar(16)**.
+ * A content-hash-derived version that is not truncated passes every test in
+ * this package and then throws at INSERT the first time somebody clicks
+ * Install.
+ */
+@Injectable()
+export class AgentPluginPackageCatalogService implements AgentPluginSkillSource {
+    private readonly logger = new Logger(AgentPluginPackageCatalogService.name);
+
+    /**
+     * Hard ceiling matching `skills.sourceCatalogVersion`'s column width.
+     * Not a style choice — exceeding it is a runtime INSERT failure.
+     */
+    static readonly MAX_VERSION_LENGTH = 16;
+
+    async listEntries(options: AgentPluginSkillSourceOptions): Promise<SkillCatalogEntry[]> {
+        const scan = await scanConfiguredPackages();
+        if (!scan.enabled) {
+            return [];
+        }
+
+        const entries: SkillCatalogEntry[] = [];
+        for (const pkg of loadedPackages(scan)) {
+            for (const skill of await this.readSkills(pkg)) {
+                entries.push(this.toEntry(pkg, skill));
+            }
+        }
+
+        const filtered = this.applyFilters(entries, options);
+        // Stable ordering, so paging through the catalog is deterministic.
+        filtered.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+        return filtered;
+    }
+
+    async getEntry(
+        slug: string,
+        options: AgentPluginSkillSourceOptions,
+    ): Promise<{ entry: SkillCatalogEntry; providerId: string } | null> {
+        // Deliberately routed through the same construction as `listEntries`
+        // rather than a separate lookup: if the two ever disagreed about
+        // slugs, the catalog would show a card whose Install button 404s.
+        const entries = await this.listEntries({ ...options, tags: undefined, search: undefined });
+        const entry = entries.find((candidate) => candidate.slug === slug);
+        return entry ? { entry, providerId: AGENT_PLUGIN_PROVIDER_ID } : null;
+    }
+
+    /**
+     * Re-reads a package's skills from disk.
+     *
+     * The scan records skill NAMES but not bodies, because a catalog listing
+     * needs names far more often than it needs 64KB of markdown per skill.
+     */
+    private async readSkills(pkg: LocalPackageCandidate): Promise<DiscoveredSkill[]> {
+        if (pkg.skillNames.length === 0) {
+            return [];
+        }
+        try {
+            const result = await discoverSkills(pkg.path);
+            return [...result.skills];
+        } catch (error) {
+            // A package that vanished between scan and read is not an error
+            // worth failing a catalog request over.
+            this.logger.warn(
+                `Agent Plugins package "${pkg.name ?? pkg.dirName}" could not be re-read: ${
+                    error instanceof Error ? error.message : error
+                }`,
+            );
+            return [];
+        }
+    }
+
+    private toEntry(pkg: LocalPackageCandidate, skill: DiscoveredSkill): SkillCatalogEntry {
+        const frontmatter: SkillFrontmatter = {
+            ...skill.frontmatter,
+            name: skill.frontmatter.name,
+            description: skill.frontmatter.description,
+        };
+        if (skill.allowedTools !== undefined) {
+            // The specification's wire form is a space-separated string; the
+            // platform works in tokens. Converted HERE, at ingest, and
+            // nowhere else — a global normalizer would change how existing
+            // skills are filtered by tool grants at run time.
+            frontmatter.allowedTools = [...skill.allowedTools];
+        }
+
+        const entry: SkillCatalogEntry = {
+            slug: skill.name,
+            title: skill.name,
+            description: skill.frontmatter.description,
+            frontmatter,
+            body: skill.body,
+            version: this.entryVersion(pkg),
+            tags: this.entryTags(skill),
+            sourceKind: 'local',
+        };
+        if (pkg.name !== undefined) {
+            entry.packageName = pkg.name;
+        }
+        if (pkg.version !== undefined) {
+            entry.packageVersion = pkg.version;
+        }
+        return entry;
+    }
+
+    /**
+     * The catalog's required `version` for a package skill.
+     *
+     * A declared package version when there is one; otherwise a short hash of
+     * the package identity, so the value still CHANGES when the package does
+     * and update detection has something to compare. Always truncated to the
+     * storage width.
+     */
+    private entryVersion(pkg: LocalPackageCandidate): string {
+        const declared = pkg.version?.trim();
+        if (declared) {
+            return declared.slice(0, AgentPluginPackageCatalogService.MAX_VERSION_LENGTH);
+        }
+        const digest = createHash('sha256')
+            .update(`${pkg.name ?? pkg.dirName}:${pkg.path}`)
+            .digest('hex');
+        return `0.0.0+${digest}`.slice(0, AgentPluginPackageCatalogService.MAX_VERSION_LENGTH);
+    }
+
+    private entryTags(skill: DiscoveredSkill): string[] {
+        const raw = skill.frontmatter['tags'];
+        if (!Array.isArray(raw)) {
+            return [];
+        }
+        return raw.filter((tag): tag is string => typeof tag === 'string');
+    }
+
+    private applyFilters(
+        entries: SkillCatalogEntry[],
+        options: AgentPluginSkillSourceOptions,
+    ): SkillCatalogEntry[] {
+        let result = entries;
+
+        if (options.tags && options.tags.length > 0) {
+            const wanted = new Set(options.tags.map((tag) => tag.toLowerCase()));
+            result = result.filter((entry) =>
+                entry.tags.some((tag) => wanted.has(tag.toLowerCase())),
+            );
+        }
+
+        if (options.search && options.search.trim().length > 0) {
+            const needle = options.search.trim().toLowerCase();
+            result = result.filter(
+                (entry) =>
+                    entry.slug.toLowerCase().includes(needle) ||
+                    entry.title.toLowerCase().includes(needle) ||
+                    entry.description.toLowerCase().includes(needle),
+            );
+        }
+
+        return result;
+    }
+}

--- a/packages/agent/src/agent-plugins/skill-source.token.ts
+++ b/packages/agent/src/agent-plugins/skill-source.token.ts
@@ -1,0 +1,58 @@
+import type { FacadeOptions, SkillCatalogEntry } from '@ever-works/plugin';
+
+/**
+ * The seam by which Agent Plugins packages contribute to the skills catalog.
+ *
+ * A token rather than a direct import, and a leaf file with type-only imports,
+ * for three reasons that each bit someone before:
+ *
+ * 1. `SkillsFacadeService` must behave **identically** when nothing is bound.
+ *    An `@Optional()` token gives that for free; a direct dependency would
+ *    make the facade require a module it does not need.
+ * 2. Binding the implementation into the `FACADES` provider array would turn
+ *    `facades.module.spec.ts` red — it asserts that array's length exactly.
+ *    A token bound by its own leaf module extends only `imports`, which is
+ *    asserted by containment.
+ * 3. Type-only imports keep this file out of the dependency cycle that
+ *    concrete imports between facades and feature modules would create.
+ *
+ * The implementation lives in the agent-plugins module and is deliberately
+ * NOT a native plugin: plugins are instantiated bare with no repository
+ * access, and the skills-provider capability is scope-blind, so a plugin
+ * could neither read a tenant-scoped registry nor scope it.
+ */
+export const AGENT_PLUGIN_SKILL_SOURCE = 'AGENT_PLUGIN_SKILL_SOURCE' as const;
+
+/**
+ * What the facade asks of a package source.
+ *
+ * Note both methods exist. `listEntries` and `getEntry` are separate code
+ * paths in the facade, and wiring only the first produces a catalog card
+ * whose Install button 404s — the install route resolves through `getEntry`.
+ */
+export interface AgentPluginSkillSource {
+    /**
+     * Every skill from every installed package, already shaped as catalog
+     * entries. Returns an empty array when the feature is off.
+     *
+     * The facade merges these LAST, so the existing first-wins slug dedupe
+     * guarantees a package can never displace a provider plugin's entry.
+     */
+    listEntries(options: AgentPluginSkillSourceOptions): Promise<SkillCatalogEntry[]>;
+
+    /** One entry by slug, or null. Must agree with `listEntries` about slugs. */
+    getEntry(
+        slug: string,
+        options: AgentPluginSkillSourceOptions,
+    ): Promise<{ entry: SkillCatalogEntry; providerId: string } | null>;
+}
+
+/** Scope and filters passed through from the facade call. */
+export interface AgentPluginSkillSourceOptions {
+    readonly facadeOptions: FacadeOptions;
+    readonly tags?: string[];
+    readonly search?: string;
+}
+
+/** Provider id reported for package-sourced entries, so install can route back here. */
+export const AGENT_PLUGIN_PROVIDER_ID = 'agent-plugins' as const;

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -909,6 +909,7 @@ describe('agent/config', () => {
                 // PR #1019 — Agents/Skills/Tasks feature added `agents.*`
                 // config group (heartbeat dispatcher gates, stuck-timeout,
                 // max batch size, etc.). Pinned alphabetically here.
+                'agentPlugins',
                 'agents',
                 'billing',
                 'branding',
@@ -974,6 +975,56 @@ describe('agent/config', () => {
                 'trigger',
                 'websiteTemplate',
             ]);
+        });
+    });
+
+    describe('agentPlugins', () => {
+        describe('isEnabled', () => {
+            it('is false when unset, so every existing deployment is unaffected', () => {
+                expect(config.agentPlugins.isEnabled()).toBe(false);
+            });
+
+            it('is true only for an explicit "true", case-insensitively', () => {
+                process.env.FEATURE_AGENT_PLUGINS = 'true';
+                expect(config.agentPlugins.isEnabled()).toBe(true);
+                process.env.FEATURE_AGENT_PLUGINS = 'TRUE';
+                expect(config.agentPlugins.isEnabled()).toBe(true);
+                process.env.FEATURE_AGENT_PLUGINS = 'True';
+                expect(config.agentPlugins.isEnabled()).toBe(true);
+            });
+
+            it.each(['false', '1', 'yes', 'on', '', '  '])(
+                'is false for %j, which is not the word true',
+                (value) => {
+                    process.env.FEATURE_AGENT_PLUGINS = value;
+                    expect(config.agentPlugins.isEnabled()).toBe(false);
+                },
+            );
+        });
+
+        describe('getPackageDirs', () => {
+            it('defaults to a path of its own, never /app/plugins', () => {
+                // /app/plugins holds the native plugins baked into the image.
+                // Pointing this there — or mounting a volume over it — once
+                // took out every AI, search and deploy capability in
+                // production, because the loader then discovered zero plugins.
+                expect(config.agentPlugins.getPackageDirs()).toBe('/app/agent-plugins');
+                expect(config.agentPlugins.getPackageDirs()).not.toBe('/app/plugins');
+            });
+
+            it('returns an explicitly configured value', () => {
+                process.env.AGENT_PLUGINS_DIR = '/srv/packages';
+                expect(config.agentPlugins.getPackageDirs()).toBe('/srv/packages');
+            });
+
+            it('falls back to the default for an EMPTY value, not through it', () => {
+                // This is why the getter uses `||` rather than `??`. envsubst
+                // renders a variable that a manifest references but the deploy
+                // workflow never exports as an empty string, and `??` would
+                // pass that straight through as if an operator had chosen it.
+                process.env.AGENT_PLUGINS_DIR = '';
+                expect(config.agentPlugins.getPackageDirs()).toBe('/app/agent-plugins');
+            });
         });
     });
 });

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -869,6 +869,51 @@ export const config = {
         },
     },
 
+    /**
+     * Agent Plugins standard interop — support for the open, cross-vendor
+     * package format at <https://github.com/agentplugins/agent-plugins-spec>.
+     *
+     * Lives HERE, in the agent package, rather than in `apps/api`'s config,
+     * and that is not a stylistic choice: the first consumer is
+     * `SkillsFacadeService` in `packages/agent/src/facades/`, which has no
+     * import path to `apps/api`. Putting the flag in the API-tier constants
+     * would strand it from its own reader.
+     */
+    agentPlugins: {
+        /**
+         * Master switch. Default `false`, so every existing deployment keeps
+         * behaving exactly as it does today: no package registry is read, no
+         * additional catalog source is consulted, nothing changes.
+         */
+        isEnabled() {
+            return (process.env.FEATURE_AGENT_PLUGINS ?? 'false').toLowerCase() === 'true';
+        },
+
+        /**
+         * Directories scanned for locally-installed packages.
+         *
+         * Three deliberate decisions:
+         *
+         * 1. `||`, not `??`. `envsubst` renders a variable that a manifest
+         *    references but the deploy workflow does not export as an EMPTY
+         *    STRING, and `??` passes an empty string straight through as if
+         *    it were a real value. `||` falls back to the default, which is
+         *    what an operator means by "I did not set this".
+         * 2. The default is NOT `/app/plugins`. That path holds the ~66
+         *    native plugins baked into the image, and an emptyDir mounted
+         *    over it once took out every AI, search and deploy capability in
+         *    production because the loader then discovered zero plugins.
+         * 3. Nothing creates the default directory — no Dockerfile mkdir, no
+         *    volume mount. It will not exist on any current deployment, so
+         *    the scanner treats a missing directory as an empty registry
+         *    rather than an error. Turning this flag on must never be able to
+         *    fail a boot.
+         */
+        getPackageDirs(): string {
+            return process.env.AGENT_PLUGINS_DIR || '/app/agent-plugins';
+        },
+    },
+
     // EW-120 Activity Feed pull-mode plumbing — per-Work HMAC secret is
     // encrypted at rest with this key. AES-256-GCM expects a 32-byte key;
     // the consumer service decodes hex / base64 / utf8 in that order.

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -152,6 +152,8 @@ import { WorkflowRun } from '../entities/workflow-run.entity';
 import { Environment } from '../entities/environment.entity';
 import { MemoryFolder } from '../entities/memory-folder.entity';
 // Repository registry (Feature G)
+import { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+import { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
 import { RepoConnection } from '../entities/repo-connection.entity';
 import { AgentRepoAttachment } from '../entities/agent-repo-attachment.entity';
 
@@ -381,6 +383,8 @@ export const ENTITIES = [
     MemoryFolder,
     // Repository registry (Feature G) — account-level repo records plus
     // the Agent → repo grant edge rows.
+    AgentPluginPackage,
+    AgentPluginPackageAllowlist,
     RepoConnection,
     AgentRepoAttachment,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -43,6 +43,8 @@
  */
 
 export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
+    'AgentPluginPackage',
+    'AgentPluginPackageAllowlist',
     'ActivityLog',
     // Agents/Skills/Tasks (PR #1019) ──
     'Agent',

--- a/packages/agent/src/entities/agent-plugin-package-allowlist.entity.ts
+++ b/packages/agent/src/entities/agent-plugin-package-allowlist.entity.ts
@@ -1,0 +1,76 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Which remotely-fetched Agent Plugins packages an operator permits.
+ *
+ * Deliberately a **separate table** from `plugin_allowlist`, and the reason is
+ * worth stating plainly: a row in `plugin_allowlist` authorises installing
+ * **executable code** into the platform process. A row here authorises
+ * fetching an **inert data package**. Those are different powers with
+ * different blast radii, and letting one table grant both would mean the
+ * safer decision silently carries the more dangerous one.
+ *
+ * Only `git` and `npm` are gated. A `local` package is already inside a
+ * directory the operator configured and controls, so an allowlist would be
+ * asking permission for bytes they put there themselves.
+ *
+ * Global (Tier D), like its sibling: this is a deployment-operator decision,
+ * not a tenant one.
+ */
+
+/** Remote sources that require an allowlist entry. */
+export type AgentPluginPackageAllowlistSource = 'git' | 'npm';
+
+@Entity({ name: 'agent_plugin_package_allowlist' })
+@Index('uq_agent_plugin_allowlist_name_source', ['packageName', 'source'], { unique: true })
+export class AgentPluginPackageAllowlist {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /**
+     * The npm package name, or the git URL, that is permitted.
+     *
+     * Matched BEFORE any network call is made — an entry is permission to
+     * fetch, so checking it after downloading would defeat the purpose.
+     */
+    @Column({ type: 'varchar', length: 2048 })
+    packageName: string;
+
+    @Column({ type: 'varchar', length: 16 })
+    source: AgentPluginPackageAllowlistSource;
+
+    /**
+     * Permitted versions, as a semver range for npm or a ref pattern for git.
+     * Null means any version of an otherwise-permitted package.
+     */
+    @Column({ type: 'varchar', length: 256, nullable: true })
+    versionRange?: string | null;
+
+    /** Expected sha512 (npm) or commit (git), when the operator pins one exactly. */
+    @Column({ type: 'varchar', length: 256, nullable: true })
+    integrity?: string | null;
+
+    /**
+     * Lets an operator revoke permission without losing the row, so the
+     * reason it existed is still visible.
+     */
+    @Column({ type: 'boolean', default: true })
+    enabled: boolean;
+
+    /** Why this entry exists — an audit note for the next operator. */
+    @Column({ type: 'text', nullable: true })
+    notes?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/agent-plugin-package.entity.ts
+++ b/packages/agent/src/entities/agent-plugin-package.entity.ts
@@ -1,0 +1,175 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { PortableDateColumn } from './_types';
+
+/**
+ * An installed **Agent Plugins** package — the open, cross-vendor package
+ * format defined at <https://github.com/agentplugins/agent-plugins-spec>.
+ *
+ * This is emphatically NOT the native Ever Works plugin table. The two are
+ * different species and the tables stay distinct on purpose:
+ *
+ * | | `plugins` (native) | `agent_plugin_packages` (this) |
+ * | - | - | - |
+ * | Contents | executable TypeScript, `import()`-ed | inert data: a manifest, markdown skills, MCP configs |
+ * | Manifest | `everworks.plugin` in `package.json` | `plugin.json`, a closed schema |
+ * | Trust | code runs in-process | data is safe to parse; only stdio MCP servers execute, behind ADR-018's gate |
+ * | Scope | deployment-wide | per tenant/organization |
+ *
+ * Confusing them is the one mistake with real consequences here, which is
+ * also why `agent_plugin_package_allowlist` is a separate table from
+ * `plugin_allowlist`: a row in the latter authorises installing **code**.
+ */
+
+/** Where a package's bytes came from. */
+export type AgentPluginPackageSource = 'local' | 'git' | 'npm';
+
+/**
+ * Install lifecycle, mirroring the native plugin table's vocabulary so an
+ * operator reading both sees the same words.
+ *
+ * - `available` — discovered and validated, but not registered for use.
+ * - `installed` — registered; its skills reach the catalog.
+ * - `failed`    — acquisition or validation failed; see `installError`.
+ */
+export type AgentPluginPackageInstallState = 'available' | 'installed' | 'failed';
+
+/**
+ * One finding recorded against a package at validation time, mirroring the
+ * conformance library's `Finding` shape.
+ *
+ * Stored rather than recomputed so the install UI can explain WHY a skill or
+ * an MCP server is missing without re-reading the package from disk — and so
+ * the explanation survives the package becoming unreadable.
+ */
+export interface AgentPluginPackageFinding {
+    readonly code: string;
+    readonly severity: 'fatal' | 'error' | 'warning';
+    readonly scope: string;
+    readonly message: string;
+    readonly subject?: string;
+    readonly at?: string;
+}
+
+@Entity({ name: 'agent_plugin_packages' })
+// A package name is unique per owner: two tenants may each install a package
+// called `acme.tools`, and one tenant may not install it twice.
+@Index('uq_agent_plugin_package_user_name', ['userId', 'name'], { unique: true })
+@Index('idx_agent_plugin_package_user', ['userId'])
+@Index('idx_agent_plugin_package_state', ['installState'])
+export class AgentPluginPackage {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    // EW-651/657 Tier A scope denormalization. No @ManyToOne — the no-cycle
+    // rule for scope entities (see user.entity.ts EW-654), and deliberately
+    // no XOR CHECK: ScopeStampingSubscriber populates BOTH columns on insert,
+    // so a XOR constraint would abort the migration on ordinary data.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    /**
+     * The manifest `name`, which is the package's identity across every
+     * conformant client. Spec section 5.5 caps it at 64 characters; the column
+     * is wider so a future release relaxing that does not need a migration.
+     */
+    @Column({ type: 'varchar', length: 120 })
+    name: string;
+
+    /**
+     * The manifest `version`, when the package declares one.
+     *
+     * Nullable on purpose: the specification forbids a client to reject a
+     * package for a missing or non-semver version, so this is metadata for
+     * update checks, never an identity or a gate.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    version?: string | null;
+
+    /** The Agent Plugins release the package targets, from its `$schema`. */
+    @Column({ type: 'varchar', length: 16 })
+    specVersion: string;
+
+    @Column({ type: 'varchar', length: 16, default: 'local' })
+    source: AgentPluginPackageSource;
+
+    /**
+     * How to find the package again: an absolute directory for `local`, a
+     * URL with a ref for `git`, a name with a version for `npm`.
+     */
+    @Column({ type: 'varchar', length: 2048 })
+    sourceRef: string;
+
+    /** Absolute path the package currently occupies on this replica. */
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    installPath?: string | null;
+
+    /**
+     * sha512 integrity for `npm`, or the resolved commit for `git`. Null for
+     * `local`, where the operator owns the bytes and there is nothing to
+     * verify against.
+     */
+    @Column({ type: 'varchar', length: 256, nullable: true })
+    integrity?: string | null;
+
+    /** The validated `plugin.json`, stored verbatim. */
+    @Column('simple-json', { nullable: true })
+    manifest?: Record<string, unknown> | null;
+
+    /**
+     * Everything the conformance library reported: skipped skills, disabled
+     * MCP configurations, tolerated manifest oddities.
+     */
+    @Column('simple-json', { default: '[]' })
+    findings: AgentPluginPackageFinding[];
+
+    /** Skill names this package contributed, for a catalog listing without a disk read. */
+    @Column('simple-json', { default: '[]' })
+    skillNames: string[];
+
+    /** MCP server names this package declares. */
+    @Column('simple-json', { default: '[]' })
+    mcpServerNames: string[];
+
+    @Column({ type: 'varchar', length: 16, default: 'available' })
+    installState: AgentPluginPackageInstallState;
+
+    /** Why the last acquisition or validation failed. Never carries a credential. */
+    @Column({ type: 'text', nullable: true })
+    installError?: string | null;
+
+    /**
+     * Content hash of the package as installed.
+     *
+     * Doubles as the synthesized catalog-entry version for a package with no
+     * declared `version` — but note it is TRUNCATED before it reaches
+     * `skills.sourceCatalogVersion`, which is varchar(16).
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    contentHash?: string | null;
+
+    // MUST be @PortableDateColumn rather than `type: 'timestamp'`: CI and e2e
+    // run better-sqlite3, which has no `timestamp` type, and TypeORM's
+    // metadata validation throws at BOOT rather than at query time. There is a
+    // guard spec for exactly this.
+    @PortableDateColumn({ nullable: true })
+    lastValidatedAt?: Date | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -179,5 +179,7 @@ export * from './environment.entity';
 // Memory Files — user-defined folders organizing uploads on /memory.
 export * from './memory-folder.entity';
 // Repository registry (Feature G) — account-level repo records + agent grants.
+export * from './agent-plugin-package.entity';
+export * from './agent-plugin-package-allowlist.entity';
 export * from './repo-connection.entity';
 export * from './agent-repo-attachment.entity';

--- a/packages/agent/src/facades/__tests__/skills.facade.agent-plugins.spec.ts
+++ b/packages/agent/src/facades/__tests__/skills.facade.agent-plugins.spec.ts
@@ -1,0 +1,269 @@
+import type { ISkillsProviderPlugin, PluginManifest, SkillCatalogEntry } from '@ever-works/plugin';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { SkillsFacadeService } from '../skills.facade';
+import type {
+    AgentPluginSkillSource,
+    AgentPluginSkillSourceOptions,
+} from '../../agent-plugins/skill-source.token';
+
+/**
+ * The Agent Plugins additive catalog source.
+ *
+ * The property that matters most here is a negative one: with nothing bound,
+ * this facade must behave EXACTLY as it did before the seam existed. Every
+ * other guarantee — packages never displacing a provider, the source being
+ * consulted even with no providers enabled, `getEntry` agreeing with
+ * `listEntries` — is about the feature working; that one is about the other
+ * ~100 deployments where the flag stays off.
+ */
+
+const entry = (slug: string, extra?: Partial<SkillCatalogEntry>): SkillCatalogEntry => ({
+    slug,
+    title: slug,
+    description: `${slug} description`,
+    frontmatter: { name: slug, description: `${slug} description` },
+    body: 'Body.',
+    version: '1.0.0',
+    tags: [],
+    ...extra,
+});
+
+/** A skills provider, shaped as the registry hands it to the facade. */
+function providerPlugin(id: string, entries: SkillCatalogEntry[]): RegisteredPlugin {
+    const plugin = {
+        id,
+        name: id,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['skills-provider'],
+        settingsSchema: { type: 'object', properties: {} },
+        configurationMode: 'hybrid',
+        providerName: id,
+        onLoad: jest.fn(),
+        onUnload: jest.fn(),
+        listEntries: jest
+            .fn()
+            .mockImplementation(({ limit, offset }: { limit: number; offset: number }) => ({
+                entries: entries.slice(offset, offset + limit),
+                total: entries.length,
+            })),
+        getEntry: jest
+            .fn()
+            .mockImplementation(
+                async (slug: string) => entries.find((e) => e.slug === slug) ?? null,
+            ),
+    } as unknown as ISkillsProviderPlugin;
+
+    return {
+        plugin,
+        manifest: {
+            id,
+            name: id,
+            version: '1.0.0',
+            description: 'Test provider',
+            category: 'utility',
+            capabilities: ['skills-provider'],
+        } as PluginManifest,
+        state: 'loaded',
+        builtIn: true,
+        stateHistory: [],
+        registeredAt: 0,
+    };
+}
+
+function registryWith(plugins: RegisteredPlugin[]): PluginRegistryService {
+    return {
+        getByCapability: jest.fn().mockReturnValue(plugins),
+        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+    } as unknown as PluginRegistryService;
+}
+
+const settingsStub = {
+    getResolvedSettings: jest.fn().mockResolvedValue({}),
+} as unknown as PluginSettingsService;
+
+/** A package source that records what the facade asked it for. */
+function packageSource(entries: SkillCatalogEntry[]): AgentPluginSkillSource & {
+    listCalls: AgentPluginSkillSourceOptions[];
+} {
+    const listCalls: AgentPluginSkillSourceOptions[] = [];
+    return {
+        listCalls,
+        async listEntries(options) {
+            listCalls.push(options);
+            return entries;
+        },
+        async getEntry(slug) {
+            const found = entries.find((e) => e.slug === slug);
+            return found ? { entry: found, providerId: 'agent-plugins' } : null;
+        },
+    };
+}
+
+describe('SkillsFacadeService — Agent Plugins additive source', () => {
+    const facadeOptions = { userId: 'user-1' } as never;
+    const listOptions = { limit: 50, offset: 0 } as never;
+
+    describe('when nothing is bound', () => {
+        it('behaves exactly as before, including the empty-provider early return', async () => {
+            const facade = new SkillsFacadeService(registryWith([]), settingsStub, undefined);
+
+            await expect(facade.listEntries(listOptions, facadeOptions)).resolves.toEqual({
+                entries: [],
+                total: 0,
+            });
+            await expect(facade.getEntry('anything', facadeOptions)).resolves.toBeNull();
+        });
+
+        it('still aggregates provider entries', async () => {
+            const facade = new SkillsFacadeService(
+                registryWith([providerPlugin('everworks-skills', [entry('plan')])]),
+                settingsStub,
+                undefined,
+            );
+
+            const result = await facade.listEntries(listOptions, facadeOptions);
+            expect(result.entries.map((e) => e.slug)).toEqual(['plan']);
+        });
+    });
+
+    describe('when a package source is bound', () => {
+        it('is consulted even when NO provider plugin is enabled', async () => {
+            // The regression this guards: the facade used to return early on
+            // an empty provider list, which would have made every package
+            // skill silently invisible. Only `everworks-skills` auto-enables,
+            // so "no provider enabled" is a real deployment state.
+            const source = packageSource([entry('from-package', { sourceKind: 'local' })]);
+            const facade = new SkillsFacadeService(
+                registryWith([]),
+                settingsStub,
+                undefined,
+                source,
+            );
+
+            const result = await facade.listEntries(listOptions, facadeOptions);
+
+            expect(result.entries.map((e) => e.slug)).toEqual(['from-package']);
+            expect(result.total).toBe(1);
+        });
+
+        it('merges package entries AFTER providers, so a package can never displace one', async () => {
+            const source = packageSource([
+                entry('shared', { description: 'from the package' }),
+                entry('unique-to-package'),
+            ]);
+            const facade = new SkillsFacadeService(
+                registryWith([
+                    providerPlugin('everworks-skills', [
+                        entry('shared', { description: 'from the provider' }),
+                    ]),
+                ]),
+                settingsStub,
+                undefined,
+                source,
+            );
+
+            const result = await facade.listEntries(listOptions, facadeOptions);
+
+            expect(result.entries.map((e) => e.slug)).toEqual(['shared', 'unique-to-package']);
+            // First-wins dedupe: the provider's version of the colliding slug
+            // survives, which is the whole safety argument for merging last.
+            expect(result.entries[0]?.description).toBe('from the provider');
+        });
+
+        it('passes the caller filters through to the source', async () => {
+            const source = packageSource([]);
+            const facade = new SkillsFacadeService(
+                registryWith([]),
+                settingsStub,
+                undefined,
+                source,
+            );
+
+            await facade.listEntries(
+                { limit: 10, offset: 0, tags: ['ops'], search: 'deploy' } as never,
+                facadeOptions,
+            );
+
+            expect(source.listCalls).toHaveLength(1);
+            expect(source.listCalls[0]?.tags).toEqual(['ops']);
+            expect(source.listCalls[0]?.search).toBe('deploy');
+        });
+
+        it('survives a throwing source without failing the catalog', async () => {
+            // Same posture as a failing provider: one bad source must not turn
+            // a working catalog into a 500.
+            const broken: AgentPluginSkillSource = {
+                listEntries: jest.fn().mockRejectedValue(new Error('disk gone')),
+                getEntry: jest.fn().mockRejectedValue(new Error('disk gone')),
+            };
+            const facade = new SkillsFacadeService(
+                registryWith([providerPlugin('everworks-skills', [entry('plan')])]),
+                settingsStub,
+                undefined,
+                broken,
+            );
+
+            const result = await facade.listEntries(listOptions, facadeOptions);
+
+            expect(result.entries.map((e) => e.slug)).toEqual(['plan']);
+            await expect(facade.getEntry('plan', facadeOptions)).resolves.toMatchObject({
+                providerId: 'everworks-skills',
+            });
+        });
+
+        it('resolves a package slug through getEntry, so Install does not 404', async () => {
+            // `listEntries` and `getEntry` are separate code paths. Wiring only
+            // the first produces a catalog card whose Install button 404s,
+            // because the install route resolves the slug through getEntry.
+            const source = packageSource([entry('from-package')]);
+            const facade = new SkillsFacadeService(
+                registryWith([]),
+                settingsStub,
+                undefined,
+                source,
+            );
+
+            await expect(facade.getEntry('from-package', facadeOptions)).resolves.toEqual({
+                entry: expect.objectContaining({ slug: 'from-package' }),
+                providerId: 'agent-plugins',
+            });
+        });
+
+        it('lets a provider win getEntry when both offer the slug', async () => {
+            const source = packageSource([entry('shared', { description: 'package' })]);
+            const facade = new SkillsFacadeService(
+                registryWith([
+                    providerPlugin('everworks-skills', [
+                        entry('shared', { description: 'provider' }),
+                    ]),
+                ]),
+                settingsStub,
+                undefined,
+                source,
+            );
+
+            const found = await facade.getEntry('shared', facadeOptions);
+
+            // Same precedence as listEntries, or the card and the install
+            // would disagree about which skill the user is getting.
+            expect(found?.providerId).toBe('everworks-skills');
+            expect(found?.entry.description).toBe('provider');
+        });
+
+        it('returns null when neither providers nor the source know the slug', async () => {
+            const facade = new SkillsFacadeService(
+                registryWith([]),
+                settingsStub,
+                undefined,
+                packageSource([]),
+            );
+
+            await expect(facade.getEntry('nope', facadeOptions)).resolves.toBeNull();
+        });
+    });
+});

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -3,6 +3,7 @@ import { DatabaseModule } from '../database/database.module';
 import { UsageModule } from '../usage/usage.module';
 import { BudgetsModule } from '../budgets/budgets.module';
 import { PolicyModule } from '../policy/policy.module';
+import { AgentPluginsModule } from '../agent-plugins/agent-plugins.module';
 
 import { AiFacadeService } from './ai.facade';
 import { SearchFacadeService } from './search.facade';
@@ -84,7 +85,11 @@ const FACADES = [
     // importing it here cannot cycle. It binds MERGE_POLICY_ENFORCER,
     // which GitFacadeService consumes @Optional() to enforce the
     // merge-policy matrix on agent-driven merges (Wave 3, D4).
-    imports: [DatabaseModule, UsageModule, BudgetsModule, PolicyModule],
+    // AgentPluginsModule is also a leaf (two entities, no facade imports), so
+    // importing it here cannot cycle. It binds AGENT_PLUGIN_SKILL_SOURCE,
+    // which SkillsFacadeService consumes @Optional() to merge Agent Plugins
+    // package skills into the catalog as an additive last source.
+    imports: [DatabaseModule, UsageModule, BudgetsModule, PolicyModule, AgentPluginsModule],
     providers: FACADES,
     exports: FACADES,
 })

--- a/packages/agent/src/facades/skills.facade.ts
+++ b/packages/agent/src/facades/skills.facade.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type {
     FacadeOptions,
     ISkillsProviderPlugin,
@@ -11,6 +11,10 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
 import { BaseFacadeService, FacadeError } from './base.facade';
+import {
+    AGENT_PLUGIN_SKILL_SOURCE,
+    type AgentPluginSkillSource,
+} from '../agent-plugins/skill-source.token';
 
 export class SkillsFacadeError extends FacadeError {
     constructor(message: string, operation: string, provider?: string, cause?: Error) {
@@ -45,6 +49,13 @@ export class SkillsFacadeService extends BaseFacadeService {
         registry: PluginRegistryService,
         settingsService: PluginSettingsService,
         @Optional() workPluginRepository?: WorkPluginRepository,
+        // APPENDED, never inserted. This facade is constructed positionally in
+        // tests (`new SkillsFacadeService(registry, settings)`), so putting a
+        // new parameter anywhere but last silently rebinds what every existing
+        // 2- and 3-argument construction passes.
+        @Optional()
+        @Inject(AGENT_PLUGIN_SKILL_SOURCE)
+        private readonly packageSource?: AgentPluginSkillSource,
     ) {
         super(registry, settingsService, workPluginRepository);
     }
@@ -59,7 +70,12 @@ export class SkillsFacadeService extends BaseFacadeService {
         facadeOptions: FacadeOptions,
     ): Promise<SkillCatalogListResult> {
         const plugins = await this.getEnabledPlugins(facadeOptions.workId, facadeOptions.userId);
-        if (plugins.length === 0) {
+        // The guard must consider the package source too. Only
+        // `everworks-skills` auto-enables, so "no skills-provider plugin
+        // enabled" is a real deployment state — and returning early there
+        // would make package skills silently invisible rather than merely
+        // absent.
+        if (plugins.length === 0 && !this.packageSource) {
             return { entries: [], total: 0 };
         }
 
@@ -104,6 +120,40 @@ export class SkillsFacadeService extends BaseFacadeService {
                 );
             }
         }
+        // Merged LAST, on purpose. The dedupe above is first-wins and
+        // `everworks-skills` sorts first as the default provider, so appending
+        // here is what guarantees a package can never displace a provider
+        // plugin's entry.
+        if (this.packageSource) {
+            try {
+                const packageEntries = await this.packageSource.listEntries({
+                    facadeOptions,
+                    tags: options.tags,
+                    search: options.search,
+                });
+                for (const entry of packageEntries) {
+                    if (seenSlugs.has(entry.slug)) {
+                        // The provider dedupe drops silently, which is fine
+                        // between plugins but not here: a package skill
+                        // colliding with a built-in slug would vanish with no
+                        // diagnostic at all.
+                        this.logger.debug(
+                            `Agent Plugins skill "${entry.slug}" from package ${entry.packageName ?? 'unknown'} is shadowed by an earlier provider entry.`,
+                        );
+                        continue;
+                    }
+                    seenSlugs.add(entry.slug);
+                    merged.push(entry);
+                }
+            } catch (err) {
+                // Same failure posture as a provider: one bad source must not
+                // turn a working catalog into a 500.
+                this.logger.warn(
+                    `Agent Plugins package source failed to listEntries: ${err instanceof Error ? err.message : err}`,
+                );
+            }
+        }
+
         return {
             entries: merged.slice(requestedOffset, requestedOffset + requestedLimit),
             total: merged.length,
@@ -131,6 +181,22 @@ export class SkillsFacadeService extends BaseFacadeService {
                 );
             }
         }
+
+        // Consulted after every provider, matching the precedence
+        // `listEntries` applies. Wiring only that method and not this one
+        // would produce a catalog card whose Install button 404s, because the
+        // install route resolves the slug through here.
+        if (this.packageSource) {
+            try {
+                const found = await this.packageSource.getEntry(slug, { facadeOptions });
+                if (found) return found;
+            } catch (err) {
+                this.logger.warn(
+                    `Agent Plugins package source failed to getEntry(${slug}): ${err instanceof Error ? err.message : err}`,
+                );
+            }
+        }
+
         return null;
     }
 }

--- a/packages/plugin/src/contracts/capabilities/skills-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/skills-provider.interface.ts
@@ -31,7 +31,31 @@ export interface SkillCatalogEntry {
 	version: string;
 	tags: string[];
 	sourceUrl?: string;
+
+	/**
+	 * Provenance, for entries that came from an Agent Plugins package rather
+	 * than from a provider plugin. All optional and all additive: an entry
+	 * without them is exactly what it was before these existed.
+	 *
+	 * Deliberately NOT carried inside `frontmatter`, even though that has an
+	 * index signature and would accept them. `installFromCatalog` writes
+	 * `frontmatter` verbatim into the stored Skill row, and that JSON is what
+	 * gets injected into the model's context — provenance is information for
+	 * the operator looking at a catalog card, not for the model reading a
+	 * skill.
+	 */
+	packageName?: string;
+	packageVersion?: string;
+	sourceKind?: SkillCatalogSourceKind;
 }
+
+/**
+ * Where a catalog entry came from.
+ *
+ * `plugin` is every entry that existed before Agent Plugins support; the
+ * others name the package source an entry was discovered through.
+ */
+export type SkillCatalogSourceKind = 'plugin' | 'local' | 'git' | 'npm';
 
 export interface SkillCatalogListOptions {
 	limit: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -981,6 +981,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.41
         version: 2.0.41(zod@3.25.76)
+      '@ever-works/agent-plugins':
+        specifier: workspace:*
+        version: link:../agent-plugins
       '@ever-works/contracts':
         specifier: workspace:*
         version: link:../contracts


### PR DESCRIPTION
## What

Phase 1 of the Agent Plugins interop program ([EW-772](https://evertech.atlassian.net/browse/EW-772)), tasks **T10–T16**, building on [#2314](https://github.com/ever-works/ever-works/pull/2314).

Installed Agent Plugins packages now contribute their skills to the existing skills catalog, behind `FEATURE_AGENT_PLUGINS`, which defaults to **off**.

| Task | Delivered |
| ---- | --------- |
| T10 | `agent_plugin_packages` + `agent_plugin_package_allowlist` entities and migration |
| T11 | Local-directory package source |
| T12 | `FEATURE_AGENT_PLUGINS` + `AGENT_PLUGINS_DIR`, with a reader |
| T13 | Catalog source wired into `SkillsFacadeService` as an `@Optional()` additive seam |
| T14 | API module and read surface (`list`, `findings`, `catalog`) |
| T15 | CLI verbs under `ever-works plugins agent-plugins` |
| T16 | End-to-end integration test |

## The design is shaped by what must NOT change

Every deployment that leaves the flag off must behave *identically*. The first test in the facade suite asserts exactly that, and the integration suite asserts it again through the real objects.

The source is bound through an `@Optional()` token, so an unbound deployment is bit-identical. It is merged **last**, so the catalog's existing first-wins slug dedupe guarantees a package can never displace a built-in skill. Both `listEntries` and `getEntry` are wired, because they are separate code paths and doing only the first produces a catalog card whose Install button 404s.

## I did not follow the plan where the plan was wrong

Before writing any code I mapped the live seams with six agents rather than trusting `plan.md`, which was written against a commit that has since moved. That found **50 stale claims**. Four changed what I built:

**The feature flag cannot live where T12 says.** `apps/api/src/config/constants.ts` is API-tier only, and T13's own consumer — `SkillsFacadeService` — is in `packages/agent`, which has no import path to `apps/api`. Following the task literally would have stranded the flag from its reader. It lives in the agent-side config, importable from both tiers.

**The facade early-returned when no provider plugin was enabled.** A source appended after that guard would have been *silently invisible*, not merely absent — and since only `everworks-skills` auto-enables, that state is real. The guard now considers the source, with a test that drives it with zero providers.

**`generate:openapi` is not a DI gate**, though the definition-of-done treats it as one. It runs with `preview: true`, so providers are never instantiated: an unbound token passes it cleanly and crashes the pod at boot.

**`migration:generate` is unusable here** — it needs a live Postgres and emits Postgres-only raw SQL. The migration is hand-written against the portable Table API, like every recent one.

## Traps handled, each with the reason recorded in the code

- **`@PortableDateColumn`, not `type: 'timestamp'`.** Under better-sqlite3 — which CI and e2e both use — TypeORM metadata validation throws at **boot**, killing every e2e shard in global-setup. This class has landed five times.
- **Entities live in `src/entities/`,** not a feature folder, which would silently drop them out of the portable-date guard and the name-drift check.
- **All three registration points.** Omitting `_entities-inventory.ts` fails *no* unit test — the table just never registers and the first query throws at runtime.
- **No XOR CHECK on scope columns.** The stamping subscriber populates both, so a XOR constraint aborts the migration on ordinary data.
- **`simple-json`, not `jsonb`** (144 of the former in this repo, zero of the latter).
- **The controller path starts with `api/`** — there is no `setGlobalPrefix`, and a path without it 404s in production while passing every test.
- **Literal routes declared before any `:param` route**, or a UUID pipe shadows and 400s them.
- **Bound via `imports`, not the `FACADES` array**, whose length `facades.module.spec.ts` asserts exactly.
- **Catalog version truncated to 16 characters** — `skills.sourceCatalogVersion` is `varchar(16)`, and an overflowing value passes every unit test then throws at INSERT on first Install.
- **Provenance stays out of `frontmatter`**, which is written verbatim into the Skill row and injected into the model's context.
- **The web app's hand-maintained copy of `SkillCatalogEntry` updated too** — it does not import the shared type, so changing one side is invisible: the API sends the field and the UI never shows it.

## Verification

| Gate | Result |
| ---- | ------ |
| Full monorepo `pnpm build` | **115/115 successful** |
| Agent suite | **9,879 passing**, 541 suites |
| New Agent Plugins tests | 57 across 6 suites |
| Regressions vs. baseline | **zero** — byte-identical failing set |
| `type-check` (agent, api, cli) | clean |
| `prettier --check`, ROOT glob | clean |
| CLI | built and `--help` verified against the real binary |

The 17 locally-failing suites are `better-sqlite3` "could not locate the bindings file", from installing this worktree with `--ignore-scripts`. I diffed the failing set before and after my changes: identical, so nothing here caused them. CI installs natives normally.

## Not in this phase

Install/update/remove routes and the admin allowlist CRUD arrive with the git and npm sources in Phase 2 — a local package is registered in place, so a write route today would do nothing that editing the directory does not.

The account-transfer whitelist is also Phase 2, and worth flagging early: the mapping pass found it is **not** the 4-place edit the plan claims, but 6 files plus a pinned barrel spec, 2 new files, the API controller and 5 web-tier files, across **two independent serializers** — the JSON envelope and the GitHub-sync directory layout. Editing one leaves the section missing from the other with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EW-772]: https://evertech.atlassian.net/browse/EW-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and loading Agent Plugin packages from configured local directories.
  * Added searchable skills catalog entries, including package name, version, and source information.
  * Added authenticated API access for installed packages, validation findings, and catalog entries.
  * Added CLI commands to list packages, review validation findings, and browse catalog skills.
  * Added configuration controls for enabling Agent Plugins and specifying package directories.
  * Added allowlist support for approved Git and npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->