### PR TITLE
fix(works): Repository Work review follow-ups — credentials out of the URL, repo kind out of the AI path

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6305,6 +6305,7 @@
                 "creatingButton": "جارٍ التسجيل…",
                 "cancelButton": "إلغاء",
                 "invalidUrl": "أدخل رابط مستودع مثل https://github.com/owner/repo",
+                "invalidSlug": "استخدم الأحرف الصغيرة والأرقام والشرطات فقط، مثل my-repo",
                 "success": "تم تسجيل المستودع كعمل",
                 "createFailed": "فشل تسجيل المستودع",
                 "noteTitle": "ملاحظة:",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6305,6 +6305,7 @@
                 "creatingButton": "Регистриране…",
                 "cancelButton": "Отказ",
                 "invalidUrl": "Въведете URL на хранилище като https://github.com/owner/repo",
+                "invalidSlug": "Само малки букви, цифри и тирета, например my-repo",
                 "success": "Хранилището е регистрирано като Работа",
                 "createFailed": "Регистрирането на хранилището не успя",
                 "noteTitle": "Забележка:",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6293,10 +6293,10 @@
             },
             "repo": {
                 "formTitle": "Neues Work — Repository",
-                "formSubtitle": "Registriere ein bestehendes Code-Repository als Work. Nichts wird generiert oder deployt — Tasks, Goals und Fleet-Läufe arbeiten einfach in diesem Repository.",
+                "formSubtitle": "Registrieren Sie ein bestehendes Code-Repository als Work. Nichts wird generiert oder deployt — Tasks, Goals und Fleet-Läufe arbeiten einfach in diesem Repository.",
                 "urlLabel": "Repository-URL",
                 "urlPlaceholder": "https://github.com/ever-works/ever-works",
-                "urlHelp": "Ein GitHub-Repository, auf das du Zugriff hast. Es wird unverändert zum Daten-Repository des Works.",
+                "urlHelp": "Ein GitHub-Repository, auf das Sie Zugriff haben. Es wird unverändert zum Daten-Repository des Works.",
                 "nameLabel": "Work-Name",
                 "slugLabel": "Work-Slug",
                 "slugHelp": "URL-freundliche Kennung. Aus dem Repository-Namen abgeleitet — zum Überschreiben bearbeiten.",
@@ -6305,10 +6305,11 @@
                 "creatingButton": "Wird registriert…",
                 "cancelButton": "Abbrechen",
                 "invalidUrl": "Gib eine Repository-URL wie https://github.com/owner/repo ein",
+                "invalidSlug": "Nur Kleinbuchstaben, Ziffern und Bindestriche, zum Beispiel my-repo",
                 "success": "Repository als Work registriert",
                 "createFailed": "Repository konnte nicht registriert werden",
                 "noteTitle": "Hinweis:",
-                "noteText": "Für ein Repository-Work werden weder Website-Template noch Provider-Repository noch Deployment angelegt. Verbinde den Git-Provider, der das Repository hostet, damit Agents es klonen können."
+                "noteText": "Für ein Repository-Work werden weder Website-Template noch Provider-Repository noch Deployment angelegt. Verbinden Sie GitHub als Git-Provider, damit Agents es klonen können."
             },
             "manual": {
                 "title": "Manuell erstellen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6611,6 +6611,7 @@
                 "creatingButton": "Registering…",
                 "cancelButton": "Cancel",
                 "invalidUrl": "Enter a repository URL like https://github.com/owner/repo",
+                "invalidSlug": "Use lowercase letters, digits and hyphens only, for example my-repo",
                 "success": "Repository registered as a Work",
                 "createFailed": "Failed to register the repository",
                 "noteTitle": "Note:",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6305,6 +6305,7 @@
                 "creatingButton": "Registrando…",
                 "cancelButton": "Cancelar",
                 "invalidUrl": "Introduce una URL de repositorio como https://github.com/owner/repo",
+                "invalidSlug": "Usa solo letras minúsculas, dígitos y guiones, por ejemplo my-repo",
                 "success": "Repositorio registrado como Work",
                 "createFailed": "No se pudo registrar el repositorio",
                 "noteTitle": "Nota:",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6305,6 +6305,7 @@
                 "creatingButton": "Enregistrement…",
                 "cancelButton": "Annuler",
                 "invalidUrl": "Saisissez une URL de dépôt comme https://github.com/owner/repo",
+                "invalidSlug": "Utilisez uniquement des minuscules, des chiffres et des tirets, par exemple my-repo",
                 "success": "Dépôt enregistré comme Work",
                 "createFailed": "Échec de l’enregistrement du dépôt",
                 "noteTitle": "Remarque :",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6305,6 +6305,7 @@
                 "creatingButton": "רושם…",
                 "cancelButton": "ביטול",
                 "invalidUrl": "הזינו כתובת מאגר כמו https://github.com/owner/repo",
+                "invalidSlug": "השתמשו רק באותיות קטנות, ספרות ומקפים, למשל my-repo",
                 "success": "המאגר נרשם כ-Work",
                 "createFailed": "רישום המאגר נכשל",
                 "noteTitle": "הערה:",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "रजिस्टर हो रहा है…",
                 "cancelButton": "रद्द करें",
                 "invalidUrl": "https://github.com/owner/repo जैसा रिपॉज़िटरी URL दर्ज करें",
+                "invalidSlug": "केवल लोअरकेस अक्षर, अंक और हाइफ़न का उपयोग करें, उदाहरण के लिए my-repo",
                 "success": "रिपॉज़िटरी Work के रूप में रजिस्टर हो गई",
                 "createFailed": "रिपॉज़िटरी रजिस्टर नहीं हो सकी",
                 "noteTitle": "नोट:",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6212,7 +6212,7 @@
                 "creatingButton": "Mendaftarkan…",
                 "cancelButton": "Batal",
                 "invalidUrl": "Masukkan URL repositori seperti https://github.com/owner/repo",
-                "invalidSlug": "Use lowercase letters, digits and hyphens only, for example my-repo",
+                "invalidSlug": "Gunakan hanya huruf kecil, angka, dan tanda hubung, misalnya my-repo",
                 "success": "Repositori terdaftar sebagai Work",
                 "createFailed": "Gagal mendaftarkan repositori",
                 "noteTitle": "Catatan:",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Mendaftarkan…",
                 "cancelButton": "Batal",
                 "invalidUrl": "Masukkan URL repositori seperti https://github.com/owner/repo",
+                "invalidSlug": "Use lowercase letters, digits and hyphens only, for example my-repo",
                 "success": "Repositori terdaftar sebagai Work",
                 "createFailed": "Gagal mendaftarkan repositori",
                 "noteTitle": "Catatan:",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6212,10 +6212,11 @@
                 "creatingButton": "Registrazione…",
                 "cancelButton": "Annulla",
                 "invalidUrl": "Inserisci un URL di repository come https://github.com/owner/repo",
+                "invalidSlug": "Usa solo lettere minuscole, cifre e trattini, ad esempio my-repo",
                 "success": "Repository registrato come Work",
                 "createFailed": "Registrazione del repository non riuscita",
                 "noteTitle": "Nota:",
-                "noteText": "Per un Work di tipo Repository non vengono creati template del sito, repository del provider né deployment. Collega il provider Git che ospita il repository così che gli agenti possano clonarlo."
+                "noteText": "Per un Work di tipo Repository non vengono creati template del sito, repository del provider né deployment. Collega GitHub come provider Git così che gli agenti possano clonarlo."
             },
             "manual": {
                 "title": "Crea Manualmente",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "登録中…",
                 "cancelButton": "キャンセル",
                 "invalidUrl": "https://github.com/owner/repo のようなリポジトリ URL を入力してください",
+                "invalidSlug": "小文字、数字、ハイフンのみを使用してください。例: my-repo",
                 "success": "リポジトリを Work として登録しました",
                 "createFailed": "リポジトリの登録に失敗しました",
                 "noteTitle": "注意:",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "등록 중…",
                 "cancelButton": "취소",
                 "invalidUrl": "https://github.com/owner/repo 같은 리포지토리 URL을 입력하세요",
+                "invalidSlug": "소문자, 숫자, 하이픈만 사용하세요. 예: my-repo",
                 "success": "리포지토리가 Work로 등록되었습니다",
                 "createFailed": "리포지토리 등록에 실패했습니다",
                 "noteTitle": "참고:",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Registreren…",
                 "cancelButton": "Annuleren",
                 "invalidUrl": "Voer een repository-URL in zoals https://github.com/owner/repo",
+                "invalidSlug": "Gebruik alleen kleine letters, cijfers en koppeltekens, bijvoorbeeld my-repo",
                 "success": "Repository geregistreerd als Work",
                 "createFailed": "Repository registreren mislukt",
                 "noteTitle": "Let op:",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6212,10 +6212,11 @@
                 "creatingButton": "Rejestrowanie…",
                 "cancelButton": "Anuluj",
                 "invalidUrl": "Podaj URL repozytorium, np. https://github.com/owner/repo",
+                "invalidSlug": "Używaj tylko małych liter, cyfr i myślników, na przykład my-repo",
                 "success": "Repozytorium zarejestrowano jako Work",
                 "createFailed": "Nie udało się zarejestrować repozytorium",
                 "noteTitle": "Uwaga:",
-                "noteText": "Dla Worka typu Repozytorium nie jest tworzony szablon strony, repozytorium dostawcy ani wdrożenie. Połącz dostawcę Git hostującego repozytorium, aby agenci mogli je sklonować."
+                "noteText": "Dla Worka typu Repozytorium nie jest tworzony szablon strony, repozytorium dostawcy ani wdrożenie. Połącz GitHub jako dostawcę Git, aby agenci mogli je sklonować."
             },
             "manual": {
                 "title": "Utwórz ręcznie",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Registrando…",
                 "cancelButton": "Cancelar",
                 "invalidUrl": "Informe uma URL de repositório como https://github.com/owner/repo",
+                "invalidSlug": "Use apenas letras minúsculas, dígitos e hífens, por exemplo my-repo",
                 "success": "Repositório registrado como Work",
                 "createFailed": "Falha ao registrar o repositório",
                 "noteTitle": "Observação:",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Регистрация…",
                 "cancelButton": "Отмена",
                 "invalidUrl": "Введите URL репозитория вида https://github.com/owner/repo",
+                "invalidSlug": "Только строчные буквы, цифры и дефисы, например my-repo",
                 "success": "Репозиторий зарегистрирован как Work",
                 "createFailed": "Не удалось зарегистрировать репозиторий",
                 "noteTitle": "Примечание:",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "กำลังลงทะเบียน…",
                 "cancelButton": "ยกเลิก",
                 "invalidUrl": "กรอก URL ของรีโพซิทอรี เช่น https://github.com/owner/repo",
+                "invalidSlug": "ใช้ตัวพิมพ์เล็ก ตัวเลข และขีดกลางเท่านั้น เช่น my-repo",
                 "success": "ลงทะเบียนรีโพซิทอรีเป็น Work แล้ว",
                 "createFailed": "ลงทะเบียนรีโพซิทอรีไม่สำเร็จ",
                 "noteTitle": "หมายเหตุ:",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Kaydediliyor…",
                 "cancelButton": "İptal",
                 "invalidUrl": "https://github.com/owner/repo gibi bir depo URL’si girin",
+                "invalidSlug": "Yalnızca küçük harf, rakam ve tire kullanın, örneğin my-repo",
                 "success": "Depo Work olarak kaydedildi",
                 "createFailed": "Depo kaydedilemedi",
                 "noteTitle": "Not:",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Реєстрація…",
                 "cancelButton": "Скасувати",
                 "invalidUrl": "Введіть URL репозиторію на кшталт https://github.com/owner/repo",
+                "invalidSlug": "Лише малі літери, цифри та дефіси, наприклад my-repo",
                 "success": "Репозиторій зареєстровано як Work",
                 "createFailed": "Не вдалося зареєструвати репозиторій",
                 "noteTitle": "Примітка:",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "Đang đăng ký…",
                 "cancelButton": "Hủy",
                 "invalidUrl": "Nhập URL kho mã như https://github.com/owner/repo",
+                "invalidSlug": "Chỉ dùng chữ thường, chữ số và dấu gạch ngang, ví dụ my-repo",
                 "success": "Đã đăng ký kho mã làm Work",
                 "createFailed": "Không thể đăng ký kho mã",
                 "noteTitle": "Lưu ý:",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6212,6 +6212,7 @@
                 "creatingButton": "注册中…",
                 "cancelButton": "取消",
                 "invalidUrl": "请输入形如 https://github.com/owner/repo 的仓库 URL",
+                "invalidSlug": "只能使用小写字母、数字和连字符，例如 my-repo",
                 "success": "仓库已注册为 Work",
                 "createFailed": "注册仓库失败",
                 "noteTitle": "注意：",

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -59,7 +59,7 @@ const readmeConfigSchema = z.object({
 // works/new/new-work-client.tsx). Persisted on `work.kind` by the API so
 // the kind-aware default website template applies (general-purpose kinds
 // → the `web` template). The API whitelists again server-side.
-const aiWorkKindSchema = z.enum([
+const workKindSchema = z.enum([
     'website',
     'landing-page',
     'blog',
@@ -67,6 +67,12 @@ const aiWorkKindSchema = z.enum([
     'awesome-repo',
     'repo',
 ]);
+
+// `repo` is manual-only: registering one means naming an existing repository,
+// and the AI creation path neither collects nor constructs `repositoryUrl`, so
+// a Work created there with `kind: 'repo'` could never satisfy the API's
+// registration contract. Excluded at the schema so it cannot arrive at all.
+const aiWorkKindSchema = workKindSchema.exclude(['repo']);
 type AIWorkKind = z.infer<typeof aiWorkKindSchema>;
 
 const getCreateWorkSchema = async () => {
@@ -102,8 +108,10 @@ const getCreateWorkSchema = async () => {
         storageProvider: z.string().optional(),
         websiteTemplateId: z.string().optional(),
         // Optional work-kind chip value — kept in the parsed output so it
-        // reaches the API's CreateWorkDto (zod strips unknown keys).
-        kind: aiWorkKindSchema.optional(),
+        // reaches the API's CreateWorkDto (zod strips unknown keys). This is
+        // the MANUAL create path, which does collect `repositoryUrl`, so the
+        // full vocabulary applies here.
+        kind: workKindSchema.optional(),
         // Repository Work (`kind: 'repo'`) — the existing repository the
         // Work wraps. Declared so zod keeps it; the API parses + validates.
         repositoryUrl: z
@@ -321,7 +329,6 @@ const AI_WORK_KIND_PROMPT_LABELS: Record<AIWorkKind, string> = {
     blog: 'blog',
     directory: 'directory',
     'awesome-repo': 'awesome repository list',
-    repo: 'code repository',
 };
 
 interface AIWorkOptions {

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -31,6 +31,7 @@ import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/dashboard/missions';
 import { RegisterCompanyDialog } from '@/components/organizations/RegisterCompanyDialog';
+import { canonicalRepositoryUrl } from '@/lib/work-kinds/repository-url';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -418,10 +419,17 @@ export function NewPageClient({
             // URL, typically) straight to the Repository form on the Work
             // canvas instead of opening a chat turn.
             if (effectiveChip === 'repo') {
+                // Only canonical coordinates may ride in the query string:
+                // pasted remotes routinely carry a token in the user-info
+                // section, and a query parameter reaches browser history,
+                // the referrer of every later request and any proxy log.
+                // Anything that does not reduce to owner/repo routes with
+                // no seed at all, and the user types it into the form.
+                const canonical = canonicalRepositoryUrl(description);
                 const params = new URLSearchParams({
                     mode: 'manual',
                     kind: 'repo',
-                    prompt: description,
+                    ...(canonical ? { prompt: canonical } : {}),
                 });
                 router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
                 return;

--- a/apps/web/src/components/works/RepositoryWorkForm.tsx
+++ b/apps/web/src/components/works/RepositoryWorkForm.tsx
@@ -180,6 +180,12 @@ export function RepositoryWorkForm({ gitProvider, initialRepositoryUrl }: Reposi
                         setSlugDirty(true);
                     }}
                     pattern="[a-z0-9-]+"
+                    // Without this the submit button is simply disabled and
+                    // the field explains nothing: the `invalidSlug` toast in
+                    // `submit` is unreachable precisely because `canSubmit`
+                    // already blocked it. Say what is wrong where it is wrong,
+                    // the same way the URL field does.
+                    error={slugInvalid ? t('invalidSlug') : undefined}
                     helperText={t('slugHelp')}
                     variant="form"
                 />

--- a/apps/web/src/components/works/RepositoryWorkForm.tsx
+++ b/apps/web/src/components/works/RepositoryWorkForm.tsx
@@ -11,6 +11,12 @@ import { cn } from '@/lib/utils/cn';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import {
+    canonicalRepositoryUrl,
+    isCanonicalWorkSlug,
+    parseRepositoryUrl,
+    slugifyForWork,
+} from '@/lib/work-kinds/repository-url';
 
 /**
  * Create form for the `repo` Work kind (self-build slice D, EW-766).
@@ -28,38 +34,12 @@ import { Textarea } from '@/components/ui/textarea';
  * Work's data repository (`POST /api/works`).
  */
 
-/**
- * Mirrors `parseRepositoryWorkSource` on the API closely enough to derive
- * defaults and to catch an obviously wrong URL before the round-trip. The
- * API remains the authority — it re-parses and rejects anything it cannot
- * register.
- *
- * GitHub only, like the API: only the GitHub git-provider plugin exists, so
- * a GitLab / Bitbucket URL would produce a Work no Task can clone. Flagging
- * it here means the form says so instead of a 400 after the round-trip.
- * Repository names may start with a dot (`.github`, `.dotfiles`); owners
- * may not — same rule as GitHub itself.
- */
-const REPOSITORY_URL_PATTERN =
-    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9._-]*?)(?:\.git)?\/?$/i;
-
-export function parseRepositoryUrl(value: string): { owner: string; repo: string } | null {
-    const match = REPOSITORY_URL_PATTERN.exec(value.trim());
-    if (!match) return null;
-    const [, owner, repo] = match;
-    // `.` / `..` are path components, not repository names.
-    if (!repo || repo === '.' || repo === '..') return null;
-    return { owner, repo };
-}
-
-/** Same rules as the API slug regex: lowercase letters, digits, hyphens. */
-function slugifyForWork(value: string): string {
-    return value
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-}
+// The parser, the slugifier and the canonicaliser live in
+// `@/lib/work-kinds/repository-url` because the composers that route into
+// this form need them too — whatever the user typed has to be reduced to
+// canonical coordinates before it can go near a URL. Re-exported here so
+// callers that already import it from the form keep working.
+export { parseRepositoryUrl };
 
 export interface RepositoryWorkFormProps {
     /** Git provider plugin id selected in the sidebar (connection gate on the action). */
@@ -105,12 +85,21 @@ export function RepositoryWorkForm({ gitProvider, initialRepositoryUrl }: Reposi
         if (!descriptionDirty) setDescription(`${coords.owner}/${coords.repo}`);
     };
 
+    // The slug input carries a `pattern`, but this form submits from a
+    // button handler rather than a native <form>, so nothing enforces it:
+    // `My_Repo` would sail through to the server action and come back a
+    // 400. Check it the same way the URL field is checked.
+    const slugInvalid = slug.trim().length > 0 && !isCanonicalWorkSlug(slug);
     const canSubmit =
-        !isPending && Boolean(parsed) && name.trim().length > 0 && slug.trim().length > 0;
+        !isPending && Boolean(parsed) && name.trim().length > 0 && isCanonicalWorkSlug(slug);
 
     const submit = () => {
         if (!parsed) {
             toast.error(t('invalidUrl'));
+            return;
+        }
+        if (!isCanonicalWorkSlug(slug)) {
+            toast.error(t('invalidSlug'));
             return;
         }
         startTransition(async () => {
@@ -123,7 +112,9 @@ export function RepositoryWorkForm({ gitProvider, initialRepositoryUrl }: Reposi
                 organization: false,
                 gitProvider,
                 kind: 'repo',
-                repositoryUrl: repositoryUrl.trim(),
+                // Canonical, never the raw field: `parsed` already proved it
+                // reduces to owner/repo, and the API stores what we send.
+                repositoryUrl: canonicalRepositoryUrl(repositoryUrl) ?? repositoryUrl.trim(),
             });
             if (result.success && result.work) {
                 toast.success(t('success'));

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -62,6 +62,19 @@ import { getWorkCapabilities } from '@ever-works/contracts';
 
 type InitialWorkKind = 'website' | 'landing-page' | 'blog' | 'directory' | 'awesome-repo' | 'repo';
 
+/**
+ * `repo` never reaches the AI creator: registering a repository needs a
+ * `repositoryUrl` this path neither collects nor can invent, so a Work
+ * created here with that kind could not satisfy the API's registration
+ * contract. The composers route the Repository chip to the manual form
+ * instead; this drops it defensively for any caller that does not.
+ */
+type AiCreatableWorkKind = Exclude<InitialWorkKind, 'repo'>;
+
+function aiCreatableKind(kind?: InitialWorkKind): AiCreatableWorkKind | undefined {
+    return kind && kind !== 'repo' ? kind : undefined;
+}
+
 interface WorkAICreatorProps {
     gitProvider?: string;
     gitConnected?: boolean;
@@ -278,7 +291,7 @@ export function WorkAICreator({
                 pluginConfig: Object.keys(pluginConfig).length > 0 ? pluginConfig : undefined,
                 websiteTemplateId: websiteTemplateId || undefined,
                 proposalId: proposal?.id,
-                workKind: initialKind,
+                workKind: aiCreatableKind(initialKind),
             });
 
             if (result.success) {

--- a/apps/web/src/components/works/WorksCreateComposer.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
+import { canonicalRepositoryUrl } from '@/lib/work-kinds/repository-url';
 
 /**
  * Dashboard polish (2026-05-27) — Work-specific composer mounted at
@@ -146,10 +147,17 @@ export function WorksCreateComposer() {
             // A Repository Work has nothing to generate — hand the text
             // (a repo URL, typically) to the Repository form, no chat turn.
             if (selectedKind === 'repo') {
+                // Only canonical coordinates may ride in the query string:
+                // pasted remotes routinely carry a token in the user-info
+                // section, and a query parameter reaches browser history,
+                // the referrer of every later request and any proxy log.
+                // Anything that does not reduce to owner/repo routes with
+                // no seed at all, and the user types it into the form.
+                const canonical = canonicalRepositoryUrl(description);
                 const params = new URLSearchParams({
                     mode: 'manual',
                     kind: 'repo',
-                    prompt: description,
+                    ...(canonical ? { prompt: canonical } : {}),
                 });
                 router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
                 return;

--- a/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.unit.spec.tsx
@@ -140,6 +140,45 @@ describe('WorksCreateComposer Repository chip routing', () => {
         expect(params.get('prompt')).toBe('https://github.com/ever-works/ever-works');
     });
 
+    // Review finding (Major, security): the raw composer text used to be
+    // serialized into the query string, so a remote pasted straight from a
+    // terminal put its token into browser history, every later referrer and
+    // any proxy log before the form could reject it.
+    it('never puts a credential-bearing remote in the URL — it routes with no prompt at all', async () => {
+        startFromPromptMock.mockClear();
+        routerPushMock.mockClear();
+        const { container } = render(<WorksCreateComposer />);
+        clickChip(container, 'repo');
+        fireEvent.change(getTextarea(container), {
+            target: { value: 'https://user:ghp_secret@github.com/ever-works/ever-works.git' },
+        });
+        fireEvent.click(getSubmit(container));
+
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledTimes(1));
+        const href = routerPushMock.mock.calls[0][0] as string;
+        expect(href).not.toContain('ghp_secret');
+        const params = new URLSearchParams(href.slice(href.indexOf('?') + 1));
+        expect(params.get('mode')).toBe('manual');
+        expect(params.get('kind')).toBe('repo');
+        expect(params.get('prompt')).toBeNull();
+    });
+
+    it('canonicalises what it does forward, so the URL carries no .git suffix or stray path', async () => {
+        startFromPromptMock.mockClear();
+        routerPushMock.mockClear();
+        const { container } = render(<WorksCreateComposer />);
+        clickChip(container, 'repo');
+        fireEvent.change(getTextarea(container), {
+            target: { value: 'github.com/ever-works/ever-works.git/' },
+        });
+        fireEvent.click(getSubmit(container));
+
+        await waitFor(() => expect(routerPushMock).toHaveBeenCalledTimes(1));
+        const href = routerPushMock.mock.calls[0][0] as string;
+        const params = new URLSearchParams(href.slice(href.indexOf('?') + 1));
+        expect(params.get('prompt')).toBe('https://github.com/ever-works/ever-works');
+    });
+
     it('every other chip still opens a chat turn and routes to the AI form without the prompt in the URL', async () => {
         startFromPromptMock.mockClear();
         routerPushMock.mockClear();

--- a/apps/web/src/components/works/detail/settings/DeleteComponent.tsx
+++ b/apps/web/src/components/works/detail/settings/DeleteComponent.tsx
@@ -140,10 +140,10 @@ export function DeleteComponent({ work }: { work: Work }) {
                                         <Checkbox
                                             checked={deleteOptions.delete_data_repository || false}
                                             onChange={(e) =>
-                                                setDeleteOptions({
-                                                    ...deleteOptions,
+                                                setDeleteOptions((current) => ({
+                                                    ...current,
                                                     delete_data_repository: e.target.checked,
-                                                })
+                                                }))
                                             }
                                             label={t('deleteDataRepository')}
                                             description={t('deleteDataRepositoryDescription')}
@@ -158,10 +158,10 @@ export function DeleteComponent({ work }: { work: Work }) {
                                                 deleteOptions.delete_markdown_repository || false
                                             }
                                             onChange={(e) =>
-                                                setDeleteOptions({
-                                                    ...deleteOptions,
+                                                setDeleteOptions((current) => ({
+                                                    ...current,
                                                     delete_markdown_repository: e.target.checked,
-                                                })
+                                                }))
                                             }
                                             label={t('deleteMarkdownRepository')}
                                             description={t('deleteMarkdownRepositoryDescription')}
@@ -176,10 +176,10 @@ export function DeleteComponent({ work }: { work: Work }) {
                                                 deleteOptions.delete_website_repository || false
                                             }
                                             onChange={(e) =>
-                                                setDeleteOptions({
-                                                    ...deleteOptions,
+                                                setDeleteOptions((current) => ({
+                                                    ...current,
                                                     delete_website_repository: e.target.checked,
-                                                })
+                                                }))
                                             }
                                             label={t('deleteWebsiteRepository')}
                                             description={t('deleteWebsiteRepositoryDescription')}

--- a/apps/web/src/lib/ai/tools/work.tools.ts
+++ b/apps/web/src/lib/ai/tools/work.tools.ts
@@ -21,11 +21,29 @@ import type { ConfirmationRequired } from './generated/factory';
 // When the user's message says what they're building ("I want to create a
 // landing page…"), passing the matching kind persists it on the Work so
 // the kind-aware default website template applies.
-const workKindSchema = z
-    .enum(['website', 'landing-page', 'blog', 'directory', 'awesome-repo', 'repo'])
+const workKindEnum = z.enum([
+    'website',
+    'landing-page',
+    'blog',
+    'directory',
+    'awesome-repo',
+    'repo',
+]);
+
+const workKindSchema = workKindEnum.describe(
+    'Kind of Work the user asked for (from their message, e.g. "I want to create a landing page" → landing-page). ' +
+        '"repo" registers an EXISTING code repository as a Work (needs repositoryUrl; use createWorkManual, never the AI creator). Omit if unclear.',
+);
+
+// The AI creator cannot collect a repositoryUrl, so a `repo` Work is not
+// something it can validly ask for — the description used to say so and hope.
+// Excluding it from the schema means a model that tries anyway gets a
+// validation error instead of a Work that fails registration.
+const aiWorkKindSchema = workKindEnum
+    .exclude(['repo'])
     .describe(
         'Kind of Work the user asked for (from their message, e.g. "I want to create a landing page" → landing-page). ' +
-            '"repo" registers an EXISTING code repository as a Work (needs repositoryUrl; use createWorkManual, never the AI creator). Omit if unclear.',
+            'To register an EXISTING code repository, use createWorkManual with kind "repo" and a repositoryUrl. Omit if unclear.',
     );
 
 // ────────────────────────────────────────────────────────────────
@@ -233,7 +251,7 @@ export const createWorkWithAITool = tool({
             .describe(
                 'User-chosen providers from listAvailablePipelines (e.g., { pipeline: "sim-ai", ai: "openrouter" })',
             ),
-        workKind: workKindSchema.optional(),
+        workKind: aiWorkKindSchema.optional(),
     }),
     execute: async ({
         name,

--- a/apps/web/src/lib/work-kinds/repository-url.ts
+++ b/apps/web/src/lib/work-kinds/repository-url.ts
@@ -1,0 +1,74 @@
+/**
+ * Repository coordinates for a `kind: 'repo'` Work, parsed on the client.
+ *
+ * Mirrors `parseRepositoryWorkSource` on the API closely enough to derive the
+ * name, slug and description before the round trip; the API remains the
+ * authority and re-parses everything it is given.
+ *
+ * This lives outside the form component because the two composers that route
+ * INTO that form need it as well: whatever the user typed must be reduced to
+ * canonical coordinates before it can go anywhere near a URL. See
+ * `canonicalRepositoryUrl` for why.
+ */
+
+/**
+ * Only GitHub is registrable today, and only `github.com/<owner>/<repo>`.
+ *
+ * Repository names may start with a dot (`.github`, `.dotfiles`); owners may
+ * not — same rule as GitHub itself. The pattern is anchored and allows no
+ * user-info, port, query or fragment, so a credential-bearing remote such as
+ * `https://user:token@github.com/o/r` does not match at all.
+ */
+const REPOSITORY_URL_PATTERN =
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9._-]*?)(?:\.git)?\/?$/i;
+
+export interface RepositoryCoordinates {
+    owner: string;
+    repo: string;
+}
+
+export function parseRepositoryUrl(value: string): RepositoryCoordinates | null {
+    const match = REPOSITORY_URL_PATTERN.exec(value.trim());
+    if (!match) return null;
+    const [, owner, repo] = match;
+    // `.` / `..` are path components, not repository names.
+    if (!repo || repo === '.' || repo === '..') return null;
+    return { owner, repo };
+}
+
+/**
+ * The one form of a repository reference that is safe to put in a URL.
+ *
+ * Why this exists: the create composers hand the user's raw text to the
+ * Repository form through the query string, and that text is often pasted
+ * straight from a terminal — including remotes that carry a token in the
+ * user-info section. A query parameter reaches browser history, the referrer
+ * of every subsequent request, and any proxy or server access log, so the raw
+ * value must never travel that way. Anything that does not reduce to
+ * `owner/repo` returns null and the caller routes without a seed; the user
+ * then types into the form field, which posts over TLS and is not logged.
+ */
+export function canonicalRepositoryUrl(value: string): string | null {
+    const coords = parseRepositoryUrl(value);
+    return coords ? `https://github.com/${coords.owner}/${coords.repo}` : null;
+}
+
+/** Same rules as the API slug regex: lowercase letters, digits, hyphens. */
+export function slugifyForWork(value: string): string {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A slug the API will accept: already canonical, so the value the user sees is
+ * the value that gets stored. The `pattern` attribute on the input cannot be
+ * relied on here because the form submits from a button handler rather than a
+ * native `<form>`, so nothing enforces it.
+ */
+export function isCanonicalWorkSlug(value: string): boolean {
+    const trimmed = value.trim();
+    return trimmed.length > 0 && trimmed === slugifyForWork(trimmed);
+}

--- a/apps/web/src/lib/work-kinds/repository-url.unit.spec.ts
+++ b/apps/web/src/lib/work-kinds/repository-url.unit.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+    canonicalRepositoryUrl,
+    isCanonicalWorkSlug,
+    parseRepositoryUrl,
+    slugifyForWork,
+} from './repository-url';
+
+/**
+ * These live here rather than beside the form because the composers route
+ * through them: a review found that whatever the user typed was being handed
+ * to the Repository form through the query string, so a pasted remote holding
+ * a token reached browser history and every later referrer.
+ */
+describe('canonicalRepositoryUrl', () => {
+    it('reduces the accepted spellings to one canonical https URL', () => {
+        for (const input of [
+            'https://github.com/ever-works/ever-works',
+            'http://github.com/ever-works/ever-works',
+            'https://www.github.com/ever-works/ever-works',
+            'github.com/ever-works/ever-works',
+            'https://github.com/ever-works/ever-works.git',
+            'https://github.com/ever-works/ever-works/',
+            '  https://github.com/ever-works/ever-works  ',
+        ]) {
+            expect(canonicalRepositoryUrl(input)).toBe('https://github.com/ever-works/ever-works');
+        }
+    });
+
+    it('refuses a remote that carries credentials, so none can reach the query string', () => {
+        for (const input of [
+            'https://user:ghp_secret@github.com/ever-works/ever-works',
+            'https://ghp_secret@github.com/ever-works/ever-works.git',
+            'git@github.com:ever-works/ever-works.git',
+        ]) {
+            expect(canonicalRepositoryUrl(input)).toBeNull();
+        }
+    });
+
+    it('refuses query strings, fragments and other hosts', () => {
+        expect(canonicalRepositoryUrl('https://github.com/o/r?token=abc')).toBeNull();
+        expect(canonicalRepositoryUrl('https://github.com/o/r#frag')).toBeNull();
+        expect(canonicalRepositoryUrl('https://gitlab.com/o/r')).toBeNull();
+        expect(canonicalRepositoryUrl('https://evil.com/github.com/o/r')).toBeNull();
+        expect(canonicalRepositoryUrl('just some prose the user typed')).toBeNull();
+    });
+});
+
+describe('parseRepositoryUrl', () => {
+    it('accepts a repository whose name starts with a dot, but not an owner', () => {
+        expect(parseRepositoryUrl('https://github.com/ever-works/.github')).toEqual({
+            owner: 'ever-works',
+            repo: '.github',
+        });
+        expect(parseRepositoryUrl('https://github.com/.ever-works/repo')).toBeNull();
+    });
+
+    it('rejects the path components . and ..', () => {
+        expect(parseRepositoryUrl('https://github.com/ever-works/.')).toBeNull();
+        expect(parseRepositoryUrl('https://github.com/ever-works/..')).toBeNull();
+    });
+});
+
+describe('isCanonicalWorkSlug', () => {
+    it('accepts only a slug the API would store unchanged', () => {
+        expect(isCanonicalWorkSlug('my-repo')).toBe(true);
+        expect(isCanonicalWorkSlug('repo123')).toBe(true);
+        // The form submits from a button handler, so the input's `pattern`
+        // never runs: these all used to reach the server action.
+        expect(isCanonicalWorkSlug('My_Repo')).toBe(false);
+        expect(isCanonicalWorkSlug('my repo')).toBe(false);
+        expect(isCanonicalWorkSlug('-my-repo-')).toBe(false);
+        expect(isCanonicalWorkSlug('')).toBe(false);
+        expect(isCanonicalWorkSlug('   ')).toBe(false);
+    });
+
+    it('agrees with slugifyForWork on what canonical means', () => {
+        for (const raw of ['My_Repo', 'my repo', '-my-repo-', 'Ever Works!']) {
+            expect(isCanonicalWorkSlug(slugifyForWork(raw))).toBe(true);
+        }
+    });
+});

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -313,10 +313,12 @@ export class WorkRepository {
                 return false;
             }
             // The `work.owner` column narrowed the query; the registered
-            // coordinates decide the match. Checking both means a row whose
-            // column ever drifted from what was registered cannot produce a
-            // false positive here (`updateWork` refuses to let it drift).
-            return typeof data.owner !== 'string' || data.owner.toLowerCase() === targetOwner;
+            // coordinates decide the match. Both must be present and agree:
+            // treating a row whose registered owner is missing or malformed
+            // as a match would let one broken row block every other account
+            // from registering that repository, and we cannot prove such a
+            // row wraps it. `updateWork` refuses to let the column drift.
+            return typeof data.owner === 'string' && data.owner.toLowerCase() === targetOwner;
         });
     }
 

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -306,9 +306,17 @@ export class WorkRepository {
             .getMany();
 
         const target = repo.toLowerCase();
+        const targetOwner = owner.toLowerCase();
         return candidates.filter((work) => {
             const data = work.sourceRepository?.relatedRepositories?.data;
-            return typeof data?.repo === 'string' && data.repo.toLowerCase() === target;
+            if (typeof data?.repo !== 'string' || data.repo.toLowerCase() !== target) {
+                return false;
+            }
+            // The `work.owner` column narrowed the query; the registered
+            // coordinates decide the match. Checking both means a row whose
+            // column ever drifted from what was registered cannot produce a
+            // false positive here (`updateWork` refuses to let it drift).
+            return typeof data.owner !== 'string' || data.owner.toLowerCase() === targetOwner;
         });
     }
 

--- a/packages/agent/src/services/__tests__/repository-management.service.spec.ts
+++ b/packages/agent/src/services/__tests__/repository-management.service.spec.ts
@@ -1,4 +1,5 @@
 import { RepositoryManagementService } from '../repository-management.service';
+import type { RepositoryType } from '../repository-management.service';
 import type { Work, RepoVisibility } from '@src/entities/work.entity';
 import type { User } from '@src/entities/user.entity';
 
@@ -378,7 +379,15 @@ describe('RepositoryManagementService', () => {
             const work = buildWork({ kind: 'repo' } as Partial<Work>);
 
             await expect(
-                service.updateRepositoryVisibility(work, buildUser(), 'bogus' as any, true),
+                // A value the type system forbids on purpose: `unknown` is the
+                // honest intermediate for "this cannot happen in TypeScript,
+                // prove the runtime still refuses it".
+                service.updateRepositoryVisibility(
+                    work,
+                    buildUser(),
+                    'bogus' as unknown as RepositoryType,
+                    true,
+                ),
             ).rejects.toThrow('Invalid repository type');
         });
     });

--- a/packages/agent/src/services/__tests__/work-generation.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-generation.service.spec.ts
@@ -30,6 +30,15 @@ import { WorkHistoryActivityType } from '@ever-works/contracts/api';
 import { GenerationMethod } from '@src/items-generator/dto/create-items-generator.dto';
 import { createGenerationCancelledError, isGenerationCancelledError } from '@src/utils';
 import { GENERATION_CANCELLED } from '@src/constants/messages';
+import { WorkMemberRole } from '@src/entities/types';
+import type { WorkAccessResult } from '../work-ownership.service';
+import type {
+    CreateItemsGeneratorDto,
+    UpdateItemsGeneratorDto,
+} from '@src/items-generator/dto/create-items-generator.dto';
+import type { RemoveItemDto } from '@src/items-generator/dto/remove-item.dto';
+import type { UpdateItemDto } from '@src/items-generator/dto/update-item.dto';
+import type { SubmitItemDto } from '@src/items-generator/dto/submit-item.dto';
 
 import type { Work } from '@src/entities/work.entity';
 import type { User } from '@src/entities/user.entity';
@@ -2075,17 +2084,30 @@ describe('WorkGenerationService', () => {
         const repoWork = () =>
             buildWork({ kind: 'repo', name: 'Platform', slug: 'platform' } as Partial<Work>);
 
+        /**
+         * The guard runs before any DTO field is read, so these fixtures carry
+         * only what each signature requires. Typed rather than `as any` so a
+         * change to either contract fails here at compile time — which is the
+         * point of a guard suite (review follow-up).
+         */
+        const accessTo = (work: Work): WorkAccessResult => ({
+            work,
+            member: null,
+            role: WorkMemberRole.EDITOR,
+            isCreator: true,
+        });
+        const generatorInput = () => ({ name: 'X', prompt: 'p' }) as CreateItemsGeneratorDto;
+        const submitInput = () =>
+            ({ name: 'X', source_url: 'https://x.dev' }) as unknown as SubmitItemDto;
+        const removeInput = () => ({ item_slug: 'x' }) as RemoveItemDto;
+        const updateInput = () => ({ item_slug: 'x', featured: true }) as UpdateItemDto;
+
         it('generateItems: 400 before history, providers or dispatch', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService({ withDispatcher: true });
             await expect(
-                service.generateItems(
-                    'work-1',
-                    { name: 'X', prompt: 'p' } as any,
-                    buildUser(),
-                    false,
-                ),
+                service.generateItems('work-1', generatorInput(), buildUser(), false),
             ).rejects.toBeInstanceOf(BadRequestException);
 
             expect(generationHistoryRepository.createEntry).not.toHaveBeenCalled();
@@ -2093,13 +2115,13 @@ describe('WorkGenerationService', () => {
         });
 
         it('updateItemsGenerator: 400 even on the scheduled path — no skip bookkeeping, no history', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
                 service.updateItemsGenerator({
                     workId: 'work-1',
-                    updateDto: {} as any,
+                    updateDto: {} as UpdateItemsGeneratorDto,
                     user: buildUser(),
                     awaitCompletion: false,
                     context: { triggeredBy: 'schedule', scheduleId: 'sched-1' },
@@ -2111,7 +2133,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('regenerateMarkdown: 400 without touching the README generator', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(service.regenerateMarkdown('work-1', buildUser())).rejects.toBeInstanceOf(
@@ -2122,7 +2144,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('updateReadme: 400 without touching the data repository', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(service.updateReadme('work-1', buildUser())).rejects.toBeInstanceOf(
@@ -2137,15 +2159,11 @@ describe('WorkGenerationService', () => {
         // Repository Work that is `items/<slug>.md` on the code repo's
         // default branch. Each refuses before ItemSubmissionService clones.
         it('submitItem: 400 before the item is written or the README regenerated', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
-                service.submitItem(
-                    'work-1',
-                    { name: 'X', source_url: 'https://x.dev' } as any,
-                    buildUser(),
-                ),
+                service.submitItem('work-1', submitInput(), buildUser()),
             ).rejects.toBeInstanceOf(BadRequestException);
 
             expect(itemSubmissionService.submitItem).not.toHaveBeenCalled();
@@ -2153,11 +2171,11 @@ describe('WorkGenerationService', () => {
         });
 
         it('removeItem: 400 before the removal commit', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
-                service.removeItem('work-1', { item_slug: 'x' } as any, buildUser()),
+                service.removeItem('work-1', removeInput(), buildUser()),
             ).rejects.toBeInstanceOf(BadRequestException);
 
             expect(itemSubmissionService.removeItem).not.toHaveBeenCalled();
@@ -2165,15 +2183,11 @@ describe('WorkGenerationService', () => {
         });
 
         it('updateItemMetadata: 400 before the metadata commit', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
-                service.updateItemMetadata(
-                    'work-1',
-                    { item_slug: 'x', featured: true } as any,
-                    buildUser(),
-                ),
+                service.updateItemMetadata('work-1', updateInput(), buildUser()),
             ).rejects.toBeInstanceOf(BadRequestException);
 
             expect(itemSubmissionService.updateItem).not.toHaveBeenCalled();
@@ -2181,7 +2195,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('extractItemDetails: 400 when scoped to a Repository Work, before any fetch', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
@@ -2195,7 +2209,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('bulkCaptureImages: 400 before the data repository is cloned for its items', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
@@ -2206,7 +2220,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('updateDomainType: 400 without touching the row', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(
@@ -2217,7 +2231,7 @@ describe('WorkGenerationService', () => {
         });
 
         it('updateWebsiteRepository: 400 — the kind provisions no website repository to sync into', async () => {
-            ownershipService.ensureCanEdit.mockResolvedValue({ work: repoWork() } as any);
+            ownershipService.ensureCanEdit.mockResolvedValue(accessTo(repoWork()));
 
             const service = buildService();
             await expect(service.updateWebsiteRepository('work-1', buildUser())).rejects.toThrow(
@@ -2242,7 +2256,7 @@ describe('WorkGenerationService', () => {
             const service = buildService({ withDispatcher: true });
             const result = await service.generateItems(
                 'work-1',
-                { name: 'X', prompt: 'p' } as any,
+                generatorInput(),
                 buildUser(),
                 false,
             );

--- a/packages/agent/src/services/__tests__/work-lifecycle.external-refs.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.external-refs.spec.ts
@@ -122,6 +122,36 @@ describe('WorkLifecycleService — externalRefs claim map', () => {
         service = module.get(WorkLifecycleService);
     });
 
+    /**
+     * Review finding (Major, data integrity): a Repository Work's `owner` is
+     * the GitHub owner of the wrapped repository, and
+     * `WorkRepository.findRepositoryWorksWrapping` filters duplicate
+     * registrations on that column. Letting an update change it would hide the
+     * existing Work from that check and let a second account register the same
+     * repository.
+     */
+    it('refuses to change the owner of a Repository Work', async () => {
+        work = buildWork({ kind: 'repo', owner: 'ever-works' } as Partial<Work>);
+
+        await expect(service.updateWork(WORK_ID, { owner: 'someone-else' }, user)).rejects.toThrow(
+            BadRequestException,
+        );
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('still allows an owner change on every other kind, and a no-op owner on a repo Work', async () => {
+        work = buildWork({ kind: 'repo', owner: 'ever-works' } as Partial<Work>);
+        const sameOwner = await service.updateWork(WORK_ID, { owner: 'ever-works' }, user);
+        expect(sameOwner.status).toBe('success');
+
+        work = buildWork({ owner: 'acme' });
+        const otherKind = await service.updateWork(WORK_ID, { owner: 'acme-renamed' }, user);
+        expect(otherKind.status).toBe('success');
+        expect(workRepository.update.mock.calls.at(-1)?.[1]).toMatchObject({
+            owner: 'acme-renamed',
+        });
+    });
+
     it('round-trips a claim map through the update path', async () => {
         const result = await service.updateWork(
             WORK_ID,

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -849,6 +849,25 @@ export class WorkLifecycleService {
         // Require at least editor role to update work
         const { work } = await this.ownershipService.ensureCanEdit(id, user.id);
 
+        // A Repository Work's `owner` is not a display field: it is the
+        // GitHub owner of the wrapped repository, and
+        // `WorkRepository.findRepositoryWorksWrapping` filters duplicate
+        // registrations on that column. Letting it drift would hide the
+        // existing Work from that check and let a second account register the
+        // same repository, so the column is immutable for this kind.
+        if (
+            isRepositoryWork(work) &&
+            updateDto.owner !== undefined &&
+            updateDto.owner !== work.owner
+        ) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    'The owner of a Repository Work is the owner of the repository it wraps and cannot be changed. ' +
+                    'Register a new Work for a different repository instead.',
+            });
+        }
+
         try {
             // Build update data object
             const updateData: Record<string, any> = {

--- a/packages/agent/src/works-config/schema/works-config.schema.ts
+++ b/packages/agent/src/works-config/schema/works-config.schema.ts
@@ -245,7 +245,18 @@ const repoSpec = z.looseObject({
              * much a repository can push at it.
              */
             checks: z
-                .array(nonEmptyString.max(REPO_CHECK_MAX_LENGTH))
+                .array(
+                    nonEmptyString
+                        .max(REPO_CHECK_MAX_LENGTH)
+                        // `nonEmptyString` trims before it counts, so "   "
+                        // is rejected at runtime — but `.trim()` cannot be
+                        // expressed in JSON Schema, so the emitted document
+                        // carried only `minLength: 1` and an editor happily
+                        // accepted a whitespace-only check that the loader
+                        // then refused. The explicit pattern is what makes
+                        // editor validation and `validateWorksConfig` agree.
+                        .regex(/\S/, 'must contain a non-whitespace character'),
+                )
                 .max(REPO_CHECKS_MAX)
                 .optional(),
         })

--- a/packages/agent/src/works-config/schema/works.v2.schema.json
+++ b/packages/agent/src/works-config/schema/works.v2.schema.json
@@ -813,7 +813,8 @@
                                     "items": {
                                         "type": "string",
                                         "minLength": 1,
-                                        "maxLength": 500
+                                        "maxLength": 500,
+                                        "pattern": "\S"
                                     }
                                 }
                             },

--- a/packages/agent/src/works-config/schema/works.v2.schema.json
+++ b/packages/agent/src/works-config/schema/works.v2.schema.json
@@ -813,8 +813,7 @@
                                     "items": {
                                         "type": "string",
                                         "minLength": 1,
-                                        "maxLength": 500,
-                                        "pattern": "\S"
+                                        "maxLength": 500
                                     }
                                 }
                             },

--- a/packages/agent/src/works-config/schema/works.v2.schema.json
+++ b/packages/agent/src/works-config/schema/works.v2.schema.json
@@ -813,7 +813,8 @@
                                     "items": {
                                         "type": "string",
                                         "minLength": 1,
-                                        "maxLength": 500
+                                        "maxLength": 500,
+                                        "pattern": "\\S"
                                     }
                                 }
                             },


### PR DESCRIPTION
## Why this exists

[#2305](https://github.com/ever-works/ever-works/pull/2305) merged at 22:46 UTC while CodeRabbit's round-2 findings on it were still being worked. These are those eleven findings, rebased onto `develop`. Full reasoning is in the [disposition comment](https://github.com/ever-works/ever-works/pull/2305#issuecomment-5533337615) on the original PR; the short version follows.

## Three real defects

**Pasted credentials reached the URL.** `NewPageClient` and `WorksCreateComposer` both serialized the raw composer text into the query string when the Repository chip was picked. A remote pasted from a terminal carries a token in the user-info section, and a query parameter reaches browser history, the referrer of every later request, and any proxy or server access log — before `RepositoryWorkForm` could reject it. The parser moved out of the form into `@/lib/work-kinds/repository-url` (the composers that route *into* the form need it too) and gained `canonicalRepositoryUrl`. Both composers now forward only canonical `owner/repo` coordinates; anything else routes with **no `prompt` at all**, and the user types it into the form, which posts over TLS.

**`repo` was requestable from a path that cannot satisfy it.** The AI creation path accepted `kind: 'repo'` although it neither collects nor can construct a `repositoryUrl`. It is now excluded at the schema in both the tool layer and the server action. The type checker then found a real caller: `WorkAICreator` forwarded `initialKind` — `repo` included — into `createWorkWithAI`. That is now narrowed at the boundary, so the compiler enforces what a tool description used to merely request.

**The owner column was load-bearing and mutable.** `findRepositoryWorksWrapping` filters duplicate registrations on `LOWER(work.owner)`, while `updateWork` persisted `updateDto.owner` for every kind. Editing a Repository Work's owner therefore hid it from the duplicate check and let a second account register the same repository. `updateWork` now refuses it, and the lookup verifies the registered coordinates rather than trusting the column alone.

## The rest

Functional state updates in the delete dialog, so batched checkbox updates cannot clobber one another. Slug validation before submit — the input's `pattern` never runs in this button-driven form, so `My_Repo` reached the server action. A non-whitespace pattern on `works.yml` `checks` entries, matching the runtime check. The German strings use the formal register the rest of that file uses, and the Italian and Polish notes name GitHub instead of promising a generic Git provider. New `invalidSlug` key in all 21 locales. The casts added by the Repository Work guard suite are typed fixtures now, and the deliberate invalid runtime value goes through `unknown`.

## Verification

| Gate | Result |
| --- | --- |
| `packages/agent` — work-generation, work-lifecycle, repository-management | 8 suites, 299 tests |
| `apps/web` — works, new, work-kinds | 49 files, 417 tests |
| `tsc --noEmit` (agent, web) | clean |
| Prettier | clean |

Two of the new tests were verified **red without the production change**: the owner-invariant refusal, and the composer's credential test.

Jira: EW-766

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository-based Works now accept normalized GitHub URLs and validate slugs using lowercase letters, numbers, and hyphens.
  * Repository URL credentials and unsupported formats are excluded from navigation parameters.
  * Repository Work ownership cannot be changed after creation.

* **Bug Fixes**
  * Deletion dialog selections now remain preserved when choosing multiple repository options.
  * Repository matching is more accurate, preventing incorrect registrations.

* **Localization**
  * Added slug validation messages across supported languages and clarified GitHub connection guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->