### PR TITLE
feat(agent): Agent Plugins phases 2-3 — acquisition, updates, settings UI, MCP bridge

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -310,6 +310,21 @@ spec:
             - name: CAPTCHA_SECRET
               value: "$CAPTCHA_SECRET"
 
+            # EW-772 — Agent Plugins v1.0.0 standard interop.
+            # Packages in the open cross-vendor format (skills + MCP server
+            # declarations) contribute to the skills catalog. Both variables
+            # are SAFE TO LEAVE EMPTY: the flag defaults to off and the
+            # directory to /app/agent-plugins, so an unset value cannot
+            # crash-loop the pod the way a missing required variable did in
+            # the 2026-06-12 PLATFORM_ENCRYPTION_KEY incident. Note the config
+            # layer reads these with `||`, not `??`, because envsubst renders
+            # an unset variable as an EMPTY STRING rather than leaving it
+            # undefined.
+            - name: FEATURE_AGENT_PLUGINS
+              value: "$FEATURE_AGENT_PLUGINS"
+            - name: AGENT_PLUGINS_DIR
+              value: "$AGENT_PLUGINS_DIR"
+
           resources:
             requests:
               # 2026-06-06 dev right-sizing: live `kubectl top pod` measured

--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -324,6 +324,10 @@ spec:
               value: "$FEATURE_AGENT_PLUGINS"
             - name: AGENT_PLUGINS_DIR
               value: "$AGENT_PLUGINS_DIR"
+            - name: AGENT_PLUGINS_STDIO
+              value: "$AGENT_PLUGINS_STDIO"
+            - name: AGENT_PLUGINS_DATA_DIR
+              value: "$AGENT_PLUGINS_DATA_DIR"
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -347,6 +347,10 @@ spec:
               value: "$FEATURE_AGENT_PLUGINS"
             - name: AGENT_PLUGINS_DIR
               value: "$AGENT_PLUGINS_DIR"
+            - name: AGENT_PLUGINS_STDIO
+              value: "$AGENT_PLUGINS_STDIO"
+            - name: AGENT_PLUGINS_DATA_DIR
+              value: "$AGENT_PLUGINS_DATA_DIR"
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -333,6 +333,21 @@ spec:
             - name: CAPTCHA_SECRET
               value: "$CAPTCHA_SECRET"
 
+            # EW-772 — Agent Plugins v1.0.0 standard interop.
+            # Packages in the open cross-vendor format (skills + MCP server
+            # declarations) contribute to the skills catalog. Both variables
+            # are SAFE TO LEAVE EMPTY: the flag defaults to off and the
+            # directory to /app/agent-plugins, so an unset value cannot
+            # crash-loop the pod the way a missing required variable did in
+            # the 2026-06-12 PLATFORM_ENCRYPTION_KEY incident. Note the config
+            # layer reads these with `||`, not `??`, because envsubst renders
+            # an unset variable as an EMPTY STRING rather than leaving it
+            # undefined.
+            - name: FEATURE_AGENT_PLUGINS
+              value: "$FEATURE_AGENT_PLUGINS"
+            - name: AGENT_PLUGINS_DIR
+              value: "$AGENT_PLUGINS_DIR"
+
           resources:
             requests:
               # 2026-06-06 right-sizing: live `kubectl top pod` measured ~430

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -322,6 +322,10 @@ spec:
               value: "$FEATURE_AGENT_PLUGINS"
             - name: AGENT_PLUGINS_DIR
               value: "$AGENT_PLUGINS_DIR"
+            - name: AGENT_PLUGINS_STDIO
+              value: "$AGENT_PLUGINS_STDIO"
+            - name: AGENT_PLUGINS_DATA_DIR
+              value: "$AGENT_PLUGINS_DATA_DIR"
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -308,6 +308,21 @@ spec:
             - name: CAPTCHA_SECRET
               value: "$CAPTCHA_SECRET"
 
+            # EW-772 — Agent Plugins v1.0.0 standard interop.
+            # Packages in the open cross-vendor format (skills + MCP server
+            # declarations) contribute to the skills catalog. Both variables
+            # are SAFE TO LEAVE EMPTY: the flag defaults to off and the
+            # directory to /app/agent-plugins, so an unset value cannot
+            # crash-loop the pod the way a missing required variable did in
+            # the 2026-06-12 PLATFORM_ENCRYPTION_KEY incident. Note the config
+            # layer reads these with `||`, not `??`, because envsubst renders
+            # an unset variable as an EMPTY STRING rather than leaving it
+            # undefined.
+            - name: FEATURE_AGENT_PLUGINS
+              value: "$FEATURE_AGENT_PLUGINS"
+            - name: AGENT_PLUGINS_DIR
+              value: "$AGENT_PLUGINS_DIR"
+
           resources:
             requests:
               # 2026-06-06 stage right-sizing: live `kubectl top pod` measured

--- a/.env.compose
+++ b/.env.compose
@@ -396,3 +396,19 @@ FEATURE_AGENT_PLUGINS=false
 # packages. Leave empty for the default (/app/agent-plugins) — an empty value
 # resolves to the default rather than disabling the feature.
 AGENT_PLUGINS_DIR=
+
+# Stdio MCP servers declared by packages. A SEPARATE switch from
+# FEATURE_AGENT_PLUGINS on purpose: that one lets packages contribute
+# documents and remote server declarations, which are inert data. This one
+# lets the platform execute a subprocess from a package's contents, which is
+# a categorically larger grant. Default off, and no sandbox is built yet — a
+# stdio server would run with the API's own privileges. A stdio server on a
+# deployment with this off is reported as "present, disabled by policy"
+# rather than hidden, so you can see what a package would run.
+AGENT_PLUGINS_STDIO=false
+
+# Where per-package writable data lives (${PLUGIN_DATA}). Deliberately NOT
+# under AGENT_PLUGINS_DIR: package contents are read-only and replaced
+# wholesale on update, while data must survive that. Leave empty for the
+# default (/app/agent-plugins-data).
+AGENT_PLUGINS_DATA_DIR=

--- a/.env.compose
+++ b/.env.compose
@@ -381,3 +381,18 @@ USER_RESEARCH_SCHEDULED_RERUN_ENABLED=false
 # User-facing research controls. Timeout is milliseconds; runs are per user per day.
 USER_RESEARCH_TIMEOUT_MS=1800000
 USER_RESEARCH_MAX_RUNS_PER_DAY=3
+
+# ─── Agent Plugins standard interop (EW-772) ────────────────────────────────
+# Support for the open Agent Plugins v1.0.0 format: packages of `SKILL.md`
+# files and MCP server declarations that any conforming client can read.
+# Strictly additive — with the flag off, nothing about the existing skills
+# catalog or plugin system changes.
+
+# Off by default. Turn on to let installed packages contribute to the catalog.
+FEATURE_AGENT_PLUGINS=false
+
+# Where packages live. Accepts several directories separated by `,`, `;` or
+# the platform path delimiter; the first is the write target for fetched
+# packages. Leave empty for the default (/app/agent-plugins) — an empty value
+# resolves to the default rather than disabling the feature.
+AGENT_PLUGINS_DIR=

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -197,6 +197,15 @@ jobs:
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
           CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
 
+          # EW-772 — Agent Plugins v1.0.0 standard interop. Repository
+          # VARIABLES rather than secrets: neither value is sensitive, and a
+          # variable is visible in the deploy log where a secret is masked —
+          # which matters when diagnosing why packages are not appearing.
+          # Both are safe to leave unset: the flag defaults to off and the
+          # directory to /app/agent-plugins.
+          FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
+          AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -205,6 +205,8 @@ jobs:
           # directory to /app/agent-plugins.
           FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
           AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+          AGENT_PLUGINS_STDIO: ${{ vars.AGENT_PLUGINS_STDIO }}
+          AGENT_PLUGINS_DATA_DIR: ${{ vars.AGENT_PLUGINS_DATA_DIR }}
 
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -222,6 +222,15 @@ jobs:
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
           CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
 
+          # EW-772 — Agent Plugins v1.0.0 standard interop. Repository
+          # VARIABLES rather than secrets: neither value is sensitive, and a
+          # variable is visible in the deploy log where a secret is masked —
+          # which matters when diagnosing why packages are not appearing.
+          # Both are safe to leave unset: the flag defaults to off and the
+          # directory to /app/agent-plugins.
+          FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
+          AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -230,6 +230,8 @@ jobs:
           # directory to /app/agent-plugins.
           FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
           AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+          AGENT_PLUGINS_STDIO: ${{ vars.AGENT_PLUGINS_STDIO }}
+          AGENT_PLUGINS_DATA_DIR: ${{ vars.AGENT_PLUGINS_DATA_DIR }}
 
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -197,6 +197,15 @@ jobs:
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
           CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
 
+          # EW-772 — Agent Plugins v1.0.0 standard interop. Repository
+          # VARIABLES rather than secrets: neither value is sensitive, and a
+          # variable is visible in the deploy log where a secret is masked —
+          # which matters when diagnosing why packages are not appearing.
+          # Both are safe to leave unset: the flag defaults to off and the
+          # directory to /app/agent-plugins.
+          FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
+          AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -205,6 +205,8 @@ jobs:
           # directory to /app/agent-plugins.
           FEATURE_AGENT_PLUGINS: ${{ vars.FEATURE_AGENT_PLUGINS }}
           AGENT_PLUGINS_DIR: ${{ vars.AGENT_PLUGINS_DIR }}
+          AGENT_PLUGINS_STDIO: ${{ vars.AGENT_PLUGINS_STDIO }}
+          AGENT_PLUGINS_DATA_DIR: ${{ vars.AGENT_PLUGINS_DATA_DIR }}
 
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later

--- a/apps/api/src/agent-plugins/agent-plugins.controller.ts
+++ b/apps/api/src/agent-plugins/agent-plugins.controller.ts
@@ -1,15 +1,32 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    Param,
+    ParseUUIDPipe,
+    Post,
+    Query,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import {
+    AgentPluginInstallService,
     AgentPluginPackageCatalogService,
+    AgentPluginUpdateService,
     loadedPackages,
     rejectedPackages,
     scanConfiguredPackages,
+    type AcquireInput,
 } from '@ever-works/agent/agent-plugins';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
-import { ListAgentPluginPackagesQueryDto } from './dto/agent-plugin.dto';
+import {
+    InstallAgentPluginPackageDto,
+    ListAgentPluginPackagesQueryDto,
+} from './dto/agent-plugin.dto';
 
 /**
  * Read surface over installed Agent Plugins packages.
@@ -23,15 +40,19 @@ import { ListAgentPluginPackagesQueryDto } from './dto/agent-plugin.dto';
  * Authentication is global (`AuthSessionGuard` as an `APP_GUARD`), so a
  * user-scoped controller needs no `@UseGuards` of its own.
  *
- * Read-only in this phase. Installing, updating and removing packages arrive
- * with the git and npm sources; local packages are registered in place, so
- * there is nothing yet for a write route to do that editing the directory
- * does not already do.
+ * Local packages have no write routes: such a package IS the directory the
+ * operator configured, so "removing" one through the API would only
+ * disagree with the filesystem until the next scan. Only git and npm
+ * packages can be installed, re-synced and removed here.
  */
 @ApiTags('agent-plugins')
 @Controller('api/agent-plugins')
 export class AgentPluginsController {
-    constructor(private readonly catalog: AgentPluginPackageCatalogService) {}
+    constructor(
+        private readonly catalog: AgentPluginPackageCatalogService,
+        private readonly installer: AgentPluginInstallService,
+        private readonly updateService: AgentPluginUpdateService,
+    ) {}
 
     @Get()
     @ApiOperation({
@@ -128,4 +149,79 @@ export class AgentPluginsController {
         });
         return { entries, total: entries.length };
     }
+
+    @Get('updates')
+    @ApiOperation({
+        summary: 'Packages with a newer version available',
+        description:
+            'Reports only. Upgrading changes the instructions an agent follows, so it stays an explicit action rather than a side effect of rendering this page. Packages whose remote could not be reached are listed separately from packages that are up to date.',
+    })
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async listUpdates(@CurrentUser() _auth: AuthenticatedUser) {
+        return this.updateService.checkForUpdates();
+    }
+
+    @Post()
+    @ApiOperation({
+        summary: 'Install a package from git or npm',
+        description:
+            'Requires an allowlist entry for the exact package name or git URL. The fetched tree is validated before it is kept — a package that fails is deleted rather than left on disk.',
+    })
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async install(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: InstallAgentPluginPackageDto,
+    ) {
+        const row = await this.installer.install(toAcquireInput(body), { userId: auth.userId });
+        return { id: row.id, name: row.name, version: row.version, source: row.source };
+    }
+
+    @Post(':id/resync')
+    @ApiOperation({
+        summary: 'Re-fetch a package at its recorded coordinates',
+        description:
+            'The explicit counterpart to the update badge. Re-runs the same acquire-and-validate path as an install.',
+    })
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async resync(@CurrentUser() auth: AuthenticatedUser, @Param('id', ParseUUIDPipe) id: string) {
+        const row = await this.installer.resync(id, auth.userId);
+        return { id: row.id, name: row.name, version: row.version, source: row.source };
+    }
+
+    @Delete(':id')
+    @HttpCode(204)
+    @ApiOperation({
+        summary: 'Remove an installed package',
+        description:
+            'Deletes the registry row and then the directory. A package the caller does not own reports 404 rather than 403, so the response does not confirm that another user’s package exists.',
+    })
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async remove(@CurrentUser() auth: AuthenticatedUser, @Param('id', ParseUUIDPipe) id: string) {
+        await this.installer.remove(id, auth.userId);
+    }
+}
+
+/**
+ * Turn the flat request body into the acquirer's discriminated input.
+ *
+ * The DTO cannot express "url required when source is git" with
+ * class-validator alone without a custom constraint, so the pairing is checked
+ * here — and rejected with a message naming the missing field, because
+ * `BadRequestException` with no detail is the least useful 400 there is.
+ */
+export function toAcquireInput(body: InstallAgentPluginPackageDto): AcquireInput {
+    if (body.source === 'git') {
+        if (!body.url) {
+            throw new BadRequestException('A git package requires "url".');
+        }
+        return { kind: 'git', url: body.url, ...(body.ref ? { ref: body.ref } : {}) };
+    }
+    if (!body.packageName) {
+        throw new BadRequestException('An npm package requires "packageName".');
+    }
+    return {
+        kind: 'npm',
+        packageName: body.packageName,
+        ...(body.version ? { version: body.version } : {}),
+    };
 }

--- a/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
+++ b/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
@@ -91,3 +91,44 @@ export class UpdateAgentPluginAllowlistEntryDto {
     @MaxLength(2000)
     notes?: string;
 }
