### PR TITLE
fix(node): make the model-process deadline specs load-independent and keep the real-kill coverage

### DIFF
--- a/apps/node/src/core/model-execution/model-process.spec.ts
+++ b/apps/node/src/core/model-execution/model-process.spec.ts
@@ -55,6 +55,15 @@ const HUNG_CLOSE_TEST_BUDGET_MS = HUNG_CLOSE_DETECTION_MS + 4_000;
  * vitest budget stays above it so that diagnosis is what the failure shows.
  */
 const REAL_PROCESS_RUN_BUDGET_MS = 15_000;
+/**
+ * Real process-timer window left for the version probe once the injected clock
+ * has been advanced to just inside the deadline. Every per-process timer is a
+ * real `setTimeout` no matter what `monotonicNow` returns, so a probe overrun
+ * can only be provoked with real milliseconds; a stub child that never closes
+ * makes that timer the sole way the run can end, so load may delay the verdict
+ * but can never hand it to a competing outcome.
+ */
+const PROBE_OVERRUN_TIMER_MS = 50;
 
 const STUB_SOURCE = String.raw`
 const fs = require('node:fs');
@@ -458,6 +467,22 @@ function createVerifiedTestContainment(): NonNullable<ModelExecutionIo['createMo
 	};
 }
 
+/**
+ * A stub child that closes cleanly, driving every deadline-precedence test.
+ *
+ * It deliberately declares NO `exitCode`/`signalCode`. A child that has already
+ * exited reports a non-null `exitCode`, so `createVerifiedTestContainment`
+ * short-circuits on its first line and resolves `{ verified: true }` without
+ * ever reaching taskkill — that, not the length of the 2.5 s production settle
+ * window, is what keeps the precedence tests off `boundedProcessTreeTermination`'s
+ * real timer and makes them load-independent. Giving this stub `exitCode: null`
+ * (as `hangingProcess` does, for the opposite reason) is not a cosmetic
+ * "realism" fix: it sends all four precedence tests straight back to the CI
+ * signature this file was repaired for — verified by mutation, 4 failed with
+ * `expected 'termination-failed' to be 'timed-out'`. The invariant is pinned
+ * executably by 'keeps the deadline-precedence stubs on the sides of the
+ * containment short-circuit they depend on'.
+ */
 function closedProcess(stdoutText: string): ChildProcess {
 	const stdout = new PassThrough();
 	const stderr = new PassThrough();
@@ -465,6 +490,7 @@ function closedProcess(stdoutText: string): ChildProcess {
 		stdout,
 		stderr,
 		stdin: new PassThrough(),
+		// No exitCode/signalCode here on purpose — see the note above before adding them.
 		kill: () => true
 	}) as unknown as ChildProcess;
 	// Close on a later macrotask, not a microtask: `runProcess` awaits the
@@ -477,6 +503,26 @@ function closedProcess(stdoutText: string): ChildProcess {
 		setImmediate(() => child.emit('close', 0, null));
 	});
 	return child;
+}
+
+/**
+ * A stub child that never closes, so the only way out of `runProcess` is its
+ * per-process timer. It reports itself alive (`exitCode`/`signalCode` null) the
+ * way a real hung child does, which is what makes the termination path — not a
+ * lucky exit — the thing under test. That pair is exactly what `closedProcess`
+ * must never grow: the two stubs sit on opposite sides of the
+ * `createVerifiedTestContainment` short-circuit deliberately, so consolidating
+ * them re-arms the deadline-precedence flake.
+ */
+function hangingProcess(): ChildProcess {
+	return Object.assign(new EventEmitter(), {
+		stdout: new PassThrough(),
+		stderr: new PassThrough(),
+		stdin: new PassThrough(),
+		exitCode: null,
+		signalCode: null,
+		kill: () => true
+	}) as unknown as ChildProcess;
 }
 
 function envValue(env: Record<string, string>, name: string): string | undefined {
@@ -1658,6 +1704,43 @@ if (process.argv.includes('--version')) {
 	);
 });
 
+// Every deadline- and cancellation-precedence test below asserts WHICH terminal
+// status wins, so none of them may let a real subprocess race a real timer for
+// that answer. The injected `monotonicNow` supplies only the numbers; each
+// per-process timer is still a real `setTimeout`
+// (model-process.internal.ts:1311), so a 1 s request budget armed a REAL 1 s
+// window around the version-probe subprocess. A saturated 33-shard runner needs
+// about that long just to boot and exit a bare Node process, so the probe was
+// killed, its containment close could not prove the tree dead, and
+// `resolveCliVersionProbe` (internal.ts:1039) short-circuited the whole run into
+// `toTerminalResult`, where `terminationFailure` (internal.ts:1553) outranks
+// `termination` (internal.ts:1563). That reddened #2297, #2303, #2304 and #2305
+// on 2026-09-03, always as `expected 'termination-failed' to be 'timed-out'`.
+// The precedence is correct — an agent whose credential-bearing tree cannot be
+// proven dead must not be reported as a routine, retryable timeout — and it is
+// not what these tests are for, so the precedence tests now drive closed stubs
+// (`closedProcess`) on the real-process request budget and the fake clock is the
+// only thing that moves a deadline.
+//
+// No coverage moved. The probe-overrun precedence those tests were accidentally
+// racing is now pinned on both sides, deterministically, by 'a proven /
+// unprovable kill ... when the version probe overruns its budget' below: its
+// stub child never closes, so the process timer is the only possible outcome and
+// load can only make the verdict later, never different. The
+// `termination-failed` status itself stays pinned by 'fails closed and stays
+// bounded when an acquired but unused containment close rejects / never
+// settles', the 2.5 s production bound by the `terminationSettleMs` clamp table,
+// and the real taskkill by the tests named above the 'real process boundary'
+// describe, where the real kill IS the subject — but on windows-2022 only.
+// The `lint-and-test` ubuntu job that went red here has never run a real
+// process-tree kill: the it.runIf(win32) tests skip outright, and the two plain
+// ones return at `!process.env.SystemRoot` in `createVerifiedTestContainment`
+// before taskkill.exe is spawned (which is why their expected status is
+// platform-conditional). So on ubuntu the precedence coverage is the
+// deterministic pair below — previously ubuntu had it only by accident, through
+// the flake itself. Anyone tempted to stub more of the win32 describe should
+// weigh that against .github/workflows/windows-job-launcher.yml, which is the
+// only job where the real kill actually runs.
 describe('executeModelProcess — request refusal', () => {
 	it('refuses a local session request that also smuggles a raw credential environment', async () => {
 		const harness = await createHarness('success');
@@ -1778,25 +1861,61 @@ describe('executeModelProcess — request refusal', () => {
 		await expect(access(harness.capturePath)).rejects.toThrow();
 	});
 
+	// Executable guard for the one unstated fact the four precedence tests below
+	// rest on. Their determinism is not a margin, it is a branch: `closedProcess`
+	// reports an exited child, so the containment close returns verified without
+	// touching taskkill or the 2.5 s settle timer, while `hangingProcess` reports
+	// a live one and cannot be verified. Adding `exitCode: null` to
+	// `closedProcess` reproduces the original CI failure on all four
+	// (`expected 'termination-failed' to be 'timed-out'`), so the invariant is
+	// asserted here rather than left to a comment a refactor can out-run.
+	it('keeps the deadline-precedence stubs on the sides of the containment short-circuit they depend on', async () => {
+		const createContainment = createVerifiedTestContainment();
+		const exited = await createContainment((() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn);
+		await exited.spawn('node', [], {});
+		const alive = await createContainment((() => hangingProcess()) as typeof spawn);
+		await alive.spawn('node', [], {});
+		const neverSpawned = await createContainment((() => closedProcess('')) as typeof spawn);
+
+		await expect(exited.close()).resolves.toEqual({ verified: true });
+		await expect(neverSpawned.close()).resolves.toEqual({ verified: true });
+		// Never a real taskkill: the stub carries no pid, so this is the same
+		// verdict on ubuntu and windows-2022.
+		await expect(alive.close()).resolves.toMatchObject({ verified: false });
+	});
+
 	it('rechecks the monotonic deadline immediately before the credentialed model spawn', async () => {
 		const harness = await createHarness('success');
 		let monotonicTime = 0;
 		let spawnCount = 0;
-		const baseSpawn = harness.spawnWithTaskkill();
-		const result = await executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-			...harness.io,
-			monotonicNow: () => monotonicTime,
-			beforeSpawn: (purpose) => {
-				if (purpose === 'model') monotonicTime = 1_001;
-			},
-			spawnFn: ((...args: Parameters<typeof spawn>) => {
-				spawnCount += 1;
-				return baseSpawn(...args);
-			}) as typeof spawn
-		});
+		const spawnPurposes: string[] = [];
+		const result = await executeModelProcess(
+			request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+			{
+				...harness.io,
+				monotonicNow: () => monotonicTime,
+				beforeSpawn: (purpose) => {
+					spawnPurposes.push(purpose);
+					if (purpose === 'model') monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+				},
+				// The recheck under test is reached only after a clean probe, so
+				// the probe is a stub that closes without a subprocess and the
+				// request budget is the real-process one: a 1 s budget armed a
+				// real 1 s timer around a real probe child and the resulting
+				// unprovable kill reported termination-failed instead.
+				spawnFn: (() => {
+					spawnCount += 1;
+					return closedProcess('codex-cli 0.146.0\n');
+				}) as typeof spawn
+			}
+		);
 
 		expect(result.status).toBe('timed-out');
+		expect(result.summary).toMatch(/wall-clock/i);
 		expect(spawnCount).toBe(1);
+		// Without this the run could satisfy both assertions above by dying at
+		// the version probe and never reaching the recheck this test names.
+		expect(spawnPurposes).toEqual(['version-probe', 'model']);
 		await expect(access(harness.capturePath)).rejects.toThrow();
 	});
 
@@ -1805,28 +1924,37 @@ describe('executeModelProcess — request refusal', () => {
 		let monotonicTime = 0;
 		let containmentCount = 0;
 		const baseCreateContainment = harness.io.createModelProcessContainment!;
-		const result = await executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-			...harness.io,
-			monotonicNow: () => monotonicTime,
-			createModelProcessContainment: async (spawnFn) => {
-				const containment = await baseCreateContainment(spawnFn);
-				containmentCount += 1;
-				// The first containment owns the version probe. Advance the fake
-				// deadline only for the credentialed model process this test names;
-				// attaching to both made the outcome depend on probe close ordering.
-				if (containmentCount === 1) return containment;
-				return {
-					...containment,
-					spawn: (async (...args: Parameters<TestContainment['spawn']>) => {
-						const child = await containment.spawn(...args);
-						child.once('close', () => {
-							monotonicTime = 1_001;
-						});
-						return child;
-					}) as TestContainment['spawn']
-				};
+		const result = await executeModelProcess(
+			request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+			{
+				...harness.io,
+				monotonicNow: () => monotonicTime,
+				// The close event is what this test is about, and a stub emits the
+				// same one through the same handler without putting two real
+				// subprocesses under two real sub-second timers: with a 1 s budget
+				// either child could overrun, and the unprovable kill that followed
+				// reported termination-failed instead of the deadline.
+				spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+				createModelProcessContainment: async (spawnFn) => {
+					const containment = await baseCreateContainment(spawnFn);
+					containmentCount += 1;
+					// The first containment owns the version probe. Advance the fake
+					// deadline only for the credentialed model process this test names;
+					// attaching to both made the outcome depend on probe close ordering.
+					if (containmentCount === 1) return containment;
+					return {
+						...containment,
+						spawn: (async (...args: Parameters<TestContainment['spawn']>) => {
+							const child = await containment.spawn(...args);
+							child.once('close', () => {
+								monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+							});
+							return child;
+						}) as TestContainment['spawn']
+					};
+				}
 			}
-		});
+		);
 
 		expect(result.status).toBe('timed-out');
 		expect(result.summary).toMatch(/wall-clock/i);
@@ -1877,29 +2005,101 @@ describe('executeModelProcess — request refusal', () => {
 		expect(spawnPurposes).toEqual(['version-probe']);
 	});
 
+	it.each([
+		['a proven kill still reports the deadline', { verified: true }, 'timed-out', /exceeded its wall-clock limit/],
+		[
+			'an unprovable kill outranks the deadline',
+			{ verified: false, detail: 'test taskkill exited with code 128' },
+			'termination-failed',
+			/termination was not verified: test taskkill exited with code 128/
+		]
+	] as const)('%s when the version probe overruns its budget', async (_shape, closeOutcome, status, summary) => {
+		const harness = await createHarness('success');
+		let monotonicTime = 0;
+		let closeCalls = 0;
+		const spawnPurposes: string[] = [];
+		let deferredRunRoot: string | undefined;
+		try {
+			const result = await executeModelProcess(
+				request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+				{
+					...harness.io,
+					monotonicNow: () => monotonicTime,
+					directoryExists: async () => true,
+					removeRunRoot: async (path) => {
+						deferredRunRoot = path;
+					},
+					// Filesystem preparation keeps the full real-process budget —
+					// every preparation step is wrapped in a real deadline timer, so
+					// a small request budget would starve the setup rather than the
+					// probe. Only once the probe is about to spawn does the injected
+					// clock leave PROBE_OVERRUN_TIMER_MS, which is exactly what
+					// `runProcess` arms its real per-process timer with.
+					beforeSpawn: (purpose) => {
+						spawnPurposes.push(purpose);
+						if (purpose === 'version-probe') {
+							monotonicTime = REAL_PROCESS_RUN_BUDGET_MS - PROBE_OVERRUN_TIMER_MS;
+						}
+					},
+					spawnFn: (() => hangingProcess()) as typeof spawn,
+					createModelProcessContainment: async (spawnFn) => ({
+						spawn: (executable, arguments_, options) => spawnFn(executable, [...arguments_], options),
+						close: async () => {
+							closeCalls += 1;
+							return closeOutcome;
+						}
+					})
+				}
+			);
+
+			expect(result.status).toBe(status);
+			expect(result.summary).toMatch(summary);
+			// This is the pair the flaky deadline tests used to decide by accident:
+			// the overrun must actually request the process-tree kill, and only an
+			// unprovable kill may displace the deadline the run asked for.
+			expect(closeCalls).toBe(1);
+			expect(result.exitCode).toBeNull();
+			// A probe that had to be killed never reaches the credentialed model.
+			expect(spawnPurposes).toEqual(['version-probe']);
+		} finally {
+			if (deferredRunRoot) await rm(deferredRunRoot, { recursive: true, force: true });
+		}
+	});
+
 	it('closes containment acquired exactly as the absolute budget expires before model spawn', async () => {
 		const harness = await createHarness('success');
 		let monotonicTime = 0;
 		let closeCalls = 0;
 		let modelSpawned = false;
-		const result = await executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-			...harness.io,
-			monotonicNow: () => monotonicTime,
-			spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
-			createModelProcessContainment: async () => {
-				monotonicTime = 1_001;
-				return {
-					spawn: (() => {
-						modelSpawned = true;
-						throw new Error('model must not spawn after the deadline');
-					}) as typeof spawn,
-					close: async () => {
-						closeCalls += 1;
-						return { verified: true };
-					}
-				};
+		// Same family as the tests above, caught before it could redden a run:
+		// the injected clock only moves at containment acquisition, so with a 1 s
+		// budget every preparation step before that (validate, trusted command,
+		// run-root realpath + mkdtemp + mkdirs — internal.ts:316-413) sat inside
+		// a REAL 1 s `withinExecutionDeadline` timer. Overrunning any of them
+		// ends the run before acquisition, leaving `expected 0 to be 1` on
+		// closeCalls. The fake clock jump is what proves the deadline here, so
+		// the real number only has to be too large for a real timer to pre-empt.
+		const result = await executeModelProcess(
+			request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+			{
+				...harness.io,
+				monotonicNow: () => monotonicTime,
+				spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+				createModelProcessContainment: async () => {
+					monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+					return {
+						spawn: (() => {
+							modelSpawned = true;
+							throw new Error('model must not spawn after the deadline');
+						}) as typeof spawn,
+						close: async () => {
+							closeCalls += 1;
+							return { verified: true };
+						}
+					};
+				}
 			}
-		});
+		);
 
 		expect(result.status).toBe('timed-out');
 		expect(closeCalls).toBe(1);
@@ -2186,25 +2386,37 @@ describe('executeModelProcess — request refusal', () => {
 		const baseCreateContainment = harness.io.createModelProcessContainment!;
 		let containmentCount = 0;
 		let monotonicTime = 0;
-		const result = await executeModelProcess(request('codex', harness.workspacePath, { timeoutMs: 1_000 }), {
-			...harness.io,
-			monotonicNow: () => monotonicTime,
-			createModelProcessContainment: async (spawnFn) => {
-				const containment = await baseCreateContainment(spawnFn);
-				containmentCount += 1;
-				if (containmentCount === 1) return containment;
-				return {
-					...containment,
-					spawn: async () => {
-						monotonicTime = 1_001;
-						throw new Error('trusted broker stopped after deadline');
-					}
-				};
+		const result = await executeModelProcess(
+			request('codex', harness.workspacePath, { timeoutMs: REAL_PROCESS_RUN_BUDGET_MS }),
+			{
+				...harness.io,
+				monotonicNow: () => monotonicTime,
+				// The launcher under test rejects before it ever calls the base
+				// spawn, so the version probe was the only real subprocess here —
+				// and under a 1 s budget its real timer, not this launcher, decided
+				// the status. A closed stub leaves the launcher as the only path to
+				// a terminal result.
+				spawnFn: (() => closedProcess('codex-cli 0.146.0\n')) as typeof spawn,
+				createModelProcessContainment: async (spawnFn) => {
+					const containment = await baseCreateContainment(spawnFn);
+					containmentCount += 1;
+					if (containmentCount === 1) return containment;
+					return {
+						...containment,
+						spawn: async () => {
+							monotonicTime = REAL_PROCESS_RUN_BUDGET_MS + 1;
+							throw new Error('trusted broker stopped after deadline');
+						}
+					};
+				}
 			}
-		});
+		);
 
 		expect(result.status).toBe('timed-out');
 		expect(result.summary).toMatch(/wall-clock/i);
+		// Without this the run could satisfy both assertions above by failing at
+		// the version probe and never reaching the launcher this test names.
+		expect(containmentCount).toBe(2);
 	});
 
 	it('bounds a never-resolving workspace validation inside the one execution deadline', async () => {


### PR DESCRIPTION
## What

`apps/node/src/core/model-execution/model-process.spec.ts` has been failing intermittently on the CI job **`lint-and-test (22.x)`** (ubuntu runners, 33 e2e shards saturating the pool). It reddened four different pull requests on 2026-09-03 — **#2297, #2303, #2304, #2305** — several times each, always in the `describe('executeModelProcess — request refusal')` block and always with the same assertion:

```
AssertionError: expected 'termination-failed' to be 'timed-out'
```

The affected tests:

- `rechecks the monotonic deadline immediately before the credentialed model spawn`
- `makes the absolute deadline win when a contained model closes after its budget`
- `makes the absolute deadline win when the trusted async launcher rejects after the budget`

All three assert **which terminal status wins**, yet each let a real subprocess race a real timer for that answer. They inject a fake clock (`monotonicNow`) and a `timeoutMs` of `1_000`, but the `1_000` also lands on a **real** `setTimeout` wrapped around a **real** node subprocess (the harness stub CLI). A loaded runner needs roughly that long just to boot and exit a bare Node process, so the version probe got killed, its containment close could not prove the process tree dead, and the safety status displaced the deadline status the test was written to observe.

A neighbouring pair (`distinguishes a structured codex model failure`, `charges a slow version probe against the single execution deadline`) occasionally timed out instead — same cause, different symptom.

## Root cause

**Not a production defect.** The chain was verified end to end against `apps/node/src/core/model-execution/model-process.internal.ts` rather than taken on trust:

| Step | Location |
| --- | --- |
| The probe budget is `Math.min(probeBudgetMs, MODEL_CLI_VERSION_PROBE_TIMEOUT_MS)` = `min(1000, 10000)` = **1000 ms** | `internal.ts:396` |
| …armed as a **real** timer around a **real** child: `setTimeout(() => requestTermination('timed-out'), processTimeoutMs)` | `internal.ts:1311` |
| The real timer beats the real child → `requestTermination` → tree safety → `containment.close()` against a live child → unverifiable | `internal.ts:1289-1311` |
| A probe that terminated abnormally short-circuits the whole run | `resolveCliVersionProbe`, `internal.ts:1039` |
| In `toTerminalResult`, `if (raw.terminationFailure)` precedes `if (raw.termination)` | `internal.ts:1553` vs `internal.ts:1563` |

The injected `monotonicNow` supplies only the *numbers*; it does not suspend a single real timer. So the deadline logic itself was deterministic while the subprocess it was measured against was not.

**The precedence at `internal.ts:1553` is correct and is deliberately left untouched.** An agent whose credential-bearing process tree cannot be proven dead must never be reported as a routine, retryable `timed-out`. Likewise the settle window is correctly measured on the real clock (production passes `performance.now()` at `internal.ts:301`) — letting a fake clock suspend a real safety deadline would be strictly worse, which is why `resolveTerminationSettleMs` (`internal.ts:1326-1331`) already clamps the test seam so it can only ever *shorten*. This is a spec budget defect, and it is fixed in the spec.

Proof by construction that the **probe**, not the model, was the source: in `makes the absolute deadline win when the trusted async launcher rejects after the budget`, the model containment's `spawn` throws before ever calling the base spawn, so the model child is `null` and its close returns `verified: true` instantly — yet that test still failed.

**Correction to the original diagnosis, worth carrying forward:** on the ubuntu `lint-and-test` job the discriminator is *not* the 2.5 s `TERMINATION_SETTLE_MS` window. `process.env.SystemRoot` is undefined on Linux, so the harness containment's close returns `{ verified: false }` **instantly**. On ubuntu, "probe overran its 1 s real budget" converts to `termination-failed` 100% of the time, not as a settle race — the settle window only discriminates on `windows-2022`. Anyone re-deriving this from the settle window will reach the wrong hypothesis.

## What changed

One file: `apps/node/src/core/model-execution/model-process.spec.ts` (test-only, +277/−65). `model-process.internal.ts` is byte-identical to `origin`.

**Four precedence tests de-flaked** — the same treatment #2310 already applied to their sibling, applied to the ones it missed. Each now drives the file's existing `closedProcess('codex-cli 0.146.0\n')` stub instead of a real version-probe subprocess, and carries `REAL_PROCESS_RUN_BUDGET_MS` instead of `1_000`, so no real timer is sub-second. The fake-clock jump is what proves deadline precedence; the real number only has to be large enough that no real timer can pre-empt it. Nothing was deleted, skipped, retried or loosened, and every original assertion is kept.

The fourth is `closes containment acquired exactly as the absolute budget expires before model spawn` — same family, caught before it could redden a run. It spawns no real subprocess, but its clock only moved at containment acquisition, so run-root preparation (`realpath`, `mkdtemp`, 8 `mkdir`s — `internal.ts:316-413`) sat inside a real 1 s `withinExecutionDeadline` window; an overrun would have left `expected 0 to be 1` on `closeCalls`.

**Two silent coverage holes closed.** Two of the tests could previously go green *for the wrong reason* — the probe short-circuits and the named mechanism never runs. They now assert they reached the stage they name: `expect(spawnPurposes).toEqual(['version-probe', 'model'])` on the model-spawn recheck, `expect(containmentCount).toBe(2)` on the async-launcher test, plus a `/wall-clock/i` summary assertion on the first.

**New deterministic coverage for the mechanism the flake was exercising by accident.** An `it.each` pair, `a proven / an unprovable kill ... when the version probe overruns its budget`, backed by a new `hangingProcess()` stub child that **never closes**. The injected clock is advanced once in `beforeSpawn('version-probe')` to leave `PROBE_OVERRUN_TIMER_MS` (50 ms) and then stays static, so `remainingMs` is a constant 50: the pre-spawn deadline checks at `internal.ts:1148-1153` can never trip and the real 50 ms process timer is the **only** way the run can end. Load can make the verdict later, never different — load-independent *by construction*, not by margin. It asserts `closeCalls === 1` (the kill really is requested), `exitCode === null` (killed, not exited), `spawnPurposes === ['version-probe']` (the model is never reached), and both status/summary outcomes.

**A guard test for the invariant the determinism rests on:** `keeps the deadline-precedence stubs on the sides of the containment short-circuit they depend on`. `closedProcess` deliberately declares no `exitCode`, so `createVerifiedTestContainment` short-circuits to `{ verified: true }` without touching taskkill; `hangingProcess` reports itself alive and cannot be verified. Adding `exitCode: null` to `closedProcess` as a cosmetic "realism" fix sends all four precedence tests straight back to the original CI signature — verified by mutation — so the invariant is now asserted executably rather than left to a comment a refactor can out-run.

A comment block above the describe records all of this in the file's existing evidence-citing voice, with the exact `internal.ts` line numbers, the four PR numbers, and the verbatim assertion.

## Why coverage did not shrink

**Nothing moved and nothing was lost.** The three flaky tests never provided real-kill coverage in the first place — they asserted *against* it (`timed-out`), and only reached the kill path by accident.

Where the real process-tree kill and the `termination-failed` status are still proven, all untouched:

- **`termination-failed` status:** `fails closed and stays bounded when an acquired but unused containment close rejects / never settles` remains the dedicated deterministic pin for the status and both summary shapes.
- **The 2.5 s production bound:** the `terminationSettleMs` clamp table (`never lets a larger / NaN / negative / Infinity ... extend the production safety deadline`) still pins `TERMINATION_SETTLE_MS = 2500` and the seam's shorten-only clamp, measuring the real window from the close call.
- **The real taskkill:** still owned by the tests named in the residual-sensitivity comment above the `real process boundary` describe — `closes version-probe containment on output limit / timeout / AbortSignal cancellation`, `kills the whole spawned process tree on timeout so no grandchild survives`, `fails closed when the containment boundary cannot verify descendant termination`, `bounds a hung containment close`, `kills the process tree and reports cancellation when its AbortSignal fires`, `terminates and reports output that exceeds the hard byte bound`, `redacts a credential fragment cut by the raw output ceiling`. In particular `closes version-probe containment on timeout before a model can start` already owns the exact real scenario the flaky tests were accidentally exercising, so no coverage needed relocating.
- **New, and net-positive for the job that was actually red:** the deterministic `it.each` pair runs on ubuntu, where every `it.runIf(win32)` real-taskkill test is *skipped*. The `lint-and-test` job therefore **gains** precedence coverage it previously had only by accident, through the flake itself.

The new test was proved non-vacuous by mutation. Temporarily relaxing `internal.ts:1553` to `if (raw.terminationFailure && !raw.termination)` produced, in 185 ms with no subprocess:

```
FAIL  ... > an unprovable kill outranks the deadline when the version probe overruns its budget
AssertionError: expected 'timed-out' to be 'termination-failed'
```

The mutation was reverted and `internal.ts` re-verified byte-identical to `origin`.

## Verification

**Before/after under matched load** (this box has 4 CPUs; load was applied with concurrent runs plus busy CPU workers):

| Tree | Load | Result for the three named tests |
| --- | --- | --- |
| base (`58239cdd4`) | none | pass |
| base | 3 concurrent runs only | pass — *two extra runs alone do not stress a 4-CPU box enough to discriminate* |
| base | 3 concurrent runs + 8 busy CPU workers | **RED 3/3 runs**, all three tests failing every run with `expected 'termination-failed' to be 'timed-out'` |
| fixed | none | pass 5/5 |
| fixed | identical heavy load | **pass 6/6** |

Across **18 full-file runs of the fixed tree**, including 6 heavily contended ones, a grep over all 13 loaded logs for any failure naming the four fixed tests or the two new rows came back **empty** — they never failed once.

**Final gates on the committed tree:**

- `cd apps/node && npx vitest run src/core/model-execution/model-process.spec.ts` — **3 consecutive green runs**, `Tests 92 passed (92)` each (42.09s / 41.76s / 41.84s). Base was 89; the +3 are the guard test and the two `it.each` rows.
- `cd apps/node && npx tsc --noEmit` — clean, no output.
- `npx prettier --check apps/node/src/core/model-execution/model-process.spec.ts` — `All matched files use Prettier code style!`
- No `console.log` added.

**On the other failures seen under artificial flood:** they are pre-existing and this was proved, not asserted — the base-tree control at identical load produced the same 11 real-boundary failures. They are the documented residual real-taskkill sensitivity that #2310 deliberately left; 7 are `it.runIf(win32)` and are skipped on the ubuntu `lint-and-test` job that was red, so they are not the CI problem being chased.

## Relationship to #2310

This **complements** PR #2310 (merged into `develop` earlier, by another engineer), which de-flaked a *different* family in the same file — the `expected hung to be result` real-process-boundary case — and added the injected I/O seams (`directoryExists`, `removeRunRoot`), the `terminationSettleMs` seam and `testTimeout: 30000`. That PR's body states deliberately that the remaining real-taskkill load sensitivity on `windows-2022` was documented rather than loosened, because the real kill path is those tests' subject. That intent is respected here: the real-kill tests are untouched, and this change only stops tests that are *not* about the real kill from accidentally depending on it.

## Follow-ups (not in this PR)

- **A minor production wart, verified and deliberately not fixed.** `boundedProcessTreeTermination` (`internal.ts:1333-1349`) arms its 2500 ms safety timer and only *then* invokes the kill on a microtask (`internal.ts:1353`). For the non-containment path that operation is `terminateProcessTree`, which spends budget on three sequential `realpath` round-trips in `resolveWindowsTreeKiller` (`internal.ts:1504-1512`) and the taskkill spawn (`internal.ts:1434`) before any process is signalled — none of it "settling". Worse, the inner `WINDOWS_TREE_KILL_TIMEOUT_MS = 2000` watchdog (`internal.ts:179`, armed `:1448`) is nested inside the outer 2500 ms window, leaving 500 ms of headroom. Consequences are diagnostic, not behavioural: on a loaded host the generic outer verdict pre-empts the more actionable inner `taskkill did not settle within 2000 ms` / `taskkill exited with code N`, and the effective settle allowance shrinks by however long path canonicalization takes. This changes no status and de-flakes nothing, and the `terminationSettleMs` clamp table measures the *current* arming point, so moving it moves that test's bounds and comment. Correct shape for a separate commit: arm the safety window at the moment the kill is actually requested, and size the outer window strictly greater than the nested watchdog.
- `withholds provider credentials and unsafe proxy data from the contained model and close path` is a real-subprocess test that failed on both trees under flood but is **not** in #2310's documented residual-sensitivity list. Worth adding to that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved process deadline and cancellation tests to behave consistently under CI load.
  * Added coverage for timeout precedence when process termination is verified or cannot be verified.
  * Strengthened assertions confirming the expected process and containment paths are exercised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->