### PR TITLE
ci: retry the dependency audit on a transport error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,45 @@ jobs:
         shell: bash
         run: |
           set +e
-          output="$(pnpm audit --prod --audit-level=high 2>&1)"
-          code=$?
+          # Retry the whole audit, not just the request. pnpm already retries
+          # the HTTP call three times internally (immediate, +10s, +1min) and
+          # STILL returns ERR_SOCKET_TIMEOUT when npm's audit endpoint is
+          # having a bad few minutes: observed four times in a row on one PR
+          # while `develop` passed in the same window. That is an outage, not
+          # a finding, and it was hard-failing unrelated PRs.
+          #
+          # This does NOT weaken the gate: a genuine HIGH/CRITICAL result is
+          # deterministic, so it reproduces on every attempt and still fails
+          # below. Only a transient transport error benefits from a retry.
+          attempt=1
+          max_attempts=3
+          while :; do
+            output="$(pnpm audit --prod --audit-level=high 2>&1)"
+            code=$?
+            if [ "$code" -eq 0 ]; then
+              printf '%s\n' "$output"
+              exit 0
+            fi
+            # Retry ONLY on a transport-level failure. A real advisory, and the
+            # retired-endpoint response handled below, are both reproducible,
+            # so retrying either just spends minutes reaching the same answer.
+            if [ "$attempt" -ge "$max_attempts" ] || ! printf '%s' "$output" | grep -qE 'ERR_SOCKET_TIMEOUT|ECONNRESET|ETIMEDOUT|EAI_AGAIN'; then
+              break
+            fi
+            echo "::notice title=Retrying dependency audit::Transport error on attempt ${attempt}/${max_attempts}; retrying in $((attempt * 15))s."
+            sleep "$((attempt * 15))"
+            attempt=$((attempt + 1))
+          done
           printf '%s\n' "$output"
-          if [ "$code" -eq 0 ]; then
-            exit 0
-          fi
           # Detect the endpoint outage by pnpm's OWN error CODE only — not by
           # human-language phrases like "410"/"retired", which could legitimately
           # appear inside a real CVE advisory description and wrongly soft-pass a
           # run that has actual vulnerabilities. `ERR_PNPM_AUDIT_BAD_RESPONSE` is
           # emitted only when the audit endpoint returns an unusable response; a
           # genuine high/critical finding never prints this token, so it still
-          # hard-fails below. Any other non-endpoint error (e.g. a network blip)
-          # also hard-fails — the conservative default.
+          # hard-fails below. A transport error has already been retried above
+          # and still hard-fails here if it never succeeded: retrying changes
+          # how often we ask, never what counts as a finding.
           if printf '%s' "$output" | grep -qF 'ERR_PNPM_AUDIT_BAD_RESPONSE'; then
             echo "::warning title=Dependency audit skipped::npm's audit endpoint is unavailable (ERR_PNPM_AUDIT_BAD_RESPONSE — legacy audit API retired, HTTP 410). The high/critical audit gate is soft for this run and re-arms automatically once a working endpoint is restored."
             exit 0


### PR DESCRIPTION
`dependency-audit` failed **four times in a row** on [#2325](https://github.com/ever-works/ever-works/pull/2325) with `ERR_SOCKET_TIMEOUT` contacting npm's audit endpoint, while `develop` passed in the same window. That is an endpoint outage, not a finding, and it was hard-failing an unrelated PR.

pnpm already retries the HTTP call three times internally (immediate, +10s, +1min) and *still* returns `ERR_SOCKET_TIMEOUT` when the endpoint is having a bad few minutes — so the retry has to wrap the whole audit rather than the request.

## This does not weaken the gate

That distinction is the whole design. A genuine HIGH/CRITICAL result is **deterministic** — it reproduces on every attempt, so retrying it changes nothing except how long you wait for the same answer. Only a *transport* error benefits from asking again.

So the retry is conditional on a transport-level error (`ERR_SOCKET_TIMEOUT`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`). A real advisory and the retired-endpoint (`ERR_PNPM_AUDIT_BAD_RESPONSE`, HTTP 410) response are both reproducible, so neither is retried. **Retrying changes how often we ask, never what counts as a finding.**

The existing soft-pass for the retired endpoint is untouched, and the existing hard-fail still runs after the loop.

## Verified against a stubbed pnpm

CI behaviour is otherwise only observable in production, so I extracted the step from the YAML and ran it against a fake `pnpm` covering each case:

| Scenario | Exit | `pnpm` calls | |
| --- | --- | --- | --- |
| Clean audit | 0 | 1 | passes, no retry |
| **Real HIGH vulnerability** | **1** | **1** | **fails at once — no retry** |
| Retired endpoint (410) | 0 | 1 | soft-pass preserved |
| Timeout ×2 then success | 0 | 3 | retries, then passes |
| Timeout on every attempt | 1 | 3 | gives up and fails |

The second row is the one that matters: a real finding still fails on the **first** attempt.

## Why this is its own PR

I hit this while working on the Agent Plugins program and deliberately kept it out of that feature branch — loosening or even touching a security gate does not belong inside an unrelated feature PR, and this deserves to be reviewed on its own terms. Reject it freely if you would rather absorb the flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