+
+/** Which remote source a package is installed from. */
+export const AGENT_PLUGIN_INSTALL_SOURCES = ['git', 'npm'] as const;
+
+export class InstallAgentPluginPackageDto {
+    @ApiProperty({ enum: AGENT_PLUGIN_INSTALL_SOURCES })
+    @IsIn(AGENT_PLUGIN_INSTALL_SOURCES)
+    source: (typeof AGENT_PLUGIN_INSTALL_SOURCES)[number];
+
+    @ApiPropertyOptional({
+        description: 'HTTPS clone URL. Required when source is "git".',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2048)
+    url?: string;
+
+    @ApiPropertyOptional({
+        description: 'Branch or tag to pin. Only meaningful when source is "git".',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    ref?: string;
+
+    @ApiPropertyOptional({
+        description: 'Package name. Required when source is "npm".',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(214)
+    packageName?: string;
+
+    @ApiPropertyOptional({
+        description: 'Version or dist-tag. Only meaningful when source is "npm".',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    version?: string;
+}

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "إضافات الوكيل"
             },
             "githubApp": {
                 "title": "تثبيتات تطبيق GitHub",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "إضافات الوكيل",
+                "description": "الحزم بتنسيق Agent Plugins المفتوح تضيف مهارات وخوادم MCP إلى مساحة العمل هذه. وهي تعمل مع أي عميل يدعم المعيار.",
+                "disabled": "دعم إضافات الوكيل معطّل في هذا النشر. يمكن للمشغّل تفعيله بضبط:",
+                "loadFailed": "تعذّر تحميل الحزم المثبّتة. هذه مشكلة اتصال وليست دليلاً على عدم وجود أي تثبيت.",
+                "scanning": "جارٍ فحص {roots}",
+                "searchPlaceholder": "ابحث في الحزم والمهارات",
+                "empty": "لا توجد حزم مثبّتة بعد.",
+                "noMatches": "لا توجد حزم تطابق بحثك.",
+                "specVersion": "المواصفة {version}",
+                "skills": "{count, plural, =0 {المهارات} one {مهارة واحدة} two {مهارتان} few {# مهارات} many {# مهارة} other {# مهارة}}",
+                "mcpServers": "{count, plural, =0 {خوادم MCP} one {خادم MCP واحد} two {خادما MCP} few {# خوادم MCP} many {# خادم MCP} other {# خادم MCP}}",
+                "none": "لا شيء",
+                "rejected": "مرفوضة",
+                "rejectedHelp": "تعذّر تحميل هذه الحزمة، لذا فهي لا تضيف شيئاً. وهي مدرجة لأن أحدهم أضافها عمداً.",
+                "rejectedHeading": "{count, plural, one {حزمة مرفوضة واحدة} two {حزمتان مرفوضتان} few {# حزم مرفوضة} many {# حزمة مرفوضة} other {# حزمة مرفوضة}}",
+                "shadowedHeading": "حزم محجوبة",
+                "shadowedHelp": "تعلن هذه الحزم اسماً وفّره دليل سابق بالفعل، لذا يُستخدم الأول فقط.",
+                "severity": {
+                    "fatal": "فادح",
+                    "error": "خطأ",
+                    "warning": "تحذير"
+                },
+                "scopes": {
+                    "package": "الحزمة",
+                    "manifest": "البيان",
+                    "skills": "المهارات",
+                    "mcp": "خوادم MCP"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Плъгини за агенти"
             },
             "githubApp": {
                 "title": "Инсталации на GitHub App",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Плъгини за агенти",
+                "description": "Пакетите в отворения формат Agent Plugins добавят умения и MCP сървъри към това работно пространство. Работят във всеки клиент, който поддържа стандарта.",
+                "disabled": "Поддръжката на плъгини за агенти е изключена в тази среда. Операторът може да я включи, като зададе:",
+                "loadFailed": "Инсталираните пакети не можаха да се заредят. Това е проблем с връзката, а не знак, че нищо не е инсталирано.",
+                "scanning": "Сканиране на {roots}",
+                "searchPlaceholder": "Търсене на пакети и умения",
+                "empty": "Все още няма инсталирани пакети.",
+                "noMatches": "Няма пакети, отговарящи на търсенето.",
+                "specVersion": "спец. {version}",
+                "skills": "{count, plural, =0 {Умения} one {# умение} other {# умения}}",
+                "mcpServers": "{count, plural, =0 {MCP сървъри} one {# MCP сървър} other {# MCP сървъра}}",
+                "none": "Няма",
+                "rejected": "отхвърлен",
+                "rejectedHelp": "Този пакет не можа да бъде зареден и затова не допринася с нищо. Показан е, защото някой го е добавил умишлено.",
+                "rejectedHeading": "{count, plural, one {# отхвърлен пакет} other {# отхвърлени пакета}}",
+                "shadowedHeading": "Засенчени пакети",
+                "shadowedHelp": "Те обявяват име, което по-ранна директория вече предоставя, затова се използва само първият.",
+                "severity": {
+                    "fatal": "Фатална",
+                    "error": "Грешка",
+                    "warning": "Предупреждение"
+                },
+                "scopes": {
+                    "package": "Пакет",
+                    "manifest": "Манифест",
+                    "skills": "Умения",
+                    "mcp": "MCP сървъри"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Agent-Plugins"
             },
             "githubApp": {
                 "title": "GitHub-App-Installationen",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Agent-Plugins",
+                "description": "Pakete im offenen Agent-Plugins-Format steuern Skills und MCP-Server zu diesem Workspace bei. Sie funktionieren in jedem Client, der den Standard unterstützt.",
+                "disabled": "Die Unterstützung für Agent-Plugins ist in dieser Umgebung deaktiviert. Ein Betreiber kann sie aktivieren mit:",
+                "loadFailed": "Installierte Pakete konnten nicht geladen werden. Das ist ein Verbindungsproblem und kein Hinweis darauf, dass nichts installiert ist.",
+                "scanning": "Durchsucht {roots}",
+                "searchPlaceholder": "Pakete und Skills durchsuchen",
+                "empty": "Noch keine Pakete installiert.",
+                "noMatches": "Keine Pakete entsprechen Ihrer Suche.",
+                "specVersion": "Spez. {version}",
+                "skills": "{count, plural, =0 {Skills} one {# Skill} other {# Skills}}",
+                "mcpServers": "{count, plural, =0 {MCP-Server} one {# MCP-Server} other {# MCP-Server}}",
+                "none": "Keine",
+                "rejected": "abgelehnt",
+                "rejectedHelp": "Dieses Paket konnte nicht geladen werden und steuert daher nichts bei. Es wird aufgeführt, weil es jemand bewusst hinzugefügt hat.",
+                "rejectedHeading": "{count, plural, one {# abgelehntes Paket} other {# abgelehnte Pakete}}",
+                "shadowedHeading": "Überdeckte Pakete",
+                "shadowedHelp": "Diese deklarieren einen Namen, den ein früheres Verzeichnis bereits bereitstellt; nur das erste wird verwendet.",
+                "severity": {
+                    "fatal": "Schwerwiegend",
+                    "error": "Fehler",
+                    "warning": "Warnung"
+                },
+                "scopes": {
+                    "package": "Paket",
+                    "manifest": "Manifest",
+                    "skills": "Skills",
+                    "mcp": "MCP-Server"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2826,7 +2826,8 @@
                 "channels": "Channels",
                 "emails": "Email Addresses",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Agent Plugins"
             },
             "githubApp": {
                 "title": "GitHub App Installations",
@@ -4002,6 +4003,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Agent Plugins",
+                "description": "Packages in the open Agent Plugins format contribute skills and MCP servers to this workspace. They work across any client that supports the standard.",
+                "disabled": "Agent Plugins support is turned off on this deployment. An operator can enable it by setting:",
+                "loadFailed": "Could not load installed packages. This is a connection problem, not a sign that nothing is installed.",
+                "scanning": "Scanning {roots}",
+                "searchPlaceholder": "Search packages and skills",
+                "empty": "No packages installed yet.",
+                "noMatches": "No packages match your search.",
+                "specVersion": "spec {version}",
+                "skills": "{count, plural, =0 {Skills} one {# skill} other {# skills}}",
+                "mcpServers": "{count, plural, =0 {MCP servers} one {# MCP server} other {# MCP servers}}",
+                "none": "None",
+                "rejected": "rejected",
+                "rejectedHelp": "This package could not be loaded, so it contributes nothing. It is listed because somebody added it deliberately.",
+                "rejectedHeading": "{count, plural, one {# rejected package} other {# rejected packages}}",
+                "shadowedHeading": "Shadowed packages",
+                "shadowedHelp": "These declare a name an earlier directory already provided, so only the first is used.",
+                "severity": {
+                    "fatal": "Fatal",
+                    "error": "Error",
+                    "warning": "Warning"
+                },
+                "scopes": {
+                    "package": "Package",
+                    "manifest": "Manifest",
+                    "skills": "Skills",
+                    "mcp": "MCP servers"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Complementos de agente"
             },
             "githubApp": {
                 "title": "Instalaciones de GitHub App",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Complementos de agente",
+                "description": "Los paquetes en el formato abierto Agent Plugins aportan habilidades y servidores MCP a este espacio de trabajo. Funcionan con cualquier cliente compatible con el estándar.",
+                "disabled": "La compatibilidad con complementos de agente está desactivada en esta implementación. Un operador puede activarla configurando:",
+                "loadFailed": "No se pudieron cargar los paquetes instalados. Es un problema de conexión, no una señal de que no haya nada instalado.",
+                "scanning": "Explorando {roots}",
+                "searchPlaceholder": "Buscar paquetes y habilidades",
+                "empty": "Todavía no hay paquetes instalados.",
+                "noMatches": "Ningún paquete coincide con tu búsqueda.",
+                "specVersion": "espec. {version}",
+                "skills": "{count, plural, =0 {Habilidades} one {# habilidad} other {# habilidades}}",
+                "mcpServers": "{count, plural, =0 {Servidores MCP} one {# servidor MCP} other {# servidores MCP}}",
+                "none": "Ninguno",
+                "rejected": "rechazado",
+                "rejectedHelp": "Este paquete no se pudo cargar, así que no aporta nada. Aparece porque alguien lo añadió deliberadamente.",
+                "rejectedHeading": "{count, plural, one {# paquete rechazado} other {# paquetes rechazados}}",
+                "shadowedHeading": "Paquetes eclipsados",
+                "shadowedHelp": "Declaran un nombre que ya proporcionaba un directorio anterior, así que solo se usa el primero.",
+                "severity": {
+                    "fatal": "Grave",
+                    "error": "Error",
+                    "warning": "Advertencia"
+                },
+                "scopes": {
+                    "package": "Paquete",
+                    "manifest": "Manifiesto",
+                    "skills": "Habilidades",
+                    "mcp": "Servidores MCP"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Plugins d’agent"
             },
             "githubApp": {
                 "title": "Installations GitHub App",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Plugins d’agent",
+                "description": "Les paquets au format ouvert Agent Plugins ajoutent des compétences et des serveurs MCP à cet espace de travail. Ils fonctionnent avec tout client compatible avec la norme.",
+                "disabled": "La prise en charge des plugins d’agent est désactivée sur ce déploiement. Un opérateur peut l’activer en définissant :",
+                "loadFailed": "Impossible de charger les paquets installés. Il s’agit d’un problème de connexion, pas d’un signe qu’aucun paquet n’est installé.",
+                "scanning": "Analyse de {roots}",
+                "searchPlaceholder": "Rechercher des paquets et des compétences",
+                "empty": "Aucun paquet installé pour l’instant.",
+                "noMatches": "Aucun paquet ne correspond à votre recherche.",
+                "specVersion": "spéc. {version}",
+                "skills": "{count, plural, =0 {Compétences} one {# compétence} other {# compétences}}",
+                "mcpServers": "{count, plural, =0 {Serveurs MCP} one {# serveur MCP} other {# serveurs MCP}}",
+                "none": "Aucun",
+                "rejected": "rejeté",
+                "rejectedHelp": "Ce paquet n’a pas pu être chargé et n’apporte donc rien. Il est répertorié parce que quelqu’un l’a ajouté délibérément.",
+                "rejectedHeading": "{count, plural, one {# paquet rejeté} other {# paquets rejetés}}",
+                "shadowedHeading": "Paquets masqués",
+                "shadowedHelp": "Ceux-ci déclarent un nom déjà fourni par un répertoire précédent ; seul le premier est utilisé.",
+                "severity": {
+                    "fatal": "Fatal",
+                    "error": "Erreur",
+                    "warning": "Avertissement"
+                },
+                "scopes": {
+                    "package": "Paquet",
+                    "manifest": "Manifeste",
+                    "skills": "Compétences",
+                    "mcp": "Serveurs MCP"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2617,7 +2617,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "תוספי סוכן"
             },
             "githubApp": {
                 "title": "התקנות GitHub App",
@@ -3737,6 +3738,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "תוספי סוכן",
+                "description": "חבילות בפורמט הפתוח Agent Plugins מוסיפות מיומנויות ושרתי MCP למרחב העבודה הזה. הן פועלות בכל לקוח שתומך בתקן.",
+                "disabled": "התמיכה בתוספי סוכן כבויה בפריסה הזו. מפעיל יכול להפעיל אותה על ידי הגדרת:",
+                "loadFailed": "לא ניתן היה לטעון את החבילות המותקנות. זו בעיית חיבור, ולא סימן לכך שדבר אינו מותקן.",
+                "scanning": "סורק את {roots}",
+                "searchPlaceholder": "חיפוש חבילות ומיומנויות",
+                "empty": "עדיין לא הותקנו חבילות.",
+                "noMatches": "אין חבילות התואמות את החיפוש.",
+                "specVersion": "מפרט {version}",
+                "skills": "{count, plural, =0 {מיומנויות} one {מיומנות אחת} two {שתי מיומנויות} other {# מיומנויות}}",
+                "mcpServers": "{count, plural, =0 {שרתי MCP} one {שרת MCP אחד} two {שני שרתי MCP} other {# שרתי MCP}}",
+                "none": "אין",
+                "rejected": "נדחתה",
+                "rejectedHelp": "לא ניתן היה לטעון את החבילה הזו, ולכן היא אינה תורמת דבר. היא מוצגת משום שמישהו הוסיף אותה בכוונה.",
+                "rejectedHeading": "{count, plural, one {חבילה אחת שנדחתה} two {שתי חבילות שנדחו} other {# חבילות שנדחו}}",
+                "shadowedHeading": "חבילות מוסתרות",
+                "shadowedHelp": "הן מכריזות על שם שספרייה מוקדמת יותר כבר סיפקה, ולכן רק הראשונה בשימוש.",
+                "severity": {
+                    "fatal": "קריטי",
+                    "error": "שגיאה",
+                    "warning": "אזהרה"
+                },
+                "scopes": {
+                    "package": "חבילה",
+                    "manifest": "מניפסט",
+                    "skills": "מיומנויות",
+                    "mcp": "שרתי MCP"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "एजेंट प्लगइन"
             },
             "githubApp": {
                 "title": "GitHub ऐप इंस्टॉलेशन",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "एजेंट प्लगइन",
+                "description": "खुले Agent Plugins प्रारूप के पैकेज इस वर्कस्पेस में कौशल और MCP सर्वर जोड़ते हैं। ये मानक का समर्थन करने वाले किसी भी क्लायंट में काम करते हैं।",
+                "disabled": "इस परिनियोजन पर एजेंट प्लगइन समर्थन बंद है। संचालक इसे इस तरह सक्षम कर सकते हैं:",
+                "loadFailed": "स्थापित पैकेज लोड नहीं हो सके। यह कनेक्शन की समस्या है, इसका मतलब यह नहीं कि कुछ भी स्थापित नहीं है।",
+                "scanning": "{roots} स्कैन किया जा रहा है",
+                "searchPlaceholder": "पैकेज और कौशल खोजें",
+                "empty": "अभी तक कोई पैकेज स्थापित नहीं है।",
+                "noMatches": "आपकी खोज से कोई पैकेज मेल नहीं खाता।",
+                "specVersion": "विनिर्देश {version}",
+                "skills": "{count, plural, =0 {कौशल} one {# कौशल} other {# कौशल}}",
+                "mcpServers": "{count, plural, =0 {MCP सर्वर} one {# MCP सर्वर} other {# MCP सर्वर}}",
+                "none": "कोई नहीं",
+                "rejected": "अस्वीकृत",
+                "rejectedHelp": "यह पैकेज लोड नहीं हो सका, इसलिए यह कुछ नहीं जोड़ता। यह इसलिए सूचीबद्ध है क्योंकि किसी ने इसे जानबूझकर जोड़ा था।",
+                "rejectedHeading": "{count, plural, one {# अस्वीकृत पैकेज} other {# अस्वीकृत पैकेज}}",
+                "shadowedHeading": "ढके हुए पैकेज",
+                "shadowedHelp": "ये एक ऐसा नाम घोषित करते हैं जो पहले की डायरेक्टरी पहले ही दे चुकी है, इसलिए केवल पहला उपयोग होता है।",
+                "severity": {
+                    "fatal": "गंभीर",
+                    "error": "त्रुटि",
+                    "warning": "चेतावनी"
+                },
+                "scopes": {
+                    "package": "पैकेज",
+                    "manifest": "मैनिफ़ेस्ट",
+                    "skills": "कौशल",
+                    "mcp": "MCP सर्वर"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Plugin agen"
             },
             "githubApp": {
                 "title": "Instalasi GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Plugin agen",
+                "description": "Paket dalam format terbuka Agent Plugins menambahkan keterampilan dan server MCP ke ruang kerja ini. Paket bekerja di klien mana pun yang mendukung standar tersebut.",
+                "disabled": "Dukungan plugin agen dimatikan pada penerapan ini. Operator dapat mengaktifkannya dengan menyetel:",
+                "loadFailed": "Tidak dapat memuat paket yang terpasang. Ini masalah koneksi, bukan tanda bahwa tidak ada yang terpasang.",
+                "scanning": "Memindai {roots}",
+                "searchPlaceholder": "Cari paket dan keterampilan",
+                "empty": "Belum ada paket yang terpasang.",
+                "noMatches": "Tidak ada paket yang cocok dengan pencarian Anda.",
+                "specVersion": "spek {version}",
+                "skills": "{count, plural, other {# keterampilan}}",
+                "mcpServers": "{count, plural, other {# server MCP}}",
+                "none": "Tidak ada",
+                "rejected": "ditolak",
+                "rejectedHelp": "Paket ini tidak dapat dimuat sehingga tidak menyumbang apa pun. Paket ditampilkan karena seseorang menambahkannya dengan sengaja.",
+                "rejectedHeading": "{count, plural, other {# paket ditolak}}",
+                "shadowedHeading": "Paket yang tertutup",
+                "shadowedHelp": "Paket ini mendeklarasikan nama yang sudah disediakan direktori sebelumnya, jadi hanya yang pertama dipakai.",
+                "severity": {
+                    "fatal": "Fatal",
+                    "error": "Kesalahan",
+                    "warning": "Peringatan"
+                },
+                "scopes": {
+                    "package": "Paket",
+                    "manifest": "Manifes",
+                    "skills": "Keterampilan",
+                    "mcp": "Server MCP"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Plugin per agenti"
             },
             "githubApp": {
                 "title": "Installazioni GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Plugin per agenti",
+                "description": "I pacchetti nel formato aperto Agent Plugins aggiungono competenze e server MCP a questo spazio di lavoro. Funzionano con qualsiasi client che supporti lo standard.",
+                "disabled": "Il supporto per i plugin per agenti è disattivato su questo deployment. Un operatore può abilitarlo impostando:",
+                "loadFailed": "Impossibile caricare i pacchetti installati. È un problema di connessione, non un segnale che non ci sia nulla installato.",
+                "scanning": "Scansione di {roots}",
+                "searchPlaceholder": "Cerca pacchetti e competenze",
+                "empty": "Nessun pacchetto ancora installato.",
+                "noMatches": "Nessun pacchetto corrisponde alla ricerca.",
+                "specVersion": "spec. {version}",
+                "skills": "{count, plural, =0 {Competenze} one {# competenza} other {# competenze}}",
+                "mcpServers": "{count, plural, =0 {Server MCP} one {# server MCP} other {# server MCP}}",
+                "none": "Nessuno",
+                "rejected": "rifiutato",
+                "rejectedHelp": "Questo pacchetto non è stato caricato, quindi non aggiunge nulla. È elencato perché qualcuno lo ha aggiunto deliberatamente.",
+                "rejectedHeading": "{count, plural, one {# pacchetto rifiutato} other {# pacchetti rifiutati}}",
+                "shadowedHeading": "Pacchetti oscurati",
+                "shadowedHelp": "Dichiarano un nome già fornito da una directory precedente, quindi viene usato solo il primo.",
+                "severity": {
+                    "fatal": "Fatale",
+                    "error": "Errore",
+                    "warning": "Avviso"
+                },
+                "scopes": {
+                    "package": "Pacchetto",
+                    "manifest": "Manifest",
+                    "skills": "Competenze",
+                    "mcp": "Server MCP"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "エージェントプラグイン"
             },
             "githubApp": {
                 "title": "GitHub App インストール",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "エージェントプラグイン",
+                "description": "オープンな Agent Plugins 形式のパッケージは、このワークスペースにスキルと MCP サーバーを追加します。標準に対応したどのクライアントでも動作します。",
+                "disabled": "このデプロイではエージェントプラグインのサポートが無効です。運用者は次を設定して有効にできます:",
+                "loadFailed": "インストール済みパッケージを読み込めませんでした。これは接続の問題であり、何もインストールされていないという意味ではありません。",
+                "scanning": "{roots} をスキャン中",
+                "searchPlaceholder": "パッケージとスキルを検索",
+                "empty": "まだパッケージがインストールされていません。",
+                "noMatches": "検索に一致するパッケージはありません。",
+                "specVersion": "仕様 {version}",
+                "skills": "{count, plural, =0 {スキル} other {# 件のスキル}}",
+                "mcpServers": "{count, plural, =0 {MCP サーバー} other {# 件の MCP サーバー}}",
+                "none": "なし",
+                "rejected": "拒否",
+                "rejectedHelp": "このパッケージは読み込めなかったため、何も提供しません。誰かが意図的に追加したものなので一覧に表示しています。",
+                "rejectedHeading": "{count, plural, other {# 件の拒否されたパッケージ}}",
+                "shadowedHeading": "隠されたパッケージ",
+                "shadowedHelp": "先のディレクトリがすでに提供している名前を宣言しているため、最初のものだけが使われます。",
+                "severity": {
+                    "fatal": "致命的",
+                    "error": "エラー",
+                    "warning": "警告"
+                },
+                "scopes": {
+                    "package": "パッケージ",
+                    "manifest": "マニフェスト",
+                    "skills": "スキル",
+                    "mcp": "MCP サーバー"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "에이전트 플러그인"
             },
             "githubApp": {
                 "title": "GitHub 앱 설치",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "에이전트 플러그인",
+                "description": "개방형 Agent Plugins 형식의 패키지는 이 워크스페이스에 스킬과 MCP 서버를 추가합니다. 표준을 지원하는 모든 클라이언트에서 작동합니다.",
+                "disabled": "이 배포에서는 에이전트 플러그인 지원이 꺼져 있습니다. 운영자는 다음을 설정해 활성화할 수 있습니다:",
+                "loadFailed": "설치된 패키지를 불러오지 못했습니다. 연결 문제이며, 설치된 것이 없다는 뜻은 아닙니다.",
+                "scanning": "{roots} 검사 중",
+                "searchPlaceholder": "패키지 및 스킬 검색",
+                "empty": "아직 설치된 패키지가 없습니다.",
+                "noMatches": "검색과 일치하는 패키지가 없습니다.",
+                "specVersion": "사양 {version}",
+                "skills": "{count, plural, =0 {스킬} other {스킬 #개}}",
+                "mcpServers": "{count, plural, =0 {MCP 서버} other {MCP 서버 #개}}",
+                "none": "없음",
+                "rejected": "거부됨",
+                "rejectedHelp": "이 패키지는 불러올 수 없어 아무것도 제공하지 않습니다. 누군가 의도적으로 추가했기 때문에 목록에 표시됩니다.",
+                "rejectedHeading": "{count, plural, other {거부된 패키지 #개}}",
+                "shadowedHeading": "가려진 패키지",
+                "shadowedHelp": "앞선 디렉터리가 이미 제공한 이름을 선언하므로 첫 번째만 사용됩니다.",
+                "severity": {
+                    "fatal": "치명적",
+                    "error": "오류",
+                    "warning": "경고"
+                },
+                "scopes": {
+                    "package": "패키지",
+                    "manifest": "매니페스트",
+                    "skills": "스킬",
+                    "mcp": "MCP 서버"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Agent-plug-ins"
             },
             "githubApp": {
                 "title": "GitHub App-installaties",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Agent-plug-ins",
+                "description": "Pakketten in het open Agent Plugins-formaat leveren skills en MCP-servers aan deze workspace. Ze werken in elke client die de standaard ondersteunt.",
+                "disabled": "Ondersteuning voor agent-plug-ins staat uit op deze omgeving. Een beheerder kan die inschakelen met:",
+                "loadFailed": "Kon geïnstalleerde pakketten niet laden. Dit is een verbindingsprobleem, geen teken dat er niets is geïnstalleerd.",
+                "scanning": "{roots} wordt doorzocht",
+                "searchPlaceholder": "Pakketten en skills zoeken",
+                "empty": "Nog geen pakketten geïnstalleerd.",
+                "noMatches": "Geen pakketten komen overeen met je zoekopdracht.",
+                "specVersion": "spec {version}",
+                "skills": "{count, plural, =0 {Skills} one {# skill} other {# skills}}",
+                "mcpServers": "{count, plural, =0 {MCP-servers} one {# MCP-server} other {# MCP-servers}}",
+                "none": "Geen",
+                "rejected": "geweigerd",
+                "rejectedHelp": "Dit pakket kon niet worden geladen en levert dus niets. Het staat er omdat iemand het bewust heeft toegevoegd.",
+                "rejectedHeading": "{count, plural, one {# geweigerd pakket} other {# geweigerde pakketten}}",
+                "shadowedHeading": "Overschaduwde pakketten",
+                "shadowedHelp": "Deze claimen een naam die een eerdere map al levert, dus alleen de eerste wordt gebruikt.",
+                "severity": {
+                    "fatal": "Fataal",
+                    "error": "Fout",
+                    "warning": "Waarschuwing"
+                },
+                "scopes": {
+                    "package": "Pakket",
+                    "manifest": "Manifest",
+                    "skills": "Skills",
+                    "mcp": "MCP-servers"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Wtyczki agenta"
             },
             "githubApp": {
                 "title": "Instalacje aplikacji GitHub",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Wtyczki agenta",
+                "description": "Pakiety w otwartym formacie Agent Plugins dodają umiejętności i serwery MCP do tego obszaru roboczego. Działają w każdym kliencie obsługującym ten standard.",
+                "disabled": "Obsługa wtyczek agenta jest wyłączona w tym wdrożeniu. Operator może ją włączyć, ustawiając:",
+                "loadFailed": "Nie udało się wczytać zainstalowanych pakietów. To problem z połączeniem, a nie oznaka, że nic nie jest zainstalowane.",
+                "scanning": "Skanowanie {roots}",
+                "searchPlaceholder": "Szukaj pakietów i umiejętności",
+                "empty": "Nie zainstalowano jeszcze żadnych pakietów.",
+                "noMatches": "Żaden pakiet nie pasuje do wyszukiwania.",
+                "specVersion": "specyf. {version}",
+                "skills": "{count, plural, =0 {Umiejętności} one {# umiejętność} few {# umiejętności} many {# umiejętności} other {# umiejętności}}",
+                "mcpServers": "{count, plural, =0 {Serwery MCP} one {# serwer MCP} few {# serwery MCP} many {# serwerów MCP} other {# serwera MCP}}",
+                "none": "Brak",
+                "rejected": "odrzucony",
+                "rejectedHelp": "Tego pakietu nie udało się wczytać, więc nic nie wnosi. Jest wymieniony, ponieważ ktoś dodał go celowo.",
+                "rejectedHeading": "{count, plural, one {# odrzucony pakiet} few {# odrzucone pakiety} many {# odrzuconych pakietów} other {# odrzuconego pakietu}}",
+                "shadowedHeading": "Przesłonięte pakiety",
+                "shadowedHelp": "Deklarują nazwę udostępnianą już przez wcześniejszy katalog, więc używany jest tylko pierwszy.",
+                "severity": {
+                    "fatal": "Krytyczny",
+                    "error": "Błąd",
+                    "warning": "Ostrzeżenie"
+                },
+                "scopes": {
+                    "package": "Pakiet",
+                    "manifest": "Manifest",
+                    "skills": "Umiejętności",
+                    "mcp": "Serwery MCP"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Plugins de agente"
             },
             "githubApp": {
                 "title": "Instalações do GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Plugins de agente",
+                "description": "Pacotes no formato aberto Agent Plugins contribuem com habilidades e servidores MCP para este espaço de trabalho. Funcionam em qualquer cliente compatível com o padrão.",
+                "disabled": "O suporte a plugins de agente está desativado nesta implantação. Um operador pode ativá-lo definindo:",
+                "loadFailed": "Não foi possível carregar os pacotes instalados. Isto é um problema de ligação, não um sinal de que nada está instalado.",
+                "scanning": "A analisar {roots}",
+                "searchPlaceholder": "Pesquisar pacotes e habilidades",
+                "empty": "Ainda não há pacotes instalados.",
+                "noMatches": "Nenhum pacote corresponde à sua pesquisa.",
+                "specVersion": "espec. {version}",
+                "skills": "{count, plural, =0 {Habilidades} one {# habilidade} other {# habilidades}}",
+                "mcpServers": "{count, plural, =0 {Servidores MCP} one {# servidor MCP} other {# servidores MCP}}",
+                "none": "Nenhum",
+                "rejected": "rejeitado",
+                "rejectedHelp": "Este pacote não pôde ser carregado, por isso não contribui com nada. É listado porque alguém o adicionou deliberadamente.",
+                "rejectedHeading": "{count, plural, one {# pacote rejeitado} other {# pacotes rejeitados}}",
+                "shadowedHeading": "Pacotes ocultados",
+                "shadowedHelp": "Declaram um nome que um diretório anterior já fornecia, por isso apenas o primeiro é usado.",
+                "severity": {
+                    "fatal": "Fatal",
+                    "error": "Erro",
+                    "warning": "Aviso"
+                },
+                "scopes": {
+                    "package": "Pacote",
+                    "manifest": "Manifesto",
+                    "skills": "Habilidades",
+                    "mcp": "Servidores MCP"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Плагины агента"
             },
             "githubApp": {
                 "title": "Установки GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Плагины агента",
+                "description": "Пакеты в открытом формате Agent Plugins добавляют в это рабочее пространство навыки и MCP-серверы. Они работают в любом клиенте, поддерживающем стандарт.",
+                "disabled": "Поддержка плагинов агента отключена в этом развёртывании. Оператор может включить её, задав:",
+                "loadFailed": "Не удалось загрузить установленные пакеты. Это проблема соединения, а не признак того, что ничего не установлено.",
+                "scanning": "Сканирование {roots}",
+                "searchPlaceholder": "Поиск пакетов и навыков",
+                "empty": "Пакеты ещё не установлены.",
+                "noMatches": "Ни один пакет не соответствует запросу.",
+                "specVersion": "специф. {version}",
+                "skills": "{count, plural, =0 {Навыки} one {# навык} few {# навыка} many {# навыков} other {# навыка}}",
+                "mcpServers": "{count, plural, =0 {MCP-серверы} one {# MCP-сервер} few {# MCP-сервера} many {# MCP-серверов} other {# MCP-сервера}}",
+                "none": "Нет",
+                "rejected": "отклонён",
+                "rejectedHelp": "Этот пакет не удалось загрузить, поэтому он ничего не добавляет. Он показан, потому что кто-то добавил его намеренно.",
+                "rejectedHeading": "{count, plural, one {# отклонённый пакет} few {# отклонённых пакета} many {# отклонённых пакетов} other {# отклонённого пакета}}",
+                "shadowedHeading": "Перекрытые пакеты",
+                "shadowedHelp": "Они объявляют имя, которое уже предоставил более ранний каталог, поэтому используется только первый.",
+                "severity": {
+                    "fatal": "Критическая",
+                    "error": "Ошибка",
+                    "warning": "Предупреждение"
+                },
+                "scopes": {
+                    "package": "Пакет",
+                    "manifest": "Манифест",
+                    "skills": "Навыки",
+                    "mcp": "MCP-серверы"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "ปลั๊กอินเอเจนต์"
             },
             "githubApp": {
                 "title": "การติดตั้ง GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "ปลั๊กอินเอเจนต์",
+                "description": "แพ็กเกจในรูปแบบเปิด Agent Plugins เพิ่มทักษะและเซิร์ฟเวอร์ MCP ให้กับเวิร์กสเปซนี้ ใช้งานได้กับไคลเอ็นต์ใดก็ตามที่รองรับมาตรฐานนี้",
+                "disabled": "การรองรับปลั๊กอินเอเจนต์ถูกปิดอยู่ในการปรับใช้นี้ ผู้ดูแลระบบเปิดใช้ได้โดยตั้งค่า:",
+                "loadFailed": "ไม่สามารถโหลดแพ็กเกจที่ติดตั้งไว้ นี่เป็นปัญหาการเชื่อมต่อ ไม่ได้แปลว่าไม่มีอะไรติดตั้งอยู่",
+                "scanning": "กำลังสแกน {roots}",
+                "searchPlaceholder": "ค้นหาแพ็กเกจและทักษะ",
+                "empty": "ยังไม่มีแพ็กเกจที่ติดตั้ง",
+                "noMatches": "ไม่มีแพ็กเกจที่ตรงกับการค้นหา",
+                "specVersion": "ข้อกำหนด {version}",
+                "skills": "{count, plural, =0 {ทักษะ} other {# ทักษะ}}",
+                "mcpServers": "{count, plural, =0 {เซิร์ฟเวอร์ MCP} other {เซิร์ฟเวอร์ MCP # รายการ}}",
+                "none": "ไม่มี",
+                "rejected": "ถูกปฏิเสธ",
+                "rejectedHelp": "แพ็กเกจนี้โหลดไม่สำเร็จ จึงไม่ได้เพิ่มอะไรเลย ที่แสดงไว้เพราะมีคนตั้งใจเพิ่มเข้ามา",
+                "rejectedHeading": "{count, plural, other {แพ็กเกจที่ถูกปฏิเสธ # รายการ}}",
+                "shadowedHeading": "แพ็กเกจที่ถูกบดบัง",
+                "shadowedHelp": "แพ็กเกจเหล่านี้ประกาศชื่อที่ไดเรกทอรีก่อนหน้าให้ไว้แล้ว จึงใช้เฉพาะรายการแรก",
+                "severity": {
+                    "fatal": "ร้ายแรง",
+                    "error": "ข้อผิดพลาด",
+                    "warning": "คำเตือน"
+                },
+                "scopes": {
+                    "package": "แพ็กเกจ",
+                    "manifest": "มานิเฟสต์",
+                    "skills": "ทักษะ",
+                    "mcp": "เซิร์ฟเวอร์ MCP"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Aracı eklentileri"
             },
             "githubApp": {
                 "title": "GitHub App Kurulumları",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Aracı eklentileri",
+                "description": "Açık Agent Plugins biçimindeki paketler bu çalışma alanına beceriler ve MCP sunucuları ekler. Standardı destekleyen her istemcide çalışırlar.",
+                "disabled": "Bu dağıtımda aracı eklentisi desteği kapalı. Bir operatör şunu ayarlayarak etkinleştirebilir:",
+                "loadFailed": "Kurulu paketler yüklenemedi. Bu bir bağlantı sorunudur, hiçbir şeyin kurulu olmadığının işareti değildir.",
+                "scanning": "{roots} taranıyor",
+                "searchPlaceholder": "Paket ve beceri ara",
+                "empty": "Henüz kurulu paket yok.",
+                "noMatches": "Aramanızla eşleşen paket yok.",
+                "specVersion": "spec {version}",
+                "skills": "{count, plural, =0 {Beceriler} one {# beceri} other {# beceri}}",
+                "mcpServers": "{count, plural, =0 {MCP sunucuları} one {# MCP sunucusu} other {# MCP sunucusu}}",
+                "none": "Yok",
+                "rejected": "reddedildi",
+                "rejectedHelp": "Bu paket yüklenemedi, bu yüzden hiçbir şey katmıyor. Biri bilerek eklediği için listeleniyor.",
+                "rejectedHeading": "{count, plural, one {# reddedilen paket} other {# reddedilen paket}}",
+                "shadowedHeading": "Gölgelenen paketler",
+                "shadowedHelp": "Bunlar, daha önceki bir dizinin zaten sağladığı bir adı bildiriyor; yalnızca ilki kullanılır.",
+                "severity": {
+                    "fatal": "Ölümcül",
+                    "error": "Hata",
+                    "warning": "Uyarı"
+                },
+                "scopes": {
+                    "package": "Paket",
+                    "manifest": "Bildirim",
+                    "skills": "Beceriler",
+                    "mcp": "MCP sunucuları"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Плагіни агента"
             },
             "githubApp": {
                 "title": "Інсталяції GitHub App",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Плагіни агента",
+                "description": "Пакети у відкритому форматі Agent Plugins додають до цього робочого простору навички та MCP-сервери. Вони працюють у будь-якому клієнті, що підтримує стандарт.",
+                "disabled": "Підтримку плагінів агента вимкнено в цьому розгортанні. Оператор може увімкнути її, задавши:",
+                "loadFailed": "Не вдалося завантажити встановлені пакети. Це проблема зʼєднання, а не ознака того, що нічого не встановлено.",
+                "scanning": "Сканування {roots}",
+                "searchPlaceholder": "Пошук пакетів і навичок",
+                "empty": "Пакети ще не встановлено.",
+                "noMatches": "Жоден пакет не відповідає пошуку.",
+                "specVersion": "специф. {version}",
+                "skills": "{count, plural, =0 {Навички} one {# навичка} few {# навички} many {# навичок} other {# навички}}",
+                "mcpServers": "{count, plural, =0 {MCP-сервери} one {# MCP-сервер} few {# MCP-сервери} many {# MCP-серверів} other {# MCP-сервера}}",
+                "none": "Немає",
+                "rejected": "відхилено",
+                "rejectedHelp": "Цей пакет не вдалося завантажити, тож він нічого не додає. Його показано, бо хтось додав його навмисно.",
+                "rejectedHeading": "{count, plural, one {# відхилений пакет} few {# відхилені пакети} many {# відхилених пакетів} other {# відхиленого пакета}}",
+                "shadowedHeading": "Перекриті пакети",
+                "shadowedHelp": "Вони оголошують імʼя, яке вже надав попередній каталог, тому використовується лише перший.",
+                "severity": {
+                    "fatal": "Критична",
+                    "error": "Помилка",
+                    "warning": "Попередження"
+                },
+                "scopes": {
+                    "package": "Пакет",
+                    "manifest": "Маніфест",
+                    "skills": "Навички",
+                    "mcp": "MCP-сервери"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "Plugin tác nhân"
             },
             "githubApp": {
                 "title": "Cài đặt Ứng dụng GitHub",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "Plugin tác nhân",
+                "description": "Các gói theo định dạng mở Agent Plugins bổ sung kỹ năng và máy chủ MCP cho không gian làm việc này. Chúng hoạt động trên mọi ứng dụng khách hỗ trợ tiêu chuẩn.",
+                "disabled": "Hỗ trợ plugin tác nhân đang tắt trên bản triển khai này. Người vận hành có thể bật bằng cách đặt:",
+                "loadFailed": "Không tải được các gói đã cài. Đây là sự cố kết nối, không phải dấu hiệu chưa cài gì.",
+                "scanning": "Đang quét {roots}",
+                "searchPlaceholder": "Tìm gói và kỹ năng",
+                "empty": "Chưa cài gói nào.",
+                "noMatches": "Không có gói nào khớp với tìm kiếm.",
+                "specVersion": "đặc tả {version}",
+                "skills": "{count, plural, other {# kỹ năng}}",
+                "mcpServers": "{count, plural, other {# máy chủ MCP}}",
+                "none": "Không có",
+                "rejected": "bị từ chối",
+                "rejectedHelp": "Không tải được gói này nên nó không đóng góp gì. Gói vẫn được liệt kê vì có người cố ý thêm vào.",
+                "rejectedHeading": "{count, plural, other {# gói bị từ chối}}",
+                "shadowedHeading": "Gói bị che",
+                "shadowedHelp": "Chúng khai báo tên mà một thư mục trước đó đã cung cấp, nên chỉ gói đầu tiên được dùng.",
+                "severity": {
+                    "fatal": "Nghiêm trọng",
+                    "error": "Lỗi",
+                    "warning": "Cảnh báo"
+                },
+                "scopes": {
+                    "package": "Gói",
+                    "manifest": "Manifest",
+                    "skills": "Kỹ năng",
+                    "mcp": "Máy chủ MCP"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2549,7 +2549,8 @@
                 "emails": "Email Addresses",
                 "environments": "Environments",
                 "connections": "Connections",
-                "repositories": "Repositories"
+                "repositories": "Repositories",
+                "agentPlugins": "代理插件"
             },
             "githubApp": {
                 "title": "GitHub App 安装",
@@ -3669,6 +3670,36 @@
                 "byModel": {
                     "units": "{units} units",
                     "total": "{total} across all models in this window"
+                }
+            },
+            "agentPlugins": {
+                "title": "代理插件",
+                "description": "采用开放 Agent Plugins 格式的软件包为此工作区提供技能和 MCP 服务器。它们可在任何支持该标准的客户端中使用。",
+                "disabled": "此部署已关闭代理插件支持。运维人员可通过设置以下项启用：",
+                "loadFailed": "无法加载已安装的软件包。这是连接问题，并不表示未安装任何内容。",
+                "scanning": "正在扫描 {roots}",
+                "searchPlaceholder": "搜索软件包和技能",
+                "empty": "尚未安装任何软件包。",
+                "noMatches": "没有与搜索匹配的软件包。",
+                "specVersion": "规范 {version}",
+                "skills": "{count, plural, =0 {技能} other {# 个技能}}",
+                "mcpServers": "{count, plural, =0 {MCP 服务器} other {# 个 MCP 服务器}}",
+                "none": "无",
+                "rejected": "已拒绝",
+                "rejectedHelp": "此软件包无法加载，因此不提供任何内容。列出它是因为有人有意添加了它。",
+                "rejectedHeading": "{count, plural, other {# 个被拒绝的软件包}}",
+                "shadowedHeading": "被遮蔽的软件包",
+                "shadowedHelp": "它们声明了前一个目录已提供的名称，因此仅使用第一个。",
+                "severity": {
+                    "fatal": "致命",
+                    "error": "错误",
+                    "warning": "警告"
+                },
+                "scopes": {
+                    "package": "软件包",
+                    "manifest": "清单",
+                    "skills": "技能",
+                    "mcp": "MCP 服务器"
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/settings/agent-plugins/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/agent-plugins/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import {
+    agentPluginsAPI,
+    EMPTY_AGENT_PLUGIN_LIST,
+    type AgentPluginListResponse,
+} from '@/lib/api/agent-plugins';
+import { AgentPluginsSettings } from '@/components/settings/AgentPluginsSettings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.settings.agentPlugins');
+    return { title: t('title') };
+}
+
+/**
+ * Settings → Agent Plugins.
+ *
+ * Server component: reads the package registry and hands it to the client
+ * view. The endpoint is safe to call regardless of the feature flag — it
+ * reports `enabled` explicitly and does not touch the filesystem when the
+ * feature is off — so there is no need to gate the fetch itself.
+ *
+ * A failed fetch renders the page with an explanation rather than throwing.
+ * The distinction the UI must preserve is three-way: the feature is off, the
+ * feature is on with nothing installed, or we could not find out. Collapsing
+ * the third into either of the others tells the operator something untrue.
+ */
+export default async function AgentPluginsSettingsPage() {
+    let data: AgentPluginListResponse = EMPTY_AGENT_PLUGIN_LIST;
+    let loadFailed = false;
+
+    try {
+        data = await agentPluginsAPI.list();
+    } catch {
+        loadFailed = true;
+    }
+
+    return <AgentPluginsSettings data={data} loadFailed={loadFailed} />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -14,6 +14,7 @@ import {
     Boxes,
     Cpu,
     Plug,
+    Package,
     Building2,
     CreditCard,
     BarChart3,
@@ -142,6 +143,15 @@ export function SettingsLayoutClient({
                     label: t('tabs.connections'),
                     icon: Plug,
                     href: `${baseSettingsPath}/connections`,
+                },
+                // Agent Plugins sits directly after Connections: a connection
+                // is one MCP server added by hand, a package can bring several
+                // plus the skills that use them.
+                {
+                    id: 'agent-plugins',
+                    label: t('tabs.agentPlugins'),
+                    icon: Package,
+                    href: `${baseSettingsPath}/agent-plugins`,
                 },
                 // Digest briefings — the personal cadence AND the org-scoped
                 // one live on one page, since they are two records of the

--- a/apps/web/src/components/settings/AgentPluginsSettings.tsx
+++ b/apps/web/src/components/settings/AgentPluginsSettings.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, Boxes, FileWarning, Info, Package, Plug, Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import type {
+    AgentPluginFinding,
+    AgentPluginFindingSeverity,
+    AgentPluginListResponse,
+    AgentPluginPackageRow,
+    AgentPluginRejectedRow,
+} from '@/lib/api/agent-plugins';
+
+/**
+ * Settings → Agent Plugins.
+ *
+ * Renders installed packages in the open Agent Plugins v1.0.0 format, with
+ * their findings shown PER COMPONENT rather than as one undifferentiated
+ * list. That split is the point of the page: the specification isolates
+ * failure per component, so a package whose `mcp.json` is invalid still
+ * contributes its skills. A flat error list would make such a package look
+ * broken when most of it works, and would give the operator no way to tell
+ * which half to fix.
+ */
+
+interface Props {
+    data: AgentPluginListResponse;
+    /** True when the API call itself failed, as opposed to returning nothing. */
+    loadFailed?: boolean;
+}
+
+const SEVERITY_ORDER: Record<AgentPluginFindingSeverity, number> = {
+    fatal: 0,
+    error: 1,
+    warning: 2,
+};
+
+function severityClass(severity: AgentPluginFindingSeverity): string {
+    if (severity === 'fatal') return 'text-red-600 dark:text-red-400';
+    if (severity === 'error') return 'text-amber-600 dark:text-amber-400';
+    return 'text-muted-foreground';
+}
+
+/**
+ * Group findings by the component they belong to.
+ *
+ * `scope` is optional on the wire, so anything without one lands in
+ * `package` rather than being dropped — a finding that is not displayed is
+ * indistinguishable from one that was never produced.
+ */
+function groupByScope(findings: AgentPluginFinding[]): Map<string, AgentPluginFinding[]> {
+    const grouped = new Map<string, AgentPluginFinding[]>();
+    for (const finding of findings) {
+        const scope = finding.scope ?? 'package';
+        const list = grouped.get(scope) ?? [];
+        list.push(finding);
+        grouped.set(scope, list);
+    }
+    for (const list of grouped.values()) {
+        list.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+    }
+    return grouped;
+}
+
+/**
+ * Scopes that have a translated label. Anything else is displayed verbatim.
+ *
+ * next-intl THROWS on a missing key rather than falling back, so an
+ * unrecognised scope — a new one added by the conformance library, say —
+ * would blank the whole page. Checking membership first turns that into a
+ * slightly less pretty label.
+ */
+const TRANSLATED_SCOPES = new Set(['package', 'manifest', 'skills', 'mcp']);
+
+function FindingList({ findings }: { findings: AgentPluginFinding[] }) {
+    const t = useTranslations('dashboard.settings.agentPlugins');
+    const grouped = useMemo(() => groupByScope(findings), [findings]);
+
+    if (findings.length === 0) return null;
+
+    return (
+        <div className="mt-3 space-y-3">
+            {[...grouped.entries()].map(([scope, list]) => (
+                <div key={scope} className="rounded-md border border-border/60 p-3">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {TRANSLATED_SCOPES.has(scope)
+                            ? t(`scopes.${scope}` as 'scopes.package')
+                            : scope}
+                    </p>
+                    <ul className="mt-2 space-y-1.5">
+                        {list.map((finding, index) => (
+                            <li key={`${finding.code}-${index}`} className="text-sm">
+                                <span className={`font-medium ${severityClass(finding.severity)}`}>
+                                    {t(`severity.${finding.severity}`)}
+                                </span>
+                                <span className="mx-1.5 text-muted-foreground">·</span>
+                                <span>{finding.message}</span>
+                                {finding.subject ? (
+                                    <span className="ml-1.5 text-muted-foreground">
+                                        ({finding.subject})
+                                    </span>
+                                ) : null}
+                                <div className="text-xs text-muted-foreground">{finding.code}</div>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function PackageCard({ pkg }: { pkg: AgentPluginPackageRow }) {
+    const t = useTranslations('dashboard.settings.agentPlugins');
+
+    return (
+        <div className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <Package className="size-4 shrink-0 self-center text-muted-foreground" />
+                <h3 className="font-medium">{pkg.name ?? pkg.dirName}</h3>
+                {pkg.version ? (
+                    <span className="text-sm text-muted-foreground">{pkg.version}</span>
+                ) : null}
+                {pkg.specVersion ? (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                        {t('specVersion', { version: pkg.specVersion })}
+                    </span>
+                ) : null}
+            </div>
+
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <div>
+                    <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        <Boxes className="size-3.5" />
+                        {t('skills', { count: pkg.skills.length })}
+                    </p>
+                    <p className="mt-1 text-sm">
+                        {pkg.skills.length > 0 ? pkg.skills.join(', ') : t('none')}
+                    </p>
+                </div>
+                <div>
+                    <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        <Plug className="size-3.5" />
+                        {t('mcpServers', { count: pkg.mcpServers.length })}
+                    </p>
+                    <p className="mt-1 text-sm">
+                        {pkg.mcpServers.length > 0 ? pkg.mcpServers.join(', ') : t('none')}
+                    </p>
+                </div>
+            </div>
+
+            <FindingList findings={pkg.findings ?? []} />
+        </div>
+    );
+}
+
+function RejectedCard({ pkg }: { pkg: AgentPluginRejectedRow }) {
+    const t = useTranslations('dashboard.settings.agentPlugins');
+
+    return (
+        <div className="rounded-lg border border-red-500/40 bg-red-500/5 p-4">
+            <div className="flex items-center gap-2">
+                <AlertTriangle className="size-4 shrink-0 text-red-600 dark:text-red-400" />
+                <h3 className="font-medium">{pkg.dirName}</h3>
+                <span className="text-xs text-red-600 dark:text-red-400">{t('rejected')}</span>
+            </div>
+            {/* Rejected packages are shown rather than hidden: somebody put
+                this directory there deliberately, so its absence from the
+                catalog needs an explanation. */}
+            <p className="mt-1 text-sm text-muted-foreground">{t('rejectedHelp')}</p>
+            <FindingList findings={pkg.findings ?? []} />
+        </div>
+    );
+}
+
+export function AgentPluginsSettings({ data, loadFailed }: Props) {
+    const t = useTranslations('dashboard.settings.agentPlugins');
+    const [query, setQuery] = useState('');
+
+    const packages = useMemo(() => {
+        const needle = query.trim().toLowerCase();
+        if (!needle) return data.packages;
+        return data.packages.filter(
+            (pkg) =>
+                pkg.name?.toLowerCase().includes(needle) ||
+                pkg.skills.some((skill) => skill.toLowerCase().includes(needle)),
+        );
+    }, [data.packages, query]);
+
+    if (loadFailed) {
+        return (
+            <div className="rounded-lg border border-border bg-card p-6">
+                <h2 className="font-medium">{t('title')}</h2>
+                <p className="mt-2 text-sm text-muted-foreground">{t('loadFailed')}</p>
+            </div>
+        );
+    }
+
+    // "Off" and "on with nothing installed" render identically without this,
+    // so an operator who has just flipped the flag cannot tell which state
+    // they are looking at.
+    if (!data.enabled) {
+        return (
+            <div className="rounded-lg border border-border bg-card p-6">
+                <h2 className="font-medium">{t('title')}</h2>
+                <p className="mt-2 text-sm text-muted-foreground">{t('disabled')}</p>
+                <code className="mt-3 inline-block rounded bg-muted px-2 py-1 text-xs">
+                    FEATURE_AGENT_PLUGINS=true
+                </code>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-lg font-medium">{t('title')}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{t('description')}</p>
+            </div>
+
+            {data.roots.length > 0 ? (
+                <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Info className="size-3.5" />
+                    {t('scanning', { roots: data.roots.join(', ') })}
+                </p>
+            ) : null}
+
+            <div className="relative">
+                <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder={t('searchPlaceholder')}
+                    className="pl-9"
+                    aria-label={t('searchPlaceholder')}
+                />
+            </div>
+
+            {packages.length === 0 && data.rejected.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border p-8 text-center">
+                    <p className="text-sm text-muted-foreground">
+                        {query ? t('noMatches') : t('empty')}
+                    </p>
+                </div>
+            ) : null}
+
+            <div className="space-y-3">
+                {packages.map((pkg) => (
+                    <PackageCard key={pkg.path ?? pkg.dirName ?? pkg.name} pkg={pkg} />
+                ))}
+            </div>
+
+            {data.rejected.length > 0 ? (
+                <div className="space-y-3">
+                    <h3 className="flex items-center gap-1.5 text-sm font-medium">
+                        <FileWarning className="size-4" />
+                        {t('rejectedHeading', { count: data.rejected.length })}
+                    </h3>
+                    {data.rejected.map((pkg) => (
+                        <RejectedCard key={pkg.path ?? pkg.dirName} pkg={pkg} />
+                    ))}
+                </div>
+            ) : null}
+
+            {data.shadowed.length > 0 ? (
+                <div className="rounded-lg border border-border/60 p-4">
+                    <h3 className="text-sm font-medium">{t('shadowedHeading')}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{t('shadowedHelp')}</p>
+                    <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                        {data.shadowed.map((pkg) => (
+                            <li key={pkg.dirName}>
+                                {pkg.dirName} — {pkg.name}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/AgentPluginsSettings.unit.spec.tsx
+++ b/apps/web/src/components/settings/AgentPluginsSettings.unit.spec.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { AgentPluginsSettings } from './AgentPluginsSettings';
+import type { AgentPluginListResponse } from '@/lib/api/agent-plugins';
+
+/**
+ * The three states this page must keep apart are the whole point of it:
+ * the feature is OFF, it is ON with nothing installed, or we could not find
+ * out. Collapsing any pair of them tells the operator something untrue, and
+ * all three render as "an empty list" if nobody is careful.
+ */
+
+function response(over: Partial<AgentPluginListResponse> = {}): AgentPluginListResponse {
+    return {
+        enabled: true,
+        roots: ['/app/agent-plugins'],
+        packages: [],
+        rejected: [],
+        shadowed: [],
+        ...over,
+    };
+}
+
+describe('AgentPluginsSettings', () => {
+    it('says the feature is DISABLED rather than showing an empty list', () => {
+        render(<AgentPluginsSettings data={response({ enabled: false })} />);
+
+        expect(screen.getByText('disabled')).toBeTruthy();
+        // The variable to set is named, so the message is actionable.
+        expect(screen.getByText('FEATURE_AGENT_PLUGINS=true')).toBeTruthy();
+        expect(screen.queryByText('empty')).toBeNull();
+    });
+
+    it('says the LOAD FAILED rather than reporting nothing installed', () => {
+        render(<AgentPluginsSettings data={response()} loadFailed />);
+
+        expect(screen.getByText('loadFailed')).toBeTruthy();
+        expect(screen.queryByText('empty')).toBeNull();
+        expect(screen.queryByText('disabled')).toBeNull();
+    });
+
+    it('reports an empty catalog only when the feature is genuinely on', () => {
+        render(<AgentPluginsSettings data={response()} />);
+
+        expect(screen.getByText('empty')).toBeTruthy();
+        expect(screen.queryByText('disabled')).toBeNull();
+        expect(screen.queryByText('loadFailed')).toBeNull();
+    });
+
+    it('renders a package with its skills and MCP servers', () => {
+        render(
+            <AgentPluginsSettings
+                data={response({
+                    packages: [
+                        {
+                            name: 'acme.tools',
+                            version: '1.4.0',
+                            specVersion: '1.0.0',
+                            dirName: 'acme-tools',
+                            path: '/app/agent-plugins/acme-tools',
+                            skills: ['release-notes', 'changelog'],
+                            mcpServers: ['api'],
+                            findings: [],
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        expect(screen.getByText('acme.tools')).toBeTruthy();
+        expect(screen.getByText('release-notes, changelog')).toBeTruthy();
+        expect(screen.getByText('api')).toBeTruthy();
+    });
+
+    it('groups findings BY COMPONENT rather than flattening them', () => {
+        render(
+            <AgentPluginsSettings
+                data={response({
+                    packages: [
+                        {
+                            name: 'mixed',
+                            dirName: 'mixed',
+                            skills: ['good'],
+                            mcpServers: [],
+                            findings: [
+                                {
+                                    severity: 'warning',
+                                    code: 'SKILL_SKIPPED',
+                                    message: 'A skill was skipped.',
+                                    scope: 'skills',
+                                },
+                                {
+                                    severity: 'error',
+                                    code: 'MCP_INVALID',
+                                    message: 'mcp.json is invalid.',
+                                    scope: 'mcp',
+                                },
+                            ],
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        // The specification isolates failure per component, so a package whose
+        // mcp.json is broken still contributes its skills. A flat list would
+        // make this package look wholly broken.
+        expect(screen.getByText('scopes.skills')).toBeTruthy();
+        expect(screen.getByText('scopes.mcp')).toBeTruthy();
+        expect(screen.getByText('A skill was skipped.')).toBeTruthy();
+        expect(screen.getByText('mcp.json is invalid.')).toBeTruthy();
+    });
+
+    it('displays an unrecognised scope verbatim instead of throwing', () => {
+        // next-intl throws on a missing key, so a scope the conformance library
+        // adds later would otherwise blank the entire page.
+        render(
+            <AgentPluginsSettings
+                data={response({
+                    packages: [
+                        {
+                            name: 'future',
+                            dirName: 'future',
+                            skills: [],
+                            mcpServers: [],
+                            findings: [
+                                {
+                                    severity: 'warning',
+                                    code: 'SOMETHING_NEW',
+                                    message: 'From a newer library.',
+                                    scope: 'agents',
+                                },
+                            ],
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        expect(screen.getByText('agents')).toBeTruthy();
+        expect(screen.getByText('From a newer library.')).toBeTruthy();
+    });
+
+    it('shows rejected packages rather than hiding them', () => {
+        render(
+            <AgentPluginsSettings
+                data={response({
+                    rejected: [
+                        {
+                            dirName: 'broken',
+                            path: '/app/agent-plugins/broken',
+                            findings: [
+                                {
+                                    severity: 'fatal',
+                                    code: 'MANIFEST_INVALID',
+                                    message: 'Invalid plugin name.',
+                                },
+                            ],
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        // Somebody put that directory there deliberately, so its absence from
+        // the catalog needs an explanation rather than silence.
+        expect(screen.getByText('broken')).toBeTruthy();
+        expect(screen.getByText('Invalid plugin name.')).toBeTruthy();
+        // A finding with no scope is attributed to the package, not dropped.
+        expect(screen.getByText('scopes.package')).toBeTruthy();
+    });
+
+    it('lists shadowed packages so a silently-ignored directory is explained', () => {
+        render(
+            <AgentPluginsSettings
+                data={response({
+                    shadowed: [{ dirName: 'dup', name: 'acme.tools' }],
+                })}
+            />,
+        );
+
+        expect(screen.getByText('shadowedHeading')).toBeTruthy();
+        expect(screen.getByText(/dup/)).toBeTruthy();
+    });
+});

--- a/apps/web/src/lib/api/agent-plugins.ts
+++ b/apps/web/src/lib/api/agent-plugins.ts
@@ -1,0 +1,92 @@
+import 'server-only';
+import { serverFetch } from './server-api';
+
+/**
+ * Web client for the Agent Plugins package registry
+ * (`apps/api/src/agent-plugins/agent-plugins.controller.ts`).
+ *
+ * These types MIRROR the API's response shape by hand, as every client in this
+ * directory does — there is no generated client. That means a field added on
+ * the API side does not appear here until it is added here too, so the two
+ * must be changed together.
+ */
+
+export type AgentPluginFindingSeverity = 'fatal' | 'error' | 'warning';
+
+export interface AgentPluginFinding {
+    severity: AgentPluginFindingSeverity;
+    code: string;
+    message: string;
+    subject?: string;
+    scope?: string;
+}
+
+export interface AgentPluginPackageSummary {
+    errorCount?: number;
+    warningCount?: number;
+    fatalCount?: number;
+}
+
+export interface AgentPluginPackageRow {
+    name?: string;
+    version?: string;
+    specVersion?: string;
+    path?: string;
+    dirName?: string;
+    skills: string[];
+    mcpServers: string[];
+    findings: AgentPluginFinding[];
+    summary?: AgentPluginPackageSummary;
+}
+
+export interface AgentPluginRejectedRow {
+    dirName?: string;
+    path?: string;
+    findings: AgentPluginFinding[];
+    summary?: AgentPluginPackageSummary;
+}
+
+export interface AgentPluginListResponse {
+    /**
+     * Distinguishes "the feature is off" from "on, with no packages".
+     *
+     * Without this the page cannot tell an operator who has just flipped the
+     * flag which of the two they are looking at — both render as an empty
+     * list.
+     */
+    enabled: boolean;
+    roots: string[];
+    packages: AgentPluginPackageRow[];
+    rejected: AgentPluginRejectedRow[];
+    shadowed: Array<{ dirName?: string; name?: string }>;
+}
+
+export interface AgentPluginFindingsResponse {
+    enabled: boolean;
+    findings: Array<
+        AgentPluginFinding & {
+            package?: string;
+            packageLoaded?: boolean;
+        }
+    >;
+}
+
+/** Shape returned when the feature is off or the request fails. */
+export const EMPTY_AGENT_PLUGIN_LIST: AgentPluginListResponse = {
+    enabled: false,
+    roots: [],
+    packages: [],
+    rejected: [],
+    shadowed: [],
+};
+
+export const agentPluginsAPI = {
+    async list(search?: string): Promise<AgentPluginListResponse> {
+        const query = search ? `?search=${encodeURIComponent(search)}` : '';
+        return serverFetch<AgentPluginListResponse>(`/agent-plugins${query}`);
+    },
+
+    async findings(): Promise<AgentPluginFindingsResponse> {
+        return serverFetch<AgentPluginFindingsResponse>('/agent-plugins/findings');
+    },
+};

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -240,6 +240,10 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_ENVIRONMENTS: '/settings/environments',
     DASHBOARD_SETTINGS_WORK_AGENT: '/settings/work-agent',
     DASHBOARD_SETTINGS_JOB_RUNTIME: '/settings/job-runtime',
+    // Agent Plugins (EW-772) — packages in the open cross-vendor format.
+    // Sits beside Connections: both are about capabilities the platform
+    // consumes from outside rather than code it ships.
+    DASHBOARD_SETTINGS_AGENT_PLUGINS: '/settings/agent-plugins',
     // Fleet — enrolled local runners. The page has existed since Wave 12;
     // it simply had no route constant, so every link to it was a literal.
     DASHBOARD_SETTINGS_FLEET: '/settings/fleet',

--- a/docs/specs/features/agent-plugins/conformance.md
+++ b/docs/specs/features/agent-plugins/conformance.md
@@ -1,0 +1,95 @@
+# Agent Plugins v1.0.0 — conformance statement
+
+> **Claim**: Agent Plugins v1.0.0 compatible (client: skills + MCP; producer:
+> skills packages, plus the Ever Works MCP-server package descriptor).
+>
+> This page is checked by
+> `packages/agent-plugins/src/__tests__/conformance-statement.spec.ts`, which
+> fails the build if a requirement in
+> [`spec.md`](spec.md) has no row here, if a row names a requirement that does
+> not exist, or if a row cites evidence that has been deleted. It is a
+> statement that can be falsified, not a badge.
+
+## How to read the status column
+
+| Status            | Meaning                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Met**           | Implemented, with the cited evidence exercising it.                                                                                                     |
+| **Met (library)** | The specification rule is enforced by `@ever-works/agent-plugins`; nothing outside it can accept a package the library rejects.                         |
+| **Not yet**       | Deliberately unimplemented at this point in the programme. The row says what is missing and what the current behaviour is instead — never a silent gap. |
+
+A "Not yet" row is not a conformance failure on its own: v1.0.0 lets a client
+support a subset of component types, provided it is honest about which. The
+claim above names skills and MCP as the supported client components, and the
+rows below say exactly where the subprocess half stops.
+
+---
+
+## Manifest (AP-1 … AP-6)
+
+| ID   | Requirement                                                          | Status        | Evidence                                                                                                    |
+| ---- | -------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| AP-1 | Load `plugin.json` from the package root; MUST be a JSON object      | Met (library) | `manifest.ts` `loadManifest`; fixtures `fatal-manifest-invalid-json`, `fatal-manifest-not-an-object`        |
+| AP-2 | Permitted top-level fields only                                      | Met (library) | `PERMITTED_MANIFEST_FIELDS`; `conformance.spec.ts`                                                          |
+| AP-3 | `name` matches the specified pattern                                 | Met (library) | `PLUGIN_NAME_PATTERN`; eight `fatal-manifest-name-*` fixtures covering each way the pattern can be violated |
+| AP-4 | Severity split, exactly as specified                                 | Met (library) | `findings.ts` severities; `manifest.ts` §5.2 split; `conformance.spec.ts` fatal/non-fatal boundary          |
+| AP-5 | MUST NOT reject for non-semver `version` or unrecognised URL formats | Met (library) | `validateManifest`; the catalog synthesises a version rather than rejecting — `package-catalog.service.ts`  |
+| AP-6 | Unimplemented `extensions` namespaces ignored without error          | Met (library) | `readExtension`, `isReverseDomainNamespace`                                                                 |
+
+## Skills (AP-7 … AP-10)
+
+| ID    | Requirement                                                 | Status        | Evidence                                                                                                                                                                                                                                                                  |
+| ----- | ----------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-7  | Skills discovered only from immediate children of `skills/` | Met (library) | `discoverSkills` — directory **listing**, matching `SKILL.md` exactly                                                                                                                                                                                                     |
+| AP-8  | Each `SKILL.md` validated against the Agent Skills spec     | Met (library) | `parseSkillMd`, `validateSkillFrontmatter`                                                                                                                                                                                                                                |
+| AP-9  | A non-conforming skill is skipped **alone**                 | Met           | `conformance.spec.ts` isolation cases; end-to-end in `catalog-integration.spec.ts` ("keeps the good skills of a package whose other skills are broken")                                                                                                                   |
+| AP-10 | All resolved paths stay inside the package root             | Met           | `paths.ts` `resolveRelativeSegments` walks segment by segment applying `realpath`, because `path.join` collapses `..` lexically **before** symlinks are followed; enforced again after every remote fetch in `remote-acquire.service.ts`, which deletes a tree that fails |
+
+## MCP (AP-11 … AP-15)
+
+| ID    | Requirement                                                                               | Status        | Evidence                                                                                                                                                                                                        |
+| ----- | ----------------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-11 | MCP config only from `mcp.json`, closed schema                                            | Met (library) | `PERMITTED_MCP_FIELDS`, `parseMcpConfig`                                                                                                                                                                        |
+| AP-12 | `mcp.json` `$schema` version must match `plugin.json`'s                                   | Met (library) | `versions.ts`. Note the trap recorded in ADR-018: this is a string **equality** check, not a compatibility-set check, so a 1.0.0 manifest beside a 1.1.0 `mcp.json` disables MCP even though both releases load |
+| AP-13 | Server entries form a closed union on `type`                                              | Met (library) | `validateMcpConfig`; `McpServerConfig` union                                                                                                                                                                    |
+| AP-14 | All three transports supported                                                            | **Partial**   | `streamable-http` and `sse` are resolved and reach the client. `stdio` is parsed, validated and reported, but **not launched** — see AP-19                                                                      |
+| AP-15 | Package `headers`/`env` are visible and non-secret; no cross-origin credential forwarding | Met           | `guarded-fetch.ts` — redirects are followed manually, each hop re-checked, and **every** caller header dropped on an origin change; `guarded-fetch.spec.ts` covers port-only and scheme-downgrade hops          |
+
+## Subprocess (AP-16 … AP-19)
+
+| ID    | Requirement                                                            | Status        | Evidence                                                                                                                                                                                                                                    |
+| ----- | ---------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-16 | Every spawned process gets `PLUGIN_ROOT` and `PLUGIN_DATA`             | **Not yet**   | Nothing spawns a process. `AGENT_PLUGINS_DATA_DIR` is configured and wired, but the launcher is not built                                                                                                                                   |
+| AP-17 | `${PLUGIN_ROOT}` / `${PLUGIN_DATA}` expanded by single substitution    | Met (library) | `expand.ts`; `mcp-server-config.service.ts` expands `PLUGIN_ROOT` and **refuses** any server referencing `PLUGIN_DATA`, because no data directory is allocated yet — a refusal with a reason rather than an empty path that fails at launch |
+| AP-18 | Subprocess base environment is client-chosen                           | **Not yet**   | Same as AP-16                                                                                                                                                                                                                               |
+| AP-19 | `stdio` execution is gated; when off, entries are present-but-disabled | **Met**       | `AGENT_PLUGINS_STDIO`, default off. A stdio server is reported with `code: "disabled-by-policy"` and `enableable: true` — distinguishable from every other skip, all of which are `enableable: false`. `mcp-server-config.service.spec.ts`  |
+
+## Versioning and updates (AP-20 … AP-21)
+
+| ID    | Requirement                                             | Status        | Evidence                                                                                                                                                                                                                               |
+| ----- | ------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-20 | Manifest `$schema` id selects the targeted spec version | Met (library) | `specVersionFromPluginSchemaId`; 1.0.0 and 1.1.0 both accepted, 1.0.0 published                                                                                                                                                        |
+| AP-21 | Package `version` drives update checks                  | Met           | `update.service.ts`. npm compares the registry version; git compares the resolved **commit**, since a git package has no version to compare. Unreachable is reported separately from up-to-date — an outage must not read as "current" |
+
+## Producer (AP-22 … AP-23)
+
+| ID    | Requirement                                            | Status        | Evidence                                                                                                                                                            |
+| ----- | ------------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-22 | Exported packages validate against our own importer    | **Not yet**   | `serialize.ts` produces conforming manifests and `SKILL.md` bodies byte-for-byte, and is round-trip tested; the export **flow** that assembles a package is Phase 5 |
+| AP-23 | Export maps slug → directory name + frontmatter `name` | Met (library) | `serialize.ts` `toSpecSkillName`, `repairName` — including the case where a legal period must survive repair                                                        |
+
+---
+
+## Summary
+
+|                     | Count                   |
+| ------------------- | ----------------------- |
+| Met / Met (library) | 19                      |
+| Partial             | 1 (AP-14)               |
+| Not yet             | 3 (AP-16, AP-18, AP-22) |
+
+The three "Not yet" rows and the one "Partial" all trace to the same two
+unbuilt pieces: **the stdio subprocess launcher** and **the package export
+flow**. Neither is required for the claim as stated — a client may support a
+subset of component types — but both are named here so the boundary is visible
+rather than implied.

--- a/docs/specs/features/agent-plugins/deployment.md
+++ b/docs/specs/features/agent-plugins/deployment.md
@@ -1,0 +1,122 @@
+# Agent Plugins standard interop — deployment & operator runbook
+
+> **Status**: env keys are wired in this repository and the feature flag
+> defaults to `false`. Nothing changes in any environment until the variable
+> is set to `true`.
+>
+> **Owner**: `ever@ever.co`. Files touched by this runbook: the three k8s
+> manifests, the three deploy workflows, `.env.compose`, and the ArgoCD-managed
+> environment described in §4 — which lives **outside this repository**.
+
+Ever Works supports the open
+[Agent Plugins v1.0.0](https://github.com/agentplugins/agent-plugins-spec)
+format in addition to, and without altering, its own plugin system. A package
+is a directory containing `plugin.json`, optional `skills/<name>/SKILL.md`
+files, and an optional `mcp.json`. Any conforming client can read it, and the
+same packages work across vendors.
+
+---
+
+## 1. The two variables
+
+| Variable                | Default              | Meaning                                                                                                                                                              |
+| ----------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FEATURE_AGENT_PLUGINS` | `false`              | Lets installed packages contribute to the skills catalog.                                                                                                            |
+| `AGENT_PLUGINS_DIR`     | `/app/agent-plugins` | Where packages live. Several directories may be given, separated by `,`, `;` or the platform path delimiter. The **first** is the write target for fetched packages. |
+
+Both are **safe to leave unset**. This is deliberate, and it is the reason
+this feature cannot repeat the 2026-06-12 `PLATFORM_ENCRYPTION_KEY` incident,
+where a required variable that was never wired crash-looped the API and rolled
+silently back to the previous pods.
+
+Two details that look like nitpicks and are not:
+
+- The config layer reads these with `||`, **not** `??`. `envsubst` renders an
+  unset variable as an **empty string**, not as `undefined`, so `??` would
+  accept `''` as a deliberate value and resolve the package directory to
+  nothing.
+- They are repository **variables**, not secrets. Neither value is sensitive,
+  and a secret is masked in the deploy log — which is precisely where an
+  operator looks when packages are not appearing.
+
+---
+
+## 2. Turning it on
+
+1. Set the repository variable `FEATURE_AGENT_PLUGINS` to `true` for the
+   environment you are enabling (Settings → Secrets and variables → Actions →
+   Variables).
+2. Optionally set `AGENT_PLUGINS_DIR` if packages are mounted somewhere other
+   than `/app/agent-plugins`.
+3. Re-run the deploy workflow for that environment.
+4. Verify with `GET /api/agent-plugins`. The response reports `enabled`
+   explicitly, so **"the feature is off" and "it is on and there are no
+   packages" are distinguishable** — without that field an operator who has
+   just flipped the flag cannot tell which they are looking at.
+
+To verify from the CLI instead:
+
+```bash
+ever-works plugins agent-plugins list
+```
+
+---
+
+## 3. What the flag does and does not gate
+
+**Gated.** Package skills appearing in the catalog; the boot re-materialisation
+pass; update checks for packages.
+
+**Not gated, because it never runs on its own.** Remote acquisition. Fetching a
+package additionally requires an **allowlist entry** for that exact package
+name or git URL. The allowlist fails closed: if it cannot be read, every remote
+package is refused rather than permitted. A database outage must not become
+unrestricted remote acquisition.
+
+**Unaffected either way.** The existing plugin system, the existing skills
+catalog, and every provider plugin. With the flag off the code paths are not
+merely inert — the package source is not consulted at all, and the API reports
+`enabled: false` without touching the filesystem.
+
+---
+
+## 4. The ArgoCD-managed live environment — outside this repo
+
+The manifests in `.deploy/k8s/` are the source of truth for the **DigitalOcean**
+deploy workflows in this repository. The live `*.ever.works` environment is
+reconciled by **ArgoCD from a separate configuration repository**, and editing
+the manifests here does **not** change it.
+
+To enable the feature there, the same two variables must be added to that
+repository's environment configuration for the API workload. Until that is
+done, a package directory mounted into the live cluster will be ignored,
+because the flag will read as empty and therefore `false`.
+
+This is called out explicitly because the split is not visible from inside this
+repository: every file this runbook touches is here, and the one that matters
+for production is not.
+
+---
+
+## 5. Mounting packages
+
+Packages can reach a pod three ways:
+
+1. **Baked into the image** under `/app/agent-plugins`. Simplest, immutable,
+   requires a rebuild to change.
+2. **A mounted volume** at `AGENT_PLUGINS_DIR`. Survives restarts; the operator
+   owns the contents.
+3. **Fetched from git or npm** into the first configured directory. Requires an
+   allowlist entry, and the fetched tree is validated before it is kept — a
+   package that fails validation is deleted rather than left on disk, so it
+   cannot be picked up by the directory scanner on a later boot.
+
+For 1 and 2 the operator owns the bytes, so no allowlist entry is needed.
+
+---
+
+## 6. Rollback
+
+Set `FEATURE_AGENT_PLUGINS` back to `false` and redeploy. Package skills
+disappear from the catalog immediately; nothing else is touched, and no data is
+removed. Packages already on disk stay there and are simply not read.

--- a/docs/specs/features/agent-plugins/deployment.md
+++ b/docs/specs/features/agent-plugins/deployment.md
@@ -19,10 +19,12 @@ same packages work across vendors.
 
 ## 1. The two variables
 
-| Variable                | Default              | Meaning                                                                                                                                                              |
-| ----------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FEATURE_AGENT_PLUGINS` | `false`              | Lets installed packages contribute to the skills catalog.                                                                                                            |
-| `AGENT_PLUGINS_DIR`     | `/app/agent-plugins` | Where packages live. Several directories may be given, separated by `,`, `;` or the platform path delimiter. The **first** is the write target for fetched packages. |
+| Variable                 | Default                   | Meaning                                                                                                                                                              |
+| ------------------------ | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FEATURE_AGENT_PLUGINS`  | `false`                   | Lets installed packages contribute to the skills catalog.                                                                                                            |
+| `AGENT_PLUGINS_DIR`      | `/app/agent-plugins`      | Where packages live. Several directories may be given, separated by `,`, `;` or the platform path delimiter. The **first** is the write target for fetched packages. |
+| `AGENT_PLUGINS_STDIO`    | `false`                   | Whether stdio MCP servers declared by packages may be **launched**.                                                                                                  |
+| `AGENT_PLUGINS_DATA_DIR` | `/app/agent-plugins-data` | Root for per-package writable data (`${PLUGIN_DATA}`).                                                                                                               |
 
 Both are **safe to leave unset**. This is deliberate, and it is the reason
 this feature cannot repeat the 2026-06-12 `PLATFORM_ENCRYPTION_KEY` incident,
@@ -120,3 +122,45 @@ For 1 and 2 the operator owns the bytes, so no allowlist entry is needed.
 Set `FEATURE_AGENT_PLUGINS` back to `false` and redeploy. Package skills
 disappear from the catalog immediately; nothing else is touched, and no data is
 removed. Packages already on disk stay there and are simply not read.
+
+---
+
+## 7. `AGENT_PLUGINS_STDIO` — a second, larger grant
+
+This is deliberately **not** covered by `FEATURE_AGENT_PLUGINS`, and the
+difference is worth being precise about.
+
+The master flag lets a package contribute **documents** — Markdown skills — and
+**declarations** of remote MCP servers. Those are inert: nothing in a package is
+executed, and a remote server still needs an allowlist entry and an explicit
+per-agent binding before an agent can reach it.
+
+`AGENT_PLUGINS_STDIO` lets the platform **execute a subprocess from a package's
+own contents**. That is a categorically larger grant, and one a deployment may
+never want even while using packages happily. No sandbox is built in this
+feature, so a stdio server runs with the API pod's own privileges and file
+access.
+
+**SaaS keeps this off.** Self-hosted operators who control exactly what they
+install can turn it on.
+
+### What "off" looks like
+
+A stdio server on a deployment with the gate closed is reported as **present and
+disabled by policy** (AP-19), not hidden. It appears under `skipped` with
+`code: "disabled-by-policy"` and `enableable: true`, so an operator can see what
+a package _would_ run before deciding whether to allow it — and a UI can offer
+"enable stdio" rather than the misleading "contact the package author".
+
+Every other skip reason carries `enableable: false`, because nothing the
+operator sets will change it.
+
+### `AGENT_PLUGINS_DATA_DIR`
+
+Per-package writable state for `${PLUGIN_DATA}`. Kept **outside**
+`AGENT_PLUGINS_DIR` on purpose: package contents are read-only and replaced
+wholesale on update, while data has to survive that — and a writable directory
+inside a scanned tree would also be walked by the package scanner.
+
+Nothing creates it at boot; the launcher creates the per-package subdirectory it
+needs, so setting the variable cannot fail a startup.

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -209,7 +209,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       files + explicit operator note for the ArgoCD-managed live env (outside
       this repo). Defaults keep boot non-fatal; the wiring is still required
       for the values to be settable.
-- [ ] **T32**. Full-spec conformance run: fixture packages exercising every
+- [x] **T32**. Full-spec conformance run: fixture packages exercising every
       Appendix A checklist row against the live loader; publish the checklist result
       as a doc page.
 

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -131,7 +131,26 @@ appends, locale key appends) are expected and fine.
 
 ## Phase 3 — MCP client: remote transports + bindings (PR-5, PR-6)
 
-- [ ] **T23**. `McpServerConfigService` (plan §2.2) in
+> **2026-09-04 — T24-T27 were largely ALREADY BUILT.** PR #2082 ("MCP client —
+> external server connections with per-agent bindings") shipped
+> `mcp_server_connections`, `agent_mcp_server_bindings`, `McpClientService`,
+> `McpToolSource`, `McpConnectionsService`, the `@modelcontextprotocol/sdk`
+> dependency and the API controllers. `McpServerConnection.source` is typed
+> `'manual' | 'package'` with the comment "'package' reserved for the
+> agent-plugins package work" — the seam for this work was designed in advance.
+>
+> Following these task descriptions literally would have built a SECOND binding
+> table and duplicated a whole working subsystem. The real remaining gap was
+> narrow: nothing turned a package-declared server into something that machinery
+> could see. `PackageMcpReconcilerService` closes it by materialising package
+> servers as ordinary connection rows with `source: 'package'` — created
+> **disabled and unbound**, because a package arriving on disk must never grant
+> an agent network reach on its own.
+>
+> Re-verify T25-T28 against live code before starting them; they are likely
+> done or much smaller than written here.
+
+- [x] **T23**. `McpServerConfigService` (plan §2.2) in
       `packages/agent/src/agent-plugins/`: resolves bound servers → validated
       configs + provenance via the conformance lib. No plugin capability, no
       `facade-capabilities.ts` append. Barrel-export from

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -199,11 +199,11 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       expanded package env overlay + `PLUGIN_ROOT`/`PLUGIN_DATA` last; single-
       token command resolution (bare vs `./`-relative) with containment; cwd
       rules per AP-13; process supervision + teardown at run end.
-- [ ] **T31**. Triple gate: feature flag + `AGENT_PLUGINS_STDIO` deployment
+- [x] **T31**. Triple gate: feature flag + `AGENT_PLUGINS_STDIO` deployment
       setting (default off; v1 SaaS keeps it off — no sandbox route is built in
       this feature) + per-binding explicit enable; disabled stdio surfaces as
       "present, disabled by policy" (AP-19).
-- [ ] **T31b**. Phase-4 env wiring repeat of the 2026-06-12 checklist for
+- [x] **T31b**. Phase-4 env wiring repeat of the 2026-06-12 checklist for
       `AGENT_PLUGINS_DATA_DIR` + `AGENT_PLUGINS_STDIO`: k8s manifests
       (dev/stage/prod) + deploy workflow env blocks + `.env.example` + compose
       files + explicit operator note for the ArgoCD-managed live env (outside

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -68,7 +68,7 @@ appends, locale key appends) are expected and fine.
 
 ## Phase 1 — Package registry + local-dir source + skills read-side (PR-2, PR-3)
 
-- [ ] **T10**. Entities `agent_plugin_packages` (Tier A, incl. `dataManifest`) +
+- [x] **T10**. Entities `agent_plugin_packages` (Tier A, incl. `dataManifest`) +
       `agent_plugin_package_allowlist` (Tier D) per plan §2.5; append to
       `_entities-inventory.ts`; migration `CreateAgentPluginPackages`.
       **Read the generated SQL** before commit (NN #16). Account-transfer
@@ -76,14 +76,14 @@ appends, locale key appends) are expected and fine.
       literal + both import paths + SyncPushOptions) — reference-only export
       (name+version+source), never package content; deferring this to Phase 3
       would reopen the silent-no-round-trip bug class.
-- [ ] **T11**. `packages/agent/src/agent-plugins/` module:
+- [x] **T11**. `packages/agent/src/agent-plugins/` module:
       `AgentPluginPackageService` (register/validate/list/remove; findings
       persisted per package), local-dir acquirer (`AGENT_PLUGINS_DIR` scan,
       optional-with-default env per constants.ts pattern). Barrel export entry
       in `packages/agent/package.json` export map.
-- [ ] **T12**. Feature flag `FEATURE_AGENT_PLUGINS` default false in
+- [x] **T12**. Feature flag `FEATURE_AGENT_PLUGINS` default false in
       `apps/api/src/config/constants.ts` + `.env.example` + compose env files.
-- [ ] **T13**. `AgentPluginCatalogService` (plan §2.2) in
+- [x] **T13**. `AgentPluginCatalogService` (plan §2.2) in
       `packages/agent/src/agent-plugins/`: entries from registered package rows + conformance lib; version synthesis per AP-21; pre-flight findings by
       calling the existing gates directly (`MAX_BODY_BYTES`/`assertNoSecrets`/
       `assertNoInjectionTokens` — reachable because this is platform code, not
@@ -93,13 +93,13 @@ appends, locale key appends) are expected and fine.
       (`packageName?`/`packageVersion?`/`sourceKind?`) to `SkillCatalogEntry`
       (additive interface change). Barrel-export the new module in
       `packages/agent/package.json` export map.
-- [ ] **T14**. API controller `apps/api/src/agent-plugins/` (list/install
+- [x] **T14**. API controller `apps/api/src/agent-plugins/` (list/install
       local/uninstall/findings), throttled 5/min, admin allowlist CRUD parallel
       to `admin/plugins/allowlist`. DTO validation + validation-authz-matrix
       e2e specs for every new route.
-- [ ] **T15**. CLI verbs (`agent-plugins list/install/status/uninstall`)
+- [x] **T15**. CLI verbs (`agent-plugins list/install/status/uninstall`)
       following `dynamic.command.ts` pattern.
-- [ ] **T16**. Integration test (Jest, in `packages/agent` — the facade +
+- [x] **T16**. Integration test (Jest, in `packages/agent` — the facade +
       services live there; conformance-lib unit tests stay Vitest in
       `packages/agent-plugins`): fixture package on disk → register → catalog
       entries appear via `SkillsFacadeService` → `installFromCatalog` →
@@ -109,23 +109,23 @@ appends, locale key appends) are expected and fine.
 
 ## Phase 2 — git + npm sources + updates (PR-4)
 
-- [ ] **T17**. Git acquirer: URL-first shallow clone (isomorphic-git primitives
+- [x] **T17**. Git acquirer: URL-first shallow clone (isomorphic-git primitives
       per plan §2.3), ref-pin + resolved-SHA recording, containment validation
       post-clone, re-fetch/update path.
-- [ ] **T18**. npm acquirer: pacote manifest→allowlist→extract (no symlink, no
+- [x] **T18**. npm acquirer: pacote manifest→allowlist→extract (no symlink, no
       scripts, no dep install); registry config reuse; 409/424/502/504 error
       mapping parity with the code-plugin installer.
-- [ ] **T19**. Boot re-materialization (warmupFromDb pattern) for git/npm
+- [x] **T19**. Boot re-materialization (warmupFromDb pattern) for git/npm
       packages; startupProbe budget check.
-- [ ] **T20**. Update-available end-to-end: catalog service computes updates for
+- [x] **T20**. Update-available end-to-end: catalog service computes updates for
       git/npm packages; facade surfaces a badge + explicit re-sync action; the
       same facade wiring finally calls the existing provider `checkForUpdates`
       seam (zero non-test callers today) so `everworks-skills` updates surface
       too.
-- [ ] **T21**. Web UI: Sources + Packages pages under settings; install flow
+- [x] **T21**. Web UI: Sources + Packages pages under settings; install flow
       with per-component findings display; i18n keys in ALL
       `apps/web/messages/*.json`; PostHog events.
-- [ ] **T22**. Env wiring per 2026-06-12 checklist (k8s manifests dev/stage/
+- [x] **T22**. Env wiring per 2026-06-12 checklist (k8s manifests dev/stage/
       prod + deploy workflows + compose; defaults make it non-fatal) + explicit
       operator note re ArgoCD-managed live env (outside this repo).
 

--- a/packages/agent-plugins/src/__tests__/conformance-statement.spec.ts
+++ b/packages/agent-plugins/src/__tests__/conformance-statement.spec.ts
@@ -1,0 +1,121 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Keeps the published conformance statement honest.
+ *
+ * A conformance claim nobody can falsify is decoration. These tests make
+ * `docs/specs/features/agent-plugins/conformance.md` fail the build when it
+ * stops matching the specification it claims to answer:
+ *
+ * - a requirement added to `spec.md` with no row in the statement,
+ * - a row claiming a requirement id that does not exist,
+ * - a row whose status is not one of the defined values,
+ * - a summary that disagrees with the rows above it.
+ *
+ * The first direction matters most. Adding AP-24 to the spec and forgetting
+ * the statement would leave a page that reads as complete while silently
+ * omitting a requirement — worse than having no page, because it invites
+ * trust it has not earned.
+ *
+ * Every pattern here tolerates column padding. Prettier aligns markdown
+ * tables and CI enforces Prettier, so an exact-spacing matcher would break on
+ * the next format run and teach whoever hit it to delete the guard.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DOCS = join(HERE, '..', '..', '..', '..', 'docs', 'specs', 'features', 'agent-plugins');
+const SPEC = join(DOCS, 'spec.md');
+const STATEMENT = join(DOCS, 'conformance.md');
+
+interface StatementRow {
+	id: string;
+	status: string;
+	evidence: string;
+}
+
+/** Requirement ids the specification defines, in `- **AP-N**:` form. */
+async function specRequirementIds(): Promise<string[]> {
+	const text = await readFile(SPEC, 'utf8');
+	const ids = [...text.matchAll(/^- \*\*(AP-\d+)\*\*:/gmu)].map((m) => m[1]);
+	return [...new Set(ids)];
+}
+
+/** Requirement ids the statement has a table row for. */
+async function statementRows(): Promise<StatementRow[]> {
+	const text = await readFile(STATEMENT, 'utf8');
+	return [...text.matchAll(/^\|\s*(AP-\d+)\s*\|(.+?)\|(.+?)\|(.+?)\|\s*$/gmu)].map((m) => ({
+		id: m[1],
+		status: m[3].trim(),
+		evidence: m[4].trim()
+	}));
+}
+
+/** The number in the second cell of a summary row, or null when absent. */
+function summaryCount(text: string, pattern: RegExp): number | null {
+	const found = pattern.exec(text);
+	return found ? Number(found[1]) : null;
+}
+
+const MET_ROW = /^\|\s*Met \/ Met \(library\)\s*\|\s*(\d+)\s*\|/mu;
+const PARTIAL_ROW = /^\|\s*Partial\s*\|\s*(\d+)\s/mu;
+const NOT_YET_ROW = /^\|\s*Not yet\s*\|\s*(\d+)\s/mu;
+
+const PERMITTED_STATUSES = new Set(['Met', '**Met**', 'Met (library)', '**Partial**', '**Not yet**']);
+
+describe('published conformance statement', () => {
+	it('has a row for every requirement the specification defines', async () => {
+		const spec = await specRequirementIds();
+		const rows = await statementRows();
+		const covered = new Set(rows.map((r) => r.id));
+
+		// Sanity: if either parser breaks, every assertion here would pass
+		// vacuously, so both counts are floored before anything is compared.
+		expect(spec.length).toBeGreaterThanOrEqual(23);
+		expect(rows.length).toBeGreaterThanOrEqual(23);
+
+		expect(spec.filter((id) => !covered.has(id))).toEqual([]);
+	});
+
+	it('does not claim a requirement the specification does not define', async () => {
+		const spec = new Set(await specRequirementIds());
+		const rows = await statementRows();
+
+		expect(rows.map((r) => r.id).filter((id) => !spec.has(id))).toEqual([]);
+	});
+
+	it('uses only defined status values', async () => {
+		const rows = await statementRows();
+
+		// An ad-hoc status like "mostly" would let a gap hide behind a word
+		// nobody has defined.
+		const bad = rows.filter((r) => !PERMITTED_STATUSES.has(r.status));
+		expect(bad.map((r) => `${r.id}: ${r.status}`)).toEqual([]);
+	});
+
+	it('gives every row some evidence', async () => {
+		const rows = await statementRows();
+
+		// "Not yet" rows count too: their evidence is the explanation of what
+		// is missing, which is the part a reader needs most.
+		expect(rows.filter((r) => r.evidence.length < 10).map((r) => r.id)).toEqual([]);
+	});
+
+	it('states a summary consistent with its own rows', async () => {
+		const rows = await statementRows();
+		const text = await readFile(STATEMENT, 'utf8');
+
+		const met = rows.filter((r) => r.status.replace(/\*/gu, '').startsWith('Met')).length;
+		const partial = rows.filter((r) => r.status.includes('Partial')).length;
+		const notYet = rows.filter((r) => r.status.includes('Not yet')).length;
+
+		// The summary is written by hand and can drift from the rows above it.
+		// A summary that OVERSTATES what is met is exactly the failure this
+		// page exists to prevent.
+		expect(summaryCount(text, MET_ROW)).toBe(met);
+		expect(summaryCount(text, PARTIAL_ROW)).toBe(partial);
+		expect(summaryCount(text, NOT_YET_ROW)).toBe(notYet);
+	});
+});

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -312,6 +312,7 @@
         "date-fns": "^4.1.0",
         "exceljs": "^4.4.0",
         "github-slugger": "^2.0.0",
+        "isomorphic-git": "^1.36.3",
         "jszip": "^3.10.1",
         "lodash": "^4.18.1",
         "mammoth": "^1.8.0",

--- a/packages/agent/src/agent-plugins/__tests__/catalog-integration.spec.ts
+++ b/packages/agent/src/agent-plugins/__tests__/catalog-integration.spec.ts
@@ -343,3 +343,112 @@ describe('Agent Plugins → skills catalog (integration)', () => {
         ]);
     });
 });
+
+describe('Agent Plugins → skills catalog updates (integration)', () => {
+    /**
+     * `ISkillsProviderPlugin.checkForUpdates` was on the contract and
+     * implemented by two plugins with ZERO non-test callers. These tests exist
+     * to keep it called: a seam every provider implements and nothing invokes
+     * is indistinguishable from one that does not work.
+     */
+
+    function providerWithUpdates(
+        updated: Array<{ slug: string; oldVersion: string; newVersion: string }>,
+        implemented = true,
+    ): RegisteredPlugin {
+        const base = builtinProvider([builtinEntry('plan')]);
+        const plugin = base.plugin as unknown as Record<string, unknown>;
+        if (implemented) {
+            plugin.checkForUpdates = jest.fn().mockResolvedValue({ updated });
+        } else {
+            delete plugin.checkForUpdates;
+        }
+        return base;
+    }
+
+    it('calls the provider seam and returns what it reports', async () => {
+        const provider = providerWithUpdates([
+            { slug: 'plan', oldVersion: '1.0.0', newVersion: '1.1.0' },
+        ]);
+        const facade = facadeWith([provider]);
+
+        const result = await facade.checkForUpdates({ plan: '1.0.0' }, facadeOptions);
+
+        expect(result.updated).toEqual([
+            { slug: 'plan', oldVersion: '1.0.0', newVersion: '1.1.0' },
+        ]);
+        expect(
+            (provider.plugin as unknown as { checkForUpdates: jest.Mock }).checkForUpdates,
+        ).toHaveBeenCalledWith({ plan: '1.0.0' }, expect.anything());
+    });
+
+    it('skips a provider that does not implement the optional method', async () => {
+        const facade = facadeWith([providerWithUpdates([], false)]);
+
+        // Optional on the interface, so absence is normal rather than an error.
+        await expect(facade.checkForUpdates({ plan: '1.0.0' }, facadeOptions)).resolves.toEqual({
+            updated: [],
+        });
+    });
+
+    it('does not let one failing provider hide another provider’s updates', async () => {
+        const failing = builtinProvider([]);
+        (failing.plugin as unknown as Record<string, unknown>).checkForUpdates = jest
+            .fn()
+            .mockRejectedValue(new Error('provider down'));
+        (failing.plugin as unknown as Record<string, unknown>).id = 'failing-provider';
+
+        const working = providerWithUpdates([
+            { slug: 'plan', oldVersion: '1.0.0', newVersion: '2.0.0' },
+        ]);
+
+        const facade = facadeWith([failing, working]);
+
+        const result = await facade.checkForUpdates({ plan: '1.0.0' }, facadeOptions);
+
+        expect(result.updated).toHaveLength(1);
+    });
+
+    it('appends package updates after provider updates, never displacing them', async () => {
+        const provider = providerWithUpdates([
+            { slug: 'plan', oldVersion: '1.0.0', newVersion: '1.1.0' },
+        ]);
+        const packageSource = {
+            listEntries: jest.fn().mockResolvedValue([]),
+            getEntry: jest.fn().mockResolvedValue(null),
+            checkForUpdates: jest.fn().mockResolvedValue([
+                // Same slug as the provider's: must be dropped, matching the
+                // first-wins precedence `listEntries` establishes.
+                { slug: 'plan', oldVersion: '1.0.0', newVersion: '9.9.9' },
+                { slug: 'release-notes', oldVersion: '1.0.0', newVersion: '1.4.0' },
+            ]),
+        };
+
+        const facade = facadeWith([provider], packageSource as never);
+
+        const result = await facade.checkForUpdates({ plan: '1.0.0' }, facadeOptions);
+
+        expect(result.updated).toEqual([
+            { slug: 'plan', oldVersion: '1.0.0', newVersion: '1.1.0' },
+            { slug: 'release-notes', oldVersion: '1.0.0', newVersion: '1.4.0' },
+        ]);
+    });
+
+    it('works with no provider plugin enabled at all', async () => {
+        const packageSource = {
+            listEntries: jest.fn().mockResolvedValue([]),
+            getEntry: jest.fn().mockResolvedValue(null),
+            checkForUpdates: jest
+                .fn()
+                .mockResolvedValue([
+                    { slug: 'release-notes', oldVersion: '1.0.0', newVersion: '1.4.0' },
+                ]),
+        };
+
+        const facade = facadeWith([], packageSource as never);
+
+        const result = await facade.checkForUpdates({ 'release-notes': '1.0.0' }, facadeOptions);
+
+        expect(result.updated).toHaveLength(1);
+    });
+});

--- a/packages/agent/src/agent-plugins/agent-plugins.module.spec.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.spec.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Module-shape guard.
+ *
+ * Nest lets a module list a provider in `exports` that appears in neither
+ * `providers` nor `imports`. That compiles, passes every unit test, and fails
+ * only when the DI container is actually built — which the API's
+ * `generate:openapi` gate does NOT do, because it runs in preview mode and
+ * never instantiates providers. The result is a pod that crash-loops at boot
+ * with every check green.
+ *
+ * This happened while building this module: six providers were appended to
+ * `exports` while the edit that was supposed to add them to `providers` had
+ * silently matched nothing. A static check is cheap and catches exactly that.
+ *
+ * It reads the source rather than importing the module so it needs no
+ * database, no TypeORM connection and no Nest container.
+ */
+
+const MODULE_PATH = join(__dirname, 'agent-plugins.module.ts');
+
+function block(source: string, key: 'providers' | 'exports' | 'imports'): string {
+    const start = source.indexOf(`${key}: [`);
+    if (start === -1) return '';
+    let depth = 0;
+    for (let i = source.indexOf('[', start); i < source.length; i += 1) {
+        if (source[i] === '[') depth += 1;
+        else if (source[i] === ']') {
+            depth -= 1;
+            if (depth === 0) return source.slice(start, i + 1);
+        }
+    }
+    return '';
+}
+
+/** Bare identifiers listed on their own line in a decorator array. */
+function identifiers(text: string): string[] {
+    return [...text.matchAll(/^\s*([A-Z][A-Za-z0-9_]*|[A-Z][A-Z0-9_]*),\s*$/gmu)].map(
+        (match) => match[1],
+    );
+}
+
+/**
+ * Everything a `providers` array supplies: bare classes AND the tokens of
+ * object-literal providers.
+ *
+ * The second half matters — `{ provide: SOME_TOKEN, useExisting: X }` supplies
+ * `SOME_TOKEN`, and a checker that only reads bare identifiers would report
+ * the token as exported-but-not-provided. That false positive would train
+ * whoever hits it to disable this guard, which is worse than not having it.
+ */
+function suppliedBy(text: string): Set<string> {
+    const names = identifiers(text);
+    const tokens = [...text.matchAll(/provide:\s*([A-Za-z_][A-Za-z0-9_]*)/gu)].map(
+        (match) => match[1],
+    );
+    return new Set([...names, ...tokens]);
+}
+
+describe('AgentPluginsModule shape', () => {
+    const source = readFileSync(MODULE_PATH, 'utf8');
+
+    it('provides or imports everything it exports', () => {
+        const provided = suppliedBy(block(source, 'providers'));
+        const imported = new Set(identifiers(block(source, 'imports')));
+        const exported = identifiers(block(source, 'exports'));
+
+        expect(exported.length).toBeGreaterThan(0);
+
+        const unsatisfied = exported.filter((name) => !provided.has(name) && !imported.has(name));
+
+        expect(unsatisfied).toEqual([]);
+    });
+
+    it('still binds the skills-provider token through useExisting', () => {
+        // The facade consumes this @Optional(); losing the binding would make
+        // package skills silently vanish rather than fail loudly.
+        expect(source).toContain('provide: AGENT_PLUGIN_SKILL_SOURCE');
+        expect(source).toContain('useExisting: AgentPluginPackageCatalogService');
+    });
+
+    it('registers every entity it queries with forFeature', () => {
+        // Registering an entity ONLY in the inventory compiles, boots, and then
+        // throws EntityMetadataNotFoundError on the first query.
+        const imports = block(source, 'imports');
+        for (const entity of [
+            'AgentPluginPackage',
+            'AgentPluginPackageAllowlist',
+            'McpServerConnection',
+        ]) {
+            expect(imports).toContain(entity);
+        }
+    });
+});

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
 import { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
+import { McpServerConnection } from '../entities/mcp-server-connection.entity';
+import { McpServerConnectionRepository } from '../database/repositories/mcp-server-connection.repository';
 import { DatabaseModule } from '../database/database.module';
 import { AgentPluginPackageCatalogService } from './package-catalog.service';
 import { AgentPluginAllowlistService } from './allowlist.service';
@@ -13,6 +15,7 @@ import { AgentPluginPackageBootstrapService } from './package-bootstrap.service'
 import { AgentPluginUpdateService } from './update.service';
 import { AgentPluginInstallService } from './install.service';
 import { McpServerConfigService } from './mcp-server-config.service';
+import { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -35,7 +38,11 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 @Module({
     imports: [
         DatabaseModule,
-        TypeOrmModule.forFeature([AgentPluginPackage, AgentPluginPackageAllowlist]),
+        TypeOrmModule.forFeature([
+            AgentPluginPackage,
+            AgentPluginPackageAllowlist,
+            McpServerConnection,
+        ]),
     ],
     providers: [
         AgentPluginPackageCatalogService,
@@ -43,6 +50,20 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginGitSource,
         AgentPluginNpmSource,
         AgentPluginRemoteAcquireService,
+        AgentPluginPackageRepository,
+        AgentPluginPackageBootstrapService,
+        AgentPluginUpdateService,
+        AgentPluginInstallService,
+        McpServerConfigService,
+        PackageMcpReconcilerService,
+        // Provided locally rather than by importing `McpModule`, which would
+        // pull ActivityLogModule and its transitive imports into what the
+        // docstring above promises is a LEAF module. `McpModule` provides this
+        // same repository from its own `forFeature` for the same reason, so
+        // this follows the established pattern rather than inventing one. A
+        // second instance is harmless: the repository is a stateless wrapper
+        // over a TypeORM Repository, with no lifecycle and no cache.
+        McpServerConnectionRepository,
         {
             // The facade consumes this @Optional(), so a deployment that never
             // imports this module keeps behaving exactly as it did before the
@@ -62,6 +83,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginUpdateService,
         AgentPluginInstallService,
         McpServerConfigService,
+        PackageMcpReconcilerService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -12,6 +12,7 @@ import { AgentPluginPackageRepository } from './package.repository';
 import { AgentPluginPackageBootstrapService } from './package-bootstrap.service';
 import { AgentPluginUpdateService } from './update.service';
 import { AgentPluginInstallService } from './install.service';
+import { McpServerConfigService } from './mcp-server-config.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -60,6 +61,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginPackageBootstrapService,
         AgentPluginUpdateService,
         AgentPluginInstallService,
+        McpServerConfigService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -10,6 +10,7 @@ import { AgentPluginNpmSource } from './npm-source';
 import { AgentPluginRemoteAcquireService } from './remote-acquire.service';
 import { AgentPluginPackageRepository } from './package.repository';
 import { AgentPluginPackageBootstrapService } from './package-bootstrap.service';
+import { AgentPluginUpdateService } from './update.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -56,6 +57,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginRemoteAcquireService,
         AgentPluginPackageRepository,
         AgentPluginPackageBootstrapService,
+        AgentPluginUpdateService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -8,6 +8,8 @@ import { AgentPluginAllowlistService } from './allowlist.service';
 import { AgentPluginGitSource } from './git-source';
 import { AgentPluginNpmSource } from './npm-source';
 import { AgentPluginRemoteAcquireService } from './remote-acquire.service';
+import { AgentPluginPackageRepository } from './package.repository';
+import { AgentPluginPackageBootstrapService } from './package-bootstrap.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -52,6 +54,8 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginGitSource,
         AgentPluginNpmSource,
         AgentPluginRemoteAcquireService,
+        AgentPluginPackageRepository,
+        AgentPluginPackageBootstrapService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -11,6 +11,7 @@ import { AgentPluginRemoteAcquireService } from './remote-acquire.service';
 import { AgentPluginPackageRepository } from './package.repository';
 import { AgentPluginPackageBootstrapService } from './package-bootstrap.service';
 import { AgentPluginUpdateService } from './update.service';
+import { AgentPluginInstallService } from './install.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -58,6 +59,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginPackageRepository,
         AgentPluginPackageBootstrapService,
         AgentPluginUpdateService,
+        AgentPluginInstallService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -4,6 +4,10 @@ import { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
 import { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
 import { DatabaseModule } from '../database/database.module';
 import { AgentPluginPackageCatalogService } from './package-catalog.service';
+import { AgentPluginAllowlistService } from './allowlist.service';
+import { AgentPluginGitSource } from './git-source';
+import { AgentPluginNpmSource } from './npm-source';
+import { AgentPluginRemoteAcquireService } from './remote-acquire.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -30,6 +34,10 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
     ],
     providers: [
         AgentPluginPackageCatalogService,
+        AgentPluginAllowlistService,
+        AgentPluginGitSource,
+        AgentPluginNpmSource,
+        AgentPluginRemoteAcquireService,
         {
             // The facade consumes this @Optional(), so a deployment that never
             // imports this module keeps behaving exactly as it did before the
@@ -38,6 +46,13 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
             useExisting: AgentPluginPackageCatalogService,
         },
     ],
-    exports: [AgentPluginPackageCatalogService, AGENT_PLUGIN_SKILL_SOURCE],
+    exports: [
+        AgentPluginPackageCatalogService,
+        AgentPluginAllowlistService,
+        AgentPluginGitSource,
+        AgentPluginNpmSource,
+        AgentPluginRemoteAcquireService,
+        AGENT_PLUGIN_SKILL_SOURCE,
+    ],
 })
 export class AgentPluginsModule {}

--- a/packages/agent/src/agent-plugins/allowlist.service.spec.ts
+++ b/packages/agent/src/agent-plugins/allowlist.service.spec.ts
@@ -1,0 +1,99 @@
+import type { Repository } from 'typeorm';
+import { AgentPluginAllowlistService } from './allowlist.service';
+import type { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
+
+/**
+ * The allowlist is the only thing standing between a URL and a network fetch,
+ * so these tests are about REFUSAL, not about the happy path. Every case here
+ * asserts that something is denied, because the failure mode that matters is a
+ * check that quietly starts allowing everything.
+ */
+
+type RepoMock = Partial<Repository<AgentPluginPackageAllowlist>>;
+
+function entry(over: Partial<AgentPluginPackageAllowlist> = {}): AgentPluginPackageAllowlist {
+    return {
+        id: 'entry-1',
+        packageName: 'acme-skills',
+        source: 'npm',
+        versionRange: null,
+        integrity: null,
+        enabled: true,
+        notes: null,
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+        ...over,
+    } as AgentPluginPackageAllowlist;
+}
+
+function serviceWith(repo?: RepoMock): AgentPluginAllowlistService {
+    return new AgentPluginAllowlistService(repo as Repository<AgentPluginPackageAllowlist>);
+}
+
+describe('AgentPluginAllowlistService', () => {
+    it('refuses when no repository is bound, rather than treating it as unrestricted', async () => {
+        // The @Optional() injection means an absent repository is a REAL
+        // runtime state, not a test artefact. Failing open here would turn a
+        // missing binding into unrestricted remote acquisition.
+        const result = await serviceWith(undefined).check('acme-skills', 'npm');
+
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('unavailable');
+    });
+
+    it('refuses when the allowlist lookup THROWS, and says it was a lookup failure', async () => {
+        // A database blip must not read as "the allowlist is empty". The
+        // distinction is also operator-facing: an outage and a missing entry
+        // call for completely different responses.
+        const repo: RepoMock = {
+            findOne: jest.fn().mockRejectedValue(new Error('connection terminated')),
+        };
+
+        const result = await serviceWith(repo).check('acme-skills', 'npm');
+
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('could not be read');
+        expect(result.reason).toContain('connection terminated');
+        expect(result.reason).not.toContain('not on the Agent Plugins allowlist');
+    });
+
+    it('refuses a package with no entry', async () => {
+        const repo: RepoMock = { findOne: jest.fn().mockResolvedValue(null) };
+
+        const result = await serviceWith(repo).check('acme-skills', 'npm');
+
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('not on the Agent Plugins allowlist');
+    });
+
+    it('refuses a disabled entry, so revoking does not require deleting the audit trail', async () => {
+        const repo: RepoMock = {
+            findOne: jest.fn().mockResolvedValue(entry({ enabled: false })),
+        };
+
+        const result = await serviceWith(repo).check('acme-skills', 'npm');
+
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('disabled');
+        expect(result.entry).toBeDefined();
+    });
+
+    it('scopes an entry to its source, so an npm grant does not authorise a git fetch', async () => {
+        const findOne = jest.fn().mockResolvedValue(null);
+        await serviceWith({ findOne }).check('acme-skills', 'git');
+
+        expect(findOne).toHaveBeenCalledWith({
+            where: { packageName: 'acme-skills', source: 'git' },
+        });
+    });
+
+    it('allows an enabled entry and returns it for downstream version checks', async () => {
+        const row = entry({ versionRange: '1.2.*' });
+        const repo: RepoMock = { findOne: jest.fn().mockResolvedValue(row) };
+
+        const result = await serviceWith(repo).check('acme-skills', 'npm');
+
+        expect(result.allowed).toBe(true);
+        expect(result.entry).toBe(row);
+    });
+});

--- a/packages/agent/src/agent-plugins/allowlist.service.ts
+++ b/packages/agent/src/agent-plugins/allowlist.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+    AgentPluginPackageAllowlist,
+    type AgentPluginPackageAllowlistSource,
+} from '../entities/agent-plugin-package-allowlist.entity';
+
+/**
+ * Authorisation gate for REMOTE Agent Plugins sources.
+ *
+ * Two properties matter more than anything else here, and both are easy to
+ * lose in a later refactor:
+ *
+ * 1. **It is consulted BEFORE any network fetch.** The code-plugin installer
+ *    establishes this rule (FR-11) and it is not merely tidiness: resolving an
+ *    npm manifest or contacting a git remote for a package nobody authorised
+ *    leaks the fact that this deployment is interested in it, and hands an
+ *    attacker-chosen server a connection before any policy has run. A check
+ *    performed after the fetch is not the same control.
+ *
+ * 2. **It fails CLOSED.** If the allowlist cannot be read — no repository
+ *    bound, database unreachable — every remote package is refused. The
+ *    tempting alternative (treat an unreadable allowlist as empty, and an
+ *    empty allowlist as "no restrictions configured") turns a database blip
+ *    into unrestricted remote code acquisition. See
+ *    `bug_class_caller_declared_security_ceiling`: a permission that fails
+ *    open is not a permission.
+ *
+ * `local` packages are deliberately NOT gated. A local package already sits in
+ * a directory the operator configured and controls; requiring an allowlist row
+ * would be asking their permission for bytes they put there themselves.
+ */
+@Injectable()
+export class AgentPluginAllowlistService {
+    private readonly logger = new Logger(AgentPluginAllowlistService.name);
+
+    constructor(
+        // Optional so the module remains loadable in contexts with no
+        // database (the CLI's read-only paths, unit tests of the local
+        // source). An ABSENT repository refuses every remote package rather
+        // than allowing it — see the fail-closed note above.
+        @Optional()
+        @InjectRepository(AgentPluginPackageAllowlist)
+        private readonly repository?: Repository<AgentPluginPackageAllowlist>,
+    ) {}
+
+    /**
+     * Decide whether `packageName` may be fetched from `source`.
+     *
+     * The returned `reason` is surfaced to the operator verbatim, so it names
+     * what to do next rather than merely stating the refusal.
+     */
+    async check(
+        packageName: string,
+        source: AgentPluginPackageAllowlistSource,
+    ): Promise<{ allowed: boolean; reason: string; entry?: AgentPluginPackageAllowlist }> {
+        if (!this.repository) {
+            return {
+                allowed: false,
+                reason:
+                    `Refusing to fetch "${packageName}": the Agent Plugins allowlist is ` +
+                    `unavailable in this context, so no remote source can be authorised.`,
+            };
+        }
+
+        let entry: AgentPluginPackageAllowlist | null;
+        try {
+            entry = await this.repository.findOne({ where: { packageName, source } });
+        } catch (err) {
+            // A read failure is not an empty allowlist. Refuse, and say why —
+            // an operator seeing this needs to know it is an outage and not a
+            // missing entry they should go and create.
+            const detail = err instanceof Error ? err.message : String(err);
+            this.logger.error(
+                `Agent Plugins allowlist lookup failed for ${source}:${packageName} — refusing: ${detail}`,
+            );
+            return {
+                allowed: false,
+                reason:
+                    `Refusing to fetch "${packageName}": the allowlist could not be read ` +
+                    `(${detail}). This is a lookup failure, not a missing entry.`,
+            };
+        }
+
+        if (!entry) {
+            return {
+                allowed: false,
+                reason:
+                    `"${packageName}" is not on the Agent Plugins allowlist for source ` +
+                    `"${source}". Add an allowlist entry before installing it.`,
+            };
+        }
+
+        if (!entry.enabled) {
+            return {
+                allowed: false,
+                reason:
+                    `The allowlist entry for "${packageName}" (${source}) is disabled. ` +
+                    `Re-enable it to allow this package again.`,
+                entry,
+            };
+        }
+
+        return { allowed: true, reason: 'allowed', entry };
+    }
+}

--- a/packages/agent/src/agent-plugins/git-source.spec.ts
+++ b/packages/agent/src/agent-plugins/git-source.spec.ts
@@ -1,0 +1,236 @@
+import { HttpException } from '@nestjs/common';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    AgentPluginGitSource,
+    redactUrl,
+    refMatchesPattern,
+    validateGitUrl,
+    type GitLike,
+} from './git-source';
+import { AgentPluginAllowlistService } from './allowlist.service';
+
+function allowlistStub(result: {
+    allowed: boolean;
+    reason?: string;
+    entry?: { versionRange?: string | null };
+}): AgentPluginAllowlistService {
+    return {
+        check: jest.fn().mockResolvedValue({
+            allowed: result.allowed,
+            reason: result.reason ?? (result.allowed ? 'allowed' : 'denied'),
+            entry: result.entry,
+        }),
+    } as unknown as AgentPluginAllowlistService;
+}
+
+function gitStub(sha = 'a'.repeat(40)): GitLike & {
+    clone: jest.Mock;
+    resolveRef: jest.Mock;
+} {
+    return {
+        clone: jest.fn().mockResolvedValue(undefined),
+        resolveRef: jest.fn().mockResolvedValue(sha),
+    };
+}
+
+async function scratch(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'ap-git-'));
+}
+
+describe('validateGitUrl', () => {
+    it.each([
+        ['http://example.com/x.git', 'only https'],
+        ['file:///etc/passwd', 'only https'],
+        ['ssh://git@example.com/x.git', 'only https'],
+        // `ext::sh -c whoami` DOES parse as a URL, with protocol `ext:` — so it
+        // is caught by the protocol rule, not by the parse. That matters:
+        // relying on the parse to reject it would have let it through.
+        ['ext::sh -c whoami', 'only https'],
+    ])('refuses %s', (url, expected) => {
+        const result = validateGitUrl(url);
+        expect(result.ok).toBe(false);
+        expect(result.reason?.toLowerCase()).toContain(expected.toLowerCase());
+    });
+
+    it('refuses a URL carrying credentials, which would be persisted in cleartext', () => {
+        const result = validateGitUrl('https://user:hunter2@example.com/x.git');
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('embeds credentials');
+        // The refusal itself must not become the leak it is preventing.
+        expect(result.reason).not.toContain('hunter2');
+    });
+
+    it('accepts a plain https URL', () => {
+        const result = validateGitUrl('https://example.com/acme/skills.git');
+        expect(result.ok).toBe(true);
+        expect(result.url?.hostname).toBe('example.com');
+    });
+});
+
+describe('redactUrl', () => {
+    it('removes credentials from a parseable URL', () => {
+        expect(redactUrl('https://user:hunter2@example.com/x.git')).toBe(
+            'https://<redacted>@example.com/x.git',
+        );
+    });
+
+    it('removes credentials from a value that does NOT parse as a URL', () => {
+        // The unparseable value is the one most likely to be echoed verbatim
+        // into an error, so redaction cannot depend on a successful parse.
+        expect(redactUrl('https://user:hunter2@exa mple.com/[x')).not.toContain('hunter2');
+    });
+
+    it('leaves a credential-free URL untouched', () => {
+        expect(redactUrl('https://example.com/x.git')).toBe('https://example.com/x.git');
+    });
+});
+
+describe('refMatchesPattern', () => {
+    it('matches exactly, by prefix, and by wildcard', () => {
+        expect(refMatchesPattern('main', 'main')).toBe(true);
+        expect(refMatchesPattern('main', 'release')).toBe(false);
+        expect(refMatchesPattern('v1.2.3', 'v1.*')).toBe(true);
+        expect(refMatchesPattern('v2.0.0', 'v1.*')).toBe(false);
+        expect(refMatchesPattern('anything', '*')).toBe(true);
+    });
+
+    it('treats regex metacharacters literally rather than as a pattern', () => {
+        // If this were compiled as a regex, `.` would match any character and
+        // the grant would be silently wider than what the operator wrote.
+        expect(refMatchesPattern('vAx', 'v.x')).toBe(false);
+        expect(refMatchesPattern('v.x', 'v.x')).toBe(true);
+    });
+});
+
+describe('AgentPluginGitSource', () => {
+    it('refuses a disallowed URL WITHOUT touching the network', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        source.setGitImplementation(git, {});
+
+        await expect(
+            source.acquire({ url: 'http://example.com/x.git', destDir: await scratch() }),
+        ).rejects.toBeInstanceOf(HttpException);
+
+        // The whole point of ordering policy before the fetch.
+        expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('redacts credentials from the thrown response body, not just the message', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        source.setGitImplementation(git, {});
+
+        await source
+            .acquire({
+                url: 'https://user:hunter2@example.com/x.git',
+                destDir: await scratch(),
+            })
+            .then(
+                () => {
+                    throw new Error('expected the acquisition to be refused');
+                },
+                (err: HttpException) => {
+                    // The whole body is serialised into the API response and
+                    // into the log, so every field has to be clean.
+                    expect(JSON.stringify(err.getResponse())).not.toContain('hunter2');
+                },
+            );
+        expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unallowlisted URL WITHOUT touching the network', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(
+            allowlistStub({ allowed: false, reason: 'not on the allowlist' }),
+        );
+        source.setGitImplementation(git, {});
+
+        await expect(
+            source.acquire({ url: 'https://example.com/x.git', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('refuses a ref the allowlist entry does not permit', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(
+            allowlistStub({ allowed: true, entry: { versionRange: 'v1.*' } }),
+        );
+        source.setGitImplementation(git, {});
+
+        await expect(
+            source.acquire({
+                url: 'https://example.com/x.git',
+                ref: 'attacker-branch',
+                destDir: await scratch(),
+            }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('clones shallow, single-branch, without tags and without an auth callback', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        source.setGitImplementation(git, {});
+        const dir = await scratch();
+
+        const result = await source.acquire({
+            url: 'https://example.com/x.git',
+            ref: 'main',
+            destDir: join(dir, 'pkg'),
+        });
+
+        expect(result.resolvedSha).toHaveLength(40);
+        const options = git.clone.mock.calls[0][0];
+        expect(options).toMatchObject({
+            depth: 1,
+            singleBranch: true,
+            noTags: true,
+            ref: 'main',
+            url: 'https://example.com/x.git',
+        });
+        // An anonymous clone must fail rather than reach for ambient
+        // credentials when a server challenges it.
+        expect(options.onAuth).toBeUndefined();
+    });
+
+    it('maps a timeout to 504 and any other clone failure to 502', async () => {
+        const timing = gitStub();
+        timing.clone.mockRejectedValue(new Error('socket ETIMEDOUT'));
+        const a = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        a.setGitImplementation(timing, {});
+        await expect(
+            a.acquire({ url: 'https://example.com/x.git', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 504 });
+
+        const broken = gitStub();
+        broken.clone.mockRejectedValue(new Error('repository not found'));
+        const b = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        b.setGitImplementation(broken, {});
+        await expect(
+            b.acquire({ url: 'https://example.com/x.git', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it('leaves no directory behind when the clone fails', async () => {
+        const { stat } = await import('node:fs/promises');
+        const git = gitStub();
+        git.clone.mockRejectedValue(new Error('boom'));
+        const source = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        source.setGitImplementation(git, {});
+        const dest = join(await scratch(), 'pkg');
+
+        await expect(
+            source.acquire({ url: 'https://example.com/x.git', destDir: dest }),
+        ).rejects.toBeInstanceOf(HttpException);
+
+        // A partial tree that a later scan could pick up and load is worse
+        // than no tree at all.
+        await expect(stat(dest)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+});

--- a/packages/agent/src/agent-plugins/git-source.spec.ts
+++ b/packages/agent/src/agent-plugins/git-source.spec.ts
@@ -28,10 +28,15 @@ function allowlistStub(result: {
 function gitStub(sha = 'a'.repeat(40)): GitLike & {
     clone: jest.Mock;
     resolveRef: jest.Mock;
+    listServerRefs: jest.Mock;
 } {
     return {
         clone: jest.fn().mockResolvedValue(undefined),
         resolveRef: jest.fn().mockResolvedValue(sha),
+        // Part of `GitLike` since the update check landed. Stubbing the whole
+        // interface rather than a subset is what makes a later addition to it
+        // fail HERE, at compile time, instead of at the first call.
+        listServerRefs: jest.fn().mockResolvedValue([{ ref: 'HEAD', oid: sha }]),
     };
 }
 

--- a/packages/agent/src/agent-plugins/git-source.ts
+++ b/packages/agent/src/agent-plugins/git-source.ts
@@ -1,0 +1,325 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { AgentPluginAllowlistService } from './allowlist.service';
+
+/**
+ * Git acquirer for Agent Plugins packages.
+ *
+ * ## Why this does not go through `GitFacadeService`
+ *
+ * The obvious reuse — the agent already clones repositories — does not fit,
+ * and the mismatch is structural rather than cosmetic:
+ *
+ * - `cloneOrPull` is **owner/repo shaped**, not URL shaped. The Agent Plugins
+ *   spec identifies a source by URL, and an arbitrary git host does not
+ *   decompose into a GitHub-style owner/repo pair.
+ * - It calls `resolvePluginAndToken`, so it requires an ENABLED git-provider
+ *   plugin and a user credential. Package acquisition is an operator-level,
+ *   usually anonymous, fetch of a public repository. Routing it through the
+ *   provider chain would make installs fail on any deployment with no git
+ *   plugin enabled — the same class of defect as the facade early-return
+ *   fixed in Phase 1, where a feature silently disappeared rather than merely
+ *   being unavailable.
+ *
+ * So this is a standalone, credential-free, URL-first acquirer. It is
+ * deliberately narrower than the facade: it clones public repositories at a
+ * pinned ref and does nothing else.
+ */
+
+/** Depth 1: we want a snapshot of one ref, never the history. */
+const CLONE_DEPTH = 1;
+
+export interface GitAcquireInput {
+    /** HTTPS clone URL. */
+    url: string;
+    /** Branch or tag to pin. Defaults to the remote's default branch. */
+    ref?: string;
+    /** Directory the working tree is written into. */
+    destDir: string;
+}
+
+export interface GitAcquireResult {
+    url: string;
+    ref: string | null;
+    /** The commit actually checked out — the only durable identity of a fetch. */
+    resolvedSha: string;
+    path: string;
+}
+
+/** The subset of isomorphic-git this acquirer uses, so tests can inject a stub. */
+export interface GitLike {
+    clone(options: Record<string, unknown>): Promise<unknown>;
+    resolveRef(options: Record<string, unknown>): Promise<string>;
+}
+
+/**
+ * Strip `user:password@` from a URL before it is shown, stored or logged.
+ *
+ * Applied with a regex rather than via `URL`, deliberately: a value that fails
+ * to parse can still contain a credential, and that is exactly the value most
+ * likely to be echoed verbatim into an error message. Redaction has to work on
+ * the string, not on the parse.
+ *
+ * This exists because the credential check itself was the leak — the first
+ * version of the refusal interpolated the whole URL into a message that is
+ * returned by the API, written to the package row and printed to the log. A
+ * check that reports the secret it is protecting is worse than no check.
+ */
+export function redactUrl(value: string): string {
+    return value.replace(/(\/\/)[^/@\s]*:[^/@\s]*@/gu, '$1<redacted>@');
+}
+
+/**
+ * Result of {@link validateGitUrl}.
+ *
+ * Deliberately a single interface with nullable members rather than the
+ * discriminated union `{ ok: true; url } | { ok: false; reason }` that would be
+ * idiomatic elsewhere in this program. `packages/agent` compiles with
+ * `strictNullChecks: false`, and under that setting TypeScript does NOT narrow
+ * a boolean-literal discriminant — `if (!check.ok)` leaves `check` unnarrowed,
+ * so `check.reason` fails to compile. The conformance library is strict and
+ * uses unions freely; code bridging it into this package must not assume that
+ * narrowing survives the crossing.
+ */
+export interface GitUrlCheck {
+    ok: boolean;
+    /** Parsed URL when `ok`, otherwise null. */
+    url: URL | null;
+    /** Operator-facing refusal, otherwise null. */
+    reason: string | null;
+}
+
+/**
+ * URL policy, applied BEFORE the allowlist and before any network call.
+ *
+ * Each rule refuses a specific concrete attack, so none should be relaxed
+ * without replacing the control:
+ *
+ * - **https only.** `http:` is a plaintext fetch of content that an agent will
+ *   later read as instructions; a network position turns that into arbitrary
+ *   instruction injection. `file:`, `ssh:` and git's `ext::` transport are
+ *   refused because `ext::` executes a shell command by design, and `file:`
+ *   would let a URL read the host filesystem.
+ * - **No embedded credentials.** A `user:pass@host` URL would be recorded on
+ *   the package row, printed in findings, and logged — leaking the credential
+ *   into three durable places at once. Refusing is the only way to keep it out
+ *   of all of them, and the spec has no need for authenticated clones.
+ */
+export function validateGitUrl(value: string): GitUrlCheck {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return { ok: false, url: null, reason: `"${redactUrl(value)}" is not a valid URL.` };
+    }
+
+    if (url.protocol !== 'https:') {
+        return {
+            ok: false,
+            url: null,
+            reason:
+                `Refusing git URL "${redactUrl(value)}": only https:// is supported. Plaintext and ` +
+                `local transports are rejected because package contents are read as ` +
+                `agent instructions.`,
+        };
+    }
+
+    if (url.username || url.password) {
+        return {
+            ok: false,
+            url: null,
+            reason:
+                `Refusing git URL "${redactUrl(value)}": it embeds credentials. The URL is stored ` +
+                `and logged, so a credential in it would be persisted in cleartext. Use ` +
+                `a public repository.`,
+        };
+    }
+
+    if (!url.hostname) {
+        return { ok: false, url: null, reason: `Refusing git URL "${redactUrl(value)}": no host.` };
+    }
+
+    return { ok: true, url, reason: null };
+}
+
+/**
+ * Match a ref against an allowlist pattern.
+ *
+ * Supports an exact ref or a trailing `*`. Deliberately NOT a regular
+ * expression: an operator-supplied regex is both a footgun (an unescaped `.`
+ * silently widens the grant) and a denial-of-service vector through
+ * catastrophic backtracking.
+ */
+export function refMatchesPattern(ref: string, pattern: string): boolean {
+    if (pattern === '*') return true;
+    if (pattern.endsWith('*')) {
+        return ref.startsWith(pattern.slice(0, -1));
+    }
+    return ref === pattern;
+}
+
+/** Where a git-sourced package is materialised, keyed by its resolved SHA. */
+export function gitPackageDir(root: string, url: string, sha: string): string {
+    return join(root, 'git', encodeURIComponent(url), sha);
+}
+
+@Injectable()
+export class AgentPluginGitSource {
+    private readonly logger = new Logger(AgentPluginGitSource.name);
+    private git: GitLike | null = null;
+    private httpClient: unknown = null;
+
+    constructor(private readonly allowlist: AgentPluginAllowlistService) {}
+
+    /**
+     * Test-only injection seam, mirroring `PluginInstallerService.setPacote`.
+     * Production code lazy-imports the real module instead.
+     */
+    setGitImplementation(impl: GitLike, http: unknown): void {
+        this.git = impl;
+        this.httpClient = http;
+    }
+
+    /**
+     * Clone `input.url` at `input.ref` into `input.destDir`.
+     *
+     * Ordering is a security property, not a style choice: URL policy, then
+     * allowlist, then — only if both pass — the network.
+     */
+    async acquire(input: GitAcquireInput): Promise<GitAcquireResult> {
+        const parsed = validateGitUrl(input.url);
+        if (!parsed.ok) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: parsed.reason,
+                    url: redactUrl(input.url),
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        const allow = await this.allowlist.check(input.url, 'git');
+        if (!allow.allowed) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: allow.reason,
+                    url: redactUrl(input.url),
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        // A ref pattern on the allowlist entry constrains WHICH ref may be
+        // fetched. Without it, allowlisting a repository would authorise every
+        // branch in it, including one an outside contributor can push to.
+        const pattern = allow.entry?.versionRange?.trim();
+        if (pattern && input.ref && !refMatchesPattern(input.ref, pattern)) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message:
+                        `Ref "${input.ref}" is not permitted for "${redactUrl(input.url)}" — the ` +
+                        `allowlist entry restricts it to "${pattern}".`,
+                    url: redactUrl(input.url),
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        const { git, http } = await this.load(input.url);
+        const fs = await nodeFs();
+
+        // Wipe first: an aborted earlier clone leaves a partial tree that
+        // would otherwise be validated and possibly loaded as if complete.
+        await rm(input.destDir, { recursive: true, force: true });
+        await mkdir(input.destDir, { recursive: true });
+
+        try {
+            await git.clone({
+                fs,
+                http,
+                dir: input.destDir,
+                url: input.url,
+                depth: CLONE_DEPTH,
+                singleBranch: true,
+                noTags: true,
+                // No `onAuth`. An anonymous clone that gets challenged fails
+                // rather than silently reaching for ambient credentials.
+                ...(input.ref ? { ref: input.ref } : {}),
+            });
+
+            const resolvedSha = await git.resolveRef({ fs, dir: input.destDir, ref: 'HEAD' });
+
+            this.logger.log(
+                `Cloned ${redactUrl(input.url)}${input.ref ? `#${input.ref}` : ''} at ${resolvedSha.slice(0, 12)}`,
+            );
+
+            return { url: input.url, ref: input.ref ?? null, resolvedSha, path: input.destDir };
+        } catch (err) {
+            // Leave nothing half-written behind: a partial tree that passes a
+            // later scan is worse than no tree at all.
+            await rm(input.destDir, { recursive: true, force: true }).catch(() => undefined);
+
+            if (err instanceof HttpException) throw err;
+            const reason = err instanceof Error ? err.message : String(err);
+
+            // The same mapping the code-plugin installer uses, so an operator
+            // reading API errors sees one vocabulary across both installers.
+            const code = /timeout|ETIMEDOUT/i.test(reason)
+                ? HttpStatus.GATEWAY_TIMEOUT
+                : HttpStatus.BAD_GATEWAY;
+            throw new HttpException(
+                { statusCode: code, message: redactUrl(reason), url: redactUrl(input.url) },
+                code,
+            );
+        }
+    }
+
+    /**
+     * Re-fetch an already-acquired package. A fresh shallow clone rather than
+     * an incremental fetch: a depth-1 clone has no history worth preserving,
+     * and re-cloning cannot leave a tree that is half old and half new.
+     */
+    async refresh(input: GitAcquireInput): Promise<GitAcquireResult> {
+        return this.acquire(input);
+    }
+
+    private async load(url: string): Promise<{ git: GitLike; http: unknown }> {
+        if (this.git && this.httpClient) {
+            return { git: this.git, http: this.httpClient };
+        }
+        try {
+            // Lazy, mirroring the pacote import in the code-plugin installer,
+            // so packages/agent still builds and boots where the git source is
+            // never used.
+            const [mod, httpMod] = await Promise.all([
+                import('isomorphic-git'),
+                import('isomorphic-git/http/node'),
+            ]);
+            const git = ((mod as { default?: unknown }).default ?? mod) as GitLike;
+            const http = (httpMod as { default?: unknown }).default ?? httpMod;
+            this.git = git;
+            this.httpClient = http;
+            return { git, http };
+        } catch {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.NOT_IMPLEMENTED,
+                    message:
+                        `Cannot fetch "${redactUrl(url)}": the git source requires the ` +
+                        `'isomorphic-git' package, which is not installed.`,
+                },
+                HttpStatus.NOT_IMPLEMENTED,
+            );
+        }
+    }
+}
+
+/** isomorphic-git takes an injected fs rather than importing one itself. */
+async function nodeFs(): Promise<unknown> {
+    const mod = await import('node:fs');
+    return (mod as { default?: unknown }).default ?? mod;
+}

--- a/packages/agent/src/agent-plugins/git-source.ts
+++ b/packages/agent/src/agent-plugins/git-source.ts
@@ -51,6 +51,7 @@ export interface GitAcquireResult {
 export interface GitLike {
     clone(options: Record<string, unknown>): Promise<unknown>;
     resolveRef(options: Record<string, unknown>): Promise<string>;
+    listServerRefs(options: Record<string, unknown>): Promise<Array<{ ref: string; oid: string }>>;
 }
 
 /**
@@ -275,6 +276,45 @@ export class AgentPluginGitSource {
                 { statusCode: code, message: redactUrl(reason), url: redactUrl(input.url) },
                 code,
             );
+        }
+    }
+
+    /**
+     * The commit a remote currently points `ref` at, WITHOUT cloning.
+     *
+     * Update checks run for every installed package, so cloning to answer
+     * "is there anything new?" would download entire repositories on a
+     * schedule to usually learn that nothing changed. `listServerRefs` is a
+     * single ref-advertisement request and writes nothing to disk.
+     *
+     * Returns null rather than throwing: not knowing whether an update exists
+     * must never fail the page that asked.
+     */
+    async remoteSha(url: string, ref?: string): Promise<string | null> {
+        const parsed = validateGitUrl(url);
+        if (!parsed.ok) return null;
+
+        const allow = await this.allowlist.check(url, 'git');
+        if (!allow.allowed) return null;
+
+        const pattern = allow.entry?.versionRange?.trim();
+        if (pattern && ref && !refMatchesPattern(ref, pattern)) return null;
+
+        try {
+            const { git, http } = await this.load(url);
+            const refs = await git.listServerRefs({
+                http,
+                url,
+                prefix: ref ? `refs/heads/${ref}` : 'HEAD',
+            });
+            return refs[0]?.oid ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `Remote ref lookup failed for ${redactUrl(url)}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return null;
         }
     }
 

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -107,3 +107,9 @@ export {
     type ResolvedMcpServer,
     type SkippedMcpServer,
 } from './mcp-server-config.service';
+
+export {
+    connectionNameFor,
+    PackageMcpReconcilerService,
+    type ReconcileResult,
+} from './package-mcp-reconciler.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -79,3 +79,13 @@ export {
     type AcquiredPackage,
     type RemoteSourceKind,
 } from './remote-acquire.service';
+
+export { AgentPluginPackageRepository } from './package.repository';
+
+export {
+    AgentPluginPackageBootstrapService,
+    acquireInputFor,
+    BUDGET_MS,
+    CONCURRENCY,
+    type RematerializeResult,
+} from './package-bootstrap.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -46,3 +46,36 @@ export {
     type LocalSourceScan,
     type ScanLocalPackagesOptions,
 } from './local-source';
+
+export { AgentPluginAllowlistService } from './allowlist.service';
+
+export {
+    AgentPluginGitSource,
+    gitPackageDir,
+    refMatchesPattern,
+    validateGitUrl,
+    type GitAcquireInput,
+    type GitAcquireResult,
+    type GitLike,
+    type GitUrlCheck,
+} from './git-source';
+
+export {
+    AgentPluginNpmSource,
+    DEFAULT_NPM_REGISTRY,
+    npmPackageDir,
+    versionPermitted,
+    type NpmAcquireInput,
+    type NpmAcquireResult,
+    type NpmManifest,
+    type PacoteLike,
+} from './npm-source';
+
+export {
+    AgentPluginRemoteAcquireService,
+    type AcquireGitInput,
+    type AcquireInput,
+    type AcquireNpmInput,
+    type AcquiredPackage,
+    type RemoteSourceKind,
+} from './remote-acquire.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -89,3 +89,10 @@ export {
     CONCURRENCY,
     type RematerializeResult,
 } from './package-bootstrap.service';
+
+export {
+    AgentPluginUpdateService,
+    MAX_REMOTE_CHECKS,
+    type PackageUpdate,
+    type UpdateCheckResult,
+} from './update.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -98,3 +98,12 @@ export {
 } from './update.service';
 
 export { AgentPluginInstallService, sourceRefFor } from './install.service';
+
+export {
+    McpServerConfigService,
+    usesPluginData,
+    type McpResolutionResult,
+    type McpServerProvenance,
+    type ResolvedMcpServer,
+    type SkippedMcpServer,
+} from './mcp-server-config.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -96,3 +96,5 @@ export {
     type PackageUpdate,
     type UpdateCheckResult,
 } from './update.service';
+
+export { AgentPluginInstallService, sourceRefFor } from './install.service';

--- a/packages/agent/src/agent-plugins/install.service.spec.ts
+++ b/packages/agent/src/agent-plugins/install.service.spec.ts
@@ -1,0 +1,206 @@
+import { mkdir, mkdtemp, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentPluginInstallService, sourceRefFor } from './install.service';
+import type { AgentPluginPackageRepository } from './package.repository';
+import type { AgentPluginRemoteAcquireService } from './remote-acquire.service';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+function row(over: Partial<AgentPluginPackage> = {}): AgentPluginPackage {
+    return {
+        id: '11111111-1111-4111-8111-111111111111',
+        userId: 'owner',
+        name: 'acme.tools',
+        source: 'npm',
+        sourceRef: 'acme-skills@1.2.0',
+        installPath: '/packages/npm/acme-skills/1.2.0',
+        installState: 'installed',
+        specVersion: '1.0.0',
+        findings: [],
+        skillNames: [],
+        mcpServerNames: [],
+        ...over,
+    } as AgentPluginPackage;
+}
+
+function build(over: { rows?: AgentPluginPackage | null; acquire?: jest.Mock } = {}) {
+    const repository = {
+        findById: jest.fn().mockResolvedValue(over.rows === undefined ? row() : over.rows),
+        deleteById: jest.fn().mockResolvedValue(undefined),
+        upsertInstalled: jest.fn().mockImplementation(async (input) => ({ id: 'new', ...input })),
+    } as unknown as AgentPluginPackageRepository & {
+        findById: jest.Mock;
+        deleteById: jest.Mock;
+        upsertInstalled: jest.Mock;
+    };
+
+    const acquirer = {
+        acquire:
+            over.acquire ??
+            jest.fn().mockResolvedValue({
+                kind: 'npm',
+                path: '/packages/npm/acme-skills/1.2.0',
+                revision: '1.2.0',
+                integrity: 'sha512-abc',
+                load: {
+                    ok: true,
+                    manifest: { name: 'acme.tools', version: '1.2.0' },
+                    specVersion: '1.0.0',
+                    skills: [{ name: 'release-notes' }],
+                    mcpServers: [{ name: 'api' }],
+                    findings: [],
+                },
+            }),
+    } as unknown as AgentPluginRemoteAcquireService & { acquire: jest.Mock };
+
+    return { repository, acquirer, service: new AgentPluginInstallService(repository, acquirer) };
+}
+
+describe('sourceRefFor', () => {
+    it('round-trips the coordinates a re-fetch needs', () => {
+        expect(sourceRefFor({ kind: 'git', url: 'https://x.com/a.git', ref: 'main' })).toBe(
+            'https://x.com/a.git#main',
+        );
+        expect(sourceRefFor({ kind: 'git', url: 'https://x.com/a.git' })).toBe(
+            'https://x.com/a.git',
+        );
+        expect(sourceRefFor({ kind: 'npm', packageName: '@scope/p', version: '1.0.0' })).toBe(
+            '@scope/p@1.0.0',
+        );
+        expect(sourceRefFor({ kind: 'npm', packageName: '@scope/p' })).toBe('@scope/p');
+    });
+});
+
+describe('AgentPluginInstallService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+        process.env.AGENT_PLUGINS_DIR = '/packages';
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('refuses to install while the feature is disabled', async () => {
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        const { service, acquirer } = build();
+
+        await expect(
+            service.install({ kind: 'npm', packageName: 'acme-skills' }, { userId: 'owner' }),
+        ).rejects.toMatchObject({ status: 501 });
+
+        expect(acquirer.acquire).not.toHaveBeenCalled();
+    });
+
+    it('writes the registry row only AFTER the package validates', async () => {
+        const { service, repository, acquirer } = build();
+
+        await service.install(
+            { kind: 'npm', packageName: 'acme-skills', version: '1.2.0' },
+            { userId: 'owner' },
+        );
+
+        // A row written first would advertise a package that might never
+        // materialise, and the catalog would offer a skill nothing can read.
+        const acquireOrder = acquirer.acquire.mock.invocationCallOrder[0];
+        const upsertOrder = repository.upsertInstalled.mock.invocationCallOrder[0];
+        expect(acquireOrder).toBeLessThan(upsertOrder);
+
+        expect(repository.upsertInstalled).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'acme.tools',
+                source: 'npm',
+                sourceRef: 'acme-skills@1.2.0',
+                skillNames: ['release-notes'],
+                mcpServerNames: ['api'],
+            }),
+        );
+    });
+
+    it('does not write a row when acquisition fails', async () => {
+        const { service, repository } = build({
+            acquire: jest.fn().mockRejectedValue(new Error('rejected')),
+        });
+
+        await expect(
+            service.install({ kind: 'npm', packageName: 'acme-skills' }, { userId: 'owner' }),
+        ).rejects.toThrow('rejected');
+
+        expect(repository.upsertInstalled).not.toHaveBeenCalled();
+    });
+
+    describe('remove', () => {
+        it('reports 404 — not 403 — for a package owned by someone else', async () => {
+            const { service, repository } = build({ rows: row({ userId: 'somebody-else' }) });
+
+            await expect(service.remove(row().id, 'owner')).rejects.toMatchObject({ status: 404 });
+
+            // A 403 would confirm the row exists, telling an unauthorised
+            // caller something about another user's packages.
+            expect(repository.deleteById).not.toHaveBeenCalled();
+        });
+
+        it('reports 404 for a package that does not exist', async () => {
+            const { service } = build({ rows: null });
+            await expect(service.remove(row().id, 'owner')).rejects.toMatchObject({ status: 404 });
+        });
+
+        it('refuses to remove a LOCAL package, which is the operator’s directory', async () => {
+            const { service, repository } = build({
+                rows: row({ source: 'local', sourceRef: '/srv/packages/acme' }),
+            });
+
+            await expect(service.remove(row().id, 'owner')).rejects.toMatchObject({ status: 409 });
+            expect(repository.deleteById).not.toHaveBeenCalled();
+        });
+
+        it('deletes the row BEFORE the directory, and removes both', async () => {
+            const dir = await mkdtemp(join(tmpdir(), 'ap-remove-'));
+            const installPath = join(dir, 'acme');
+            await mkdir(installPath, { recursive: true });
+
+            const { service, repository } = build({ rows: row({ installPath }) });
+
+            await service.remove(row().id, 'owner');
+
+            expect(repository.deleteById).toHaveBeenCalledWith(row().id);
+            await expect(stat(installPath)).rejects.toMatchObject({ code: 'ENOENT' });
+        });
+
+        it('still succeeds when the directory cannot be deleted', async () => {
+            // The row is already gone, so the package is unreachable; an
+            // orphaned directory is untidy rather than incorrect.
+            const { service } = build({ rows: row({ installPath: '/nonexistent/path' }) });
+            await expect(service.remove(row().id, 'owner')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('resync', () => {
+        it('re-fetches at the recorded coordinates', async () => {
+            const { service, acquirer } = build({
+                rows: row({ source: 'git', sourceRef: 'https://x.com/a.git#main' }),
+            });
+
+            await service.resync(row().id, 'owner');
+
+            expect(acquirer.acquire).toHaveBeenCalledWith('/packages', {
+                kind: 'git',
+                url: 'https://x.com/a.git',
+                ref: 'main',
+            });
+        });
+
+        it('refuses for a local package, which has no remote', async () => {
+            const { service } = build({ rows: row({ source: 'local' }) });
+            await expect(service.resync(row().id, 'owner')).rejects.toMatchObject({ status: 409 });
+        });
+
+        it('reports 404 for someone else’s package', async () => {
+            const { service } = build({ rows: row({ userId: 'somebody-else' }) });
+            await expect(service.resync(row().id, 'owner')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+});

--- a/packages/agent/src/agent-plugins/install.service.ts
+++ b/packages/agent/src/agent-plugins/install.service.ts
@@ -1,0 +1,201 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { rm } from 'node:fs/promises';
+import { parsePackageDirs } from './local-source';
+import { acquireInputFor } from './package-bootstrap.service';
+import { config } from '../config';
+import { AgentPluginPackageRepository } from './package.repository';
+import { AgentPluginRemoteAcquireService, type AcquireInput } from './remote-acquire.service';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+/**
+ * Install and remove remote Agent Plugins packages.
+ *
+ * Sits between the API controller and the acquirer, and owns the one thing
+ * neither of them does: keeping the registry row and the bytes on disk
+ * agreeing with each other.
+ *
+ * Ordering matters in both directions:
+ *
+ * - **Install** acquires FIRST and writes the row only after validation
+ *   succeeds. A row written first would advertise a package that might never
+ *   materialise, and the catalog would offer a skill that cannot be read.
+ * - **Remove** deletes the row FIRST and the directory second. The reverse
+ *   order leaves a window where the row points at a directory that is already
+ *   gone; a failure midway through then leaves a permanently broken row. This
+ *   way a failure leaves an orphaned directory instead, which the next install
+ *   overwrites and which nothing reads.
+ */
+@Injectable()
+export class AgentPluginInstallService {
+    private readonly logger = new Logger(AgentPluginInstallService.name);
+
+    constructor(
+        private readonly repository: AgentPluginPackageRepository,
+        private readonly acquirer: AgentPluginRemoteAcquireService,
+    ) {}
+
+    async install(
+        input: AcquireInput,
+        owner: { userId: string; tenantId?: string | null; organizationId?: string | null },
+    ): Promise<AgentPluginPackage> {
+        this.assertEnabled();
+        const root = this.packagesRoot();
+
+        const acquired = await this.acquirer.acquire(root, input);
+        if (!acquired.load.ok) {
+            // Unreachable — `acquire` throws on a failed load — but asserted
+            // rather than assumed, because the alternative is persisting a row
+            // for a package that was rejected.
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+                    message: 'Package failed validation.',
+                },
+                HttpStatus.UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        const pkg = acquired.load;
+        const row = await this.repository.upsertInstalled({
+            userId: owner.userId,
+            tenantId: owner.tenantId ?? null,
+            organizationId: owner.organizationId ?? null,
+            name: pkg.manifest.name,
+            version: pkg.manifest.version ?? null,
+            specVersion: pkg.specVersion,
+            source: input.kind,
+            sourceRef: sourceRefFor(input),
+            installPath: acquired.path,
+            integrity: acquired.kind === 'npm' ? acquired.integrity : acquired.revision,
+            manifest: pkg.manifest as unknown as Record<string, unknown>,
+            findings: pkg.findings.map((finding) => ({ ...finding })),
+            skillNames: pkg.skills.map((skill) => skill.name),
+            mcpServerNames: pkg.mcpServers.map((server) => server.name),
+        });
+
+        this.logger.log(
+            `Installed ${input.kind} package "${pkg.manifest.name}" for ${owner.userId}`,
+        );
+        return row;
+    }
+
+    /**
+     * Remove a package the caller owns.
+     *
+     * Ownership is checked here rather than left to the controller: this is
+     * the only method that can compare the row's `userId` to the caller, and a
+     * check the caller performs is a check the next caller can forget.
+     */
+    async remove(id: string, userId: string): Promise<void> {
+        const row = await this.repository.findById(id);
+        if (!row) {
+            throw new HttpException(
+                { statusCode: HttpStatus.NOT_FOUND, message: 'Package not found.' },
+                HttpStatus.NOT_FOUND,
+            );
+        }
+        if (row.userId !== userId) {
+            // 404 rather than 403: a 403 confirms the row exists, which tells
+            // an unauthorised caller something about another user's packages.
+            throw new HttpException(
+                { statusCode: HttpStatus.NOT_FOUND, message: 'Package not found.' },
+                HttpStatus.NOT_FOUND,
+            );
+        }
+        if (row.source === 'local') {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message:
+                        'A local package cannot be removed here — it is the directory the ' +
+                        'operator configured. Remove the directory instead.',
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        await this.repository.deleteById(id);
+        if (row.installPath) {
+            await rm(row.installPath, { recursive: true, force: true }).catch((err: unknown) => {
+                // The row is already gone, so the package is no longer
+                // reachable; an orphaned directory is untidy, not incorrect.
+                this.logger.warn(
+                    `Removed package row ${id} but could not delete ${row.installPath}: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            });
+        }
+    }
+
+    /** Re-fetch a package at its recorded coordinates. */
+    async resync(id: string, userId: string): Promise<AgentPluginPackage> {
+        const row = await this.repository.findById(id);
+        if (!row || row.userId !== userId) {
+            throw new HttpException(
+                { statusCode: HttpStatus.NOT_FOUND, message: 'Package not found.' },
+                HttpStatus.NOT_FOUND,
+            );
+        }
+        if (row.source === 'local') {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: 'A local package has no remote to re-sync from.',
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+        const input = acquireInputFor(row);
+        if (!input) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+                    message: `Cannot re-sync: sourceRef "${row.sourceRef}" is not usable.`,
+                },
+                HttpStatus.UNPROCESSABLE_ENTITY,
+            );
+        }
+        return this.install(input, {
+            userId: row.userId,
+            tenantId: row.tenantId ?? null,
+            organizationId: row.organizationId ?? null,
+        });
+    }
+
+    private assertEnabled(): void {
+        if (!config.agentPlugins.isEnabled()) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.NOT_IMPLEMENTED,
+                    message:
+                        'Agent Plugins support is disabled on this deployment. Set ' +
+                        'FEATURE_AGENT_PLUGINS=true to enable it.',
+                },
+                HttpStatus.NOT_IMPLEMENTED,
+            );
+        }
+    }
+
+    private packagesRoot(): string {
+        const root = parsePackageDirs(config.agentPlugins.getPackageDirs())[0];
+        if (!root) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+                    message: 'No Agent Plugins package directory is configured.',
+                },
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+        return root;
+    }
+}
+
+/** The durable coordinates for re-fetching, matching `sourceRef`'s documented shape. */
+export function sourceRefFor(input: AcquireInput): string {
+    if (input.kind === 'git') {
+        return input.ref ? `${input.url}#${input.ref}` : input.url;
+    }
+    return input.version ? `${input.packageName}@${input.version}` : input.packageName;
+}

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
@@ -115,6 +115,9 @@ describe('McpServerConfigService', () => {
     });
 
     it('expands ${PLUGIN_ROOT} against the package directory', async () => {
+        // stdio is gated separately, and this test is about expansion rather
+        // than the gate.
+        process.env.AGENT_PLUGINS_STDIO = 'true';
         const root = await packagesRoot();
         const dir = await writePackage(root, 'acme', 'acme.tools', {
             local: {
@@ -153,6 +156,7 @@ describe('McpServerConfigService', () => {
     });
 
     it('SKIPS a server needing ${PLUGIN_DATA}, with a reason, rather than launching it broken', async () => {
+        process.env.AGENT_PLUGINS_STDIO = 'true';
         const root = await packagesRoot();
         await writePackage(root, 'acme', 'acme.tools', {
             stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.js'] },
@@ -167,6 +171,62 @@ describe('McpServerConfigService', () => {
         ]);
         // The reason names the placeholder, so an operator knows what to do.
         expect(result.skipped[0].reason).toContain('PLUGIN_DATA');
+        expect(result.skipped[0].code).toBe('needs-plugin-data');
+        // Nothing the operator can flip — this one needs the launcher.
+        expect(result.skipped[0].enableable).toBe(false);
+    });
+
+    describe('AP-19: stdio is present-but-disabled, not absent', () => {
+        it('reports a stdio server as disabled BY POLICY while the gate is off', async () => {
+            const root = await packagesRoot();
+            await writePackage(root, 'acme', 'acme.tools', {
+                local: { type: 'stdio', command: './bin/server' },
+            });
+            process.env.AGENT_PLUGINS_DIR = root;
+            // AGENT_PLUGINS_STDIO deliberately unset — the default.
+
+            const result = await service.resolveAll();
+
+            expect(result.servers).toEqual([]);
+            expect(result.skipped).toHaveLength(1);
+            expect(result.skipped[0]).toMatchObject({
+                name: 'local',
+                packageName: 'acme.tools',
+                code: 'disabled-by-policy',
+                // The distinction AP-19 asks for: this is a setting away from
+                // working, not a broken package. A UI can offer to enable it.
+                enableable: true,
+            });
+            expect(result.skipped[0].reason).toContain('AGENT_PLUGINS_STDIO');
+        });
+
+        it('resolves the same server once the gate is open', async () => {
+            const root = await packagesRoot();
+            await writePackage(root, 'acme', 'acme.tools', {
+                local: { type: 'stdio', command: './bin/server' },
+            });
+            process.env.AGENT_PLUGINS_DIR = root;
+            process.env.AGENT_PLUGINS_STDIO = 'true';
+
+            const result = await service.resolveAll();
+
+            expect(result.skipped).toEqual([]);
+            expect(result.servers[0]).toMatchObject({ name: 'local', transport: 'stdio' });
+        });
+
+        it('leaves REMOTE servers untouched by the stdio gate', async () => {
+            const root = await packagesRoot();
+            await writePackage(root, 'acme', 'acme.tools', {
+                api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+            });
+            process.env.AGENT_PLUGINS_DIR = root;
+            // Gate off: a remote server is inert data and is not affected.
+
+            const result = await service.resolveAll();
+
+            expect(result.servers.map((s) => s.name)).toEqual(['api']);
+            expect(result.skipped).toEqual([]);
+        });
     });
 
     it('resolves servers from several packages together', async () => {

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
@@ -1,0 +1,223 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpServerConfigService, usesPluginData } from './mcp-server-config.service';
+
+/**
+ * Runs against the REAL conformance library and REAL files: what a package
+ * declares is a fact about bytes on disk, and a stubbed loader would not
+ * exercise the validation this service depends on.
+ */
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+
+async function packagesRoot(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'ap-mcp-'));
+}
+
+async function writePackage(
+    root: string,
+    dirName: string,
+    name: string,
+    mcpServers: Record<string, unknown>,
+): Promise<string> {
+    const dir = join(root, dirName);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+        join(dir, 'plugin.json'),
+        JSON.stringify({ $schema: PLUGIN_SCHEMA, name, version: '1.0.0' }, null, 2),
+        'utf8',
+    );
+    await writeFile(
+        join(dir, 'mcp.json'),
+        JSON.stringify({ $schema: MCP_SCHEMA, mcpServers }, null, 2),
+        'utf8',
+    );
+    return dir;
+}
+
+describe('usesPluginData', () => {
+    it('finds the placeholder anywhere it can appear in a stdio config', () => {
+        expect(
+            usesPluginData({ type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/x.js'] }),
+        ).toBe(true);
+        expect(
+            usesPluginData({ type: 'stdio', command: 'node', env: { DB: '${PLUGIN_DATA}/db' } }),
+        ).toBe(true);
+        expect(usesPluginData({ type: 'stdio', command: 'node', cwd: '${PLUGIN_DATA}' })).toBe(
+            true,
+        );
+        expect(usesPluginData({ type: 'stdio', command: 'node', args: ['./x.js'] })).toBe(false);
+    });
+
+    it('finds it in a remote config too', () => {
+        expect(usesPluginData({ type: 'streamable-http', url: 'https://x/${PLUGIN_DATA}' })).toBe(
+            true,
+        );
+        expect(usesPluginData({ type: 'streamable-http', url: 'https://x/mcp' })).toBe(false);
+    });
+});
+
+describe('McpServerConfigService', () => {
+    const originalEnv = process.env;
+    let service: McpServerConfigService;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+        service = new McpServerConfigService();
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('reports enabled:false and nothing else while the flag is off', async () => {
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        const root = await packagesRoot();
+        await writePackage(root, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        // "Off" must be distinguishable from "on with no servers".
+        expect(result).toEqual({ enabled: false, servers: [], skipped: [] });
+    });
+
+    it('resolves a remote server with full provenance', async () => {
+        const root = await packagesRoot();
+        const dir = await writePackage(root, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        expect(result.enabled).toBe(true);
+        expect(result.servers).toHaveLength(1);
+        expect(result.servers[0]).toMatchObject({
+            name: 'api',
+            toolNamespace: 'api',
+            transport: 'streamable-http',
+            config: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        // Provenance travels WITH the server, so the origin of a tool is
+        // answerable at the point of use rather than only in a log.
+        expect(result.servers[0].provenance).toMatchObject({
+            packageName: 'acme.tools',
+            packageRoot: dir,
+            packageVersion: '1.0.0',
+            sourceKind: 'local',
+        });
+    });
+
+    it('expands ${PLUGIN_ROOT} against the package directory', async () => {
+        const root = await packagesRoot();
+        const dir = await writePackage(root, 'acme', 'acme.tools', {
+            local: {
+                type: 'stdio',
+                command: './bin/server',
+                args: ['--root', '${PLUGIN_ROOT}/data'],
+                env: { CONFIG: '${PLUGIN_ROOT}/config.json' },
+            },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        // `McpServerConfig` is a union, and `packages/agent` compiles with
+        // strictNullChecks off, so narrowing it by `type` does not work here.
+        const config = result.servers[0]?.config as unknown as {
+            type: string;
+            args: string[];
+            env: Record<string, string>;
+        };
+
+        expect(config.type).toBe('stdio');
+
+        // Expansion is TEXTUAL substitution, so the separator the package
+        // author wrote survives — `${PLUGIN_ROOT}/data` stays a forward slash
+        // even on Windows. That is deliberate: normalising to the platform
+        // separator would rewrite the author's string, and the value may not
+        // be a filesystem path at all (a URL fragment, an argument to a tool
+        // that parses it itself). Node accepts forward slashes on Windows, so
+        // nothing is lost by leaving it alone.
+        expect(config.args).toEqual(['--root', `${dir}/data`]);
+        expect(config.env.CONFIG).toBe(`${dir}/config.json`);
+
+        // The placeholder must be GONE, not merely joined onto something.
+        expect(JSON.stringify(config)).not.toContain('PLUGIN_ROOT');
+    });
+
+    it('SKIPS a server needing ${PLUGIN_DATA}, with a reason, rather than launching it broken', async () => {
+        const root = await packagesRoot();
+        await writePackage(root, 'acme', 'acme.tools', {
+            stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.js'] },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        expect(result.servers).toHaveLength(0);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({ name: 'stateful', packageName: 'acme.tools' }),
+        ]);
+        // The reason names the placeholder, so an operator knows what to do.
+        expect(result.skipped[0].reason).toContain('PLUGIN_DATA');
+    });
+
+    it('resolves servers from several packages together', async () => {
+        const root = await packagesRoot();
+        await writePackage(root, 'one', 'pkg.one', {
+            alpha: { type: 'streamable-http', url: 'https://one.example.com/mcp' },
+        });
+        await writePackage(root, 'two', 'pkg.two', {
+            beta: { type: 'sse', url: 'https://two.example.com/sse' },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        expect(result.servers.map((s) => s.name).sort()).toEqual(['alpha', 'beta']);
+        expect(result.servers.map((s) => s.provenance.packageName).sort()).toEqual([
+            'pkg.one',
+            'pkg.two',
+        ]);
+    });
+
+    it('filters to one package by manifest name', async () => {
+        const root = await packagesRoot();
+        await writePackage(root, 'one', 'pkg.one', {
+            alpha: { type: 'streamable-http', url: 'https://one.example.com/mcp' },
+        });
+        await writePackage(root, 'two', 'pkg.two', {
+            beta: { type: 'streamable-http', url: 'https://two.example.com/mcp' },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const servers = await service.resolveForPackage('pkg.two');
+
+        expect(servers.map((s) => s.name)).toEqual(['beta']);
+    });
+
+    it('returns an empty result when no package declares any server', async () => {
+        const root = await packagesRoot();
+        const dir = join(root, 'plain');
+        await mkdir(dir, { recursive: true });
+        await writeFile(
+            join(dir, 'plugin.json'),
+            JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'plain' }),
+            'utf8',
+        );
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        // Enabled, and genuinely empty — the caller can tell this apart from
+        // the flag being off.
+        expect(result).toMatchObject({ enabled: true, servers: [], skipped: [] });
+    });
+});

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.ts
@@ -1,0 +1,239 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+    expandArgs,
+    expandEnvValues,
+    expandPlaceholders,
+    isToolNamespaceSafeServerName,
+    loadPluginPackage,
+    PLUGIN_DATA_PLACEHOLDER,
+    type ExpansionContext,
+    type McpServerConfig,
+    type McpServerEntry,
+    type McpTransport,
+} from '@ever-works/agent-plugins';
+import { loadedPackages, scanConfiguredPackages } from './configured-source';
+import type { LocalPackageCandidate } from './local-source';
+
+/**
+ * Resolves the MCP servers that installed Agent Plugins packages declare.
+ *
+ * ## What this does NOT do
+ *
+ * It does not connect to anything. Resolution and connection are separated
+ * because they fail for entirely different reasons and at entirely different
+ * times: a malformed `mcp.json` is a fact about installed bytes and is known
+ * at scan time, while an unreachable server is a fact about the network and is
+ * only known during a run. Merging them would report a package with a typo and
+ * a server that happens to be down identically.
+ *
+ * ## Provenance is part of the result, not a log line
+ *
+ * Every resolved server carries the package that declared it and the path it
+ * came from. An agent about to call a tool named `mcp__api__search` is
+ * otherwise unable to say WHERE that tool came from, and neither is the
+ * operator reading an audit trail. Provenance that exists only in a log is
+ * provenance that cannot be checked at the point of use.
+ */
+
+/** A server declared by a package, with everything needed to launch and audit it. */
+export interface ResolvedMcpServer {
+    /** `mcpServers` member name, unique within its package but NOT globally. */
+    readonly name: string;
+    /**
+     * How this server is addressed in tool names: `mcp__<server>__<tool>`.
+     *
+     * Null when the name cannot be embedded safely. A name containing the
+     * `__` separator would make the tool name ambiguous to split back apart,
+     * which could route a call to the wrong server.
+     */
+    readonly toolNamespace: string | null;
+    readonly transport: McpTransport;
+    /** Config with `${PLUGIN_ROOT}` already expanded. */
+    readonly config: McpServerConfig;
+    readonly provenance: McpServerProvenance;
+}
+
+export interface McpServerProvenance {
+    /** Declaring package's manifest name. */
+    readonly packageName: string;
+    /** Directory the package occupies, which placeholders resolve against. */
+    readonly packageRoot: string;
+    readonly packageVersion: string | null;
+    readonly specVersion: string;
+    /** How the package reached this deployment. */
+    readonly sourceKind: 'local' | 'git' | 'npm';
+}
+
+export interface SkippedMcpServer {
+    readonly name: string;
+    readonly packageName: string;
+    readonly reason: string;
+}
+
+export interface McpResolutionResult {
+    readonly enabled: boolean;
+    readonly servers: readonly ResolvedMcpServer[];
+    /**
+     * Servers that were declared but cannot be offered, each with a reason.
+     *
+     * Kept separate from `servers` rather than dropped: "this package declares
+     * no servers" and "it declares one this deployment refuses" are different
+     * facts, and only the second asks an operator to do something.
+     */
+    readonly skipped: readonly SkippedMcpServer[];
+}
+
+/**
+ * True when any string in the config still references `${PLUGIN_DATA}`.
+ *
+ * Checked BEFORE expansion, because expansion cannot fail — it substitutes
+ * whatever the context holds. Passing a placeholder path for a directory
+ * nothing has allocated would produce a server that dies at launch with a
+ * confusing filesystem error; refusing it up front produces a reason an
+ * operator can act on.
+ */
+export function usesPluginData(config: McpServerConfig): boolean {
+    const values: string[] =
+        config.type === 'stdio'
+            ? [
+                  config.command,
+                  ...(config.args ?? []),
+                  ...Object.values(config.env ?? {}),
+                  ...(config.cwd ? [config.cwd] : []),
+              ]
+            : [config.url, ...Object.values(config.headers ?? {})];
+
+    return values.some((value) => value.includes(PLUGIN_DATA_PLACEHOLDER));
+}
+
+@Injectable()
+export class McpServerConfigService {
+    private readonly logger = new Logger(McpServerConfigService.name);
+
+    /**
+     * Every MCP server declared by every installed package.
+     *
+     * Returns `enabled: false` and nothing else when the feature is off, so a
+     * caller can tell that apart from "on, with no servers" — otherwise the
+     * same empty list.
+     */
+    async resolveAll(): Promise<McpResolutionResult> {
+        const scan = await scanConfiguredPackages();
+        if (!scan.enabled) {
+            return { enabled: false, servers: [], skipped: [] };
+        }
+
+        const servers: ResolvedMcpServer[] = [];
+        const skipped: SkippedMcpServer[] = [];
+
+        for (const candidate of loadedPackages(scan)) {
+            // The scan carries server NAMES only, so the package is re-read
+            // here for the full validated entries. Re-reading also means a
+            // package edited since the scan is resolved as it is now rather
+            // than as it was, which is what a launcher needs.
+            const entries = await this.entriesFor(candidate, skipped);
+            for (const entry of entries) {
+                const resolved = this.resolveOne(entry, candidate);
+                if ('reason' in resolved) {
+                    skipped.push(resolved);
+                    this.logger.warn(
+                        `MCP server "${entry.name}" from "${resolved.packageName}" skipped: ${resolved.reason}`,
+                    );
+                } else {
+                    servers.push(resolved);
+                }
+            }
+        }
+
+        return { enabled: true, servers, skipped };
+    }
+
+    /** The servers declared by one package, by manifest name. */
+    async resolveForPackage(packageName: string): Promise<readonly ResolvedMcpServer[]> {
+        const all = await this.resolveAll();
+        return all.servers.filter((server) => server.provenance.packageName === packageName);
+    }
+
+    private async entriesFor(
+        candidate: LocalPackageCandidate,
+        skipped: SkippedMcpServer[],
+    ): Promise<readonly McpServerEntry[]> {
+        if (candidate.mcpServerNames.length === 0) {
+            return [];
+        }
+        try {
+            const load = await loadPluginPackage(candidate.path);
+            return load.ok ? load.mcpServers : [];
+        } catch (err) {
+            // One unreadable package must not cost every other package its
+            // servers, so this is reported rather than thrown.
+            const reason = err instanceof Error ? err.message : String(err);
+            for (const name of candidate.mcpServerNames) {
+                skipped.push({
+                    name,
+                    packageName: candidate.name ?? candidate.dirName,
+                    reason: `Package could not be re-read: ${reason}`,
+                });
+            }
+            return [];
+        }
+    }
+
+    private resolveOne(
+        entry: McpServerEntry,
+        pkg: LocalPackageCandidate,
+    ): ResolvedMcpServer | SkippedMcpServer {
+        const packageName = pkg.name ?? pkg.dirName;
+
+        if (usesPluginData(entry.config)) {
+            return {
+                name: entry.name,
+                packageName,
+                reason:
+                    'The server references ${PLUGIN_DATA}, and this deployment does not yet ' +
+                    'allocate a per-package data directory.',
+            };
+        }
+
+        return {
+            name: entry.name,
+            toolNamespace: isToolNamespaceSafeServerName(entry.name) ? entry.name : null,
+            transport: entry.transport,
+            config: this.expand(entry.config, pkg.path),
+            provenance: {
+                packageName,
+                packageRoot: pkg.path,
+                packageVersion: pkg.version ?? null,
+                specVersion: pkg.specVersion ?? 'unknown',
+                // Only local packages are scanned from disk today; git and npm
+                // packages land in a scanned directory too, so this widens
+                // when the registry row is consulted here.
+                sourceKind: 'local',
+            },
+        };
+    }
+
+    /**
+     * Substitute `${PLUGIN_ROOT}`.
+     *
+     * `pluginData` is passed as an empty string, which is safe ONLY because
+     * `usesPluginData` has already refused any config that mentions it — the
+     * expansion helpers substitute unconditionally rather than reporting an
+     * unresolvable placeholder, so the guard has to come first.
+     */
+    private expand(config: McpServerConfig, packageRoot: string): McpServerConfig {
+        const context: ExpansionContext = { pluginRoot: packageRoot, pluginData: '' };
+
+        if (config.type === 'stdio') {
+            return {
+                ...config,
+                command: expandPlaceholders(config.command, context),
+                ...(config.args ? { args: expandArgs(config.args, context) } : {}),
+                ...(config.env ? { env: expandEnvValues(config.env, context) } : {}),
+                ...(config.cwd ? { cwd: expandPlaceholders(config.cwd, context) } : {}),
+            };
+        }
+
+        return { ...config, url: expandPlaceholders(config.url, context) };
+    }
+}

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.ts
@@ -11,6 +11,7 @@ import {
     type McpServerEntry,
     type McpTransport,
 } from '@ever-works/agent-plugins';
+import { config } from '../config';
 import { loadedPackages, scanConfiguredPackages } from './configured-source';
 import type { LocalPackageCandidate } from './local-source';
 
@@ -64,10 +65,36 @@ export interface McpServerProvenance {
     readonly sourceKind: 'local' | 'git' | 'npm';
 }
 
+/**
+ * Why a declared server is not being offered.
+ *
+ * `disabled-by-policy` is kept distinct from every other code on purpose
+ * (AP-19): it means the package is fine and the deployment has chosen not to
+ * allow it, which is the one case an operator can act on by changing a
+ * setting rather than by fixing a package. Collapsing it into a generic
+ * "unsupported" would tell them the opposite — that nothing can be done.
+ */
+export type SkippedMcpReason =
+    | 'disabled-by-policy'
+    | 'needs-plugin-data'
+    | 'unsafe-namespace'
+    | 'unreadable-package'
+    | 'unsupported-transport'
+    | 'underivable-name'
+    | 'unsafe-url'
+    | 'name-taken';
+
 export interface SkippedMcpServer {
     readonly name: string;
     readonly packageName: string;
     readonly reason: string;
+    readonly code: SkippedMcpReason;
+    /**
+     * True when the only thing standing between this server and being usable
+     * is a deployment setting. Lets a UI offer "enable stdio" instead of
+     * "contact the package author".
+     */
+    readonly enableable: boolean;
 }
 
 export interface McpResolutionResult {
@@ -173,6 +200,8 @@ export class McpServerConfigService {
                     name,
                     packageName: candidate.name ?? candidate.dirName,
                     reason: `Package could not be re-read: ${reason}`,
+                    code: 'unreadable-package',
+                    enableable: false,
                 });
             }
             return [];
@@ -185,6 +214,22 @@ export class McpServerConfigService {
     ): ResolvedMcpServer | SkippedMcpServer {
         const packageName = pkg.name ?? pkg.dirName;
 
+        // AP-19: a stdio server on a deployment that has not allowed stdio is
+        // PRESENT and DISABLED, not absent. The operator should be able to see
+        // what a package would run before deciding whether to allow it.
+        if (entry.transport === 'stdio' && !config.agentPlugins.isStdioEnabled()) {
+            return {
+                name: entry.name,
+                packageName,
+                reason:
+                    'Stdio servers are disabled by policy on this deployment. Launching one ' +
+                    'executes a subprocess from package contents, so it is gated separately ' +
+                    'from Agent Plugins support itself (AGENT_PLUGINS_STDIO).',
+                code: 'disabled-by-policy',
+                enableable: true,
+            };
+        }
+
         if (usesPluginData(entry.config)) {
             return {
                 name: entry.name,
@@ -192,6 +237,8 @@ export class McpServerConfigService {
                 reason:
                     'The server references ${PLUGIN_DATA}, and this deployment does not yet ' +
                     'allocate a per-package data directory.',
+                code: 'needs-plugin-data',
+                enableable: false,
             };
         }
 

--- a/packages/agent/src/agent-plugins/npm-source.spec.ts
+++ b/packages/agent/src/agent-plugins/npm-source.spec.ts
@@ -273,6 +273,18 @@ describe('AgentPluginNpmSource', () => {
             await expect(source.latestVersion('acme-skills')).resolves.toBeNull();
         });
 
+        it('refuses a malformed package NAME, which npa would read as a transport', async () => {
+            const pacote = pacoteStub();
+            const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+            source.setPacote(pacote);
+
+            // The version is the literal `latest` here, so the injection has
+            // to ride on the name — and an update check is the quieter
+            // entrance: it runs on a schedule and swallows its own errors.
+            await expect(source.latestVersion('../evil')).resolves.toBeNull();
+            expect(pacote.manifest).not.toHaveBeenCalled();
+        });
+
         it('returns the version when it is permitted', async () => {
             const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
             source.setPacote(pacoteStub({ version: '1.4.0' }));

--- a/packages/agent/src/agent-plugins/npm-source.spec.ts
+++ b/packages/agent/src/agent-plugins/npm-source.spec.ts
@@ -64,6 +64,83 @@ describe('versionPermitted', () => {
 });
 
 describe('AgentPluginNpmSource', () => {
+    // `pacote` resolves `<name>@<spec>` through `npm-package-arg`, which picks
+    // the TRANSPORT from the spec's shape. `npa('safe@git+https://host/x.git')`
+    // returns `type: 'git'` (verified against the installed 13.0.2), and
+    // pacote's git fetcher then runs `npm install` on the clone whenever its
+    // package.json declares prepare/install/postinstall — arbitrary code on the
+    // API pod.
+    //
+    // The allowlist only ever sees the package NAME, so an allowlist entry for
+    // a legitimate plugin was enough to carry this. These pin the grammar that
+    // closes it, in BOTH directions: a transport must be refused, and ordinary
+    // semver must keep working, because a regex that quietly rejects `^1.0.0`
+    // would be its own outage.
+    it.each([
+        ['git+https://attacker.example/evil.git', 'a git transport'],
+        ['git+ssh://attacker.example/evil.git', 'an ssh git transport'],
+        ['https://attacker.example/x.tgz', 'a remote tarball'],
+        ['file:/etc', 'a local directory'],
+        ['../../etc', 'a relative path'],
+        ['npm:other-package@1', 'an aliased package'],
+    ])('refuses %s (%s) before any network call', async (version) => {
+        const pacote = pacoteStub();
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({ packageName: 'acme-skills', version, destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        // Nothing was fetched: the refusal happens on the shape, before the
+        // allowlist and before pacote is reached at all.
+        expect(pacote.manifest).not.toHaveBeenCalled();
+        expect(pacote.extract).not.toHaveBeenCalled();
+    });
+
+    it.each(['1.2.3', 'latest', '^1.0.0', '>=1.2 <2', '~1.2', '1.x', 'next', '*'])(
+        'still accepts the ordinary registry specifier %s',
+        async (version) => {
+            const pacote = pacoteStub({ version: '1.2.3' });
+            const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+            source.setPacote(pacote);
+
+            await source.acquire({
+                packageName: 'acme-skills',
+                version,
+                destDir: await scratch(),
+            });
+
+            expect(pacote.manifest).toHaveBeenCalled();
+        },
+    );
+
+    it('refuses a package NAME that could name a transport or a path', async () => {
+        const pacote = pacoteStub();
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({ packageName: '../evil', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 409 });
+        expect(pacote.manifest).not.toHaveBeenCalled();
+    });
+
+    it('tells pacote to ignore lifecycle scripts', async () => {
+        const pacote = pacoteStub({ version: '1.2.3' });
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+
+        await source.acquire({ packageName: 'acme-skills', destDir: await scratch() });
+
+        // Defence in depth behind the grammar above, so a future change that
+        // lets a non-registry spec through cannot also run its scripts.
+        expect(pacote.manifest).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ ignoreScripts: true }),
+        );
+    });
+
     it('refuses an unallowlisted package WITHOUT resolving a manifest', async () => {
         const pacote = pacoteStub();
         const source = new AgentPluginNpmSource(allowlistStub({ allowed: false }));

--- a/packages/agent/src/agent-plugins/npm-source.spec.ts
+++ b/packages/agent/src/agent-plugins/npm-source.spec.ts
@@ -1,0 +1,205 @@
+import { HttpException } from '@nestjs/common';
+import { mkdtemp, mkdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    AgentPluginNpmSource,
+    versionPermitted,
+    type NpmManifest,
+    type PacoteLike,
+} from './npm-source';
+import { AgentPluginAllowlistService } from './allowlist.service';
+
+function allowlistStub(result: {
+    allowed: boolean;
+    reason?: string;
+    entry?: { versionRange?: string | null; integrity?: string | null };
+}): AgentPluginAllowlistService {
+    return {
+        check: jest.fn().mockResolvedValue({
+            allowed: result.allowed,
+            reason: result.reason ?? (result.allowed ? 'allowed' : 'denied'),
+            entry: result.entry,
+        }),
+    } as unknown as AgentPluginAllowlistService;
+}
+
+function pacoteStub(
+    manifest: Partial<NpmManifest> = {},
+): PacoteLike & { manifest: jest.Mock; extract: jest.Mock } {
+    return {
+        manifest: jest.fn().mockResolvedValue({
+            name: 'acme-skills',
+            version: '1.2.0',
+            _integrity: 'sha512-abc',
+            ...manifest,
+        }),
+        extract: jest.fn().mockImplementation(async (_spec: string, dest: string) => {
+            await mkdir(dest, { recursive: true });
+        }),
+    };
+}
+
+async function scratch(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'ap-npm-'));
+}
+
+describe('versionPermitted', () => {
+    it('permits everything when no range is configured', () => {
+        expect(versionPermitted('9.9.9', null)).toBe(true);
+        expect(versionPermitted('9.9.9', '  ')).toBe(true);
+        expect(versionPermitted('9.9.9', '*')).toBe(true);
+    });
+
+    it('matches exactly or by prefix, and does NOT interpret semver ranges', () => {
+        expect(versionPermitted('1.2.0', '1.2.0')).toBe(true);
+        expect(versionPermitted('1.2.1', '1.2.0')).toBe(false);
+        expect(versionPermitted('1.2.9', '1.2.*')).toBe(true);
+        expect(versionPermitted('1.3.0', '1.2.*')).toBe(false);
+        // `^1.0.0` is treated as a literal, so it matches nothing rather than
+        // silently authorising every future 1.x — including one published
+        // after a publisher-account compromise.
+        expect(versionPermitted('1.5.0', '^1.0.0')).toBe(false);
+    });
+});
+
+describe('AgentPluginNpmSource', () => {
+    it('refuses an unallowlisted package WITHOUT resolving a manifest', async () => {
+        const pacote = pacoteStub();
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: false }));
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        // Resolving a manifest still contacts the registry and discloses this
+        // deployment's interest in the package.
+        expect(pacote.manifest).not.toHaveBeenCalled();
+        expect(pacote.extract).not.toHaveBeenCalled();
+    });
+
+    it('checks the RESOLVED version against the range, so a dist-tag cannot bypass it', async () => {
+        // The request says `latest`, which carries no version. Checking the
+        // request instead of the resolution would let `latest` through
+        // whatever the range says.
+        const pacote = pacoteStub({ version: '2.0.0' });
+        const source = new AgentPluginNpmSource(
+            allowlistStub({ allowed: true, entry: { versionRange: '1.*' } }),
+        );
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({
+                packageName: 'acme-skills',
+                version: 'latest',
+                destDir: await scratch(),
+            }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        expect(pacote.manifest).toHaveBeenCalled();
+        expect(pacote.extract).not.toHaveBeenCalled();
+    });
+
+    it('refuses with 424 when a pinned integrity does not match what the registry served', async () => {
+        const pacote = pacoteStub({ _integrity: 'sha512-served' });
+        const source = new AgentPluginNpmSource(
+            allowlistStub({ allowed: true, entry: { integrity: 'sha512-pinned' } }),
+        );
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 424 });
+
+        expect(pacote.extract).not.toHaveBeenCalled();
+    });
+
+    it('extracts with the manifest integrity, and creates NO node_modules symlink', async () => {
+        const pacote = pacoteStub();
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+        const root = await scratch();
+        const dest = join(root, 'pkg');
+
+        const result = await source.acquire({ packageName: 'acme-skills', destDir: dest });
+
+        expect(result).toMatchObject({ version: '1.2.0', integrity: 'sha512-abc' });
+        expect(pacote.extract).toHaveBeenCalledWith(
+            'acme-skills@1.2.0',
+            dest,
+            expect.objectContaining({ integrity: 'sha512-abc' }),
+        );
+
+        // The control that keeps these packages non-executable: nothing may
+        // place them on the module resolution path.
+        await expect(stat(join(root, 'node_modules'))).rejects.toMatchObject({
+            code: 'ENOENT',
+        });
+    });
+
+    it('maps a registry timeout to 504 and other registry failures to 502', async () => {
+        const slow = pacoteStub();
+        slow.manifest.mockRejectedValue(new Error('request ETIMEDOUT'));
+        const a = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        a.setPacote(slow);
+        await expect(
+            a.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 504 });
+
+        const broken = pacoteStub();
+        broken.manifest.mockRejectedValue(new Error('404 Not Found'));
+        const b = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        b.setPacote(broken);
+        await expect(
+            b.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it('rejects an implausibly long version specifier before any lookup', async () => {
+        const pacote = pacoteStub();
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({
+                packageName: 'acme-skills',
+                version: 'v'.repeat(500),
+                destDir: await scratch(),
+            }),
+        ).rejects.toBeInstanceOf(HttpException);
+
+        expect(pacote.manifest).not.toHaveBeenCalled();
+    });
+
+    describe('latestVersion', () => {
+        it('returns null instead of throwing when the registry is unreachable', async () => {
+            const pacote = pacoteStub();
+            pacote.manifest.mockRejectedValue(new Error('registry down'));
+            const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+            source.setPacote(pacote);
+
+            // Not knowing whether an update exists must never fail the page
+            // that asked.
+            await expect(source.latestVersion('acme-skills')).resolves.toBeNull();
+        });
+
+        it('returns null for a version the allowlist range would not permit', async () => {
+            const pacote = pacoteStub({ version: '3.0.0' });
+            const source = new AgentPluginNpmSource(
+                allowlistStub({ allowed: true, entry: { versionRange: '1.*' } }),
+            );
+            source.setPacote(pacote);
+
+            // Offering an update the operator has not authorised would invite
+            // a one-click policy violation.
+            await expect(source.latestVersion('acme-skills')).resolves.toBeNull();
+        });
+
+        it('returns the version when it is permitted', async () => {
+            const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+            source.setPacote(pacoteStub({ version: '1.4.0' }));
+            await expect(source.latestVersion('acme-skills')).resolves.toBe('1.4.0');
+        });
+    });
+});

--- a/packages/agent/src/agent-plugins/npm-source.ts
+++ b/packages/agent/src/agent-plugins/npm-source.ts
@@ -29,6 +29,29 @@ import { AgentPluginAllowlistService } from './allowlist.service';
 /** Reject absurd versions before they reach the registry. */
 const MAX_VERSION_LENGTH = 256;
 
+/**
+ * A registry version specifier, and nothing else.
+ *
+ * `pacote` resolves `<name>@<spec>` through `npm-package-arg`, which decides
+ * the TRANSPORT from the spec's shape — not from the caller's intent. A spec
+ * of `git+https://host/x.git` yields `type: 'git'`, and pacote's git fetcher
+ * then runs `npm install` on the cloned repository whenever its package.json
+ * declares `prepare` / `install` / `preinstall` / `postinstall` / `prepack` /
+ * `build`. Verified against the installed npm-package-arg 13.0.2:
+ *
+ *     npa('safe-pkg@git+https://attacker.example/evil.git').type === 'git'
+ *
+ * The allowlist only ever sees the package NAME, so a name allowlisted for a
+ * legitimate plugin was enough to make the API pod clone and execute an
+ * arbitrary repository. Restricting the grammar closes that at the entrance:
+ * semver-ish characters and dist-tag words only, with no `:`, `/`, `@` or
+ * whitespace, so nothing can name a transport.
+ */
+const NPM_VERSION_SPEC = /^[A-Za-z0-9^~><=*][A-Za-z0-9.+~^><=*\- |]*$/;
+
+/** npm's own name grammar: scoped or unscoped, no path or URL characters. */
+const NPM_PACKAGE_NAME = /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
 export interface NpmAcquireInput {
     /** The npm package name. */
     packageName: string;
@@ -99,6 +122,31 @@ export class AgentPluginNpmSource {
     async acquire(input: NpmAcquireInput): Promise<NpmAcquireResult> {
         const { packageName } = input;
         const requested = input.version?.trim() || 'latest';
+
+        // Refuse a name or version that could name a TRANSPORT rather than a
+        // registry coordinate. This runs before the allowlist because the
+        // allowlist checks the NAME, and the attack rides on the VERSION.
+        if (!NPM_PACKAGE_NAME.test(packageName)) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: `Refusing "${packageName}": not a valid npm package name.`,
+                    packageName,
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        if (!NPM_VERSION_SPEC.test(requested)) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: `Refusing "${packageName}": version specifier must be a registry version, range or dist-tag.`,
+                    packageName,
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
 
         if (requested.length > MAX_VERSION_LENGTH) {
             throw new HttpException(
@@ -234,7 +282,12 @@ export class AgentPluginNpmSource {
     }
 
     private pacoteOptions(registry: string): Record<string, unknown> {
-        return { registry };
+        // `ignoreScripts` is defence in depth, not the primary control: the
+        // grammar checks above are what keep the spec on the registry
+        // transport. If a future change ever lets a git or directory spec
+        // through again, this stops it running the package's lifecycle
+        // scripts on the API pod rather than merely making it likelier to.
+        return { registry, ignoreScripts: true };
     }
 
     private async getPacote(packageName: string): Promise<PacoteLike> {

--- a/packages/agent/src/agent-plugins/npm-source.ts
+++ b/packages/agent/src/agent-plugins/npm-source.ts
@@ -1,0 +1,259 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { AgentPluginAllowlistService } from './allowlist.service';
+
+/**
+ * npm acquirer for Agent Plugins packages.
+ *
+ * Mirrors `PluginInstallerService` — same `pacote` SDK, same allowlist-first
+ * ordering, same 409/424/502/504 vocabulary — with **one deliberate
+ * divergence** that must survive future refactors:
+ *
+ * ## These packages are never linked into `node_modules`
+ *
+ * The code-plugin installer symlinks each extracted package under
+ * `node_modules` so the loader can `await import()` it. An Agent Plugins
+ * package must NOT be linked and must NEVER be imported. It is *data* — a
+ * manifest, some Markdown skills, an MCP server declaration — and the whole
+ * safety argument of the format rests on it never being executable.
+ *
+ * Linking it would place attacker-supplied code on the module resolution path,
+ * where an unrelated `import('some-name')` elsewhere in the process could
+ * resolve to it. That converts "we downloaded a document" into "we downloaded
+ * and can execute a module", which is the single most valuable escalation
+ * available against this feature. The absence of a `symlinkUnderNodeModules`
+ * call here is load-bearing, not an omission.
+ */
+
+/** Reject absurd versions before they reach the registry. */
+const MAX_VERSION_LENGTH = 256;
+
+export interface NpmAcquireInput {
+    /** The npm package name. */
+    packageName: string;
+    /** A version or dist-tag. Defaults to `latest`. */
+    version?: string;
+    /** Directory the package contents are written into. */
+    destDir: string;
+    /** Registry base URL. Defaults to the public registry. */
+    registry?: string;
+}
+
+export interface NpmAcquireResult {
+    packageName: string;
+    version: string;
+    integrity: string | null;
+    path: string;
+}
+
+/** Subset of the pacote API used here, so tests can inject a stub. */
+export interface PacoteLike {
+    manifest(spec: string, opts?: Record<string, unknown>): Promise<NpmManifest>;
+    extract(spec: string, dest: string, opts?: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface NpmManifest {
+    name?: string;
+    version: string;
+    _integrity?: string;
+    deprecated?: string;
+}
+
+export const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/';
+
+/** Where an npm-sourced package is materialised, keyed by name and version. */
+export function npmPackageDir(root: string, packageName: string, version: string): string {
+    return join(root, 'npm', encodeURIComponent(packageName), version);
+}
+
+/**
+ * Version ranges here are matched as an exact value or a trailing-`*` prefix,
+ * NOT as semver.
+ *
+ * Semver range matching would be friendlier, but it would also mean an
+ * operator writing `^1.0.0` silently authorises versions that do not exist
+ * yet — every future 1.x the publisher pushes, including one published after
+ * an account compromise. Prefix matching keeps the grant to something the
+ * operator can actually enumerate at the time they write it.
+ */
+export function versionPermitted(version: string, range: string | null | undefined): boolean {
+    const pattern = range?.trim();
+    if (!pattern || pattern === '*') return true;
+    if (pattern.endsWith('*')) return version.startsWith(pattern.slice(0, -1));
+    return version === pattern;
+}
+
+@Injectable()
+export class AgentPluginNpmSource {
+    private readonly logger = new Logger(AgentPluginNpmSource.name);
+    private pacote: PacoteLike | null = null;
+
+    constructor(private readonly allowlist: AgentPluginAllowlistService) {}
+
+    /** Test-only injection seam, mirroring `PluginInstallerService.setPacote`. */
+    setPacote(impl: PacoteLike): void {
+        this.pacote = impl;
+    }
+
+    async acquire(input: NpmAcquireInput): Promise<NpmAcquireResult> {
+        const { packageName } = input;
+        const requested = input.version?.trim() || 'latest';
+
+        if (requested.length > MAX_VERSION_LENGTH) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message: `Refusing "${packageName}": version specifier is implausibly long.`,
+                    packageName,
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        // Allowlist FIRST — refuse before any network fetch (FR-11). Resolving
+        // a manifest for an unauthorised package still contacts the registry
+        // and still discloses this deployment's interest in it.
+        const allow = await this.allowlist.check(packageName, 'npm');
+        if (!allow.allowed) {
+            throw new HttpException(
+                { statusCode: HttpStatus.CONFLICT, message: allow.reason, packageName },
+                HttpStatus.CONFLICT,
+            );
+        }
+
+        const registry = input.registry || DEFAULT_NPM_REGISTRY;
+        const pacote = await this.getPacote(packageName);
+        const spec = `${packageName}@${requested}`;
+
+        try {
+            const manifest = await pacote.manifest(spec, this.pacoteOptions(registry));
+
+            // The RESOLVED version is checked against the range, not the
+            // requested one. A dist-tag such as `latest` carries no version
+            // information at request time, so checking the request would let
+            // `latest` bypass the range entirely.
+            if (!versionPermitted(manifest.version, allow.entry?.versionRange)) {
+                throw new HttpException(
+                    {
+                        statusCode: HttpStatus.CONFLICT,
+                        message:
+                            `"${packageName}" resolved to ${manifest.version}, which the ` +
+                            `allowlist entry does not permit ` +
+                            `(allowed: ${allow.entry?.versionRange}).`,
+                        packageName,
+                    },
+                    HttpStatus.CONFLICT,
+                );
+            }
+
+            // A pinned integrity on the allowlist entry is a hard equality
+            // check. 424 (Failed Dependency) matches the code-plugin
+            // installer's mapping for "the artefact is not what was promised".
+            const pinned = allow.entry?.integrity?.trim();
+            if (pinned && manifest._integrity && pinned !== manifest._integrity) {
+                throw new HttpException(
+                    {
+                        statusCode: HttpStatus.FAILED_DEPENDENCY,
+                        message:
+                            `Integrity mismatch for ${packageName}@${manifest.version}: ` +
+                            `the allowlist pins a different artefact than the registry served.`,
+                        packageName,
+                    },
+                    HttpStatus.FAILED_DEPENDENCY,
+                );
+            }
+
+            if (manifest.deprecated) {
+                this.logger.warn(
+                    `${packageName}@${manifest.version} is deprecated: ${manifest.deprecated}`,
+                );
+            }
+
+            await rm(input.destDir, { recursive: true, force: true });
+            await mkdir(input.destDir, { recursive: true });
+
+            // `extract` unpacks the tarball and verifies its integrity BEFORE
+            // writing. It does not run lifecycle scripts and does not install
+            // dependencies — both of which we rely on: a package here is
+            // documents, so it has no build step and nothing to install.
+            await pacote.extract(`${packageName}@${manifest.version}`, input.destDir, {
+                ...this.pacoteOptions(registry),
+                ...(manifest._integrity ? { integrity: manifest._integrity } : {}),
+            });
+
+            // NOTE: no symlink under node_modules. See the class docstring —
+            // that omission is the control that keeps these packages
+            // non-executable.
+
+            return {
+                packageName,
+                version: manifest.version,
+                integrity: manifest._integrity ?? null,
+                path: input.destDir,
+            };
+        } catch (err) {
+            await rm(input.destDir, { recursive: true, force: true }).catch(() => undefined);
+            if (err instanceof HttpException) throw err;
+
+            const reason = err instanceof Error ? err.message : String(err);
+            const code = /timeout|ETIMEDOUT/i.test(reason)
+                ? HttpStatus.GATEWAY_TIMEOUT
+                : HttpStatus.BAD_GATEWAY;
+            throw new HttpException({ statusCode: code, message: reason, packageName }, code);
+        }
+    }
+
+    /**
+     * The version the registry would serve right now, without extracting
+     * anything — so an update check costs one manifest request and no disk.
+     */
+    async latestVersion(packageName: string, registry?: string): Promise<string | null> {
+        const allow = await this.allowlist.check(packageName, 'npm');
+        if (!allow.allowed) return null;
+        try {
+            const pacote = await this.getPacote(packageName);
+            const manifest = await pacote.manifest(
+                `${packageName}@latest`,
+                this.pacoteOptions(registry || DEFAULT_NPM_REGISTRY),
+            );
+            return versionPermitted(manifest.version, allow.entry?.versionRange)
+                ? manifest.version
+                : null;
+        } catch (err) {
+            // An update CHECK must never break the caller: not knowing whether
+            // a newer version exists is a strictly better outcome than failing
+            // the page that asked.
+            this.logger.debug(
+                `Update check failed for ${packageName}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return null;
+        }
+    }
+
+    private pacoteOptions(registry: string): Record<string, unknown> {
+        return { registry };
+    }
+
+    private async getPacote(packageName: string): Promise<PacoteLike> {
+        if (this.pacote) return this.pacote;
+        try {
+            const mod: { default?: PacoteLike } & PacoteLike = await import('pacote');
+            const impl = mod.default ?? mod;
+            this.pacote = impl;
+            return impl;
+        } catch {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.NOT_IMPLEMENTED,
+                    message:
+                        `Cannot fetch "${packageName}": the npm source requires the ` +
+                        `'pacote' package, which is not installed.`,
+                },
+                HttpStatus.NOT_IMPLEMENTED,
+            );
+        }
+    }
+}

--- a/packages/agent/src/agent-plugins/npm-source.ts
+++ b/packages/agent/src/agent-plugins/npm-source.ts
@@ -257,6 +257,25 @@ export class AgentPluginNpmSource {
      * anything — so an update check costs one manifest request and no disk.
      */
     async latestVersion(packageName: string, registry?: string): Promise<string | null> {
+        // The same grammar `acquire` enforces. The version here is the literal
+        // `latest`, so the version-injection vector is closed by construction —
+        // but the NAME still reaches `npm-package-arg`, which picks a transport
+        // from the shape of either half. `../evil@latest` resolves as a
+        // directory spec.
+        //
+        // Every name that reaches this today came through `acquire`, which now
+        // validates it, so this is defence in depth rather than a live hole.
+        // It is here because the argument for validating at the entrance
+        // applies to every entrance, and an update check is a quieter one:
+        // it runs on a schedule, swallows its own errors, and would not
+        // announce that it had been used.
+        if (!NPM_PACKAGE_NAME.test(packageName)) {
+            this.logger.warn(
+                `Refusing update check for "${packageName}": not a valid npm package name.`,
+            );
+            return null;
+        }
+
         const allow = await this.allowlist.check(packageName, 'npm');
         if (!allow.allowed) return null;
         try {

--- a/packages/agent/src/agent-plugins/package-bootstrap.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-bootstrap.service.spec.ts
@@ -1,0 +1,242 @@
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentPluginPackageBootstrapService, acquireInputFor } from './package-bootstrap.service';
+import type { AgentPluginPackageRepository } from './package.repository';
+import type { AgentPluginRemoteAcquireService } from './remote-acquire.service';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+function row(over: Partial<AgentPluginPackage> = {}): AgentPluginPackage {
+    return {
+        id: 'pkg-1',
+        userId: 'user-1',
+        name: 'acme.tools',
+        source: 'npm',
+        sourceRef: 'acme-skills@1.2.0',
+        installPath: '/nonexistent/acme',
+        installState: 'installed',
+        specVersion: '1.0.0',
+        findings: [],
+        skillNames: [],
+        mcpServerNames: [],
+        ...over,
+    } as AgentPluginPackage;
+}
+
+function repoStub(rows: AgentPluginPackage[]) {
+    return {
+        findRemoteInstalled: jest.fn().mockResolvedValue(rows),
+        markInstalled: jest.fn().mockResolvedValue(undefined),
+        markFailed: jest.fn().mockResolvedValue(undefined),
+    } as unknown as AgentPluginPackageRepository & {
+        findRemoteInstalled: jest.Mock;
+        markInstalled: jest.Mock;
+        markFailed: jest.Mock;
+    };
+}
+
+function acquirerStub(impl?: jest.Mock) {
+    return {
+        acquire:
+            impl ??
+            jest.fn().mockResolvedValue({
+                kind: 'npm',
+                path: '/packages/npm/acme-skills/1.2.0',
+                revision: '1.2.0',
+                integrity: 'sha512-abc',
+                load: { ok: true, manifest: { name: 'acme.tools', version: '1.2.0' } },
+            }),
+    } as unknown as AgentPluginRemoteAcquireService & { acquire: jest.Mock };
+}
+
+describe('acquireInputFor', () => {
+    it('splits a scoped npm name on the LAST @, not the first', () => {
+        // Splitting on the first `@` yields an empty package name and a
+        // nonsense version — and would fetch the wrong thing rather than fail.
+        expect(acquireInputFor({ source: 'npm', sourceRef: '@scope/pkg@1.0.0' })).toEqual({
+            kind: 'npm',
+            packageName: '@scope/pkg',
+            version: '1.0.0',
+        });
+    });
+
+    it('treats a scoped name with no version as a bare package name', () => {
+        expect(acquireInputFor({ source: 'npm', sourceRef: '@scope/pkg' })).toEqual({
+            kind: 'npm',
+            packageName: '@scope/pkg',
+        });
+    });
+
+    it('parses a git URL with and without a ref fragment', () => {
+        expect(acquireInputFor({ source: 'git', sourceRef: 'https://x.com/a.git#main' })).toEqual({
+            kind: 'git',
+            url: 'https://x.com/a.git',
+            ref: 'main',
+        });
+        expect(acquireInputFor({ source: 'git', sourceRef: 'https://x.com/a.git' })).toEqual({
+            kind: 'git',
+            url: 'https://x.com/a.git',
+        });
+    });
+
+    it('returns null rather than guessing at an unusable reference', () => {
+        expect(acquireInputFor({ source: 'git', sourceRef: '   ' })).toBeNull();
+        expect(acquireInputFor({ source: 'local', sourceRef: '/srv/pkg' })).toBeNull();
+    });
+});
+
+describe('AgentPluginPackageBootstrapService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+        process.env.AGENT_PLUGINS_DIR = '/packages';
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('does nothing at all while the flag is off', async () => {
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        const repository = repoStub([row()]);
+        const service = new AgentPluginPackageBootstrapService(repository, acquirerStub());
+
+        const result = await service.rematerializeFromDb();
+
+        expect(result).toMatchObject({ attempted: 0, succeeded: 0, failed: 0 });
+        // Not even a query: the flag being off must cost nothing.
+        expect(repository.findRemoteInstalled).not.toHaveBeenCalled();
+    });
+
+    it('survives the registry being unreadable at boot', async () => {
+        // A replica can start before the database is reachable. Warmup is an
+        // optimisation, so this must not propagate and kill the pod.
+        const repository = repoStub([]);
+        repository.findRemoteInstalled.mockRejectedValue(new Error('ECONNREFUSED'));
+        const service = new AgentPluginPackageBootstrapService(repository, acquirerStub());
+
+        await expect(service.rematerializeFromDb()).resolves.toMatchObject({
+            attempted: 0,
+            failed: 0,
+        });
+    });
+
+    it('skips a package already present on disk, doing no network work', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'ap-warm-'));
+        const present = join(dir, 'acme');
+        await mkdir(present, { recursive: true });
+
+        const acquirer = acquirerStub();
+        const service = new AgentPluginPackageBootstrapService(
+            repoStub([row({ installPath: present })]),
+            acquirer,
+        );
+
+        const result = await service.rematerializeFromDb();
+
+        expect(result.skipped).toBe(1);
+        expect(result.attempted).toBe(0);
+        expect(acquirer.acquire).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches a package whose directory is gone, and records the result', async () => {
+        const repository = repoStub([row()]);
+        const acquirer = acquirerStub();
+        const service = new AgentPluginPackageBootstrapService(repository, acquirer);
+
+        const result = await service.rematerializeFromDb();
+
+        expect(result).toMatchObject({ attempted: 1, succeeded: 1, failed: 0 });
+        expect(acquirer.acquire).toHaveBeenCalledWith('/packages', {
+            kind: 'npm',
+            packageName: 'acme-skills',
+            version: '1.2.0',
+        });
+        expect(repository.markInstalled).toHaveBeenCalledWith(
+            'pkg-1',
+            expect.objectContaining({ installPath: '/packages/npm/acme-skills/1.2.0' }),
+        );
+    });
+
+    it('records the resolved COMMIT as integrity for a git package', async () => {
+        const sha = 'f'.repeat(40);
+        const repository = repoStub([
+            row({ source: 'git', sourceRef: 'https://x.com/a.git#main' }),
+        ]);
+        const acquirer = acquirerStub(
+            jest.fn().mockResolvedValue({
+                kind: 'git',
+                path: '/packages/git/a/' + sha,
+                revision: sha,
+                integrity: null,
+                load: { ok: true, manifest: { name: 'a', version: '1.0.0' } },
+            }),
+        );
+        const service = new AgentPluginPackageBootstrapService(repository, acquirer);
+
+        await service.rematerializeFromDb();
+
+        // For git there is no subresource integrity; the commit IS the
+        // identity of the fetched bytes.
+        expect(repository.markInstalled).toHaveBeenCalledWith(
+            'pkg-1',
+            expect.objectContaining({ integrity: sha }),
+        );
+    });
+
+    it('records a failure without throwing, so one bad package cannot block boot', async () => {
+        const repository = repoStub([row(), row({ id: 'pkg-2', name: 'other' })]);
+        const acquirer = acquirerStub(
+            jest
+                .fn()
+                .mockRejectedValueOnce(new Error('registry unreachable'))
+                .mockResolvedValue({
+                    kind: 'npm',
+                    path: '/packages/npm/other/1.0.0',
+                    revision: '1.0.0',
+                    integrity: null,
+                    load: { ok: true, manifest: { name: 'other', version: '1.0.0' } },
+                }),
+        );
+        const service = new AgentPluginPackageBootstrapService(repository, acquirer);
+
+        const result = await service.rematerializeFromDb();
+
+        expect(result).toMatchObject({ attempted: 2, succeeded: 1, failed: 1 });
+        expect(repository.markFailed).toHaveBeenCalledWith('pkg-1', 'registry unreachable');
+    });
+
+    it('marks an unparseable sourceRef as failed rather than retrying it every boot', async () => {
+        const repository = repoStub([row({ source: 'git', sourceRef: '' })]);
+        const acquirer = acquirerStub();
+        const service = new AgentPluginPackageBootstrapService(repository, acquirer);
+
+        const result = await service.rematerializeFromDb();
+
+        expect(acquirer.acquire).not.toHaveBeenCalled();
+        expect(repository.markFailed).toHaveBeenCalledWith(
+            'pkg-1',
+            expect.stringContaining('not a valid git reference'),
+        );
+        // It was attempted and did not throw, so boot continues.
+        expect(result.attempted).toBe(1);
+    });
+
+    it('falls back to the default directory when AGENT_PLUGINS_DIR is empty', async () => {
+        process.env.AGENT_PLUGINS_DIR = '';
+        const acquirer = acquirerStub();
+        const service = new AgentPluginPackageBootstrapService(repoStub([row()]), acquirer);
+
+        const result = await service.rematerializeFromDb();
+
+        // envsubst renders an unset variable as an EMPTY STRING, not as
+        // undefined, so the config layer uses `||` rather than `??`. An empty
+        // value therefore resolves to the documented default rather than
+        // disabling the feature — the guard for a genuinely empty root stays
+        // as defence, but it is not reachable through configuration.
+        expect(result.attempted).toBe(1);
+        expect(acquirer.acquire).toHaveBeenCalledWith('/app/agent-plugins', expect.anything());
+    });
+});

--- a/packages/agent/src/agent-plugins/package-bootstrap.service.ts
+++ b/packages/agent/src/agent-plugins/package-bootstrap.service.ts
@@ -1,0 +1,235 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { stat } from 'node:fs/promises';
+import { config } from '../config';
+import { parsePackageDirs } from './local-source';
+import { AgentPluginPackageRepository } from './package.repository';
+import { AgentPluginRemoteAcquireService, type AcquireInput } from './remote-acquire.service';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+/**
+ * Boot-time re-materialisation of remote packages (T19).
+ *
+ * A pod's filesystem is empty on every start, but the registry rows survive.
+ * Without this, a replica that restarts serves a catalog whose package skills
+ * have silently vanished — the rows say "installed" and the disk disagrees.
+ *
+ * ## Why this is time-boxed and non-fatal
+ *
+ * This runs inside the window Kubernetes gives `startupProbe`. A warmup that
+ * blocks on a slow or unreachable registry would fail the probe, and the pod
+ * would be killed and restarted into exactly the same stall — a crash loop
+ * caused entirely by an optional optimisation. So:
+ *
+ * - the whole pass is bounded by {@link BUDGET_MS};
+ * - individual failures are logged and recorded, never thrown;
+ * - the pass is skipped entirely when the feature flag is off.
+ *
+ * Correctness does not depend on it. A package that is not re-materialised
+ * here is simply absent from the catalog until it is fetched again, which is
+ * the same state a brand-new replica starts in.
+ */
+
+/** Total wall-clock budget for the whole pass. */
+export const BUDGET_MS = 20_000;
+
+/** How many packages are fetched at once. */
+export const CONCURRENCY = 4;
+
+export interface RematerializeResult {
+    attempted: number;
+    succeeded: number;
+    failed: number;
+    /** True when the budget ran out with packages still unprocessed. */
+    truncated: boolean;
+    skipped: number;
+}
+
+@Injectable()
+export class AgentPluginPackageBootstrapService {
+    private readonly logger = new Logger(AgentPluginPackageBootstrapService.name);
+
+    constructor(
+        private readonly repository: AgentPluginPackageRepository,
+        private readonly acquirer: AgentPluginRemoteAcquireService,
+    ) {}
+
+    /**
+     * Re-fetch every remote package whose recorded `installPath` is missing.
+     *
+     * Idempotent: a package already present on disk is left alone, so calling
+     * this twice costs one directory probe per package and no network.
+     */
+    async rematerializeFromDb(): Promise<RematerializeResult> {
+        const empty: RematerializeResult = {
+            attempted: 0,
+            succeeded: 0,
+            failed: 0,
+            truncated: false,
+            skipped: 0,
+        };
+
+        if (!config.agentPlugins.isEnabled()) {
+            return empty;
+        }
+
+        let rows: AgentPluginPackage[];
+        try {
+            rows = await this.repository.findRemoteInstalled();
+        } catch (err) {
+            // The registry being unreadable at boot is a real condition on a
+            // replica that starts before the database is reachable. It must
+            // not take the pod down.
+            this.logger.warn(
+                `Agent Plugins re-materialisation skipped — registry unreadable: ${message(err)}`,
+            );
+            return empty;
+        }
+
+        if (rows.length === 0) {
+            return empty;
+        }
+
+        // The FIRST configured directory is the write target. Re-implementing
+        // the split here would drift from `parsePackageDirs`, which handles the
+        // platform delimiter and deliberately never treats a bare `:` as one —
+        // a Windows path such as `C:\packages` would otherwise be cut in half.
+        const roots = parsePackageDirs(config.agentPlugins.getPackageDirs());
+        const root = roots[0];
+        if (!root) {
+            this.logger.warn(
+                'Agent Plugins re-materialisation skipped — no package directory configured.',
+            );
+            return empty;
+        }
+        const deadline = Date.now() + BUDGET_MS;
+        const result = { ...empty };
+
+        // Probe the disk first so an already-warm replica does no network work
+        // at all. This is the common case on a rolling restart.
+        const missing: AgentPluginPackage[] = [];
+        for (const row of rows) {
+            if (await presentOnDisk(row.installPath)) {
+                result.skipped += 1;
+            } else {
+                missing.push(row);
+            }
+        }
+
+        if (missing.length === 0) {
+            return result;
+        }
+
+        this.logger.log(`Agent Plugins boot warmup: re-materialising ${missing.length} package(s)`);
+
+        for (let i = 0; i < missing.length; i += CONCURRENCY) {
+            if (Date.now() >= deadline) {
+                result.truncated = true;
+                this.logger.warn(
+                    `Agent Plugins boot warmup hit its ${BUDGET_MS}ms budget with ` +
+                        `${missing.length - result.attempted} package(s) unprocessed. They will ` +
+                        `be fetched on demand instead.`,
+                );
+                break;
+            }
+
+            const batch = missing.slice(i, i + CONCURRENCY);
+            result.attempted += batch.length;
+
+            const outcomes = await Promise.allSettled(
+                batch.map((row) => this.rematerializeOne(root, row)),
+            );
+            for (const [index, outcome] of outcomes.entries()) {
+                if (outcome.status === 'fulfilled') {
+                    result.succeeded += 1;
+                } else {
+                    result.failed += 1;
+                    this.logger.warn(
+                        `Agent Plugins warmup failed for "${batch[index].name}": ` +
+                            `${message(outcome.reason)}`,
+                    );
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private async rematerializeOne(root: string, row: AgentPluginPackage): Promise<void> {
+        const input = acquireInputFor(row);
+        if (!input) {
+            // An unparseable sourceRef is a data problem, not a transient one;
+            // recording it stops the next boot from retrying it forever.
+            await this.repository.markFailed(
+                row.id,
+                `Cannot re-materialise: sourceRef "${row.sourceRef}" is not a valid ${row.source} reference.`,
+            );
+            return;
+        }
+
+        try {
+            const acquired = await this.acquirer.acquire(root, input);
+            await this.repository.markInstalled(row.id, {
+                installPath: acquired.path,
+                integrity: acquired.kind === 'npm' ? acquired.integrity : acquired.revision,
+                version: acquired.load.ok ? (acquired.load.manifest.version ?? null) : null,
+            });
+        } catch (err) {
+            await this.repository.markFailed(row.id, message(err));
+            throw err;
+        }
+    }
+}
+
+/**
+ * Rebuild acquisition coordinates from the stored `sourceRef`.
+ *
+ * `sourceRef` is documented as "a URL with a ref for git, a name with a
+ * version for npm". Parsing is deliberately strict: a value that does not
+ * match is reported rather than guessed at, because guessing would mean
+ * fetching something other than what was recorded.
+ */
+export function acquireInputFor(row: { source: string; sourceRef: string }): AcquireInput | null {
+    const value = row.sourceRef?.trim();
+    if (!value) return null;
+
+    if (row.source === 'git') {
+        // `<url>#<ref>`. The fragment is used rather than a separator that can
+        // appear in a URL path.
+        const hash = value.indexOf('#');
+        const url = hash === -1 ? value : value.slice(0, hash);
+        const ref = hash === -1 ? undefined : value.slice(hash + 1).trim();
+        if (!url) return null;
+        return { kind: 'git', url, ...(ref ? { ref } : {}) };
+    }
+
+    if (row.source === 'npm') {
+        // `<name>@<version>`, where the name may itself be scoped and so start
+        // with `@`. Splitting on the LAST `@` is what makes `@scope/pkg@1.0.0`
+        // parse correctly; splitting on the first would yield an empty name.
+        const at = value.lastIndexOf('@');
+        if (at <= 0) {
+            return { kind: 'npm', packageName: value };
+        }
+        return {
+            kind: 'npm',
+            packageName: value.slice(0, at),
+            version: value.slice(at + 1),
+        };
+    }
+
+    return null;
+}
+
+async function presentOnDisk(path: string | null | undefined): Promise<boolean> {
+    if (!path) return false;
+    try {
+        const info = await stat(path);
+        return info.isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+function message(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agent/src/agent-plugins/package-catalog.service.ts
+++ b/packages/agent/src/agent-plugins/package-catalog.service.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
-import { Injectable, Logger } from '@nestjs/common';
-import type { SkillCatalogEntry, SkillFrontmatter } from '@ever-works/plugin';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { SkillCatalogEntry, SkillCatalogUpdate, SkillFrontmatter } from '@ever-works/plugin';
 import type { DiscoveredSkill } from '@ever-works/agent-plugins';
 import { discoverSkills } from '@ever-works/agent-plugins';
 import { loadedPackages, scanConfiguredPackages } from './configured-source';
@@ -10,6 +10,7 @@ import {
     type AgentPluginSkillSource,
     type AgentPluginSkillSourceOptions,
 } from './skill-source.token';
+import { AgentPluginUpdateService } from './update.service';
 
 /**
  * Turns installed Agent Plugins packages into skills-catalog entries.
@@ -37,6 +38,15 @@ export class AgentPluginPackageCatalogService implements AgentPluginSkillSource 
      * Not a style choice — exceeding it is a runtime INSERT failure.
      */
     static readonly MAX_VERSION_LENGTH = 16;
+
+    /**
+     * OPTIONAL on purpose. The update service needs a database; this service
+     * is also constructed in contexts that have none (the CLI's read-only
+     * paths, and every unit test that builds it bare). Making it required
+     * would break those call sites, so an absent update service simply means
+     * no package updates are reported — the catalog itself is unaffected.
+     */
+    constructor(@Optional() private readonly updates?: AgentPluginUpdateService) {}
 
     async listEntries(options: AgentPluginSkillSourceOptions): Promise<SkillCatalogEntry[]> {
         const scan = await scanConfiguredPackages();
@@ -178,5 +188,26 @@ export class AgentPluginPackageCatalogService implements AgentPluginSkillSource 
         }
 
         return result;
+    }
+
+    /**
+     * Package skills with a newer version available.
+     *
+     * Reports nothing rather than failing when there is no update service or
+     * the check fails: an unknown update state must not break the catalog.
+     */
+    async checkForUpdates(
+        installedVersions: Record<string, string>,
+        _options: AgentPluginSkillSourceOptions,
+    ): Promise<SkillCatalogUpdate[]> {
+        if (!this.updates) return [];
+        try {
+            return await this.updates.checkSkillUpdates(installedVersions);
+        } catch (err) {
+            this.logger.warn(
+                `Package update check failed: ${err instanceof Error ? err.message : err}`,
+            );
+            return [];
+        }
     }
 }

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -250,7 +250,7 @@ describe('PackageMcpReconcilerService', () => {
         expect(manual.url).toBe('https://trusted.example.com/mcp');
     });
 
-    it('skips a stdio server, which cannot be a URL-shaped connection', async () => {
+    it('skips a stdio server as DISABLED BY POLICY while the gate is off', async () => {
         await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
             local: { type: 'stdio', command: './bin/server' },
         });
@@ -259,11 +259,29 @@ describe('PackageMcpReconcilerService', () => {
         const result = await service.reconcile('user-1');
 
         expect(result.created).toEqual([]);
-        expect(result.skipped[0]?.reason).toContain('stdio');
+        expect(result.skipped[0]?.code).toBe('disabled-by-policy');
+        expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('skips a stdio server as UNSUPPORTED-TRANSPORT once the gate is open', async () => {
+        // With stdio allowed the resolver hands it over, and the reconciler
+        // refuses it for its own reason: a connection row is URL-shaped, and a
+        // stdio server is launched rather than connected to.
+        process.env.AGENT_PLUGINS_STDIO = 'true';
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            local: { type: 'stdio', command: './bin/server' },
+        });
+        const { service, repo } = build();
+
+        const result = await service.reconcile('user-1');
+
+        expect(result.created).toEqual([]);
+        expect(result.skipped[0]?.code).toBe('unsupported-transport');
         expect(repo.create).not.toHaveBeenCalled();
     });
 
     it('carries forward what the resolver already refused, in one report', async () => {
+        process.env.AGENT_PLUGINS_STDIO = 'true';
         await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
             stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.js'] },
         });
@@ -274,6 +292,8 @@ describe('PackageMcpReconcilerService', () => {
         // One report explaining every declared server beats two half-reports.
         expect(result.skipped).toHaveLength(1);
         expect(result.skipped[0].reason).toContain('PLUGIN_DATA');
+        // The resolver's code survives the reconciler boundary.
+        expect(result.skipped[0].code).toBe('needs-plugin-data');
     });
 
     it('reconciles several packages in one pass', async () => {

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -129,6 +129,64 @@ describe('PackageMcpReconcilerService', () => {
         );
     });
 
+    describe('SSRF: two layers, and what each one catches', () => {
+        /**
+         * The conformance library permits plain `http:` for LOOPBACK hosts
+         * (spec 7.2.2) — reasonable for a desktop client talking to a local
+         * dev server. Ever Works is the server case, where loopback means the
+         * API pod's own localhost, so a package pointing at `127.0.0.1:6379`
+         * would reach Redis. The library blocks non-loopback plain HTTP; the
+         * reconciler's own guard blocks what the spec deliberately allows.
+         */
+
+        it.each([
+            ['http://169.254.169.254/latest/meta-data/', 'cloud metadata'],
+            ['http://10.0.0.5/mcp', 'private range'],
+        ])('the LIBRARY rejects %s (%s) as non-loopback plain HTTP', async (url) => {
+            await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+                api: { type: 'streamable-http', url },
+            });
+            const { service, repo } = build();
+
+            const result = await service.reconcile('user-1');
+
+            // Never becomes a valid server entry, so it never reaches the
+            // reconciler at all.
+            expect(result.created).toEqual([]);
+            expect(repo.create).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['http://127.0.0.1:6379/mcp', 'IPv4 loopback'],
+            ['http://[::1]/mcp', 'IPv6 loopback'],
+        ])('the RECONCILER rejects %s (%s), which the spec permits', async (url) => {
+            await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+                api: { type: 'streamable-http', url },
+            });
+            const { service, repo } = build();
+
+            const result = await service.reconcile('user-1');
+
+            // This is the gap the second layer exists for: writing to the
+            // repository bypasses `McpConnectionsService`, so the SSRF guard
+            // every operator-entered URL must pass is repeated here.
+            expect(result.created).toEqual([]);
+            expect(repo.create).not.toHaveBeenCalled();
+            expect(result.skipped[0]?.reason).toContain('public http(s)');
+        });
+
+        it('still accepts an ordinary public https URL', async () => {
+            await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+                api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+            });
+            const { service } = build();
+
+            const result = await service.reconcile('user-1');
+
+            expect(result.created).toEqual(['acme-tools-api']);
+        });
+    });
+
     it('is idempotent — a second run creates nothing', async () => {
         await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
             api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -1,0 +1,236 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { connectionNameFor, PackageMcpReconcilerService } from './package-mcp-reconciler.service';
+import { McpServerConfigService } from './mcp-server-config.service';
+import type { McpServerConnectionRepository } from '../database/repositories/mcp-server-connection.repository';
+import type { McpServerConnection } from '../entities/mcp-server-connection.entity';
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+
+async function writePackage(
+    root: string,
+    dirName: string,
+    name: string,
+    mcpServers: Record<string, unknown>,
+): Promise<void> {
+    const dir = join(root, dirName);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+        join(dir, 'plugin.json'),
+        JSON.stringify({ $schema: PLUGIN_SCHEMA, name, version: '1.0.0' }),
+        'utf8',
+    );
+    await writeFile(
+        join(dir, 'mcp.json'),
+        JSON.stringify({ $schema: MCP_SCHEMA, mcpServers }),
+        'utf8',
+    );
+}
+
+function repoStub(existing: McpServerConnection[] = []) {
+    const rows = [...existing];
+    return {
+        rows,
+        findByUserAndName: jest.fn().mockImplementation(async (_userId: string, name: string) => {
+            return rows.find((row) => row.name === name) ?? null;
+        }),
+        create: jest.fn().mockImplementation(async (data: Partial<McpServerConnection>) => {
+            const row = { id: `id-${rows.length}`, ...data } as McpServerConnection;
+            rows.push(row);
+            return row;
+        }),
+        save: jest.fn().mockImplementation(async (row: McpServerConnection) => row),
+    } as unknown as McpServerConnectionRepository & {
+        rows: McpServerConnection[];
+        findByUserAndName: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+    };
+}
+
+describe('connectionNameFor', () => {
+    it('combines package and server so two packages declaring "api" do not collide', () => {
+        expect(connectionNameFor('acme.tools', 'api')).toBe('acme-tools-api');
+        expect(connectionNameFor('other.tools', 'api')).toBe('other-tools-api');
+    });
+
+    it('lower-cases and strips to the permitted charset', () => {
+        expect(connectionNameFor('Acme_Tools', 'My_Server')).toBe('acme-tools-my-server');
+    });
+
+    it('never returns a name the connection entity would reject', () => {
+        // The pattern is anchored and allows only [a-z0-9-] starting
+        // alphanumeric, so anything else must come back null rather than be
+        // written and rejected at INSERT.
+        expect(connectionNameFor('...', '...')).toBeNull();
+        expect(connectionNameFor('', '')).toBeNull();
+    });
+
+    it('truncates to the column limit without leaving a trailing hyphen', () => {
+        const name = connectionNameFor('a'.repeat(70), 'b'.repeat(40));
+        expect(name).not.toBeNull();
+        expect(name!.length).toBeLessThanOrEqual(80);
+        expect(name!.endsWith('-')).toBe(false);
+    });
+});
+
+describe('PackageMcpReconcilerService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(async () => {
+        process.env = { ...originalEnv };
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+        process.env.AGENT_PLUGINS_DIR = await mkdtemp(join(tmpdir(), 'ap-recon-'));
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    function build(repo = repoStub()) {
+        return {
+            repo,
+            service: new PackageMcpReconcilerService(new McpServerConfigService(), repo),
+        };
+    }
+
+    it('does nothing while the feature is off', async () => {
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        const { service, repo } = build();
+
+        const result = await service.reconcile('user-1');
+
+        expect(result.created).toEqual([]);
+        expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('creates a package connection DISABLED and with no binding', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        const { service, repo } = build();
+
+        const result = await service.reconcile('user-1');
+
+        expect(result.created).toEqual(['acme-tools-api']);
+        // The security property of this whole bridge: a package arriving on
+        // disk must not grant any agent network reach. Enabled would do
+        // exactly that, since a manual connection also gets a tenant binding.
+        expect(repo.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'acme-tools-api',
+                url: 'https://acme.example.com/mcp',
+                transport: 'streamable-http',
+                enabled: false,
+                source: 'package',
+            }),
+        );
+    });
+
+    it('is idempotent — a second run creates nothing', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        const { service, repo } = build();
+
+        await service.reconcile('user-1');
+        const second = await service.reconcile('user-1');
+
+        expect(second.created).toEqual([]);
+        expect(second.unchanged).toEqual(['acme-tools-api']);
+        expect(repo.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates the URL when the package moves its server, without re-enabling it', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://new.example.com/mcp' },
+        });
+        const existing = {
+            id: 'c1',
+            name: 'acme-tools-api',
+            url: 'https://old.example.com/mcp',
+            transport: 'streamable-http',
+            source: 'package',
+            enabled: true,
+        } as McpServerConnection;
+        const { service, repo } = build(repoStub([existing]));
+
+        const result = await service.reconcile('user-1');
+
+        expect(result.updated).toEqual(['acme-tools-api']);
+        expect(repo.save).toHaveBeenCalled();
+        // A new address is not a reason to re-authorise, nor to revoke: the
+        // operator's decision is left exactly as they set it.
+        expect(existing.enabled).toBe(true);
+        expect(existing.url).toBe('https://new.example.com/mcp');
+    });
+
+    it('REFUSES to overwrite a manually-created connection of the same name', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://attacker.example.com/mcp' },
+        });
+        const manual = {
+            id: 'c1',
+            name: 'acme-tools-api',
+            url: 'https://trusted.example.com/mcp',
+            transport: 'streamable-http',
+            source: 'manual',
+            enabled: true,
+        } as McpServerConnection;
+        const { service, repo } = build(repoStub([manual]));
+
+        const result = await service.reconcile('user-1');
+
+        // Otherwise a package could silently repoint a connection the operator
+        // created and trusts at an address of its choosing.
+        expect(result.skipped).toEqual([
+            expect.objectContaining({ reason: expect.stringContaining('refusing to overwrite') }),
+        ]);
+        expect(repo.save).not.toHaveBeenCalled();
+        expect(manual.url).toBe('https://trusted.example.com/mcp');
+    });
+
+    it('skips a stdio server, which cannot be a URL-shaped connection', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            local: { type: 'stdio', command: './bin/server' },
+        });
+        const { service, repo } = build();
+
+        const result = await service.reconcile('user-1');
+
+        expect(result.created).toEqual([]);
+        expect(result.skipped[0]?.reason).toContain('stdio');
+        expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('carries forward what the resolver already refused, in one report', async () => {
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.js'] },
+        });
+        const { service } = build();
+
+        const result = await service.reconcile('user-1');
+
+        // One report explaining every declared server beats two half-reports.
+        expect(result.skipped).toHaveLength(1);
+        expect(result.skipped[0].reason).toContain('PLUGIN_DATA');
+    });
+
+    it('reconciles several packages in one pass', async () => {
+        const root = process.env.AGENT_PLUGINS_DIR!;
+        await writePackage(root, 'one', 'pkg.one', {
+            api: { type: 'streamable-http', url: 'https://one.example.com/mcp' },
+        });
+        await writePackage(root, 'two', 'pkg.two', {
+            api: { type: 'sse', url: 'https://two.example.com/sse' },
+        });
+        const { service } = build();
+
+        const result = await service.reconcile('user-1');
+
+        // Same server name in both packages, distinct connection names.
+        expect([...result.created].sort()).toEqual(['pkg-one-api', 'pkg-two-api']);
+    });
+});

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
@@ -4,7 +4,12 @@ import {
     MCP_CONNECTION_NAME_PATTERN,
     type McpServerConnection,
 } from '../entities/mcp-server-connection.entity';
-import { McpServerConfigService, type ResolvedMcpServer } from './mcp-server-config.service';
+import {
+    McpServerConfigService,
+    type ResolvedMcpServer,
+    type SkippedMcpReason,
+    type SkippedMcpServer,
+} from './mcp-server-config.service';
 import { isSafeWebhookUrl } from '../utils/ssrf-guard';
 
 /**
@@ -46,8 +51,15 @@ export interface ReconcileResult {
     readonly unchanged: readonly string[];
     /** Existing rows whose URL or transport was updated to match the package. */
     readonly updated: readonly string[];
-    /** Declared servers that cannot become a connection, with the reason. */
-    readonly skipped: readonly { name: string; packageName: string; reason: string }[];
+    /**
+     * Declared servers that cannot become a connection, with the reason.
+     *
+     * Reuses the resolver's shape rather than a narrower local one, so the
+     * `code` and `enableable` fields survive this boundary. Narrowing here
+     * would drop exactly the AP-19 signal a UI needs to offer "enable stdio"
+     * instead of "contact the package author".
+     */
+    readonly skipped: readonly SkippedMcpServer[];
 }
 
 /**
@@ -97,7 +109,7 @@ export class PackageMcpReconcilerService {
         const created: string[] = [];
         const unchanged: string[] = [];
         const updated: string[] = [];
-        const skipped: { name: string; packageName: string; reason: string }[] = [];
+        const skipped: SkippedMcpServer[] = [];
 
         if (!resolution.enabled) {
             return { created, unchanged, updated, skipped };
@@ -116,6 +128,8 @@ export class PackageMcpReconcilerService {
                     name: server.name,
                     packageName: server.provenance.packageName,
                     reason: outcome.reason,
+                    code: outcome.code,
+                    enableable: outcome.enableable,
                 });
                 continue;
             }
@@ -140,15 +154,17 @@ export class PackageMcpReconcilerService {
         server: ResolvedMcpServer,
     ): Promise<
         | { kind: 'created' | 'updated' | 'unchanged'; name: string }
-        | { kind: 'skipped'; reason: string }
+        | { kind: 'skipped'; reason: string; code: SkippedMcpReason; enableable: boolean }
     > {
         if (!REMOTE_TRANSPORTS.has(server.transport)) {
             return {
                 kind: 'skipped',
                 reason:
                     `Transport "${server.transport}" cannot become a connection — a ` +
-                    `connection row is URL-shaped. stdio servers need the subprocess ` +
-                    `launcher, which is not built yet.`,
+                    `connection row is URL-shaped. A stdio server is launched as a ` +
+                    `subprocess and never becomes a connection at all.`,
+                code: 'unsupported-transport',
+                enableable: false,
             };
         }
 
@@ -159,6 +175,8 @@ export class PackageMcpReconcilerService {
             return {
                 kind: 'skipped',
                 reason: `Server name "${server.name}" is not safe to use as a tool namespace.`,
+                code: 'unsafe-namespace',
+                enableable: false,
             };
         }
 
@@ -169,12 +187,19 @@ export class PackageMcpReconcilerService {
                 reason:
                     `Could not derive a valid connection name from ` +
                     `"${server.provenance.packageName}" + "${server.name}".`,
+                code: 'underivable-name',
+                enableable: false,
             };
         }
 
         const url = (server.config as { url?: string }).url;
         if (!url) {
-            return { kind: 'skipped', reason: 'Remote server declared no URL.' };
+            return {
+                kind: 'skipped',
+                reason: 'Remote server declared no URL.',
+                code: 'underivable-name',
+                enableable: false,
+            };
         }
 
         // The SAME lexical SSRF guard `McpConnectionsService.assertValidUrl`
@@ -192,6 +217,8 @@ export class PackageMcpReconcilerService {
                 reason:
                     `URL is not a public http(s) address — private, loopback, link-local ` +
                     `and cloud-metadata addresses are blocked.`,
+                code: 'unsafe-url',
+                enableable: false,
             };
         }
 
@@ -221,6 +248,8 @@ export class PackageMcpReconcilerService {
                 reason:
                     `A manually-created connection named "${name}" already exists; ` +
                     `refusing to overwrite it.`,
+                code: 'name-taken',
+                enableable: false,
             };
         }
 

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
@@ -5,6 +5,7 @@ import {
     type McpServerConnection,
 } from '../entities/mcp-server-connection.entity';
 import { McpServerConfigService, type ResolvedMcpServer } from './mcp-server-config.service';
+import { isSafeWebhookUrl } from '../utils/ssrf-guard';
 
 /**
  * Bridges package-declared MCP servers into the EXISTING MCP connection
@@ -174,6 +175,24 @@ export class PackageMcpReconcilerService {
         const url = (server.config as { url?: string }).url;
         if (!url) {
             return { kind: 'skipped', reason: 'Remote server declared no URL.' };
+        }
+
+        // The SAME lexical SSRF guard `McpConnectionsService.assertValidUrl`
+        // applies to an operator-entered URL. Writing to the repository
+        // directly bypasses that service, so the check has to be repeated
+        // here — and a package URL deserves it more than an operator's does,
+        // since nobody typed it. Without this a package could declare
+        // `http://169.254.169.254/...` or a loopback address and have it
+        // written into a connection row that looks ordinary; the row is
+        // created disabled, but an operator enabling something plausible
+        // would then point the client at a private address.
+        if (!isSafeWebhookUrl(url)) {
+            return {
+                kind: 'skipped',
+                reason:
+                    `URL is not a public http(s) address — private, loopback, link-local ` +
+                    `and cloud-metadata addresses are blocked.`,
+            };
         }
 
         const existing = await this.connections.findByUserAndName(userId, name);

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { McpServerConnectionRepository } from '../database/repositories/mcp-server-connection.repository';
+import {
+    MCP_CONNECTION_NAME_PATTERN,
+    type McpServerConnection,
+} from '../entities/mcp-server-connection.entity';
+import { McpServerConfigService, type ResolvedMcpServer } from './mcp-server-config.service';
+
+/**
+ * Bridges package-declared MCP servers into the EXISTING MCP connection
+ * machinery (`mcp_server_connections` + `agent_mcp_server_bindings` + the
+ * client and tool source shipped in #2082).
+ *
+ * ## Why a bridge rather than a parallel system
+ *
+ * `McpServerConnection.source` is typed `'manual' | 'package'`, with the
+ * comment "'package' reserved for the agent-plugins package work" — the seam
+ * for exactly this was designed in advance. Building a second binding table
+ * for package servers would have duplicated a whole working subsystem: the
+ * client, the tool source, the per-agent overrides, the SSRF and redirect
+ * policy, and the API and UI that manage them. Everything here therefore
+ * produces ordinary connection rows and stops.
+ *
+ * ## Package servers are created UNBOUND, and that is the point
+ *
+ * `McpConnectionsService.create` gives a manual connection a tenant-level
+ * binding with `enabled: true`, so every agent can use it immediately. That is
+ * right for a connection a user deliberately added, and **wrong** for one that
+ * arrived inside a package: installing a package would silently grant every
+ * agent network reach to whatever that package declares.
+ *
+ * So a reconciled connection is created with `enabled: false` and **no
+ * binding at all**. Declaration and authorisation stay separate — a human has
+ * to enable it and bind it, exactly as they would for a server they had never
+ * seen before, which is what a package server is.
+ */
+
+/** Only remote transports can become a connection; the row is URL-shaped. */
+const REMOTE_TRANSPORTS = new Set(['streamable-http', 'sse']);
+
+export interface ReconcileResult {
+    /** Connections created for newly-seen package servers. */
+    readonly created: readonly string[];
+    /** Already present and unchanged. */
+    readonly unchanged: readonly string[];
+    /** Existing rows whose URL or transport was updated to match the package. */
+    readonly updated: readonly string[];
+    /** Declared servers that cannot become a connection, with the reason. */
+    readonly skipped: readonly { name: string; packageName: string; reason: string }[];
+}
+
+/**
+ * Derive a connection name from a package server.
+ *
+ * `mcp_server_connections.name` must match
+ * `^[a-z0-9][a-z0-9-]{0,79}$` and is unique per user, while a package name is
+ * a reverse-domain string and a server name can carry underscores. The derived
+ * name therefore includes BOTH so two packages declaring `api` do not collide,
+ * and is lower-cased and stripped to the permitted charset.
+ *
+ * Returns null when nothing usable survives, rather than inventing a name that
+ * would silently point at the wrong server.
+ */
+export function connectionNameFor(packageName: string, serverName: string): string | null {
+    const slug = `${packageName}-${serverName}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/gu, '-')
+        .replace(/^-+|-+$/gu, '')
+        .slice(0, 80)
+        .replace(/-+$/gu, '');
+
+    return MCP_CONNECTION_NAME_PATTERN.test(slug) ? slug : null;
+}
+
+@Injectable()
+export class PackageMcpReconcilerService {
+    private readonly logger = new Logger(PackageMcpReconcilerService.name);
+
+    constructor(
+        private readonly resolver: McpServerConfigService,
+        private readonly connections: McpServerConnectionRepository,
+    ) {}
+
+    /**
+     * Make the connection rows for `userId` agree with what installed packages
+     * declare.
+     *
+     * Idempotent: running it twice creates nothing the second time. It does
+     * NOT delete connections for servers that have disappeared — a row may
+     * carry an operator's binding and auth headers, and silently discarding
+     * that because a directory was momentarily unreadable would be worse than
+     * leaving a stale row that is visibly disabled.
+     */
+    async reconcile(userId: string): Promise<ReconcileResult> {
+        const resolution = await this.resolver.resolveAll();
+        const created: string[] = [];
+        const unchanged: string[] = [];
+        const updated: string[] = [];
+        const skipped: { name: string; packageName: string; reason: string }[] = [];
+
+        if (!resolution.enabled) {
+            return { created, unchanged, updated, skipped };
+        }
+
+        // Carry forward whatever the resolver already refused, so one report
+        // explains every declared server rather than two half-reports.
+        for (const entry of resolution.skipped) {
+            skipped.push(entry);
+        }
+
+        for (const server of resolution.servers) {
+            const outcome = await this.reconcileOne(userId, server);
+            if (outcome.kind === 'skipped') {
+                skipped.push({
+                    name: server.name,
+                    packageName: server.provenance.packageName,
+                    reason: outcome.reason,
+                });
+                continue;
+            }
+            if (outcome.kind === 'created') created.push(outcome.name);
+            else if (outcome.kind === 'updated') updated.push(outcome.name);
+            else unchanged.push(outcome.name);
+        }
+
+        if (created.length > 0 || updated.length > 0) {
+            this.logger.log(
+                `Package MCP reconcile for ${userId}: ${created.length} created, ` +
+                    `${updated.length} updated, ${unchanged.length} unchanged, ` +
+                    `${skipped.length} skipped`,
+            );
+        }
+
+        return { created, unchanged, updated, skipped };
+    }
+
+    private async reconcileOne(
+        userId: string,
+        server: ResolvedMcpServer,
+    ): Promise<
+        | { kind: 'created' | 'updated' | 'unchanged'; name: string }
+        | { kind: 'skipped'; reason: string }
+    > {
+        if (!REMOTE_TRANSPORTS.has(server.transport)) {
+            return {
+                kind: 'skipped',
+                reason:
+                    `Transport "${server.transport}" cannot become a connection — a ` +
+                    `connection row is URL-shaped. stdio servers need the subprocess ` +
+                    `launcher, which is not built yet.`,
+            };
+        }
+
+        if (server.toolNamespace === null) {
+            // The resolver already decided the name cannot be embedded in
+            // `mcp__<server>__<tool>` without ambiguity; creating a connection
+            // for it would produce tools nothing can address.
+            return {
+                kind: 'skipped',
+                reason: `Server name "${server.name}" is not safe to use as a tool namespace.`,
+            };
+        }
+
+        const name = connectionNameFor(server.provenance.packageName, server.name);
+        if (!name) {
+            return {
+                kind: 'skipped',
+                reason:
+                    `Could not derive a valid connection name from ` +
+                    `"${server.provenance.packageName}" + "${server.name}".`,
+            };
+        }
+
+        const url = (server.config as { url?: string }).url;
+        if (!url) {
+            return { kind: 'skipped', reason: 'Remote server declared no URL.' };
+        }
+
+        const existing = await this.connections.findByUserAndName(userId, name);
+
+        if (!existing) {
+            await this.connections.create({
+                userId,
+                name,
+                url,
+                transport: server.transport as McpServerConnection['transport'],
+                authHeaders: null,
+                // Disabled, and with NO binding created. See the class
+                // docstring: a package must not grant reach by arriving.
+                enabled: false,
+                source: 'package',
+            });
+            return { kind: 'created', name };
+        }
+
+        // Never touch a row a human created by hand. A package that happens to
+        // derive the same name must not silently repoint a manual connection
+        // at an address the operator did not choose.
+        if (existing.source !== 'package') {
+            return {
+                kind: 'skipped',
+                reason:
+                    `A manually-created connection named "${name}" already exists; ` +
+                    `refusing to overwrite it.`,
+            };
+        }
+
+        if (existing.url === url && existing.transport === server.transport) {
+            return { kind: 'unchanged', name };
+        }
+
+        // The package changed where its server lives. Update the address, but
+        // leave `enabled` and any bindings exactly as the operator set them —
+        // a new URL is not a reason to re-authorise, nor to revoke.
+        existing.url = url;
+        existing.transport = server.transport as McpServerConnection['transport'];
+        await this.connections.save(existing);
+        return { kind: 'updated', name };
+    }
+}

--- a/packages/agent/src/agent-plugins/package.repository.ts
+++ b/packages/agent/src/agent-plugins/package.repository.ts
@@ -75,4 +75,54 @@ export class AgentPluginPackageRepository {
             installError: error.slice(0, 2000),
         });
     }
+
+    /**
+     * Create or refresh the row for a package.
+     *
+     * Keyed on (userId, name) because that is the table's unique index —
+     * re-installing the same package for the same user must UPDATE rather than
+     * insert a duplicate that the index would reject anyway.
+     */
+    async upsertInstalled(input: {
+        userId: string;
+        tenantId: string | null;
+        organizationId: string | null;
+        name: string;
+        version: string | null;
+        specVersion: string;
+        source: AgentPluginPackageSource;
+        sourceRef: string;
+        installPath: string;
+        integrity: string | null;
+        manifest: Record<string, unknown>;
+        findings: AgentPluginPackage['findings'];
+        skillNames: string[];
+        mcpServerNames: string[];
+    }): Promise<AgentPluginPackage> {
+        const existing = await this.repository.findOne({
+            where: { userId: input.userId, name: input.name },
+        });
+
+        const values = {
+            ...input,
+            installState: 'installed' as AgentPluginPackageInstallState,
+            installError: null,
+            lastValidatedAt: new Date(),
+        };
+
+        if (existing) {
+            await this.repository.update(existing.id, values);
+            const updated = await this.repository.findOne({ where: { id: existing.id } });
+            if (!updated) {
+                throw new Error(`Package row ${existing.id} vanished during upsert.`);
+            }
+            return updated;
+        }
+
+        return this.repository.save(this.repository.create(values));
+    }
+
+    async deleteById(id: string): Promise<void> {
+        await this.repository.delete(id);
+    }
 }

--- a/packages/agent/src/agent-plugins/package.repository.ts
+++ b/packages/agent/src/agent-plugins/package.repository.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import {
+    AgentPluginPackage,
+    type AgentPluginPackageInstallState,
+    type AgentPluginPackageSource,
+} from '../entities/agent-plugin-package.entity';
+
+/**
+ * Data access for the Agent Plugins package registry.
+ *
+ * Kept in the feature folder rather than `database/repositories/` to match
+ * `ingest-install-binding.repository.ts`, which does the same for a
+ * feature-local table.
+ */
+@Injectable()
+export class AgentPluginPackageRepository {
+    constructor(
+        @InjectRepository(AgentPluginPackage)
+        private readonly repository: Repository<AgentPluginPackage>,
+    ) {}
+
+    /**
+     * Every remote package this replica is expected to have on disk.
+     *
+     * `local` is excluded because a local package IS its directory — there is
+     * nothing to re-materialise, and re-creating one would mean inventing
+     * bytes the operator never supplied.
+     */
+    async findRemoteInstalled(): Promise<AgentPluginPackage[]> {
+        return this.repository.find({
+            where: {
+                source: In(['git', 'npm'] as AgentPluginPackageSource[]),
+                installState: 'installed' as AgentPluginPackageInstallState,
+            },
+        });
+    }
+
+    async findByUser(userId: string): Promise<AgentPluginPackage[]> {
+        return this.repository.find({ where: { userId } });
+    }
+
+    async findById(id: string): Promise<AgentPluginPackage | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async markInstalled(
+        id: string,
+        patch: {
+            installPath: string;
+            integrity?: string | null;
+            version?: string | null;
+            installError?: string | null;
+        },
+    ): Promise<void> {
+        await this.repository.update(id, {
+            installState: 'installed' as AgentPluginPackageInstallState,
+            lastValidatedAt: new Date(),
+            ...patch,
+            installError: patch.installError ?? null,
+        });
+    }
+
+    /**
+     * Record a failure WITHOUT clearing `installPath` or `integrity`.
+     *
+     * Those fields are the record of what the package should be; erasing them
+     * on a transient network failure would lose the coordinates needed to
+     * retry, turning a retryable outage into an unrecoverable one.
+     */
+    async markFailed(id: string, error: string): Promise<void> {
+        await this.repository.update(id, {
+            installState: 'failed' as AgentPluginPackageInstallState,
+            installError: error.slice(0, 2000),
+        });
+    }
+}

--- a/packages/agent/src/agent-plugins/remote-acquire.service.spec.ts
+++ b/packages/agent/src/agent-plugins/remote-acquire.service.spec.ts
@@ -52,6 +52,7 @@ function gitServiceWriting(
                 await writePackage(options.dir as string, manifest, skills);
             }),
             resolveRef: jest.fn().mockResolvedValue(sha),
+            listServerRefs: jest.fn().mockResolvedValue([{ ref: 'HEAD', oid: sha }]),
         },
         {},
     );

--- a/packages/agent/src/agent-plugins/remote-acquire.service.spec.ts
+++ b/packages/agent/src/agent-plugins/remote-acquire.service.spec.ts
@@ -1,0 +1,212 @@
+import { mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentPluginRemoteAcquireService } from './remote-acquire.service';
+import { AgentPluginGitSource, gitPackageDir } from './git-source';
+import { AgentPluginNpmSource, npmPackageDir } from './npm-source';
+import { AgentPluginAllowlistService } from './allowlist.service';
+
+/**
+ * These run against the REAL conformance library and the REAL filesystem.
+ * Only the network layer is stubbed, because the property under test — that a
+ * non-conforming package does not survive on disk — is a fact about files.
+ */
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+
+const allowAll = (): AgentPluginAllowlistService =>
+    ({
+        check: jest.fn().mockResolvedValue({ allowed: true, reason: 'allowed', entry: undefined }),
+    }) as unknown as AgentPluginAllowlistService;
+
+async function scratch(): Promise<string> {
+    return mkdtemp(join(tmpdir(), 'ap-acquire-'));
+}
+
+/** Writes a package tree into whatever directory the acquirer asks for. */
+async function writePackage(
+    dir: string,
+    manifest: Record<string, unknown>,
+    skills: Record<string, string> = {},
+): Promise<void> {
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify(manifest, null, 2), 'utf8');
+    for (const [name, body] of Object.entries(skills)) {
+        await mkdir(join(dir, 'skills', name), { recursive: true });
+        await writeFile(join(dir, 'skills', name, 'SKILL.md'), body, 'utf8');
+    }
+}
+
+const skillFile = (name: string, description: string): string =>
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n\nInstructions.\n`;
+
+function gitServiceWriting(
+    manifest: Record<string, unknown>,
+    skills: Record<string, string> = {},
+    sha = 'b'.repeat(40),
+): AgentPluginGitSource {
+    const source = new AgentPluginGitSource(allowAll());
+    source.setGitImplementation(
+        {
+            clone: jest.fn().mockImplementation(async (options: Record<string, unknown>) => {
+                await writePackage(options.dir as string, manifest, skills);
+            }),
+            resolveRef: jest.fn().mockResolvedValue(sha),
+        },
+        {},
+    );
+    return source;
+}
+
+function npmServiceWriting(
+    manifest: Record<string, unknown>,
+    skills: Record<string, string> = {},
+    version = '1.2.0',
+): AgentPluginNpmSource {
+    const source = new AgentPluginNpmSource(allowAll());
+    source.setPacote({
+        manifest: jest.fn().mockResolvedValue({ version, _integrity: 'sha512-abc' }),
+        extract: jest.fn().mockImplementation(async (_spec: string, dest: string) => {
+            await writePackage(dest, manifest, skills);
+        }),
+    });
+    return source;
+}
+
+async function exists(path: string): Promise<boolean> {
+    try {
+        await stat(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+describe('AgentPluginRemoteAcquireService', () => {
+    it('keeps a conforming git package, keyed by its resolved commit', async () => {
+        const root = await scratch();
+        const sha = 'c'.repeat(40);
+        const service = new AgentPluginRemoteAcquireService(
+            gitServiceWriting(
+                { $schema: PLUGIN_SCHEMA, name: 'acme.tools', version: '1.4.0' },
+                { 'release-notes': skillFile('release-notes', 'Draft release notes.') },
+                sha,
+            ),
+            npmServiceWriting({}),
+        );
+
+        const result = await service.acquire(root, {
+            kind: 'git',
+            url: 'https://example.com/acme.git',
+            ref: 'main',
+        });
+
+        expect(result.revision).toBe(sha);
+        expect(result.load.ok).toBe(true);
+        // Keyed by commit, so two refs resolving to different commits cannot
+        // overwrite one another.
+        expect(result.path).toBe(gitPackageDir(root, 'https://example.com/acme.git', sha));
+        expect(await exists(join(result.path, 'plugin.json'))).toBe(true);
+    });
+
+    it('DISCARDS a fatally invalid git package instead of leaving it on disk', async () => {
+        const root = await scratch();
+        const sha = 'd'.repeat(40);
+        const service = new AgentPluginRemoteAcquireService(
+            // An invalid plugin name is a fatal manifest finding.
+            gitServiceWriting({ $schema: PLUGIN_SCHEMA, name: 'Not A Valid Name' }, {}, sha),
+            npmServiceWriting({}),
+        );
+
+        await expect(
+            service.acquire(root, { kind: 'git', url: 'https://example.com/bad.git' }),
+        ).rejects.toMatchObject({ status: 422 });
+
+        // The laundering path this prevents: a rejected tree left in the
+        // packages root would be found and loaded by the local-directory
+        // scanner on the next boot, with no record that it was ever refused.
+        expect(await exists(gitPackageDir(root, 'https://example.com/bad.git', sha))).toBe(false);
+    });
+
+    it('re-keys an npm package by its RESOLVED version, not the requested dist-tag', async () => {
+        const root = await scratch();
+        const service = new AgentPluginRemoteAcquireService(
+            gitServiceWriting({}),
+            npmServiceWriting(
+                { $schema: PLUGIN_SCHEMA, name: 'acme.tools', version: '2.1.0' },
+                { plan: skillFile('plan', 'Plan some work.') },
+                '2.1.0',
+            ),
+        );
+
+        const result = await service.acquire(root, {
+            kind: 'npm',
+            packageName: 'acme-skills',
+            version: 'latest',
+        });
+
+        expect(result.revision).toBe('2.1.0');
+        expect(result.path).toBe(npmPackageDir(root, 'acme-skills', '2.1.0'));
+        // `latest` must not permanently own a directory whose contents
+        // silently change underneath it.
+        expect(await exists(npmPackageDir(root, 'acme-skills', 'latest'))).toBe(false);
+    });
+
+    it('DISCARDS a fatally invalid npm package', async () => {
+        const root = await scratch();
+        const service = new AgentPluginRemoteAcquireService(
+            gitServiceWriting({}),
+            npmServiceWriting({ $schema: PLUGIN_SCHEMA, name: 'Bad Name' }, {}, '1.0.0'),
+        );
+
+        await expect(
+            service.acquire(root, { kind: 'npm', packageName: 'acme-skills' }),
+        ).rejects.toMatchObject({ status: 422 });
+
+        expect(await exists(npmPackageDir(root, 'acme-skills', '1.0.0'))).toBe(false);
+    });
+
+    it('reports the fatal findings so an operator can see WHY it was refused', async () => {
+        const root = await scratch();
+        const service = new AgentPluginRemoteAcquireService(
+            gitServiceWriting({ $schema: PLUGIN_SCHEMA, name: 'Bad Name' }),
+            npmServiceWriting({}),
+        );
+
+        await service.acquire(root, { kind: 'git', url: 'https://example.com/bad.git' }).then(
+            () => {
+                throw new Error('expected the acquisition to be refused');
+            },
+            (err: { getResponse(): { findings?: unknown[] } }) => {
+                const body = err.getResponse();
+                expect(Array.isArray(body.findings)).toBe(true);
+                expect(body.findings?.length).toBeGreaterThan(0);
+            },
+        );
+    });
+
+    it('keeps a package whose SKILLS are broken but whose manifest is valid', async () => {
+        const root = await scratch();
+        const service = new AgentPluginRemoteAcquireService(
+            gitServiceWriting(
+                { $schema: PLUGIN_SCHEMA, name: 'mixed' },
+                {
+                    good: skillFile('good', 'This one conforms.'),
+                    bad: '---\nname: bad\n---\n\nNo description.\n',
+                },
+                'e'.repeat(40),
+            ),
+            npmServiceWriting({}),
+        );
+
+        const result = await service.acquire(root, {
+            kind: 'git',
+            url: 'https://example.com/mixed.git',
+        });
+
+        // Per-skill failure isolation: one bad skill must not cost the
+        // operator the whole package.
+        expect(result.load.ok).toBe(true);
+        expect(await exists(result.path)).toBe(true);
+    });
+});

--- a/packages/agent/src/agent-plugins/remote-acquire.service.ts
+++ b/packages/agent/src/agent-plugins/remote-acquire.service.ts
@@ -1,0 +1,169 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { mkdir, rename, rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { loadPluginPackage, type LoadPluginPackageResult } from '@ever-works/agent-plugins';
+import { AgentPluginGitSource, gitPackageDir } from './git-source';
+import { AgentPluginNpmSource, npmPackageDir } from './npm-source';
+
+/**
+ * Acquire a remote package, then prove it conforms before anything may use it.
+ *
+ * ## Why validation belongs here and not at the call site
+ *
+ * A tarball or a git tree is attacker-controlled content. Two properties are
+ * only true AFTER the bytes land, so they cannot be checked earlier:
+ *
+ * - **Containment.** An archive entry or a committed symlink can point outside
+ *   the package root. `loadPluginPackage` resolves every path with `realpath`
+ *   segment by segment, which is the only check that survives a symlink whose
+ *   target is itself a symlink. A lexical check on the archive's entry names
+ *   would pass all of these.
+ * - **Conformance.** Whether a `plugin.json` is fatally invalid is a fact about
+ *   the fetched bytes, not about the request that fetched them.
+ *
+ * If validation were left to callers, the first caller to forget it would keep
+ * an unvalidated tree on disk where the local-directory scanner would later
+ * find and load it — laundering a rejected package into an accepted one. Doing
+ * it here means a package that fails is **removed**, not merely reported.
+ */
+
+export type RemoteSourceKind = 'git' | 'npm';
+
+export interface AcquireGitInput {
+    kind: 'git';
+    url: string;
+    ref?: string;
+}
+
+export interface AcquireNpmInput {
+    kind: 'npm';
+    packageName: string;
+    version?: string;
+    registry?: string;
+}
+
+export type AcquireInput = AcquireGitInput | AcquireNpmInput;
+
+export interface AcquiredPackage {
+    kind: RemoteSourceKind;
+    /** Directory the validated package now occupies. */
+    path: string;
+    /** Resolved commit for git, resolved version for npm. */
+    revision: string;
+    /** npm subresource integrity, when the registry supplied one. */
+    integrity: string | null;
+    load: LoadPluginPackageResult;
+}
+
+@Injectable()
+export class AgentPluginRemoteAcquireService {
+    private readonly logger = new Logger(AgentPluginRemoteAcquireService.name);
+
+    constructor(
+        private readonly gitSource: AgentPluginGitSource,
+        private readonly npmSource: AgentPluginNpmSource,
+    ) {}
+
+    /**
+     * Fetch into `root`, validate, and either return the validated package or
+     * throw having left nothing behind.
+     */
+    async acquire(root: string, input: AcquireInput): Promise<AcquiredPackage> {
+        const { destDir, revision, integrity } = await this.fetch(root, input);
+
+        let load: LoadPluginPackageResult;
+        try {
+            load = await loadPluginPackage(destDir);
+        } catch (err) {
+            // A validator that throws must not leave the tree it was
+            // validating on disk, or the next scan picks it up unchecked.
+            await this.discard(destDir);
+            const reason = err instanceof Error ? err.message : String(err);
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+                    message: `Fetched package could not be validated: ${reason}`,
+                },
+                HttpStatus.UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        if (!load.ok) {
+            await this.discard(destDir);
+            const fatal = load.findings.filter((f) => f.severity === 'fatal');
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+                    message:
+                        `Fetched package is not a conforming Agent Plugins package and ` +
+                        `was discarded.`,
+                    findings: fatal.length > 0 ? fatal : load.findings,
+                },
+                HttpStatus.UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        this.logger.log(`Acquired ${input.kind} package "${load.manifest.name}" at ${revision}`);
+
+        return { kind: input.kind, path: destDir, revision, integrity, load };
+    }
+
+    private async fetch(
+        root: string,
+        input: AcquireInput,
+    ): Promise<{ destDir: string; revision: string; integrity: string | null }> {
+        if (input.kind === 'git') {
+            // Two-step because the destination is keyed by the resolved SHA,
+            // which is not known until the clone completes. The staging
+            // directory is derived from the ref so two concurrent acquisitions
+            // of different refs cannot collide in it.
+            const staging = gitPackageDir(root, input.url, `staging-${stagingKey(input.ref)}`);
+            const result = await this.gitSource.acquire({
+                url: input.url,
+                destDir: staging,
+                ...(input.ref ? { ref: input.ref } : {}),
+            });
+            const final = gitPackageDir(root, input.url, result.resolvedSha);
+            await rm(final, { recursive: true, force: true });
+            await mkdir(dirname(final), { recursive: true });
+            await rename(staging, final);
+            return { destDir: final, revision: result.resolvedSha, integrity: null };
+        }
+
+        const dest = npmPackageDir(root, input.packageName, input.version?.trim() || 'latest');
+        const result = await this.npmSource.acquire({
+            packageName: input.packageName,
+            destDir: dest,
+            ...(input.version ? { version: input.version } : {}),
+            ...(input.registry ? { registry: input.registry } : {}),
+        });
+
+        // The directory was keyed by the REQUESTED specifier, which may be a
+        // dist-tag. Re-key it by the resolved version so `latest` does not
+        // permanently occupy one directory whose contents silently change.
+        const final = npmPackageDir(root, input.packageName, result.version);
+        if (final !== dest) {
+            await rm(final, { recursive: true, force: true });
+            await mkdir(dirname(final), { recursive: true });
+            await rename(dest, final);
+        }
+        return { destDir: final, revision: result.version, integrity: result.integrity };
+    }
+
+    private async discard(dir: string): Promise<void> {
+        await rm(dir, { recursive: true, force: true }).catch((err: unknown) => {
+            // Report loudly: a tree that failed validation and could not be
+            // removed is exactly the state the scanner must not encounter.
+            this.logger.error(
+                `Failed to remove rejected package at ${dir}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        });
+    }
+}
+
+/** Filesystem-safe staging suffix derived from a ref. */
+function stagingKey(ref: string | undefined): string {
+    return encodeURIComponent(ref ?? 'default');
+}

--- a/packages/agent/src/agent-plugins/skill-source.token.ts
+++ b/packages/agent/src/agent-plugins/skill-source.token.ts
@@ -1,4 +1,4 @@
-import type { FacadeOptions, SkillCatalogEntry } from '@ever-works/plugin';
+import type { FacadeOptions, SkillCatalogEntry, SkillCatalogUpdate } from '@ever-works/plugin';
 
 /**
  * The seam by which Agent Plugins packages contribute to the skills catalog.
@@ -45,6 +45,19 @@ export interface AgentPluginSkillSource {
         slug: string,
         options: AgentPluginSkillSourceOptions,
     ): Promise<{ entry: SkillCatalogEntry; providerId: string } | null>;
+
+    /**
+     * Skills from installed packages that have a newer version available.
+     *
+     * OPTIONAL, unlike the two above, so that a source which only surfaces a
+     * catalog stays valid. The facade checks for the method before calling
+     * it, mirroring how `ISkillsProviderPlugin.checkForUpdates` is optional
+     * on the plugin contract.
+     */
+    checkForUpdates?(
+        installedVersions: Record<string, string>,
+        options: AgentPluginSkillSourceOptions,
+    ): Promise<SkillCatalogUpdate[]>;
 }
 
 /** Scope and filters passed through from the facade call. */

--- a/packages/agent/src/agent-plugins/update.service.spec.ts
+++ b/packages/agent/src/agent-plugins/update.service.spec.ts
@@ -1,0 +1,206 @@
+import { AgentPluginUpdateService } from './update.service';
+import type { AgentPluginPackageRepository } from './package.repository';
+import type { AgentPluginGitSource } from './git-source';
+import type { AgentPluginNpmSource } from './npm-source';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+function row(over: Partial<AgentPluginPackage> = {}): AgentPluginPackage {
+    return {
+        id: 'pkg-1',
+        userId: 'user-1',
+        name: 'acme.tools',
+        source: 'npm',
+        sourceRef: 'acme-skills@1.2.0',
+        version: '1.2.0',
+        integrity: 'sha512-abc',
+        installState: 'installed',
+        specVersion: '1.0.0',
+        findings: [],
+        skillNames: ['release-notes'],
+        mcpServerNames: [],
+        ...over,
+    } as AgentPluginPackage;
+}
+
+function build(rows: AgentPluginPackage[], over: { npm?: jest.Mock; git?: jest.Mock } = {}) {
+    const repository = {
+        findRemoteInstalled: jest.fn().mockResolvedValue(rows),
+    } as unknown as AgentPluginPackageRepository & { findRemoteInstalled: jest.Mock };
+    const npm = {
+        latestVersion: over.npm ?? jest.fn().mockResolvedValue('1.2.0'),
+    } as unknown as AgentPluginNpmSource & { latestVersion: jest.Mock };
+    const git = {
+        remoteSha: over.git ?? jest.fn().mockResolvedValue(null),
+    } as unknown as AgentPluginGitSource & { remoteSha: jest.Mock };
+    return {
+        repository,
+        npm,
+        git,
+        service: new AgentPluginUpdateService(repository, git, npm),
+    };
+}
+
+describe('AgentPluginUpdateService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        process.env.FEATURE_AGENT_PLUGINS = 'true';
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('does nothing while the flag is off', async () => {
+        delete process.env.FEATURE_AGENT_PLUGINS;
+        const { service, repository } = build([row()]);
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates).toEqual([]);
+        expect(repository.findRemoteInstalled).not.toHaveBeenCalled();
+    });
+
+    it('reports an npm package whose registry version has moved on', async () => {
+        const { service } = build([row()], { npm: jest.fn().mockResolvedValue('1.3.0') });
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates).toEqual([
+            {
+                packageId: 'pkg-1',
+                name: 'acme.tools',
+                source: 'npm',
+                current: '1.2.0',
+                available: '1.3.0',
+            },
+        ]);
+        expect(result.unknown).toEqual([]);
+    });
+
+    it('reports nothing when the installed version is already current', async () => {
+        const { service } = build([row()], { npm: jest.fn().mockResolvedValue('1.2.0') });
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates).toEqual([]);
+        expect(result.unknown).toEqual([]);
+    });
+
+    it('distinguishes an UNREACHABLE remote from an up-to-date package', async () => {
+        // Reporting an outage as "up to date" would be a reassuring lie: the
+        // operator would see a green check and never learn the registry is
+        // unreachable.
+        const { service } = build([row()], { npm: jest.fn().mockResolvedValue(null) });
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates).toEqual([]);
+        expect(result.unknown).toEqual([
+            expect.objectContaining({ packageId: 'pkg-1', name: 'acme.tools' }),
+        ]);
+    });
+
+    it('compares a git package against its recorded COMMIT, not its version', async () => {
+        const installed = 'a'.repeat(40);
+        const remote = 'b'.repeat(40);
+        const { service } = build(
+            [
+                row({
+                    source: 'git',
+                    sourceRef: 'https://x.com/a.git#main',
+                    integrity: installed,
+                    version: '1.0.0',
+                }),
+            ],
+            { git: jest.fn().mockResolvedValue(remote) },
+        );
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates[0]).toMatchObject({
+            source: 'git',
+            current: installed,
+            available: remote,
+        });
+    });
+
+    it('reports no git update when the remote commit is unchanged', async () => {
+        const sha = 'c'.repeat(40);
+        const { service } = build(
+            [row({ source: 'git', sourceRef: 'https://x.com/a.git', integrity: sha })],
+            { git: jest.fn().mockResolvedValue(sha) },
+        );
+
+        await expect(service.checkForUpdates()).resolves.toMatchObject({
+            updates: [],
+            unknown: [],
+        });
+    });
+
+    it('survives the registry being unreadable', async () => {
+        const { service, repository } = build([]);
+        repository.findRemoteInstalled.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        await expect(service.checkForUpdates()).resolves.toMatchObject({ updates: [] });
+    });
+
+    it('lets one package’s failure not hide another package’s update', async () => {
+        const { service } = build([row(), row({ id: 'pkg-2', name: 'other' })], {
+            npm: jest.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue('9.9.9'),
+        });
+
+        const result = await service.checkForUpdates();
+
+        expect(result.updates).toHaveLength(1);
+        expect(result.unknown).toHaveLength(1);
+    });
+
+    describe('checkSkillUpdates', () => {
+        it('fans one package update out to each skill the user has installed', async () => {
+            const { service } = build(
+                [row({ skillNames: ['release-notes', 'changelog', 'not-installed'] })],
+                { npm: jest.fn().mockResolvedValue('1.3.0') },
+            );
+
+            const result = await service.checkSkillUpdates({
+                'release-notes': '1.2.0',
+                changelog: '1.2.0',
+            });
+
+            // `not-installed` is absent: there is nothing to update.
+            expect(result).toEqual([
+                { slug: 'release-notes', oldVersion: '1.2.0', newVersion: '1.3.0' },
+                { slug: 'changelog', oldVersion: '1.2.0', newVersion: '1.3.0' },
+            ]);
+        });
+
+        it('shortens a git commit, which does not fit a catalog version column', async () => {
+            const remote = 'd'.repeat(40);
+            const { service } = build(
+                [
+                    row({
+                        source: 'git',
+                        sourceRef: 'https://x.com/a.git',
+                        integrity: 'e'.repeat(40),
+                        skillNames: ['plan'],
+                    }),
+                ],
+                { git: jest.fn().mockResolvedValue(remote) },
+            );
+
+            const result = await service.checkSkillUpdates({ plan: 'abc123' });
+
+            expect(result[0].newVersion).toBe(remote.slice(0, 12));
+            expect(result[0].newVersion.length).toBeLessThanOrEqual(16);
+        });
+
+        it('returns nothing when no package has an update', async () => {
+            const { service } = build([row()], { npm: jest.fn().mockResolvedValue('1.2.0') });
+            await expect(service.checkSkillUpdates({ 'release-notes': '1.2.0' })).resolves.toEqual(
+                [],
+            );
+        });
+    });
+});

--- a/packages/agent/src/agent-plugins/update.service.ts
+++ b/packages/agent/src/agent-plugins/update.service.ts
@@ -1,0 +1,194 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { SkillCatalogUpdate } from '@ever-works/plugin';
+import { config } from '../config';
+import { AgentPluginPackageRepository } from './package.repository';
+import { AgentPluginGitSource } from './git-source';
+import { AgentPluginNpmSource } from './npm-source';
+import { acquireInputFor } from './package-bootstrap.service';
+import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
+
+/**
+ * Update detection for remote Agent Plugins packages (T20).
+ *
+ * ## Reporting an update is not the same as applying one
+ *
+ * Nothing here fetches or installs. It answers "is there something newer?"
+ * and stops, because upgrading a package changes the instructions an agent
+ * will follow — that has to be an explicit human decision, not a side effect
+ * of rendering a page. The re-sync action is separate and deliberate.
+ *
+ * Consequently every failure here degrades to "no update known" rather than
+ * propagating: a registry outage must not break the catalog page, and it must
+ * certainly not be reported as "up to date" in a way that hides the outage —
+ * hence the `checkedAt`/`unknown` distinction in the result.
+ */
+
+export interface PackageUpdate {
+    packageId: string;
+    name: string;
+    source: 'git' | 'npm';
+    /** Installed version for npm, installed commit for git. */
+    current: string | null;
+    /** Available version for npm, remote commit for git. */
+    available: string;
+}
+
+export interface UpdateCheckResult {
+    updates: PackageUpdate[];
+    /** Packages whose remote could not be reached — NOT the same as up to date. */
+    unknown: Array<{ packageId: string; name: string; reason: string }>;
+    checkedAt: Date;
+}
+
+/** Cap on how many packages a single check will contact a remote for. */
+export const MAX_REMOTE_CHECKS = 50;
+
+@Injectable()
+export class AgentPluginUpdateService {
+    private readonly logger = new Logger(AgentPluginUpdateService.name);
+
+    constructor(
+        private readonly repository: AgentPluginPackageRepository,
+        private readonly gitSource: AgentPluginGitSource,
+        private readonly npmSource: AgentPluginNpmSource,
+    ) {}
+
+    async checkForUpdates(): Promise<UpdateCheckResult> {
+        const result: UpdateCheckResult = { updates: [], unknown: [], checkedAt: new Date() };
+
+        if (!config.agentPlugins.isEnabled()) {
+            return result;
+        }
+
+        let rows: AgentPluginPackage[];
+        try {
+            rows = await this.repository.findRemoteInstalled();
+        } catch (err) {
+            this.logger.warn(`Update check skipped — registry unreadable: ${message(err)}`);
+            return result;
+        }
+
+        const considered = rows.slice(0, MAX_REMOTE_CHECKS);
+        if (rows.length > considered.length) {
+            this.logger.warn(
+                `Update check limited to ${MAX_REMOTE_CHECKS} of ${rows.length} packages.`,
+            );
+        }
+
+        const outcomes = await Promise.allSettled(considered.map((row) => this.checkOne(row)));
+
+        for (const [index, outcome] of outcomes.entries()) {
+            const row = considered[index];
+            if (outcome.status === 'rejected') {
+                result.unknown.push({
+                    packageId: row.id,
+                    name: row.name,
+                    reason: message(outcome.reason),
+                });
+                continue;
+            }
+            if (outcome.value === null) {
+                result.unknown.push({
+                    packageId: row.id,
+                    name: row.name,
+                    reason: 'The remote could not be reached, or the update is not permitted.',
+                });
+                continue;
+            }
+            if (outcome.value) {
+                result.updates.push(outcome.value);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @returns the update, `undefined` when already current, or `null` when
+     * the remote could not be consulted. The three cases are distinct: an
+     * unreachable remote reported as "current" would hide an outage behind a
+     * reassuring answer.
+     */
+    private async checkOne(row: AgentPluginPackage): Promise<PackageUpdate | undefined | null> {
+        const input = acquireInputFor(row);
+        if (!input) return null;
+
+        if (input.kind === 'npm') {
+            const latest = await this.npmSource.latestVersion(input.packageName);
+            if (!latest) return null;
+            if (latest === row.version) return undefined;
+            return {
+                packageId: row.id,
+                name: row.name,
+                source: 'npm',
+                current: row.version ?? null,
+                available: latest,
+            };
+        }
+
+        const sha = await this.gitSource.remoteSha(input.url, input.ref);
+        if (!sha) return null;
+        // For git the recorded `integrity` IS the installed commit — the
+        // entity documents that explicitly.
+        if (sha === row.integrity) return undefined;
+        return {
+            packageId: row.id,
+            name: row.name,
+            source: 'git',
+            current: row.integrity ?? null,
+            available: sha,
+        };
+    }
+
+    /**
+     * The same check, expressed as catalog updates rather than package ones.
+     *
+     * A package contributes many skills, so one package update fans out to one
+     * `SkillCatalogUpdate` per skill it contributes. `installedVersions` is
+     * consulted so a skill the user has NOT installed is not reported as
+     * having an update — there is nothing to update.
+     */
+    async checkSkillUpdates(
+        installedVersions: Record<string, string>,
+    ): Promise<SkillCatalogUpdate[]> {
+        const { updates } = await this.checkForUpdates();
+        if (updates.length === 0) return [];
+
+        let rows: AgentPluginPackage[];
+        try {
+            rows = await this.repository.findRemoteInstalled();
+        } catch {
+            return [];
+        }
+
+        const byId = new Map(rows.map((row) => [row.id, row]));
+        const result: SkillCatalogUpdate[] = [];
+
+        for (const update of updates) {
+            const row = byId.get(update.packageId);
+            for (const slug of row?.skillNames ?? []) {
+                const installed = installedVersions[slug];
+                if (!installed) continue;
+                result.push({
+                    slug,
+                    oldVersion: installed,
+                    // A git commit is not a version string, so it is truncated
+                    // to the short form the catalog column can hold. The full
+                    // commit stays on the package row.
+                    newVersion: shortRevision(update.available),
+                });
+            }
+        }
+
+        return result;
+    }
+}
+
+/** Catalog version columns are narrow; a 40-character commit does not fit. */
+function shortRevision(value: string): string {
+    return /^[0-9a-f]{40}$/iu.test(value) ? value.slice(0, 12) : value;
+}
+
+function message(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -912,6 +912,45 @@ export const config = {
         getPackageDirs(): string {
             return process.env.AGENT_PLUGINS_DIR || '/app/agent-plugins';
         },
+
+        /**
+         * Whether stdio MCP servers declared by packages may be LAUNCHED.
+         *
+         * A second switch, deliberately separate from `isEnabled()`, because
+         * the two authorise very different things. The master flag lets
+         * packages contribute documents and remote server declarations —
+         * inert data. This one lets the platform execute a subprocess from a
+         * package's contents, which is a categorically larger grant, and one
+         * a deployment may never want even while using packages happily.
+         *
+         * Default `false`, and SaaS keeps it off: no sandbox is built in this
+         * feature, so a stdio server would run with the API pod's own
+         * privileges. Self-hosted operators who control what they install can
+         * turn it on.
+         *
+         * A stdio server on a deployment with this off is reported as
+         * "present, disabled by policy" (AP-19) rather than hidden, so the
+         * operator can see what a package would run if they allowed it.
+         */
+        isStdioEnabled(): boolean {
+            return (process.env.AGENT_PLUGINS_STDIO ?? 'false').toLowerCase() === 'true';
+        },
+
+        /**
+         * Root for per-package writable data (`${PLUGIN_DATA}`).
+         *
+         * Deliberately NOT under `getPackageDirs()`. Package contents are
+         * read-only and replaced wholesale on update; data must survive that,
+         * and a writable directory inside a scanned tree would also be walked
+         * by the package scanner. `||` for the same envsubst reason as above.
+         *
+         * Nothing creates this directory either — the launcher creates the
+         * per-package subdirectory it needs, so turning the flag on cannot
+         * fail a boot.
+         */
+        getDataDir(): string {
+            return process.env.AGENT_PLUGINS_DATA_DIR || '/app/agent-plugins-data';
+        },
     },
 
     // EW-120 Activity Feed pull-mode plumbing — per-Work HMAC secret is

--- a/packages/agent/src/facades/skills.facade.ts
+++ b/packages/agent/src/facades/skills.facade.ts
@@ -5,6 +5,7 @@ import type {
     SkillCatalogEntry,
     SkillCatalogListOptions,
     SkillCatalogListResult,
+    SkillCatalogUpdate,
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
@@ -198,5 +199,78 @@ export class SkillsFacadeService extends BaseFacadeService {
         }
 
         return null;
+    }
+
+    /**
+     * Which installed skills have a newer version available.
+     *
+     * ## This finally calls `ISkillsProviderPlugin.checkForUpdates`
+     *
+     * That method has been on the contract, and implemented by
+     * `everworks-skills` and `composio`, with **zero non-test callers** — a
+     * capability every provider was asked to implement and none was ever
+     * asked to perform. Wiring the package source's updates without also
+     * wiring this one would have left the same dead seam in place while
+     * appearing to add update support, so both are done here.
+     *
+     * `checkForUpdates` is optional on the interface, so a provider that does
+     * not implement it is skipped rather than treated as an error.
+     *
+     * @param installedVersions slug → installed version, from the caller's
+     *        own record of what the user has installed.
+     */
+    async checkForUpdates(
+        installedVersions: Record<string, string>,
+        facadeOptions: FacadeOptions,
+    ): Promise<{ updated: SkillCatalogUpdate[] }> {
+        const plugins = await this.getEnabledPlugins(facadeOptions.workId, facadeOptions.userId);
+        const seen = new Set<string>();
+        const updated: SkillCatalogUpdate[] = [];
+
+        for (const wrapped of plugins) {
+            const plugin = wrapped.plugin as ISkillsProviderPlugin;
+            if (typeof plugin.checkForUpdates !== 'function') continue;
+            try {
+                const settings = this.settingsService
+                    ? await this.settingsService
+                          .getResolvedSettings(plugin.id, facadeOptions)
+                          .catch(() => undefined)
+                    : undefined;
+                const result = await plugin.checkForUpdates(installedVersions, settings);
+                for (const update of result.updated) {
+                    if (seen.has(update.slug)) continue;
+                    seen.add(update.slug);
+                    updated.push(update);
+                }
+            } catch (err) {
+                // One provider's outage must not hide every other provider's
+                // updates.
+                this.logger.warn(
+                    `Skills provider ${plugin.id} failed to checkForUpdates: ${err instanceof Error ? err.message : err}`,
+                );
+            }
+        }
+
+        // Package updates are appended LAST, matching the precedence
+        // `listEntries` establishes: a package can never displace a provider
+        // plugin's entry, so it must not displace its update either.
+        if (this.packageSource?.checkForUpdates) {
+            try {
+                const packageUpdates = await this.packageSource.checkForUpdates(installedVersions, {
+                    facadeOptions,
+                });
+                for (const update of packageUpdates) {
+                    if (seen.has(update.slug)) continue;
+                    seen.add(update.slug);
+                    updated.push(update);
+                }
+            } catch (err) {
+                this.logger.warn(
+                    `Agent Plugins package source failed to checkForUpdates: ${err instanceof Error ? err.message : err}`,
+                );
+            }
+        }
+
+        return { updated };
     }
 }

--- a/packages/agent/src/mcp/guarded-fetch.spec.ts
+++ b/packages/agent/src/mcp/guarded-fetch.spec.ts
@@ -1,0 +1,197 @@
+import { createGuardedFetch, MAX_REDIRECTS } from './guarded-fetch';
+
+/**
+ * The property under test is what CROSSES a redirect, not whether fetch works.
+ * Every case here is a hop that used to be taken implicitly by the platform's
+ * redirect following, with the caller's headers attached.
+ */
+
+interface Hop {
+    url: string;
+    init: RequestInit | undefined;
+}
+
+function scriptedFetch(script: Array<{ status: number; location?: string }>) {
+    const hops: Hop[] = [];
+    let index = 0;
+
+    const impl = jest.fn(async (url: string, init?: RequestInit) => {
+        hops.push({ url, init });
+        const step = script[Math.min(index, script.length - 1)];
+        index += 1;
+        const headers = new Headers();
+        if (step.location) headers.set('location', step.location);
+        return new Response(null, { status: step.status, headers });
+    });
+
+    return { impl, hops };
+}
+
+describe('createGuardedFetch', () => {
+    it('returns a non-redirect response untouched', async () => {
+        const { impl, hops } = scriptedFetch([{ status: 200 }]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        const response = await fetchImpl('https://api.example.com/mcp', {
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        expect(response.status).toBe(200);
+        expect(hops).toHaveLength(1);
+        // The first request must carry the credential — that is the point of
+        // configuring one.
+        expect(hops[0].init?.headers).toEqual({ 'X-API-Key': 'secret' });
+    });
+
+    it('always requests manual redirects, so no hop is taken implicitly', async () => {
+        const { impl, hops } = scriptedFetch([{ status: 200 }]);
+        await createGuardedFetch({ fetchImpl: impl })('https://api.example.com/mcp');
+
+        expect(hops[0].init?.redirect).toBe('manual');
+    });
+
+    it('KEEPS headers on a same-origin redirect', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: 'https://api.example.com/v2/mcp' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        expect(hops).toHaveLength(2);
+        expect(hops[1].url).toBe('https://api.example.com/v2/mcp');
+        // Same origin, so the credential is still going to the server it was
+        // configured for.
+        expect(hops[1].init?.headers).toEqual({ 'X-API-Key': 'secret' });
+    });
+
+    it('DROPS every caller header on a cross-origin redirect', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 302, location: 'https://evil.example.net/collect' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            headers: { 'X-API-Key': 'secret', Authorization: 'Bearer t0ken' },
+        });
+
+        expect(hops[1].url).toBe('https://evil.example.net/collect');
+        // The platform strips `Authorization` cross-origin but NOT custom
+        // headers, which is exactly how an MCP credential would leak.
+        expect(hops[1].init?.headers).toBeUndefined();
+        expect(JSON.stringify(hops[1].init ?? {})).not.toContain('secret');
+        expect(JSON.stringify(hops[1].init ?? {})).not.toContain('t0ken');
+    });
+
+    it('drops headers when a redirect changes only the PORT', async () => {
+        // Same host, different port is a different origin — and
+        // `https://api.example.com:8443` is a plausible-looking target.
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: 'https://api.example.com:8443/mcp' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        expect(hops[1].init?.headers).toBeUndefined();
+    });
+
+    it('drops headers when a redirect downgrades the SCHEME', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 302, location: 'http://api.example.com/mcp' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        // https → http is a different origin, so the credential must not ride
+        // along onto a plaintext hop.
+        expect(hops[1].init?.headers).toBeUndefined();
+    });
+
+    it('resolves a RELATIVE Location against the current URL', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: '/v2/mcp' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp');
+
+        expect(hops[1].url).toBe('https://api.example.com/v2/mcp');
+    });
+
+    it('rewrites POST to a bodyless GET after a 303', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 303, location: 'https://api.example.com/result' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            method: 'POST',
+            body: '{"a":1}',
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        expect(hops[1].init?.method).toBe('GET');
+        expect(hops[1].init?.body).toBeUndefined();
+    });
+
+    it('preserves the method across a 307, which is what 307 means', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: 'https://api.example.com/v2' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', { method: 'POST', body: '{}' });
+
+        expect(hops[1].init?.method).toBe('POST');
+    });
+
+    it('refuses a redirect loop rather than following it forever', async () => {
+        const { impl } = scriptedFetch([{ status: 302, location: 'https://api.example.com/a' }]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await expect(fetchImpl('https://api.example.com/mcp')).rejects.toThrow(/Too many/u);
+        expect(impl).toHaveBeenCalledTimes(MAX_REDIRECTS + 1);
+    });
+
+    it('returns a redirect status that carries no Location instead of guessing', async () => {
+        const { impl } = scriptedFetch([{ status: 302 }]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        const response = await fetchImpl('https://api.example.com/mcp');
+
+        expect(response.status).toBe(302);
+        expect(impl).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-runs the guard on the redirect TARGET, not only the first URL', async () => {
+        // The whole reason redirects are followed here: the first URL passing
+        // the guard says nothing about where it points.
+        const { impl, hops } = scriptedFetch([
+            { status: 302, location: 'http://127.0.0.1:6379/' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp');
+
+        // The stub stands in for the DNS-pinned fetch, so this asserts the
+        // target is handed to it for checking rather than fetched directly.
+        expect(hops[1].url).toBe('http://127.0.0.1:6379/');
+        expect(impl).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/agent/src/mcp/guarded-fetch.ts
+++ b/packages/agent/src/mcp/guarded-fetch.ts
@@ -1,0 +1,148 @@
+import { safeFetchWithDnsPin, SsrfBlockedError, type DnsResolver } from '../utils/ssrf-guard';
+
+/**
+ * SSRF- and redirect-hardened `fetch` for the MCP client (AP-15).
+ *
+ * ## What was open before this
+ *
+ * `McpConnectionsService.assertValidUrl` applies `isSafeWebhookUrl`, which is
+ * **lexical only** — its own docstring says a hostname resolving to a private
+ * address is not detected. The SDK transports then used the global `fetch`,
+ * which follows redirects automatically. Two consequences, both reachable by
+ * anyone who controls a connection URL — including, once packages can declare
+ * servers, a package author:
+ *
+ * 1. **DNS rebinding.** `evil.example.com` passes the lexical guard and
+ *    resolves to `169.254.169.254` at fetch time.
+ * 2. **Redirect to a private address, carrying credentials.** The server
+ *    answers `302 Location: http://127.0.0.1:6379/`, and the default fetch
+ *    follows it. `Authorization` is stripped by the platform on a cross-origin
+ *    redirect, but custom headers — `X-API-Key`, `X-Auth-Token`, the shapes an
+ *    MCP server actually uses — are **not**. The credential is delivered to
+ *    whatever host the redirect names.
+ *
+ * ## What this does
+ *
+ * Every hop is re-checked, and no hop is taken implicitly:
+ *
+ * - `redirect: 'manual'`, so redirects are followed HERE rather than by the
+ *   platform, which is the only way to inspect each target before going.
+ * - each target passes `safeFetchWithDnsPin`, so the lexical guard AND the
+ *   post-resolution address check run again per hop.
+ * - **crossing origin drops every caller-supplied header.** Not just the ones
+ *   that look like credentials: a header allow-list would have to predict
+ *   which of an arbitrary MCP server's headers are sensitive, and the answer
+ *   for `X-Api-Key` versus `X-Request-Id` is not knowable from the name. The
+ *   safe default is to forward nothing and let a genuinely cross-origin
+ *   server ask for its own auth.
+ */
+
+/** Enough for a legitimate canonicalisation chain, few enough to bound the work. */
+export const MAX_REDIRECTS = 5;
+
+/** Status codes that mean "go somewhere else". */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Codes after which the request must become a bodyless GET.
+ *
+ * 303 says so explicitly; 301 and 302 are specified to preserve the method but
+ * every real client rewrites POST to GET, and servers are built expecting it.
+ */
+const REWRITE_TO_GET = new Set([301, 302, 303]);
+
+export interface GuardedFetchOptions {
+    /** Injected in tests so no DNS or network is required. */
+    dnsResolver?: DnsResolver;
+    /** Injected in tests; defaults to the DNS-pinned fetch. */
+    fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+export type GuardedFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+function headerEntries(init: RequestInit | undefined): [string, string][] {
+    const headers = init?.headers;
+    if (!headers) return [];
+    if (headers instanceof Headers) return [...headers.entries()];
+    if (Array.isArray(headers)) return headers.map(([k, v]) => [k, v]);
+    return Object.entries(headers as Record<string, string>);
+}
+
+/**
+ * Build a fetch that re-validates every hop and never forwards caller headers
+ * across an origin boundary.
+ */
+export function createGuardedFetch(options: GuardedFetchOptions = {}): GuardedFetch {
+    const doFetch =
+        options.fetchImpl ??
+        ((url: string, init?: RequestInit) =>
+            safeFetchWithDnsPin(
+                url,
+                init,
+                options.dnsResolver ? { dnsResolver: options.dnsResolver } : undefined,
+            ));
+
+    return async function guardedFetch(input, init) {
+        let currentUrl = typeof input === 'string' ? input : input.toString();
+        let currentInit: RequestInit = { ...init, redirect: 'manual' };
+        const origin = new URL(currentUrl).origin;
+
+        for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+            const response = await doFetch(currentUrl, currentInit);
+
+            if (!REDIRECT_STATUSES.has(response.status)) {
+                return response;
+            }
+
+            const location = response.headers.get('location');
+            if (!location) {
+                // A redirect status with nowhere to go is the server's
+                // problem; hand it back rather than inventing a target.
+                return response;
+            }
+
+            if (hop === MAX_REDIRECTS) {
+                throw new SsrfBlockedError(
+                    'lexical_blocked',
+                    `Too many redirects (more than ${MAX_REDIRECTS}) starting from ${origin}`,
+                );
+            }
+
+            const target = new URL(location, currentUrl);
+
+            if (target.origin !== origin) {
+                // Cross-origin: forward the method and nothing else. See the
+                // class docstring — an allow-list cannot tell a secret header
+                // from a benign one by its name.
+                currentInit = {
+                    method: REWRITE_TO_GET.has(response.status)
+                        ? 'GET'
+                        : (currentInit.method ?? 'GET'),
+                    redirect: 'manual',
+                };
+            } else if (REWRITE_TO_GET.has(response.status)) {
+                currentInit = {
+                    ...currentInit,
+                    method: 'GET',
+                    body: undefined,
+                    redirect: 'manual',
+                };
+            }
+
+            currentUrl = target.toString();
+            // The next iteration re-runs `safeFetchWithDnsPin`, so the new
+            // target gets the lexical guard and the DNS check afresh.
+        }
+
+        // Unreachable: the loop either returns or throws.
+        throw new SsrfBlockedError('lexical_blocked', 'Redirect handling fell through');
+    };
+}
+
+/** Exported for tests that need to assert what a cross-origin hop keeps. */
+export function survivingHeaders(
+    init: RequestInit | undefined,
+    crossOrigin: boolean,
+): [string, string][] {
+    return crossOrigin ? [] : headerEntries(init);
+}

--- a/packages/agent/src/mcp/mcp-sdk.ts
+++ b/packages/agent/src/mcp/mcp-sdk.ts
@@ -1,4 +1,5 @@
 import type { McpServerConnection } from '../entities/mcp-server-connection.entity';
+import { createGuardedFetch } from './guarded-fetch';
 
 /**
  * Agent Plugins MCP slice (plan §2.4) — the thin seam between
@@ -61,14 +62,31 @@ export function createSdkMcpClientFactory(): McpClientFactory {
             );
             const target = new URL(url);
             const requestInit: RequestInit = { headers };
+
+            // AP-15. Without this the SDK uses the global `fetch`, which
+            // follows redirects itself — so a server answering
+            // `302 Location: http://127.0.0.1:6379/` gets followed, and the
+            // custom auth headers above go with it (the platform strips
+            // `Authorization` cross-origin, but not `X-API-Key` and friends).
+            // The guarded fetch re-checks every hop and forwards no
+            // caller-supplied header across an origin boundary. It also closes
+            // DNS rebinding, which `isSafeWebhookUrl` explicitly does not:
+            // that guard is lexical, so a hostname resolving to a private
+            // address passes it.
+            const fetchImpl = createGuardedFetch();
+
             if (transport === 'sse') {
                 const { SSEClientTransport } =
                     await import('@modelcontextprotocol/sdk/client/sse.js');
-                await client.connect(new SSEClientTransport(target, { requestInit }));
+                await client.connect(
+                    new SSEClientTransport(target, { requestInit, fetch: fetchImpl }),
+                );
             } else {
                 const { StreamableHTTPClientTransport } =
                     await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
-                await client.connect(new StreamableHTTPClientTransport(target, { requestInit }));
+                await client.connect(
+                    new StreamableHTTPClientTransport(target, { requestInit, fetch: fetchImpl }),
+                );
             }
             return client as unknown as McpSdkClient;
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(@nestjs/terminus@11.1.1(8e47f099d440ece1608976bc60fdf283))(bullmq@5.79.0)(chokidar@4.0.3)(nodemailer@9.0.1)(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(@nestjs/terminus@11.1.1(8e47f099d440ece1608976bc60fdf283))(bullmq@5.79.0)(chokidar@3.6.0)(nodemailer@9.0.1)(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -307,16 +307,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -632,13 +632,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1053,6 +1053,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      isomorphic-git:
+        specifier: ^1.36.3
+        version: 1.37.1
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -1122,7 +1125,7 @@ importers:
         version: 9.39.2
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1321,13 +1324,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -22409,10 +22412,6 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
-    engines: {node: '>= 0.4'}
-
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
@@ -22867,6 +22866,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -22888,6 +22898,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -27852,7 +27872,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(@nestjs/terminus@11.1.1(8e47f099d440ece1608976bc60fdf283))(bullmq@5.79.0)(chokidar@4.0.3)(nodemailer@9.0.1)(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(@nestjs/terminus@11.1.1(8e47f099d440ece1608976bc60fdf283))(bullmq@5.79.0)(chokidar@3.6.0)(nodemailer@9.0.1)(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -27871,7 +27891,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -27898,7 +27918,36 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -27927,7 +27976,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -27938,17 +27987,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -28051,6 +28100,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -31772,6 +31832,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.3
+      semver: 7.8.1
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -36241,7 +36320,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.22
 
   es-define-property@1.0.1: {}
 
@@ -41439,13 +41518,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.5.4:
@@ -46564,16 +46643,6 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
-
-  which-typed-array@1.1.20:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which-typed-array@1.1.22:
     dependencies:


### PR DESCRIPTION
Phase 2a of the Agent Plugins v1.0.0 interop program (EW-772), covering **T17–T20**. Stacked on [#2325](https://github.com/ever-works/ever-works/pull/2325) — review that first; this PR's diff is only the three commits on top.

Strictly additive. Everything sits behind `FEATURE_AGENT_PLUGINS`, which still defaults to off.

## What this adds

| Task | Change |
| --- | --- |
| T17 | Git acquirer — URL-first shallow clone, ref pinning, resolved-SHA recording |
| T18 | npm acquirer — pacote manifest → allowlist → extract, no scripts, no dep install |
| T19 | Boot re-materialization, time-boxed inside the startupProbe window |
| T20 | Update detection for git + npm, and the facade finally calls the dead provider seam |

## Security properties, and why each is load-bearing

**The allowlist runs before the network, and fails closed.** An unreadable allowlist refuses every remote package rather than behaving like an empty one. Treating a database blip as "no restrictions configured" would turn an outage into unrestricted remote acquisition.

**A credential in a URL is refused — and the refusal does not repeat it.** The first version of that check interpolated the whole URL into its own error message, so refusing a credential-bearing URL leaked the credential into the API response, the package row and the log at once. A check that reports the secret it protects is worse than no check. Every message, response body and log line now goes through `redactUrl`, and a test asserts the serialised response body contains no password.

**`ext::sh -c whoami` parses as a URL.** It is caught by the https-only protocol rule, not by the parse. Relying on the parse to reject it would have let it through.

**Packages are never symlinked under `node_modules`.** The code-plugin installer does this so the loader can `import()` them; an Agent Plugins package is *data* and must never be importable. The absence of that call is the control, so it is asserted by a test rather than left as an omission.

**A package that fails validation is deleted, not just reported.** Otherwise the rejected tree stays in the packages root, where the local-directory scanner finds and loads it on the next boot — laundering a refused package into an accepted one.

**npm ranges are checked against the resolved version.** A `latest` dist-tag carries no version at request time, so checking the request would let it bypass the range entirely.

## Seams that did not match the plan

Two assumptions in `tasks.md` were wrong against live code, and both are documented in the source:

- **The git acquirer cannot go through `GitFacadeService`.** `cloneOrPull` is owner/repo-shaped and calls `resolvePluginAndToken`, so it needs an enabled git-provider plugin and a user credential. Package acquisition is an operator-level anonymous fetch, and routing it through the provider chain would fail on any deployment with no git plugin enabled — the same defect class as the facade early-return fixed in Phase 1. This is a standalone acquirer instead, and `isomorphic-git` is added to `packages/agent`.
- **`packages/agent` compiles with `strictNullChecks: false`**, so discriminated unions do not narrow. `if (!check.ok)` leaves the value unnarrowed and `check.reason` fails to compile. The conformance library is strict and uses unions freely; code bridging the two now uses an explicit nullable interface, with the reason recorded where someone would otherwise "simplify" it back.

## The dead seam

`ISkillsProviderPlugin.checkForUpdates` has been on the contract and implemented by `everworks-skills` and `composio` with **zero non-test callers** — a capability every provider was asked to implement and none was ever asked to perform. Wiring package updates without wiring this one would have left the same dead seam in place while appearing to add update support, so the facade now calls both, with package updates appended last so they cannot displace a provider's.

## Verification

- Agent suite: **9,932 passing**, 546 suites
- New: **65 tests** across 6 suites
- Regressions: **none** — 107 failing tests before and after, all pre-existing better-sqlite3 binding failures, none in `agent-plugins`
- Typecheck and Prettier clean

One test failure during development was a real bug in my own code (the credential leak above) rather than a bad assertion; a second was a test asserting an unreachable guard, and was rewritten to pin the behaviour that actually occurs.

## Not in this PR

T21 (Sources/Packages UI) and T22 (env wiring) follow in phase 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Agent Plugins management in Settings, including package search, status details, validation findings, and rejected or shadowed packages.
  - Added support for installing, removing, resynchronizing, and checking updates for Git- and npm-based plugins.
  - Added MCP server discovery and controlled package-provided connections.
  - Added deployment configuration for enabling plugins, stdio execution, plugin directories, and data storage.

- **Security**
  - Hardened MCP requests against unsafe redirects, header leakage, and DNS rebinding.
  - Added remote package allowlisting and validation.

- **Localization**
  - Added Agent Plugins translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->