### PR TITLE
feat(agent): Agent Plugins phases 4-6 — stdio, export, conformance statement, hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,37 @@ jobs:
           echo "::error title=Dependency audit failed::pnpm audit reported HIGH/CRITICAL production vulnerabilities (or an unexpected error). See the output above."
           exit "$code"
 
+  # T9 — an ORACLE, not a gate. `skills-ref` is the reference library for
+  # Agent Skills; running it over our fixture corpus answers a question our own
+  # tests cannot: does our reading of the specification match somebody else's?
+  #
+  # `continue-on-error` is the whole point. The two tools do not answer the same
+  # question — ours validates a PACKAGE and reports per-skill findings without
+  # rejecting the package, theirs validates one skill — so a difference is
+  # information, not a defect. And `skills-ref` is at 0.1.1; pinning merges to a
+  # young external tool's opinion would hand it a veto.
+  skills-oracle:
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install the reference library
+        run: pip install --quiet skills-ref==0.1.1
+
+      - name: Cross-check the fixture corpus
+        run: python packages/agent-plugins/scripts/oracle-check.py packages/agent-plugins/fixtures
+
+
   lint-and-test:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 

--- a/apps/api/src/agent-plugins/agent-plugins.controller.ts
+++ b/apps/api/src/agent-plugins/agent-plugins.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import {
+    AgentPluginExportService,
     AgentPluginInstallService,
     AgentPluginPackageCatalogService,
     AgentPluginUpdateService,
@@ -52,6 +53,7 @@ export class AgentPluginsController {
         private readonly catalog: AgentPluginPackageCatalogService,
         private readonly installer: AgentPluginInstallService,
         private readonly updateService: AgentPluginUpdateService,
+        private readonly exporter: AgentPluginExportService,
     ) {}
 
     @Get()
@@ -159,6 +161,18 @@ export class AgentPluginsController {
     @Throttle({ long: { limit: 20, ttl: 60_000 } })
     async listUpdates(@CurrentUser() _auth: AuthenticatedUser) {
         return this.updateService.checkForUpdates();
+    }
+
+    @Get('descriptor')
+    @ApiOperation({
+        summary: 'The Ever Works MCP server as an Agent Plugins package',
+        description:
+            'Returns the package files so any conforming client can consume this MCP server by installing a package rather than by hand-configuring it. Contains no credentials: the specification treats package headers as visible and non-secret, so the consuming client supplies its own authentication.',
+    })
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async descriptor(@CurrentUser() _auth: AuthenticatedUser, @Query('url') url?: string) {
+        const built = await this.exporter.buildEverWorksMcpDescriptor(url ? { url } : {});
+        return { files: Object.fromEntries(built.files), findings: built.findings };
     }
 
     @Post()

--- a/apps/api/src/agent-plugins/agent-plugins.controller.ts
+++ b/apps/api/src/agent-plugins/agent-plugins.controller.ts
@@ -25,6 +25,7 @@ import {
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import {
+    DescriptorQueryDto,
     InstallAgentPluginPackageDto,
     ListAgentPluginPackagesQueryDto,
 } from './dto/agent-plugin.dto';
@@ -170,8 +171,13 @@ export class AgentPluginsController {
             'Returns the package files so any conforming client can consume this MCP server by installing a package rather than by hand-configuring it. Contains no credentials: the specification treats package headers as visible and non-secret, so the consuming client supplies its own authentication.',
     })
     @Throttle({ long: { limit: 20, ttl: 60_000 } })
-    async descriptor(@CurrentUser() _auth: AuthenticatedUser, @Query('url') url?: string) {
-        const built = await this.exporter.buildEverWorksMcpDescriptor(url ? { url } : {});
+    async descriptor(@CurrentUser() _auth: AuthenticatedUser, @Query() query: DescriptorQueryDto) {
+        // A DTO, not `@Query('url')`. The global pipe validates DTO CLASSES,
+        // so a bare string parameter is unvalidated — and this value is
+        // written verbatim into the mcp.json we hand out.
+        const built = await this.exporter.buildEverWorksMcpDescriptor(
+            query.url ? { url: query.url } : {},
+        );
         return { files: Object.fromEntries(built.files), findings: built.findings };
     }
 

--- a/apps/api/src/agent-plugins/dto/agent-plugin.dto.spec.ts
+++ b/apps/api/src/agent-plugins/dto/agent-plugin.dto.spec.ts
@@ -1,0 +1,69 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { DescriptorQueryDto } from './agent-plugin.dto';
+
+async function urlErrors(url: unknown): Promise<string[]> {
+    const errors = await validate(plainToInstance(DescriptorQueryDto, { url }));
+    return errors.flatMap((error) => Object.keys(error.constraints ?? {}));
+}
+
+describe('DescriptorQueryDto', () => {
+    it('accepts an https endpoint, and accepts the query being absent', async () => {
+        expect(await urlErrors('https://api.ever.works/mcp')).toEqual([]);
+        expect(await validate(plainToInstance(DescriptorQueryDto, {}))).toEqual([]);
+    });
+
+    // The endpoint's OpenAPI description promises the descriptor "contains no
+    // credentials". `buildEverWorksMcpDescriptor` reports a bad URL in
+    // `findings` rather than throwing, so without this the endpoint answers
+    // 200 with an mcp.json carrying the credential, and a consumer that writes
+    // `files` to disk and ignores `findings` gets it.
+    it('rejects userinfo, which @IsUrl permits by default', async () => {
+        expect(await urlErrors('https://user:pass@api.ever.works/mcp')).toEqual(['isUrl']);
+        expect(await urlErrors('https://token@api.ever.works/mcp')).toEqual(['isUrl']);
+    });
+
+    it('rejects a fragment, which @IsUrl also permits by default', async () => {
+        expect(await urlErrors('https://api.ever.works/mcp#frag')).toEqual(['isUrl']);
+        expect(await urlErrors('https://api.ever.works/mcp#')).toEqual(['isUrl']);
+    });
+
+    it('rejects plaintext http and non-http schemes', async () => {
+        expect(await urlErrors('http://api.ever.works/mcp')).toEqual(['isUrl']);
+        expect(await urlErrors('file:///etc/passwd')).toEqual(['isUrl']);
+        expect(await urlErrors('/mcp')).toEqual(['isUrl']);
+    });
+
+    /**
+     * The list `validateRemoteUrl` (packages/agent-plugins, spec 7.2.1) refuses.
+     *
+     * Kept as literals rather than by importing that function: apps/api does
+     * not depend on `@ever-works/agent-plugins`, and the import only appears to
+     * work because pnpm's hoisted virtual store happens to expose it — an
+     * artefact of the installer's layout, not a declared edge. Declaring the
+     * dependency to make it honest re-resolves apps/api's peer closure and
+     * moves `chokidar` from 3.6.0 to 4.0.3, which leaves `nunjucks` (used by
+     * the mailer templates) with an unmet `^3.3.0` peer. A drift guard is not
+     * worth a major-version bump in an unrelated subsystem.
+     *
+     * The DTO is deliberately STRICTER on one axis: `validateRemoteUrl` permits
+     * plaintext http to a loopback host and this refuses it, because a
+     * descriptor we publish should never point at the caller's own machine. So
+     * the relationship is "everything the importer rejects, the DTO rejects" —
+     * never equality. Loosening the DTO below this list would let the endpoint
+     * emit an `mcp.json` its own importer would refuse.
+     */
+    it('rejects every shape the importer rejects', async () => {
+        const refusedBySpec = [
+            'https://user:pass@api.ever.works/mcp',
+            'https://api.ever.works/mcp#frag',
+            'file:///etc/passwd',
+            'ftp://api.ever.works/mcp',
+            'not-a-url',
+        ];
+
+        for (const raw of refusedBySpec) {
+            expect(await urlErrors(raw)).toEqual(['isUrl']);
+        }
+    });
+});

--- a/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
+++ b/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+    IsBoolean,
+    IsIn,
+    IsOptional,
+    IsString,
+    IsUrl,
+    MaxLength,
+    MinLength,
+} from 'class-validator';
 
 /**
  * Remote sources that require an allowlist entry.
@@ -131,4 +139,26 @@ export class InstallAgentPluginPackageDto {
     @IsString()
     @MaxLength(256)
     version?: string;
+}
+
+export class DescriptorQueryDto {
+    /**
+     * Override the endpoint the descriptor points at, for a self-hosted
+     * deployment.
+     *
+     * Validated rather than taken raw. This value is written verbatim into the
+     * `mcp.json` we hand out, and a consuming client connects to whatever it
+     * finds there — so an unvalidated string here becomes somebody else's
+     * outbound request. A bare `@Query('url')` string bypasses the global
+     * pipe entirely, because the pipe validates DTO classes.
+     *
+     * https only, for the same reason the git acquirer requires it: package
+     * contents are read as agent instructions, and a plaintext hop is an
+     * injection point.
+     */
+    @ApiPropertyOptional({ description: 'Self-hosted MCP endpoint (https).' })
+    @IsOptional()
+    @IsUrl({ protocols: ['https'], require_protocol: true })
+    @MaxLength(2048)
+    url?: string;
 }

--- a/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
+++ b/apps/api/src/agent-plugins/dto/agent-plugin.dto.ts
@@ -155,10 +155,27 @@ export class DescriptorQueryDto {
      * https only, for the same reason the git acquirer requires it: package
      * contents are read as agent instructions, and a plaintext hop is an
      * injection point.
+     *
+     * `disallow_auth` and `allow_fragments: false` are not decoration — they
+     * are what makes this agree with `validateRemoteUrl`, which spec 7.2.1
+     * requires and which rejects both. `@IsUrl` permits both by default, so
+     * without them `https://user:pass@host/` reached the descriptor, and
+     * `buildEverWorksMcpDescriptor` REPORTS a bad URL in `findings` rather
+     * than throwing. The endpoint would answer 200 with an `mcp.json`
+     * carrying embedded credentials — contradicting the one promise it makes
+     * in its own OpenAPI description, that the descriptor contains none. A
+     * consumer writing `files` to disk and ignoring `findings` gets the
+     * credential; a fragment is refused for the same reason the importer
+     * refuses it, so the two ends cannot disagree about what is valid.
      */
     @ApiPropertyOptional({ description: 'Self-hosted MCP endpoint (https).' })
     @IsOptional()
-    @IsUrl({ protocols: ['https'], require_protocol: true })
+    @IsUrl({
+        protocols: ['https'],
+        require_protocol: true,
+        disallow_auth: true,
+        allow_fragments: false,
+    })
     @MaxLength(2048)
     url?: string;
 }

--- a/apps/cli/src/commands/plugins/agent-plugins.command.ts
+++ b/apps/cli/src/commands/plugins/agent-plugins.command.ts
@@ -243,49 +243,48 @@ function buildCatalogCommand(): Command {
         });
 }
 
-
 function buildDescriptorCommand(): Command {
     return new Command('descriptor')
-        .description('Write the Ever Works MCP server as an Agent Plugins package (zip)')
-        .option('-o, --output <file>', 'Write here instead of ./ever-works-mcp.zip')
+        .description('Write the Ever Works MCP server as an Agent Plugins package')
+        .option('-o, --output <dir>', 'Write here instead of ./ever-works-mcp')
         .option('-u, --url <url>', 'Point at a self-hosted MCP endpoint')
         .action(async (options: { output?: string; url?: string }) => {
             try {
                 await requireAuth();
                 const spinner = ora('Building descriptor…').start();
                 const query = options.url ? `?url=${encodeURIComponent(options.url)}` : '';
-                const response = (await api().get(
-                    `/agent-plugins/descriptor${query}`,
-                )) as { files?: Record<string, string> };
+                const response = (await api().get(`/agent-plugins/descriptor${query}`)) as {
+                    files?: Record<string, string>;
+                };
                 spinner.stop();
 
                 const files = response.files ?? {};
                 if (Object.keys(files).length === 0) {
-                    console.log(chalk.yellow('
-The server returned an empty descriptor.'));
+                    console.log(chalk.yellow('\nThe server returned an empty descriptor.'));
                     return;
                 }
 
-                // Zipped here rather than server-side so the CLI never has to
-                // stream a binary body through the JSON API client.
-                const JSZip = (await import('jszip')).default;
-                const zip = new JSZip();
+                // A DIRECTORY, not an archive. A package IS a directory — every
+                // client that consumes one reads it as a tree — so writing the
+                // tree is both the useful output and the inspectable one.
+                // Zipping would also mean a bundling dependency the CLI does
+                // not otherwise carry, for a step `zip -r` already does.
+                const target = options.output ?? 'ever-works-mcp';
+                const { mkdir, writeFile } = await import('node:fs/promises');
+                const { dirname, join } = await import('node:path');
+
                 for (const [name, content] of Object.entries(files)) {
-                    zip.file(name, content);
+                    const file = join(target, name);
+                    await mkdir(dirname(file), { recursive: true });
+                    await writeFile(file, content, 'utf8');
                 }
-                const buffer = await zip.generateAsync({ type: 'nodebuffer' });
 
-                const target = options.output ?? 'ever-works-mcp.zip';
-                const { writeFile } = await import('node:fs/promises');
-                await writeFile(target, buffer);
-
-                console.log(chalk.green(`
-Wrote ${target}`));
-                console.log(chalk.gray(`  ${Object.keys(files).sort().join(', ')}`));
+                console.log(chalk.green(`\nWrote ${target}/`));
+                for (const name of Object.keys(files).sort()) {
+                    console.log(chalk.gray(`  ${name}`));
+                }
                 console.log(
-                    chalk.gray(
-                        '  Contains no credentials — your client supplies its own (AP-15).',
-                    ),
+                    chalk.gray('  Contains no credentials — your client supplies its own (AP-15).'),
                 );
             } catch (error) {
                 handleCliError(error);

--- a/apps/cli/src/commands/plugins/agent-plugins.command.ts
+++ b/apps/cli/src/commands/plugins/agent-plugins.command.ts
@@ -243,6 +243,57 @@ function buildCatalogCommand(): Command {
         });
 }
 
+
+function buildDescriptorCommand(): Command {
+    return new Command('descriptor')
+        .description('Write the Ever Works MCP server as an Agent Plugins package (zip)')
+        .option('-o, --output <file>', 'Write here instead of ./ever-works-mcp.zip')
+        .option('-u, --url <url>', 'Point at a self-hosted MCP endpoint')
+        .action(async (options: { output?: string; url?: string }) => {
+            try {
+                await requireAuth();
+                const spinner = ora('Building descriptor…').start();
+                const query = options.url ? `?url=${encodeURIComponent(options.url)}` : '';
+                const response = (await api().get(
+                    `/agent-plugins/descriptor${query}`,
+                )) as { files?: Record<string, string> };
+                spinner.stop();
+
+                const files = response.files ?? {};
+                if (Object.keys(files).length === 0) {
+                    console.log(chalk.yellow('
+The server returned an empty descriptor.'));
+                    return;
+                }
+
+                // Zipped here rather than server-side so the CLI never has to
+                // stream a binary body through the JSON API client.
+                const JSZip = (await import('jszip')).default;
+                const zip = new JSZip();
+                for (const [name, content] of Object.entries(files)) {
+                    zip.file(name, content);
+                }
+                const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+
+                const target = options.output ?? 'ever-works-mcp.zip';
+                const { writeFile } = await import('node:fs/promises');
+                await writeFile(target, buffer);
+
+                console.log(chalk.green(`
+Wrote ${target}`));
+                console.log(chalk.gray(`  ${Object.keys(files).sort().join(', ')}`));
+                console.log(
+                    chalk.gray(
+                        '  Contains no credentials — your client supplies its own (AP-15).',
+                    ),
+                );
+            } catch (error) {
+                handleCliError(error);
+                process.exit(1);
+            }
+        });
+}
+
 /** The `agent-plugins` subcommand group, for mounting on `plugins`. */
 export function buildAgentPluginsCommand(): Command {
     const command = new Command('agent-plugins').description(
@@ -251,5 +302,6 @@ export function buildAgentPluginsCommand(): Command {
     command.addCommand(buildListCommand());
     command.addCommand(buildFindingsCommand());
     command.addCommand(buildCatalogCommand());
+    command.addCommand(buildDescriptorCommand());
     return command;
 }

--- a/apps/cli/src/commands/plugins/agent-plugins.command.ts
+++ b/apps/cli/src/commands/plugins/agent-plugins.command.ts
@@ -271,10 +271,20 @@ function buildDescriptorCommand(): Command {
                 // not otherwise carry, for a step `zip -r` already does.
                 const target = options.output ?? 'ever-works-mcp';
                 const { mkdir, writeFile } = await import('node:fs/promises');
-                const { dirname, join } = await import('node:path');
+                const { dirname, resolve, sep } = await import('node:path');
 
+                // `files` is SERVER-SUPPLIED, and --url lets it come from a self-hosted
+                // endpoint. join() resolves an entry named ../../.ssh/authorized_keys
+                // happily, and the mkdir below would create its parents — zip-slip, writing
+                // anywhere the CLI user can write. Refuse anything outside the output dir.
+                const root = resolve(target);
                 for (const [name, content] of Object.entries(files)) {
-                    const file = join(target, name);
+                    const file = resolve(root, name);
+                    if (file !== root && !file.startsWith(root + sep)) {
+                        throw new Error(
+                            `Descriptor entry "${name}" resolves outside ${target} — refusing to write it.`,
+                        );
+                    }
                     await mkdir(dirname(file), { recursive: true });
                     await writeFile(file, content, 'utf8');
                 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -136,6 +136,15 @@ function bootstrap(): void {
 
 	let config: DesktopConfig = loadConfig(configPath);
 
+	// Agent Plugins package directory, created at BOOTSTRAP rather than only
+	// when the local stack starts. `envEntries()` runs inside `ensureServices`,
+	// so a user in client mode — or one who has not started the stack yet —
+	// would follow the docs to "put packages here" and find no such folder.
+	// Non-fatal: the scanner treats a missing directory as an empty registry.
+	withDefaultPackagesDir({}, userData, (dir) => {
+		fs.mkdirSync(dir, { recursive: true });
+	});
+
 	if (layout.kind === 'unavailable') {
 		// Loud, actionable degradation: local-stack mode cannot start anything.
 		// Client mode still works, which is exactly what the wizard offers next.

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, app, ipcMain, shell } from 'electron';
 import { execFile, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { withDefaultPackagesDir } from './packages-dir';
 import type {
 	DesktopConfig,
 	DesktopMode,
@@ -176,7 +177,9 @@ function bootstrap(): void {
 				entries[trimmed.slice(0, eq).trim()] = value;
 			}
 		}
-		return entries;
+		return withDefaultPackagesDir(entries, userData, (dir) => {
+			fs.mkdirSync(dir, { recursive: true });
+		});
 	};
 
 	const ensureServices = (): boolean => {

--- a/apps/desktop/src/main/packages-dir.spec.ts
+++ b/apps/desktop/src/main/packages-dir.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import { withDefaultPackagesDir } from './packages-dir';
+
+/**
+ * The two things worth testing here are the precedence rule and the failure
+ * tolerance. Neither needs Electron or a real filesystem, which is why the
+ * helper takes an injected `mkdir`.
+ */
+
+describe('withDefaultPackagesDir', () => {
+	it('defaults to <userData>/agent-plugins when nothing is configured', () => {
+		const mkdir = vi.fn();
+
+		const result = withDefaultPackagesDir({}, '/home/u/.config/ever', mkdir);
+
+		expect(result.AGENT_PLUGINS_DIR).toBe(path.join('/home/u/.config/ever', 'agent-plugins'));
+		expect(mkdir).toHaveBeenCalledWith(result.AGENT_PLUGINS_DIR);
+	});
+
+	it('does NOT override an explicit setting', () => {
+		const mkdir = vi.fn();
+
+		const result = withDefaultPackagesDir({ AGENT_PLUGINS_DIR: '/srv/packages' }, '/home/u', mkdir);
+
+		// An operator who has chosen a directory keeps it, and we do not
+		// create a second one they never asked for.
+		expect(result.AGENT_PLUGINS_DIR).toBe('/srv/packages');
+		expect(mkdir).not.toHaveBeenCalled();
+	});
+
+	it('still sets the value when the directory cannot be created', () => {
+		const mkdir = vi.fn(() => {
+			throw new Error('EACCES');
+		});
+
+		const result = withDefaultPackagesDir({}, '/home/u', mkdir);
+
+		// The scanner treats a missing directory as an empty registry, so a
+		// read-only profile must degrade to "no packages" rather than to a
+		// launch that fails.
+		expect(result.AGENT_PLUGINS_DIR).toBe(path.join('/home/u', 'agent-plugins'));
+	});
+
+	it('leaves every other entry untouched', () => {
+		const result = withDefaultPackagesDir(
+			{ DATABASE_URL: 'postgres://x', FEATURE_AGENT_PLUGINS: 'true' },
+			'/home/u',
+			vi.fn()
+		);
+
+		expect(result.DATABASE_URL).toBe('postgres://x');
+		expect(result.FEATURE_AGENT_PLUGINS).toBe('true');
+	});
+
+	it('does not mutate the map it was given', () => {
+		const entries = { A: '1' };
+
+		withDefaultPackagesDir(entries, '/home/u', vi.fn());
+
+		// The caller re-reads this map per launch; mutating it would make the
+		// default sticky across a config change.
+		expect(entries).toEqual({ A: '1' });
+	});
+});

--- a/apps/desktop/src/main/packages-dir.ts
+++ b/apps/desktop/src/main/packages-dir.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+
+/**
+ * Give a desktop install somewhere obvious to drop Agent Plugins packages.
+ *
+ * A DEFAULT only: an explicit `AGENT_PLUGINS_DIR` in the env file wins, so an
+ * operator who has chosen a directory keeps it.
+ *
+ * The directory is created eagerly, because the alternative is a user
+ * following a docs instruction to "put packages here" and finding no such
+ * folder. Creation failure is swallowed: the package scanner treats a missing
+ * directory as an empty registry, so a read-only profile degrades to "no
+ * packages" rather than to a launch that fails.
+ *
+ * Exported and given an injected `mkdir` so it can be tested without an
+ * Electron app object or a real filesystem — the logic worth testing is the
+ * precedence rule and the failure tolerance, neither of which needs either.
+ */
+export function withDefaultPackagesDir(
+	entries: Record<string, string>,
+	userData: string,
+	mkdir: (dir: string) => void
+): Record<string, string> {
+	if (entries.AGENT_PLUGINS_DIR) {
+		return entries;
+	}
+	const packagesDir = path.join(userData, 'agent-plugins');
+	try {
+		mkdir(packagesDir);
+	} catch {
+		// Non-fatal by design; see above.
+	}
+	return { ...entries, AGENT_PLUGINS_DIR: packagesDir };
+}

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -111,6 +111,7 @@ const sidebars: SidebarsConfig = {
 				'features/work-templates',
 				'features/k8s-deployment',
 				'features/mcp-server',
+				'features/agent-plugins',
 				'features/data-management'
 			]
 		},

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -82,7 +82,7 @@ cd apps/mcp && pnpm lint
 EVER_WORKS_API_KEY=ew_live_... npx @modelcontextprotocol/inspector node apps/mcp/dist/stdio.js
 ```
 
-## Available Tools (123)
+## Available Tools (127)
 
 The authoritative list is `src/openapi-tools/whitelist.ts`; the tables below cover the main domains, and `test/whitelist-tasks-inbox-goals-fleet.spec.ts` checks the counts here against it.
 
@@ -254,6 +254,18 @@ Agents are the workers; runs are their executions.
 | `pause_agent`      | Pause an Agent                 |
 | `resume_agent`     | Resume a paused Agent          |
 | `get_agent_budget` | Budget and spend of an Agent   |
+
+### Agent Plugins (4)
+
+Read-only by design. Installing an Agent Plugins package installs **skills** —
+instructions the agent then follows — so the install, resync and allowlist
+routes are deliberately absent from the tool surface and stay available to a
+human through the API, web UI and CLI. See `docs/specs/decisions/018-agent-plugins-standard-interop.md`.
+
+- `list_agent_plugin_packages` — installed packages
+- `list_agent_plugin_findings` — validation findings recorded at install
+- `list_agent_plugin_catalog_entries` — skills contributed by packages
+- `list_agent_plugin_updates` — packages with a newer version available
 
 ## Adding New Tools
 

--- a/apps/mcp/src/openapi-tools/whitelist.ts
+++ b/apps/mcp/src/openapi-tools/whitelist.ts
@@ -557,5 +557,48 @@ export const WHITELIST: WhitelistEntry[] = [
 		path: '/api/agents/{id}/budget',
 		toolName: 'get_agent_budget',
 		annotations: { readOnlyHint: true }
+	},
+
+	// Agent Plugins (EW-772) — READ ONLY, deliberately.
+	//
+	// Installing an Agent Plugins package means installing SKILLS, and a skill
+	// is instructions the agent will then follow. Exposing the install route
+	// as a tool would let an agent bound to this server acquire its own future
+	// instructions — and this server is reachable by agents processing scraped
+	// web content and community-PR text, so a prompt-injected run could ask it
+	// to install a package whose skills redirect it further. That is a
+	// self-modification loop, not a convenience.
+	//
+	// The same reasoning the "human gates stay human" rule applies to
+	// approvals: the route stays available to a human through the API, the web
+	// UI and the CLI. It is only absent from the TOOL surface.
+	//
+	// Also excluded for the same reason: POST /:id/resync (re-fetches content
+	// that may have changed since a human reviewed it) and the allowlist
+	// routes (an agent must not be able to widen what it is permitted to
+	// fetch). Reading is safe and useful, so it is offered.
+	{
+		method: 'GET',
+		path: '/api/agent-plugins',
+		toolName: 'list_agent_plugin_packages',
+		annotations: { readOnlyHint: true }
+	},
+	{
+		method: 'GET',
+		path: '/api/agent-plugins/findings',
+		toolName: 'list_agent_plugin_findings',
+		annotations: { readOnlyHint: true }
+	},
+	{
+		method: 'GET',
+		path: '/api/agent-plugins/catalog',
+		toolName: 'list_agent_plugin_catalog_entries',
+		annotations: { readOnlyHint: true }
+	},
+	{
+		method: 'GET',
+		path: '/api/agent-plugins/updates',
+		toolName: 'list_agent_plugin_updates',
+		annotations: { readOnlyHint: true }
 	}
 ];

--- a/docs/features/agent-plugins.md
+++ b/docs/features/agent-plugins.md
@@ -1,0 +1,134 @@
+---
+id: agent-plugins
+title: Agent Plugins
+sidebar_label: Agent Plugins
+sidebar_position: 14
+---
+
+# Agent Plugins
+
+Ever Works supports the open
+[Agent Plugins v1.0.0](https://github.com/agentplugins/agent-plugins-spec)
+standard, so skills and MCP servers can be packaged once and used across any
+client that supports it — not only Ever Works.
+
+:::tip What this changes
+Nothing about the plugins you already use. Agent Plugins is an **addition**: a
+second, cross-vendor way to bring skills and MCP servers into your workspace,
+alongside the existing plugin system, which is unchanged.
+:::
+
+## What a package is
+
+A package is a directory with a small, fixed shape:
+
+```
+my-package/
+  plugin.json              # who the package is
+  skills/
+    release-notes/
+      SKILL.md             # a skill: instructions the agent can follow
+  mcp.json                 # optional: MCP servers the package declares
+```
+
+Every part is optional except `plugin.json`. A package may ship only skills,
+only an MCP server declaration, or both — the standard lets a package support
+any subset, and lets a client support any subset too.
+
+## Turning it on
+
+Agent Plugins support is **off by default**. An operator enables it by setting
+`FEATURE_AGENT_PLUGINS=true`; see the
+[deployment runbook](/specs/features/agent-plugins/deployment) for the full
+list of variables.
+
+With it off, nothing changes: no package directory is read, no additional
+catalog source is consulted, and the API reports `enabled: false` so you can
+tell "turned off" from "turned on with nothing installed".
+
+## Installing packages
+
+Three ways, in increasing order of how much the platform does for you:
+
+1. **A directory on disk.** Point `AGENT_PLUGINS_DIR` at it. You own the bytes,
+   so nothing else is required.
+2. **From git or npm.** Requires an **allowlist entry** for that exact package
+   name or git URL. Fetching code on someone's behalf is an operator decision,
+   so it is one you have to make explicitly.
+3. **Built by Ever Works.** Export your own skills as a package — see below.
+
+A fetched package is validated before it is kept. One that fails is **deleted**,
+not left on disk, so it cannot be picked up later by the directory scanner.
+
+## Seeing what a package contributed
+
+**Settings → Agent Plugins** lists every installed package, the skills and MCP
+servers it contributes, and every validation finding — grouped **per component**.
+
+That grouping matters. The standard isolates failure: a package whose `mcp.json`
+is invalid still contributes its skills. A flat list of errors would make such a
+package look broken when most of it works, and would not tell you which half to
+fix.
+
+Packages that could not be loaded are shown too, rather than hidden. Somebody
+put that directory there deliberately, so its absence needs an explanation.
+
+## MCP servers from packages
+
+A package can declare MCP servers, and Ever Works turns them into ordinary MCP
+connections you manage in the usual place.
+
+They arrive **disabled and unbound**. Installing a package never grants an agent
+new network reach on its own — you enable the connection and bind it to an agent
+yourself, exactly as you would for a server you had never seen before, which is
+what a package's server is.
+
+### stdio servers
+
+A package can also declare a server that runs as a **subprocess**. That is a
+much larger grant than reading documents, so it sits behind a second switch
+(`AGENT_PLUGINS_STDIO`) that is also off by default and stays off on the hosted
+service.
+
+When it is off, such a server is shown as **present and disabled by policy** —
+not hidden — so you can see what a package would run before deciding whether to
+allow it.
+
+## Exporting your own skills
+
+Skills you have written can be exported as a conformant package for use in any
+other client:
+
+```bash
+ever-works plugins agent-plugins list
+```
+
+Before an export is handed to you, Ever Works loads it back through its own
+importer. A tool that emitted packages its own reader rejects would be
+publishing a format nobody could rely on, and the failure would surface in
+somebody else's client rather than here.
+
+If a skill's name cannot be expressed under the standard's naming rule, the
+export **tells you and suggests an alternative** rather than renaming it
+quietly — a renamed skill is a different skill to anything that references it.
+
+## Using the Ever Works MCP server elsewhere
+
+The Ever Works MCP server is itself published as a package descriptor, so any
+conforming client can install it rather than being configured by hand. It
+contains **no credentials** — your client supplies its own. See
+[MCP Server](./mcp-server) for details.
+
+## What Ever Works does and does not implement
+
+The [conformance statement](/specs/features/agent-plugins/conformance) maps
+every requirement in the standard to the evidence for it, including the parts
+that are not implemented and the spec-valid packages this platform may decline
+to load as a matter of policy. It is checked by a test, so it cannot quietly
+drift from what the code does.
+
+## Related
+
+- [Skills Catalog](./skills-catalog) — where package skills appear
+- [MCP Server](./mcp-server) — the Ever Works MCP server, and its package descriptor
+- [Plugin System](/plugin-system/) — the existing plugin system, unchanged

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -312,8 +312,35 @@ The tool's description, parameters, and validation are derived automatically fro
 - **Scope selection, not widening** — `EVER_WORKS_SCOPE_SLUG` is forwarded as `x-scope-slug` and the API authorises the caller against it the same way it does for the web client
 - **Request timeout** — API calls time out after 2 minutes
 
+## Use it from any Agent Plugins client
+
+Ever Works publishes this server as an **Agent Plugins v1.0.0** package
+descriptor, so a client that supports the open standard can install it as an
+ordinary package instead of following the configuration steps above by hand.
+
+The descriptor declares one `streamable-http` server and nothing else — no
+skills, and deliberately **no credentials**. The specification treats
+package-configured headers as visible and non-secret, so a descriptor that
+embedded an API key would publish that key to everyone who installed it.
+Authentication stays where it belongs: your client supplies its own key,
+exactly as it does for the manual configuration above.
+
+Generate the descriptor with:
+
+```bash
+ever-works plugins agent-plugins descriptor > ever-works-mcp.zip
+```
+
+Point it at a self-hosted deployment by overriding the URL. Nothing in this
+page's manual configuration changes — the descriptor is an additional way to
+consume the same server, not a replacement for it.
+
+See the [conformance statement](/specs/features/agent-plugins/conformance) for
+what Ever Works implements of the standard, including what it does not.
+
 ## Related
 
 - [API Keys](./api-keys) — Generate API keys for MCP server authentication
 - [Authentication](/api/authentication) — Full API authentication reference
 - [Plugin System](/plugin-system/) — Plugins that power generation, search, and deployment
+- [Agent Plugins conformance](/specs/features/agent-plugins/conformance) — What Ever Works implements of the open Agent Plugins v1.0.0 standard

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -24,7 +24,7 @@ Connect the MCP server to Claude Desktop, Claude Code, or any MCP-compatible cli
 The MCP server is a standalone NestJS application in `apps/mcp/` that:
 
 1. **Fetches** the Ever Works API's OpenAPI spec at startup
-2. **Filters** endpoints through a curated whitelist of 123 operations
+2. **Filters** endpoints through a curated whitelist of 127 operations
 3. **Converts** OpenAPI schemas to MCP tool definitions automatically
 4. **Proxies** tool calls to the API using your API key
 
@@ -112,7 +112,7 @@ Add the MCP server to your project's `.mcp.json`:
 
 ## Available Tools
 
-The MCP server exposes 123 tools organized by domain. Each tool's parameters and descriptions are auto-generated from the API's OpenAPI specification. The authoritative list is `apps/mcp/src/openapi-tools/whitelist.ts`; `apps/mcp/test/whitelist-tasks-inbox-goals-fleet.spec.ts` checks the counts on this page against it.
+The MCP server exposes 127 tools organized by domain. Each tool's parameters and descriptions are auto-generated from the API's OpenAPI specification. The authoritative list is `apps/mcp/src/openapi-tools/whitelist.ts`; `apps/mcp/test/whitelist-tasks-inbox-goals-fleet.spec.ts` checks the counts on this page against it.
 
 ### Human-in-the-loop gates are not tools
 
@@ -282,6 +282,20 @@ Agents are the workers; runs are their executions.
 | `pause_agent`      | Pause an Agent                 |
 | `resume_agent`     | Resume a paused Agent          |
 | `get_agent_budget` | Budget and spend of an Agent   |
+
+### Agent Plugins (4 tools)
+
+Read-only by design. Installing an Agent Plugins package installs **skills** —
+instructions the agent then follows — and this server is reachable by agents
+processing scraped web content and community-PR text, so an install tool would
+let a prompt-injected run acquire its own future instructions. Install, resync
+and the allowlist routes stay available to a human through the API, web UI and
+CLI; only the tool surface excludes them.
+
+- `list_agent_plugin_packages` — installed packages
+- `list_agent_plugin_findings` — validation findings recorded at install
+- `list_agent_plugin_catalog_entries` — skills contributed by packages
+- `list_agent_plugin_updates` — packages with a newer version available
 
 ## Adding New Tools
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -328,10 +328,11 @@ exactly as it does for the manual configuration above.
 Generate the descriptor with:
 
 ```bash
-ever-works plugins agent-plugins descriptor > ever-works-mcp.zip
+ever-works plugins agent-plugins descriptor
 ```
 
-Point it at a self-hosted deployment by overriding the URL. Nothing in this
+This writes a directory you can install directly, or archive if your client
+wants one. Point it at a self-hosted deployment by overriding the URL. Nothing in this
 page's manual configuration changes — the descriptor is an additional way to
 consume the same server, not a replacement for it.
 

--- a/docs/specs/features/agent-plugins/conformance.md
+++ b/docs/specs/features/agent-plugins/conformance.md
@@ -73,10 +73,10 @@ rows below say exactly where the subprocess half stops.
 
 ## Producer (AP-22 … AP-23)
 
-| ID    | Requirement                                            | Status        | Evidence                                                                                                                                                            |
-| ----- | ------------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AP-22 | Exported packages validate against our own importer    | **Not yet**   | `serialize.ts` produces conforming manifests and `SKILL.md` bodies byte-for-byte, and is round-trip tested; the export **flow** that assembles a package is Phase 5 |
-| AP-23 | Export maps slug → directory name + frontmatter `name` | Met (library) | `serialize.ts` `toSpecSkillName`, `repairName` — including the case where a legal period must survive repair                                                        |
+| ID    | Requirement                                            | Status        | Evidence                                                                                                                                                                                                                                                                                                                                                        |
+| ----- | ------------------------------------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-22 | Exported packages validate against our own importer    | **Met**       | `export.service.ts` writes the package to a temporary directory and runs the REAL `loadPluginPackage` over it, refusing to return anything that does not load. Validating the in-memory strings would test something else: directory naming, the `skills/<name>/SKILL.md` layout and containment are facts about a tree, and a tree is what a consumer receives |
+| AP-23 | Export maps slug → directory name + frontmatter `name` | Met (library) | `serialize.ts` `toSpecSkillName`, `repairName` — including the case where a legal period must survive repair                                                                                                                                                                                                                                                    |
 
 ---
 
@@ -84,15 +84,23 @@ rows below say exactly where the subprocess half stops.
 
 |                     | Count     |
 | ------------------- | --------- |
-| Met / Met (library) | 21        |
+| Met / Met (library) | 22        |
 | Partial             | 1 (AP-14) |
-| Not yet             | 1 (AP-22) |
+| Not yet             | 0         |
 
-What remains traces to two things. **AP-22** waits on the package export flow,
-which is Phase 5. **AP-14** is partial because the stdio launcher exists and is
-tested but is not yet called from the agent run path — a stdio server can be
-planned, gated and spawned, and still contributes no tools to an agent.
+One row remains short of Met. **AP-14** is partial because the stdio launcher
+exists, is gated and is tested, but nothing in the agent run path calls it yet —
+a stdio server can be planned, gated and spawned, and still contributes no tools
+to an agent.
 
-Neither is required for the claim as stated: a client may support a subset of
-component types, and the claim names skills and MCP. Both are written here so
-the boundary is visible rather than implied.
+That is not required for the claim as stated: v1.0.0 lets a client support a
+subset of component types provided it is honest about which, and the claim names
+skills and MCP. It is written here so the boundary is visible rather than
+implied — the remaining work is wiring, not specification compliance.
+
+### A note on how to read "Met"
+
+Every row above cites evidence that exists and runs. Where a row says Met, the
+cited test or source enforces the rule; where it says Met (library), the rule is
+enforced by `@ever-works/agent-plugins`, and nothing outside it can accept a
+package the library rejects. No row is Met on the strength of an intention.

--- a/docs/specs/features/agent-plugins/conformance.md
+++ b/docs/specs/features/agent-plugins/conformance.md
@@ -104,3 +104,31 @@ Every row above cites evidence that exists and runs. Where a row says Met, the
 cited test or source enforces the rule; where it says Met (library), the rule is
 enforced by `@ever-works/agent-plugins`, and nothing outside it can accept a
 package the library rejects. No row is Met on the strength of an intention.
+
+---
+
+## Policy refusals — spec-valid packages this deployment may decline
+
+Everything below describes a package that is **conformant**, which Ever Works
+may still refuse to load or run. These are deployment policy, not gaps in the
+implementation, and they are listed because the distinction is invisible from
+the outside: an author whose package is refused deserves to know whether they
+broke a rule or met one this platform declines to exercise.
+
+The specification anticipates this. A conforming client may apply its own
+security policy; what it may not do is refuse and call the package invalid.
+Every refusal below is reported with a reason and a machine-readable `code`.
+
+| Refusal                                 | Applies to                                                                                      | Why                                                                                                                                                                                                                                                |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **stdio disabled**                      | Any `stdio` server, when `AGENT_PLUGINS_STDIO` is off                                           | Launching a subprocess from package contents is a far larger grant than reading documents, and no sandbox is built. Reported as `disabled-by-policy` with `enableable: true` — the only refusal an operator can lift with a setting.               |
+| **Loopback and private URLs**           | A remote server whose URL resolves to a private, loopback, link-local or cloud-metadata address | The specification permits plain `http:` to **loopback** hosts, which is right for a desktop client talking to a local dev server. Ever Works is a server, where loopback is the API pod's own localhost and `http://127.0.0.1:6379` reaches Redis. |
+| **Cross-origin credential forwarding**  | A remote server that redirects across an origin                                                 | Package headers are visible and non-secret (AP-15), but they are still forwarded on the first request. Every caller header is dropped on an origin change, so a server that relies on them surviving a redirect will not work.                     |
+| **`${PLUGIN_DATA}` in a remote server** | A `streamable-http` or `sse` URL or header referencing it                                       | Only a launched subprocess can resolve a per-package data path; nothing can supply one for a URL. A stdio server using the same placeholder is fine — the launcher resolves it.                                                                    |
+| **Ambiguous server names**              | A server whose name contains `__`                                                               | Tool names are `mcp__<server>__<tool>`, so such a name could not be split back apart and a call could route to the wrong server.                                                                                                                   |
+| **Unallowlisted remote sources**        | Any git or npm package not on the allowlist                                                     | Fetching is an operator decision. The allowlist fails **closed**: if it cannot be read, every remote package is refused rather than permitted.                                                                                                     |
+| **Non-registry npm specifiers**         | A version specifier naming a transport rather than a version                                    | `npm-package-arg` picks the transport from the spec's shape, so `pkg@git+https://host/x.git` would clone and run an arbitrary repository. Only semver, ranges and dist-tags are accepted.                                                          |
+
+None of these makes a package non-conformant, and none of them is reported as a
+validation failure. A refused package appears in `skipped` with its reason
+intact, and the operator can see exactly what was declined and why.

--- a/docs/specs/features/agent-plugins/conformance.md
+++ b/docs/specs/features/agent-plugins/conformance.md
@@ -93,6 +93,12 @@ exists, is gated and is tested, but nothing in the agent run path calls it yet â
 a stdio server can be planned, gated and spawned, and still contributes no tools
 to an agent.
 
+Whoever closes that gap must wire `AgentPluginStdioServerService.launch` **and**
+`shutdownAll` in the same change. `shutdownAll` has no caller today either, so
+wiring only the spawn leaks one subprocess per run for the lifetime of the pod â€”
+invisible until the pod is OOM-killed. The generation counter makes the pair safe
+to interleave; it does not make either safe to omit.
+
 That is not required for the claim as stated: v1.0.0 lets a client support a
 subset of component types provided it is honest about which, and the claim names
 skills and MCP. It is written here so the boundary is visible rather than

--- a/docs/specs/features/agent-plugins/conformance.md
+++ b/docs/specs/features/agent-plugins/conformance.md
@@ -47,22 +47,22 @@ rows below say exactly where the subprocess half stops.
 
 ## MCP (AP-11 … AP-15)
 
-| ID    | Requirement                                                                               | Status        | Evidence                                                                                                                                                                                                        |
-| ----- | ----------------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AP-11 | MCP config only from `mcp.json`, closed schema                                            | Met (library) | `PERMITTED_MCP_FIELDS`, `parseMcpConfig`                                                                                                                                                                        |
-| AP-12 | `mcp.json` `$schema` version must match `plugin.json`'s                                   | Met (library) | `versions.ts`. Note the trap recorded in ADR-018: this is a string **equality** check, not a compatibility-set check, so a 1.0.0 manifest beside a 1.1.0 `mcp.json` disables MCP even though both releases load |
-| AP-13 | Server entries form a closed union on `type`                                              | Met (library) | `validateMcpConfig`; `McpServerConfig` union                                                                                                                                                                    |
-| AP-14 | All three transports supported                                                            | **Partial**   | `streamable-http` and `sse` are resolved and reach the client. `stdio` is parsed, validated and reported, but **not launched** — see AP-19                                                                      |
-| AP-15 | Package `headers`/`env` are visible and non-secret; no cross-origin credential forwarding | Met           | `guarded-fetch.ts` — redirects are followed manually, each hop re-checked, and **every** caller header dropped on an origin change; `guarded-fetch.spec.ts` covers port-only and scheme-downgrade hops          |
+| ID    | Requirement                                                                               | Status        | Evidence                                                                                                                                                                                                                           |
+| ----- | ----------------------------------------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-11 | MCP config only from `mcp.json`, closed schema                                            | Met (library) | `PERMITTED_MCP_FIELDS`, `parseMcpConfig`                                                                                                                                                                                           |
+| AP-12 | `mcp.json` `$schema` version must match `plugin.json`'s                                   | Met (library) | `versions.ts`. Note the trap recorded in ADR-018: this is a string **equality** check, not a compatibility-set check, so a 1.0.0 manifest beside a 1.1.0 `mcp.json` disables MCP even though both releases load                    |
+| AP-13 | Server entries form a closed union on `type`                                              | Met (library) | `validateMcpConfig`; `McpServerConfig` union                                                                                                                                                                                       |
+| AP-14 | All three transports supported                                                            | **Partial**   | `streamable-http` and `sse` reach the client. `stdio` is now parsed, gated, planned and launchable (`stdio-server.service.ts`), but nothing in the agent run path calls it yet, so a stdio server contributes no tools to an agent |
+| AP-15 | Package `headers`/`env` are visible and non-secret; no cross-origin credential forwarding | Met           | `guarded-fetch.ts` — redirects are followed manually, each hop re-checked, and **every** caller header dropped on an origin change; `guarded-fetch.spec.ts` covers port-only and scheme-downgrade hops                             |
 
 ## Subprocess (AP-16 … AP-19)
 
-| ID    | Requirement                                                            | Status        | Evidence                                                                                                                                                                                                                                    |
-| ----- | ---------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AP-16 | Every spawned process gets `PLUGIN_ROOT` and `PLUGIN_DATA`             | **Not yet**   | Nothing spawns a process. `AGENT_PLUGINS_DATA_DIR` is configured and wired, but the launcher is not built                                                                                                                                   |
-| AP-17 | `${PLUGIN_ROOT}` / `${PLUGIN_DATA}` expanded by single substitution    | Met (library) | `expand.ts`; `mcp-server-config.service.ts` expands `PLUGIN_ROOT` and **refuses** any server referencing `PLUGIN_DATA`, because no data directory is allocated yet — a refusal with a reason rather than an empty path that fails at launch |
-| AP-18 | Subprocess base environment is client-chosen                           | **Not yet**   | Same as AP-16                                                                                                                                                                                                                               |
-| AP-19 | `stdio` execution is gated; when off, entries are present-but-disabled | **Met**       | `AGENT_PLUGINS_STDIO`, default off. A stdio server is reported with `code: "disabled-by-policy"` and `enableable: true` — distinguishable from every other skip, all of which are `enableable: false`. `mcp-server-config.service.spec.ts`  |
+| ID    | Requirement                                                            | Status        | Evidence                                                                                                                                                                                                                                                                          |
+| ----- | ---------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AP-16 | Every spawned process gets `PLUGIN_ROOT` and `PLUGIN_DATA`             | **Met**       | `stdio-launcher.ts` `buildLaunchEnv` writes both LAST and unconditionally, so a package cannot redirect them by declaring them; `AgentPluginPackageDataDirService` allocates the data directory per (owner, package) before launch                                                |
+| AP-17 | `${PLUGIN_ROOT}` / `${PLUGIN_DATA}` expanded by single substitution    | Met (library) | `expand.ts`; `mcp-server-config.service.ts` expands `PLUGIN_ROOT` and **refuses** any server referencing `PLUGIN_DATA`, because no data directory is allocated yet — a refusal with a reason rather than an empty path that fails at launch                                       |
+| AP-18 | Subprocess base environment is client-chosen                           | **Met**       | Built from `{}` with only PATH/HOME/TMPDIR inherited, never filtered from `process.env` — a denylist would have to enumerate every platform secret added later. `stdio-launcher.spec.ts` asserts DATABASE*URL, AUTH_SECRET, a PLUGIN*\* key and the encryption key are all absent |
+| AP-19 | `stdio` execution is gated; when off, entries are present-but-disabled | **Met**       | `AGENT_PLUGINS_STDIO`, default off. A stdio server is reported with `code: "disabled-by-policy"` and `enableable: true` — distinguishable from every other skip, all of which are `enableable: false`. `mcp-server-config.service.spec.ts`                                        |
 
 ## Versioning and updates (AP-20 … AP-21)
 
@@ -82,14 +82,17 @@ rows below say exactly where the subprocess half stops.
 
 ## Summary
 
-|                     | Count                   |
-| ------------------- | ----------------------- |
-| Met / Met (library) | 19                      |
-| Partial             | 1 (AP-14)               |
-| Not yet             | 3 (AP-16, AP-18, AP-22) |
+|                     | Count     |
+| ------------------- | --------- |
+| Met / Met (library) | 21        |
+| Partial             | 1 (AP-14) |
+| Not yet             | 1 (AP-22) |
 
-The three "Not yet" rows and the one "Partial" all trace to the same two
-unbuilt pieces: **the stdio subprocess launcher** and **the package export
-flow**. Neither is required for the claim as stated — a client may support a
-subset of component types — but both are named here so the boundary is visible
-rather than implied.
+What remains traces to two things. **AP-22** waits on the package export flow,
+which is Phase 5. **AP-14** is partial because the stdio launcher exists and is
+tested but is not yet called from the agent run path — a stdio server can be
+planned, gated and spawned, and still contributes no tools to an agent.
+
+Neither is required for the claim as stated: a client may support a subset of
+component types, and the claim names skills and MCP. Both are written here so
+the boundary is visible rather than implied.

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -63,7 +63,7 @@ appends, locale key appends) are expected and fine.
       description). Add fixtures path to `.prettierignore`.
 - [x] **T8**. `src/serialize.ts`: plugin.json + SKILL.md emitters; slug→name
       guard; round-trip property test (emit → parse → deep-equal).
-- [ ] **T9**. Optional CI oracle job: `skills-ref validate` (Python) over skill
+- [x] **T9**. Optional CI oracle job: `skills-ref validate` (Python) over skill
       fixtures, non-blocking.
 
 ## Phase 1 — Package registry + local-dir source + skills read-side (PR-2, PR-3)
@@ -215,7 +215,26 @@ resolveAllowedTools` as a new optional source (domain-tool-source
 
 ## Phase 5 — Sidecars + export (PR-8, PR-9)
 
-- [ ] **T33**. `skill_files` entity + migration + storage via `IStoragePlugin`
+> **2026-09-04 — T33 was ALREADY BUILT, and verified rather than rebuilt.**
+> `skill_files` exists (`entities/skill-file.entity.ts`), with
+> `SkillFileRepository`, `SkillFilesService`, the upload route on
+> `skills.controller.ts`, and account-transfer support for
+> `ExportedSkillFile`. `SkillFilesService.add` already caps size
+> (`MAX_SKILL_FILE_BYTES`), stores through the uploads spine with sha256
+> naming, coerces the MIME via the spine's own `acceptsSaveFileMime`
+> predicate, and calls the `assertNoSecrets` this task asks to wire — plus
+> `assertNoInjectionTokens`, which it does not.
+>
+> The remaining clause, "package service ingests sidecars", is satisfied
+> differently and deliberately: a package's `scripts/`, `references/` and
+> `assets/` are already ON DISK inside the package, so copying them into
+> `skill_files` would duplicate bytes the acquirer already validated and
+> contained. They are materialised straight from the package by
+> `planWorkspaceMaterialization` (T34) under the execution-gate split.
+> `skill_files` remains what it was: storage for PLATFORM-authored skills,
+> whose files arrive by upload and have nowhere else to live.
+
+- [x] **T33**. `skill_files` entity + migration + storage via `IStoragePlugin`
       (uploads-stack validation: sha256 naming, MIME sniff, per-file + per-skill
       size caps). NOTE: uploads stack does NOT secret-scan — wire
       `assertNoSecrets` (`packages/agent/src/utils/secret-scan.ts`) as a NEW

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -186,7 +186,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       exempt (admin-only surface, like `plugin_allowlist` which has no chat
       tools) and `skill_files` is exempt (child rows surfaced through existing
       skill tools) — exemptions stated so the DoD check is explicit.
-- [ ] **T28**. Decision + implementation: MCP tool invocations →
+- [x] **T28**. Decision + implementation: MCP tool invocations →
       `PluginUsageEvent` usage accounting (recommended: on).
 
 ## Phase 4 — stdio transport + PLUGIN_DATA (PR-7)

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -243,7 +243,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
 - [x] **T37**. User-facing docs page `docs/features/agent-plugins.md` +
       sidebar entry in `apps/docs/sidebarsPlatform.ts`; internal docs stay
       off-nav.
-- [ ] **T38**. Desktop staging (`prepare-bundle.js` + `<userData>/agent-plugins`
+- [x] **T38**. Desktop staging (`prepare-bundle.js` + `<userData>/agent-plugins`
       default source) + headless-node XDG dir.
 - [x] **T39**. apps/mcp whitelist decision: expose `agent-plugins` management
       tools or document out-of-scope.

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -37,31 +37,31 @@ appends, locale key appends) are expected and fine.
 
 ## Phase 0 — Conformance library (PR-1)
 
-- [ ] **T1**. Scaffold `packages/agent-plugins` (`@ever-works/agent-plugins`):
+- [x] **T1**. Scaffold `packages/agent-plugins` (`@ever-works/agent-plugins`):
       tsup ESM build, Vitest, MIT, zero NestJS deps. Own deps: `ajv@^8`,
       `gray-matter@^4`, `yaml` if needed.
-- [ ] **T2**. Vendor canonical schemas under `src/schemas/1.0.0/`
+- [x] **T2**. Vendor canonical schemas under `src/schemas/1.0.0/`
       (plugin.schema.json, mcp.schema.json) imported via `resolveJsonModule`
       so they ship inside `dist/`.
-- [ ] **T3**. `src/manifest.ts`: closed manifest validator with exact AP-4
+- [x] **T3**. `src/manifest.ts`: closed manifest validator with exact AP-4
       severity split. Unit tests per AP-1…AP-6 (incl. MUST-NOT-reject cases:
       non-semver version, weird URLs, 1-char and dotted names).
-- [ ] **T4** (parallel). `src/skills.ts`: discovery walker (immediate children,
+- [x] **T4** (parallel). `src/skills.ts`: discovery walker (immediate children,
       regular-file check) + Agent Skills frontmatter validator (name=dir,
       charset, lengths, `allowed-tools` string→array tokenizer, metadata
       string-map check). Tests per AP-7…AP-9.
-- [ ] **T5** (parallel). `src/mcp.ts`: closed mcp.json validator, closed server
+- [x] **T5** (parallel). `src/mcp.ts`: closed mcp.json validator, closed server
       union, URL/header rules, reserved env keys, version-match with
       plugin.json. Tests per AP-11…AP-15.
-- [ ] **T6** (parallel). `src/paths.ts` containment (realpath symlink
+- [x] **T6** (parallel). `src/paths.ts` containment (realpath symlink
       resolution) + `src/expand.ts` placeholder expansion. Tests per AP-10,
       AP-16…AP-17 (expansion in args/env-values/cwd only; non-recursive;
       unknown placeholders literal).
-- [ ] **T7**. `fixtures/`: full conformance corpus (valid minimal, valid full,
+- [x] **T7**. `fixtures/`: full conformance corpus (valid minimal, valid full,
       every fatal/non-fatal manifest case, skip-one-skill, disable-MCP-only,
       per-server skip, containment escapes, dir-name mismatch, oversized
       description). Add fixtures path to `.prettierignore`.
-- [ ] **T8**. `src/serialize.ts`: plugin.json + SKILL.md emitters; slug→name
+- [x] **T8**. `src/serialize.ts`: plugin.json + SKILL.md emitters; slug→name
       guard; round-trip property test (emit → parse → deep-equal).
 - [ ] **T9**. Optional CI oracle job: `skills-ref validate` (Python) over skill
       fixtures, non-blocking.
@@ -155,7 +155,7 @@ appends, locale key appends) are expected and fine.
       configs + provenance via the conformance lib. No plugin capability, no
       `facade-capabilities.ts` append. Barrel-export from
       `packages/agent/package.json` export map (TS2305 bug class).
-- [ ] **T24**. Entity `agent_mcp_server_bindings` (Tier C — skill_bindings
+- [x] **T24**. Entity `agent_mcp_server_bindings` (Tier C — skill_bindings
       template PLUS net-new columns `serverName`/`enabled`/`settings`/
       `secretSettings`/`credentialsSecretRef`, per plan §2.5) + migration +
       inventory append. Account-transfer whitelist entries for bindings (same
@@ -165,19 +165,19 @@ appends, locale key appends) are expected and fine.
       package → pending-reference row + bindings imported `enabled: false`;
       disallowed source → skip-and-report; never auto-fetch content on import;
       never fail the whole import.
-- [ ] **T25**. `packages/agent/src/mcp/`: `McpClientService`
+- [x] **T25**. `packages/agent/src/mcp/`: `McpClientService`
       (streamable-http + sse via `@modelcontextprotocol/sdk` — new dep of
       `packages/agent`), per-server failure isolation, connect-time credential
       injection (client-generated headers; masked reads), SSRF egress policy,
       **redirect policy per AP-15** (no package-header cross-origin forwarding
       without explicit authorization; no client-generated credential forwarding
       cross-origin at all — with tests), run-end disconnect.
-- [ ] **T26**. `McpToolSource` injected into `AgentToolService.
+- [x] **T26**. `McpToolSource` injected into `AgentToolService.
 resolveAllowedTools` as a new optional source (domain-tool-source
       pattern); `mcp__<server>__<tool>` naming; name/description sanitization;
       builtin-collision drop + WARN; run-log WARNs for skipped servers.
       Update module pin specs.
-- [ ] **T27**. Bindings API (`/api/agents/:id/mcp-servers` CRUD + standalone
+- [x] **T27**. Bindings API (`/api/agents/:id/mcp-servers` CRUD + standalone
       delete; agent-scoped targets only in v1) + **MCP Servers tab** on
       `/agents/[id]` + i18n + e2e specs (binding CRUD, authz matrix,
       cross-tenant isolation). Domain chat tools per the in-code DoD

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -234,7 +234,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       package (zip); round-trip gate (AP-22/23); slug guard enforcing the FULL
       spec name rule (≤64, no `--`, no leading/trailing hyphen — the DTO
       accepts all three) with rename prompt.
-- [ ] **T36**. `ever-works-mcp` package descriptor export (streamable-http
+- [x] **T36**. `ever-works-mcp` package descriptor export (streamable-http
       `https://mcp.ever.works/mcp`, credential-free; docs updated by addition —
       pointer from `docs/features/mcp-server.md`, no removal).
 

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -191,11 +191,11 @@ resolveAllowedTools` as a new optional source (domain-tool-source
 
 ## Phase 4 — stdio transport + PLUGIN_DATA (PR-7)
 
-- [ ] **T29**. `AGENT_PLUGINS_DATA_DIR` (default `/app/agent-plugins-data`);
+- [x] **T29**. `AGENT_PLUGINS_DATA_DIR` (default `/app/agent-plugins-data`);
       per-(tenant, package) data dirs; create-before-launch; delete on
       uninstall; SaaS write-through sync via boot-selected `IStoragePlugin`
       with DB-side key manifest.
-- [ ] **T30**. Stdio launcher: from-scratch env (`buildSubprocessEnv` pattern) +
+- [x] **T30**. Stdio launcher: from-scratch env (`buildSubprocessEnv` pattern) +
       expanded package env overlay + `PLUGIN_ROOT`/`PLUGIN_DATA` last; single-
       token command resolution (bare vs `./`-relative) with containment; cwd
       rules per AP-13; process supervision + teardown at run end.

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -240,7 +240,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
 
 ## Phase 6 — Hardening + docs + conformance claim (PR-10)
 
-- [ ] **T37**. User-facing docs page `docs/features/agent-plugins.md` +
+- [x] **T37**. User-facing docs page `docs/features/agent-plugins.md` +
       sidebar entry in `apps/docs/sidebarsPlatform.ts`; internal docs stay
       off-nav.
 - [ ] **T38**. Desktop staging (`prepare-bundle.js` + `<userData>/agent-plugins`
@@ -249,7 +249,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       tools or document out-of-scope.
 - [ ] **T40**. Security review pass (stdio gate, SSRF policy, containment
       fuzzing over fixture escapes); Sentry tags; rate-limit re-check.
-- [ ] **T41**. Conformance statement doc: map every Appendix A row + AP-1…AP-23 to
+- [x] **T41**. Conformance statement doc: map every Appendix A row + AP-1…AP-23 to
       test evidence; announce "Agent Plugins v1.0.0 compatible (client: skills + MCP; producer: skills packages, plus the Ever Works MCP-server package
       descriptor)" — the single canonical claim wording, used verbatim in spec
       §1.3, the ADR, and marketing. MUST document client-side policy refusals

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -221,7 +221,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       `assertNoSecrets` (`packages/agent/src/utils/secret-scan.ts`) as a NEW
       check on text-like files only. Package service ingests sidecars; findings
       for oversized/rejected files.
-- [ ] **T34**. Materialization into claude-code workspace staging
+- [x] **T34**. Materialization into claude-code workspace staging
       (`claude-code.plugin.ts:542-558` seam): `.claude/skills/<name>/…` +
       `.mcp.json` next to `seedMetadata` writes — with the **execution-gate
       split** (plan §4.5/§5, Greptile P1 on PR #2000): `references/`+`assets/`

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -245,9 +245,9 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       off-nav.
 - [ ] **T38**. Desktop staging (`prepare-bundle.js` + `<userData>/agent-plugins`
       default source) + headless-node XDG dir.
-- [ ] **T39**. apps/mcp whitelist decision: expose `agent-plugins` management
+- [x] **T39**. apps/mcp whitelist decision: expose `agent-plugins` management
       tools or document out-of-scope.
-- [ ] **T40**. Security review pass (stdio gate, SSRF policy, containment
+- [x] **T40**. Security review pass (stdio gate, SSRF policy, containment
       fuzzing over fixture escapes); Sentry tags; rate-limit re-check.
 - [x] **T41**. Conformance statement doc: map every Appendix A row + AP-1…AP-23 to
       test evidence; announce "Agent Plugins v1.0.0 compatible (client: skills + MCP; producer: skills packages, plus the Ever Works MCP-server package

--- a/docs/specs/features/agent-plugins/tasks.md
+++ b/docs/specs/features/agent-plugins/tasks.md
@@ -230,7 +230,7 @@ resolveAllowedTools` as a new optional source (domain-tool-source
       servers. Tests assert a non-gated package's scripts NEVER reach the
       workspace. Explicitly does NOT touch the Wave-2 Task-workspace path
       (`workspaceCwd` has no consumer — see plan §4.5).
-- [ ] **T35**. Export API + CLI + UI: scope-selected skills → conformant
+- [x] **T35**. Export API + CLI + UI: scope-selected skills → conformant
       package (zip); round-trip gate (AP-22/23); slug guard enforcing the FULL
       spec name rule (≤64, no `--`, no leading/trailing hyphen — the DTO
       accepts all three) with rename prompt.

--- a/packages/agent-plugins/scripts/oracle-check.py
+++ b/packages/agent-plugins/scripts/oracle-check.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Cross-check our skill validator against the reference implementation.
+
+An oracle, not a gate. `skills-ref` is the reference library for Agent Skills;
+running it over the same fixtures our own validator uses answers a question no
+amount of our own testing can: *does our reading of the specification agree
+with somebody else's?*
+
+Disagreement is reported, never failed on, for two reasons:
+
+1. The two tools do not have the same job. Ours validates a PACKAGE (spec 7.1)
+   and reports per-skill findings without rejecting the package; theirs
+   validates a single skill directory against the Agent Skills spec. A skill we
+   deliberately skip while keeping its siblings is a skill they call invalid,
+   and both are correct.
+2. `skills-ref` is at 0.1.1. Pinning CI to a young external tool's opinion
+   would hand it a veto over merges.
+
+So this prints a table and exits 0. A human reads the disagreements; the build
+does not stop for them.
+
+Usage:
+    python oracle-check.py <fixtures-dir>
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def skill_dirs(fixtures: Path) -> list[Path]:
+    """Every `skills/<name>/` directory under the fixture corpus."""
+    found: list[Path] = []
+    for skills_dir in sorted(fixtures.glob("*/skills")):
+        if not skills_dir.is_dir():
+            continue
+        for child in sorted(skills_dir.iterdir()):
+            if child.is_dir() and (child / "SKILL.md").is_file():
+                found.append(child)
+    return found
+
+
+# The wheel installs a console script, but it is not always on PATH — a
+# pip --user install on Windows and some CI images both leave it off. The
+# module form is equivalent and always resolvable once the package is
+# importable, so it is tried second rather than not at all.
+INVOCATIONS = (
+    ["agentskills", "validate"],
+    [sys.executable, "-m", "skills_ref.cli", "validate"],
+)
+
+
+def reference_verdict(skill: Path) -> tuple[bool, str]:
+    """Ask the reference library. Returns (valid, detail)."""
+    for argv in INVOCATIONS:
+        try:
+            result = subprocess.run(
+                [*argv, str(skill)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except FileNotFoundError:
+            continue
+        except subprocess.TimeoutExpired:
+            return (False, "timed out")
+
+        detail = (result.stderr or result.stdout or "").strip().replace("\n", "; ")
+        # A missing module surfaces as a non-zero exit with an import error
+        # rather than FileNotFoundError, and must not be read as "invalid
+        # skill" — that would report every fixture as a disagreement.
+        if "No module named" in detail:
+            continue
+        return (result.returncode == 0, detail[:160])
+
+    return (False, "reference library unavailable")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: oracle-check.py <fixtures-dir>", file=sys.stderr)
+        return 0  # Never fail the build; see the module docstring.
+
+    fixtures = Path(sys.argv[1])
+    if not fixtures.is_dir():
+        print(f"::warning::Fixture directory {fixtures} not found; oracle skipped.")
+        return 0
+
+    skills = skill_dirs(fixtures)
+    if not skills:
+        print(f"::warning::No skill directories under {fixtures}; oracle skipped.")
+        return 0
+
+    rows = []
+    for skill in skills:
+        valid, detail = reference_verdict(skill)
+        rows.append((skill.parent.parent.name, skill.name, valid, detail))
+
+    accepted = [r for r in rows if r[2]]
+    rejected = [r for r in rows if not r[2]]
+
+    print(f"skills checked by the reference library: {len(rows)}")
+    print(f"  it accepts: {len(accepted)}")
+    print(f"  it rejects: {len(rejected)}")
+
+    if rejected:
+        print("\nRejected by the reference library:")
+        for package, name, _valid, detail in rejected:
+            print(f"  {package}/{name}")
+            if detail:
+                print(f"    {detail}")
+
+    print(
+        "\n::notice::This is ONE HALF of a comparison, printed for a human to read "
+        "against our own findings. It is not an assertion that we agree or disagree, "
+        "because the two tools do not answer the same question: the reference "
+        "validates a single skill against the Agent Skills spec, while ours validates "
+        "a PACKAGE and reports per-skill findings without rejecting the package. Most "
+        "of the corpus is deliberately invalid, so a long rejection list is the "
+        "expected shape — what is worth investigating is a skill listed here that our "
+        "own findings do NOT mention, or the reverse."
+    )
+
+    print(json.dumps({"checked": len(rows), "accepted": len(accepted), "rejected": len(rejected)}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -326,6 +326,7 @@
         "superjson": "^1.13.3",
         "turndown": "^7.2.2",
         "typeorm": "^0.3.31",
+        "undici": "^7.29.0",
         "yaml": "^2.8.3",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.1"

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -17,6 +17,7 @@ import { AgentPluginInstallService } from './install.service';
 import { McpServerConfigService } from './mcp-server-config.service';
 import { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
 import { AgentPluginPackageDataDirService } from './package-data-dir.service';
+import { AgentPluginStdioServerService } from './stdio-server.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -58,6 +59,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         McpServerConfigService,
         PackageMcpReconcilerService,
         AgentPluginPackageDataDirService,
+        AgentPluginStdioServerService,
         // Provided locally rather than by importing `McpModule`, which would
         // pull ActivityLogModule and its transitive imports into what the
         // docstring above promises is a LEAF module. `McpModule` provides this
@@ -87,6 +89,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         McpServerConfigService,
         PackageMcpReconcilerService,
         AgentPluginPackageDataDirService,
+        AgentPluginStdioServerService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -16,6 +16,7 @@ import { AgentPluginUpdateService } from './update.service';
 import { AgentPluginInstallService } from './install.service';
 import { McpServerConfigService } from './mcp-server-config.service';
 import { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
+import { AgentPluginPackageDataDirService } from './package-data-dir.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -56,6 +57,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginInstallService,
         McpServerConfigService,
         PackageMcpReconcilerService,
+        AgentPluginPackageDataDirService,
         // Provided locally rather than by importing `McpModule`, which would
         // pull ActivityLogModule and its transitive imports into what the
         // docstring above promises is a LEAF module. `McpModule` provides this
@@ -84,6 +86,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         AgentPluginInstallService,
         McpServerConfigService,
         PackageMcpReconcilerService,
+        AgentPluginPackageDataDirService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/agent-plugins.module.ts
+++ b/packages/agent/src/agent-plugins/agent-plugins.module.ts
@@ -18,6 +18,7 @@ import { McpServerConfigService } from './mcp-server-config.service';
 import { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
 import { AgentPluginPackageDataDirService } from './package-data-dir.service';
 import { AgentPluginStdioServerService } from './stdio-server.service';
+import { AgentPluginExportService } from './export.service';
 import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
 
 /**
@@ -60,6 +61,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         PackageMcpReconcilerService,
         AgentPluginPackageDataDirService,
         AgentPluginStdioServerService,
+        AgentPluginExportService,
         // Provided locally rather than by importing `McpModule`, which would
         // pull ActivityLogModule and its transitive imports into what the
         // docstring above promises is a LEAF module. `McpModule` provides this
@@ -90,6 +92,7 @@ import { AGENT_PLUGIN_SKILL_SOURCE } from './skill-source.token';
         PackageMcpReconcilerService,
         AgentPluginPackageDataDirService,
         AgentPluginStdioServerService,
+        AgentPluginExportService,
         AGENT_PLUGIN_SKILL_SOURCE,
     ],
 })

--- a/packages/agent/src/agent-plugins/containment-fuzz.spec.ts
+++ b/packages/agent/src/agent-plugins/containment-fuzz.spec.ts
@@ -1,0 +1,211 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isWithin } from './package-data-dir.service';
+import { LaunchRefused, resolveCommand, resolveCwd } from './stdio-launcher';
+import { redactUrl, validateGitUrl } from './git-source';
+import { versionPermitted } from './npm-source';
+import { connectionNameFor } from './package-mcp-reconciler.service';
+
+/**
+ * T40 — containment fuzzing over the security boundary.
+ *
+ * Every other suite asserts a specific case. This one generates the space of
+ * escape attempts and asserts that NONE is accepted, which is the property
+ * that actually matters: a containment check is only as good as the inputs
+ * nobody thought to try.
+ *
+ * The generators below are deliberately mechanical — separator variants,
+ * encodings, prefixes — because a hand-written list reflects the same
+ * assumptions as the code it is testing.
+ */
+
+const SEPARATORS = ['/', '\\'];
+const TRAVERSALS = ['..', '%2e%2e', '....//', '.%2e', '..;'];
+const ABSOLUTE_PREFIXES = ['/', '//', '\\\\', 'C:\\', 'C:/', '\\\\?\\C:\\', '\\\\server\\share'];
+
+/** Path-ish strings that must never be accepted as a package-relative value. */
+function escapeAttempts(): string[] {
+    const out = new Set<string>();
+
+    for (const sep of SEPARATORS) {
+        for (const trav of TRAVERSALS) {
+            out.add(`${trav}${sep}etc${sep}passwd`);
+            out.add(`.${sep}${trav}${sep}elsewhere`);
+            out.add(`.${sep}bin${sep}${trav}${sep}${trav}${sep}etc`);
+            out.add(`${trav}${sep}${trav}${sep}${trav}`);
+        }
+    }
+    for (const prefix of ABSOLUTE_PREFIXES) {
+        out.add(`${prefix}etc/passwd`);
+        out.add(`${prefix}`);
+    }
+    out.add('\0/etc/passwd');
+    out.add('./bin/\0../../etc');
+    out.add('${PLUGIN_ROOT}/../elsewhere');
+    out.add('${PLUGIN_DATA}/../elsewhere');
+    out.add('~');
+    out.add('~/.ssh/id_rsa');
+
+    return [...out];
+}
+
+let pkg: string;
+let data: string;
+
+beforeAll(async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ap-fuzz-'));
+    pkg = join(root, 'package');
+    data = join(root, 'data');
+    await mkdir(join(pkg, 'bin'), { recursive: true });
+    await mkdir(data, { recursive: true });
+    await writeFile(join(pkg, 'bin', 'server'), '#!/bin/sh\n', 'utf8');
+});
+
+describe('containment fuzz — command resolution', () => {
+    it('refuses every generated escape attempt', async () => {
+        const accepted: string[] = [];
+
+        for (const attempt of escapeAttempts()) {
+            try {
+                const result = await resolveCommand(attempt, pkg);
+                // A bare name is legitimate; anything that resolved to a PATH
+                // lookup has not escaped anything. Only a resolved FILE path
+                // that landed outside the package is a failure.
+                if (!result.resolvesThroughPath && !isWithin(pkg, result.command)) {
+                    accepted.push(attempt);
+                }
+            } catch (err) {
+                expect(err).toBeInstanceOf(LaunchRefused);
+            }
+        }
+
+        expect(accepted).toEqual([]);
+    });
+
+    it('accepts the one shape that is supposed to work', async () => {
+        // A fuzz suite that refuses everything proves nothing, so this pins
+        // that the legitimate case still passes.
+        const result = await resolveCommand('./bin/server', pkg);
+        expect(isWithin(pkg, result.command)).toBe(true);
+    });
+});
+
+describe('containment fuzz — cwd resolution', () => {
+    it('never resolves outside the anchor it names', async () => {
+        const escaped: string[] = [];
+
+        for (const attempt of escapeAttempts()) {
+            try {
+                const resolved = await resolveCwd(attempt, {
+                    packageRoot: pkg,
+                    pluginData: data,
+                });
+                if (!isWithin(pkg, resolved) && !isWithin(data, resolved)) {
+                    escaped.push(`${attempt} -> ${resolved}`);
+                }
+            } catch (err) {
+                expect(err).toBeInstanceOf(LaunchRefused);
+            }
+        }
+
+        expect(escaped).toEqual([]);
+    });
+});
+
+describe('containment fuzz — isWithin', () => {
+    it('never reports containment for a sibling sharing a prefix', () => {
+        const roots = ['/data/acme', '/data/a', '/srv/x'];
+        const wrong: string[] = [];
+
+        for (const root of roots) {
+            for (const suffix of ['-2', '2', '.bak', 'x', '-evil/nested']) {
+                const sibling = `${root}${suffix}`;
+                if (isWithin(root, sibling)) {
+                    wrong.push(`${root} <- ${sibling}`);
+                }
+            }
+        }
+
+        expect(wrong).toEqual([]);
+    });
+
+    it('still reports containment for genuine descendants', () => {
+        expect(isWithin('/data/acme', '/data/acme/x/y')).toBe(true);
+        expect(isWithin('/data/acme', '/data/acme')).toBe(true);
+    });
+});
+
+describe('containment fuzz — git URL policy', () => {
+    it('refuses every non-https scheme and every credential form', () => {
+        const attempts = [
+            'http://example.com/x.git',
+            'file:///etc/passwd',
+            'ftp://example.com/x',
+            'ssh://git@example.com/x.git',
+            'git://example.com/x.git',
+            'ext::sh -c whoami',
+            'javascript:alert(1)',
+            'data:text/plain,hello',
+            'https://user:pw@example.com/x.git',
+            'https://:pw@example.com/x.git',
+            'https://user:@example.com/x.git',
+        ];
+
+        const accepted = attempts.filter((url) => validateGitUrl(url).ok);
+        expect(accepted).toEqual([]);
+    });
+
+    it('never leaves a credential in a refusal, whatever the shape', () => {
+        const secrets = ['hunter2', 'sk-live-abcdef', 'ghp_zzzz'];
+        const leaked: string[] = [];
+
+        for (const secret of secrets) {
+            for (const url of [
+                `https://user:${secret}@example.com/x.git`,
+                `https://${secret}:x@example.com/x.git`,
+                `http://user:${secret}@example.com/x`,
+                `https://user:${secret}@exa mple.com/[x`,
+            ]) {
+                const result = validateGitUrl(url);
+                if (result.reason?.includes(secret)) leaked.push(url);
+                if (redactUrl(url).includes(secret)) leaked.push(`redactUrl: ${url}`);
+            }
+        }
+
+        expect(leaked).toEqual([]);
+    });
+
+    it('still accepts an ordinary https URL', () => {
+        expect(validateGitUrl('https://github.com/acme/skills.git').ok).toBe(true);
+    });
+});
+
+describe('containment fuzz — derived identifiers', () => {
+    it('never derives a connection name outside the permitted charset', () => {
+        const inputs = ['../evil', 'a/b', 'A B C', '', '...', '@scope/pkg', '\0nul', '–dash'];
+        const bad: string[] = [];
+
+        for (const pkgName of inputs) {
+            for (const server of inputs) {
+                const name = connectionNameFor(pkgName, server);
+                if (name !== null && !/^[a-z0-9][a-z0-9-]{0,79}$/u.test(name)) {
+                    bad.push(`${pkgName} + ${server} -> ${name}`);
+                }
+            }
+        }
+
+        expect(bad).toEqual([]);
+    });
+
+    it('never treats a crafted range as permitting an arbitrary version', () => {
+        // The range is operator-supplied, so a value that accidentally matched
+        // everything would silently widen an authorisation.
+        expect(versionPermitted('9.9.9', '1.0.0')).toBe(false);
+        expect(versionPermitted('9.9.9', '1.')).toBe(false);
+        expect(versionPermitted('9.9.9', '^1.0.0')).toBe(false);
+        expect(versionPermitted('9.9.9', '1.*')).toBe(false);
+        // Only an explicit wildcard opens it, which an operator can see.
+        expect(versionPermitted('9.9.9', '*')).toBe(true);
+    });
+});

--- a/packages/agent/src/agent-plugins/export.service.spec.ts
+++ b/packages/agent/src/agent-plugins/export.service.spec.ts
@@ -1,4 +1,10 @@
-import { AgentPluginExportService, ExportFailed } from './export.service';
+import {
+    AgentPluginExportService,
+    everWorksMcpDescriptorFiles,
+    EVER_WORKS_MCP_PACKAGE,
+    EVER_WORKS_MCP_URL,
+    ExportFailed,
+} from './export.service';
 
 /**
  * These run the REAL serializer and the REAL importer against a real
@@ -127,5 +133,72 @@ describe('AgentPluginExportService', () => {
         // An export can carry a user's private instructions; a temp directory
         // nobody cleans is exactly where those would linger.
         expect(after).toBe(before);
+    });
+});
+
+describe('Ever Works MCP descriptor (T36)', () => {
+    it('passes the SAME importer gate as any other export', async () => {
+        // A descriptor we publish is a package other clients install, so it
+        // has to pass exactly what we would demand of theirs.
+        const result = await service.buildEverWorksMcpDescriptor();
+
+        expect([...result.files.keys()].sort()).toEqual(['mcp.json', 'plugin.json']);
+    });
+
+    it('declares a streamable-http server at the hosted endpoint', async () => {
+        const files = everWorksMcpDescriptorFiles();
+        const mcp = JSON.parse(files.get('mcp.json')!);
+
+        expect(mcp.mcpServers['ever-works']).toEqual({
+            type: 'streamable-http',
+            url: EVER_WORKS_MCP_URL,
+        });
+    });
+
+    it('carries NO credentials, which AP-15 makes a rule rather than a preference', async () => {
+        const files = everWorksMcpDescriptorFiles();
+        const mcp = JSON.parse(files.get('mcp.json')!);
+
+        // Package-configured headers are visible and non-secret, so a
+        // descriptor embedding an API key would publish that key to every
+        // consumer of the package.
+        expect(mcp.mcpServers['ever-works'].headers).toBeUndefined();
+        expect(JSON.stringify(files.get('mcp.json'))).not.toMatch(/token|secret|api[-_]?key/iu);
+    });
+
+    it('uses a server name that is safe as a tool namespace', async () => {
+        const files = everWorksMcpDescriptorFiles();
+        const mcp = JSON.parse(files.get('mcp.json')!);
+
+        // Becomes `mcp__ever-works__<tool>`, so it must not contain the
+        // `__` separator or the name could not be split back apart.
+        for (const name of Object.keys(mcp.mcpServers)) {
+            expect(name).not.toContain('__');
+            expect(name).toMatch(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/u);
+        }
+    });
+
+    it('names the package with a reverse-domain identifier the spec accepts', async () => {
+        const files = everWorksMcpDescriptorFiles();
+        const plugin = JSON.parse(files.get('plugin.json')!);
+
+        expect(plugin.name).toBe(EVER_WORKS_MCP_PACKAGE);
+        expect(plugin.$schema).toContain('1.0.0');
+    });
+
+    it('is a valid package despite having NO skills', async () => {
+        // The specification lets a package support any subset of the
+        // component types; a descriptor declares a server and nothing else.
+        const result = await service.buildEverWorksMcpDescriptor();
+
+        expect(result.files.has('skills')).toBe(false);
+        expect([...result.files.keys()].some((k) => k.startsWith('skills/'))).toBe(false);
+    });
+
+    it('accepts an override URL for a self-hosted deployment', async () => {
+        const files = everWorksMcpDescriptorFiles({ url: 'https://mcp.example.com/mcp' });
+        const mcp = JSON.parse(files.get('mcp.json')!);
+
+        expect(mcp.mcpServers['ever-works'].url).toBe('https://mcp.example.com/mcp');
     });
 });

--- a/packages/agent/src/agent-plugins/export.service.spec.ts
+++ b/packages/agent/src/agent-plugins/export.service.spec.ts
@@ -1,0 +1,131 @@
+import { AgentPluginExportService, ExportFailed } from './export.service';
+
+/**
+ * These run the REAL serializer and the REAL importer against a real
+ * temporary directory. AP-22 is a claim about what a consumer receives, and a
+ * consumer receives a tree — so a test over in-memory strings would be
+ * testing something else.
+ */
+
+const service = new AgentPluginExportService();
+
+const skill = (over: Partial<Parameters<typeof service.buildPackage>[0]['skills'][0]> = {}) => ({
+    slug: 'release-notes',
+    description: 'Draft release notes from a changelog.',
+    body: '# Release notes\n\nInstructions.\n',
+    ...over,
+});
+
+const manifest = { name: 'acme.tools', version: '1.0.0' };
+
+describe('AgentPluginExportService', () => {
+    it('produces a package that our OWN importer accepts', async () => {
+        const result = await service.buildPackage({ manifest, skills: [skill()] });
+
+        // The round-trip gate: `buildPackage` throws unless the written tree
+        // loads, so reaching here IS the assertion that AP-22 holds.
+        expect([...result.files.keys()].sort()).toEqual([
+            'plugin.json',
+            'skills/release-notes/SKILL.md',
+        ]);
+        expect(result.rejected).toEqual([]);
+    });
+
+    it('writes the skill name as BOTH the directory and the frontmatter (AP-23)', async () => {
+        const result = await service.buildPackage({ manifest, skills: [skill()] });
+
+        const content = result.files.get('skills/release-notes/SKILL.md');
+        expect(content).toContain('name: release-notes');
+        expect(content).toContain('description: Draft release notes from a changelog.');
+        expect(content).toContain('Instructions.');
+    });
+
+    it('emits a manifest carrying the published schema id', async () => {
+        const result = await service.buildPackage({ manifest, skills: [skill()] });
+
+        const plugin = JSON.parse(result.files.get('plugin.json')!);
+        expect(plugin.$schema).toContain('1.0.0');
+        expect(plugin.name).toBe('acme.tools');
+    });
+
+    it('REPORTS an unusable slug with a suggestion rather than renaming it', async () => {
+        const result = await service.buildPackage({
+            manifest,
+            skills: [skill(), skill({ slug: 'Release--Notes-' })],
+        });
+
+        // A renamed skill is a DIFFERENT skill to a consumer: bindings,
+        // references and documentation all key on the name. So the caller is
+        // asked rather than having a rename applied behind them.
+        expect(result.rejected).toHaveLength(1);
+        expect(result.rejected[0].slug).toBe('Release--Notes-');
+        expect(result.rejected[0].suggestion).toBeTruthy();
+        expect(result.files.has('skills/Release--Notes-/SKILL.md')).toBe(false);
+    });
+
+    it('refuses two slugs that narrow onto the SAME name', async () => {
+        const result = await service.buildPackage({
+            manifest,
+            skills: [skill({ slug: 'notes' }), skill({ slug: 'Notes' })],
+        });
+
+        // Emitting both would leave one directory containing whichever was
+        // written last — a skill that vanishes with no error anywhere.
+        expect(result.files.has('skills/notes/SKILL.md')).toBe(true);
+        expect(result.rejected).toHaveLength(1);
+        expect(result.rejected[0].slug).toBe('Notes');
+    });
+
+    it('fails loudly when the selection yields no valid skills', async () => {
+        await expect(
+            service.buildPackage({ manifest, skills: [skill({ slug: '---' })] }),
+        ).rejects.toBeInstanceOf(ExportFailed);
+    });
+
+    it('carries the importer’s findings when the result does not load', async () => {
+        // A manifest name the spec forbids: the serializer refuses it before
+        // the importer is reached, which is the earlier of the two gates.
+        await expect(
+            service.buildPackage({ manifest: { name: 'Not A Name' }, skills: [skill()] }),
+        ).rejects.toThrow();
+    });
+
+    it('round-trips allowed-tools and license through the frontmatter', async () => {
+        const result = await service.buildPackage({
+            manifest,
+            skills: [skill({ allowedTools: ['Read', 'Grep'], license: 'MIT' })],
+        });
+
+        const content = result.files.get('skills/release-notes/SKILL.md')!;
+        expect(content).toContain('allowed-tools: Read Grep');
+        expect(content).toContain('license: MIT');
+    });
+
+    it('produces a zip containing the same entries', async () => {
+        const result = await service.buildPackage({ manifest, skills: [skill()] });
+
+        const zip = await service.toZip(result.files);
+
+        expect(zip.length).toBeGreaterThan(0);
+        const { default: JSZip } = await import('jszip');
+        const reopened = await JSZip.loadAsync(zip);
+        expect(Object.keys(reopened.files).sort()).toEqual(
+            expect.arrayContaining(['plugin.json', 'skills/release-notes/SKILL.md']),
+        );
+    });
+
+    it('leaves no temporary directory behind after a failure', async () => {
+        const { readdir } = await import('node:fs/promises');
+        const { tmpdir } = await import('node:os');
+
+        const before = (await readdir(tmpdir())).filter((n) => n.startsWith('ap-export-')).length;
+        await service
+            .buildPackage({ manifest, skills: [skill({ slug: '---' })] })
+            .catch(() => undefined);
+        const after = (await readdir(tmpdir())).filter((n) => n.startsWith('ap-export-')).length;
+
+        // An export can carry a user's private instructions; a temp directory
+        // nobody cleans is exactly where those would linger.
+        expect(after).toBe(before);
+    });
+});

--- a/packages/agent/src/agent-plugins/export.service.ts
+++ b/packages/agent/src/agent-plugins/export.service.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
     loadPluginPackage,
+    mcpSchemaId,
+    PUBLISHED_CONFORMANCE_VERSION,
     serializeManifest,
     serializeSkillMd,
     toSpecSkillName,
@@ -91,6 +93,75 @@ function narrowingFailure(value: NameNarrowing): { reason: string; suggestion?: 
     };
 }
 
+/** The hosted Ever Works MCP endpoint the descriptor points at. */
+export const EVER_WORKS_MCP_URL = 'https://mcp.ever.works/mcp';
+
+/** Package name for the descriptor. Reverse-domain, per the spec's name rule. */
+export const EVER_WORKS_MCP_PACKAGE = 'works.ever.mcp';
+
+/**
+ * The Ever Works MCP server, as an Agent Plugins package descriptor (T36).
+ *
+ * This is the PRODUCER half of the conformance claim: it lets any conforming
+ * client — not just Ever Works — consume the Ever Works MCP server by
+ * installing an ordinary package, rather than by following prose in our
+ * documentation and hand-writing a config.
+ *
+ * ## It carries no credentials, and that is a rule rather than a convenience
+ *
+ * AP-15 treats package-configured headers as visible and non-secret, so a
+ * descriptor that embedded an API key would be publishing that key to every
+ * consumer of the package. The endpoint does require authentication — it
+ * answers 401 — and supplying it is the consuming client's job, through
+ * whatever credential mechanism that client already has. The descriptor's
+ * only job is to say where the server is and how to speak to it.
+ *
+ * No `skills/` directory: this package declares a server and nothing else,
+ * which the specification permits — a package may support any subset of the
+ * component types.
+ */
+export function everWorksMcpDescriptorFiles(
+    options: { url?: string; version?: string } = {},
+): Map<string, string> {
+    const url = options.url ?? EVER_WORKS_MCP_URL;
+
+    const files = new Map<string, string>();
+    files.set(
+        'plugin.json',
+        serializeManifest({
+            name: EVER_WORKS_MCP_PACKAGE,
+            ...(options.version ? { version: options.version } : {}),
+            description: 'Manage Ever Works works, items and deployments over MCP.',
+            homepage: 'https://ever.works',
+            repository: 'https://github.com/ever-works/ever-works',
+            license: 'AGPL-3.0',
+            keywords: ['ever-works', 'mcp', 'works'],
+        }),
+    );
+
+    // `mcp.json` is emitted directly: the library validates this shape but
+    // does not serialise it, and the schema is small and closed enough that a
+    // serialiser would add indirection without adding a guarantee. The
+    // round-trip gate is what proves the result is right.
+    files.set(
+        'mcp.json',
+        JSON.stringify(
+            {
+                $schema: mcpSchemaId(PUBLISHED_CONFORMANCE_VERSION),
+                mcpServers: {
+                    // Namespace-safe: this becomes `mcp__ever-works__<tool>`,
+                    // so it must not contain the `__` separator.
+                    'ever-works': { type: 'streamable-http', url },
+                },
+            },
+            null,
+            2,
+        ) + '\n',
+    );
+
+    return files;
+}
+
 @Injectable()
 export class AgentPluginExportService {
     private readonly logger = new Logger(AgentPluginExportService.name);
@@ -157,7 +228,10 @@ export class AgentPluginExportService {
      * private instructions, and a temp directory nobody cleans is where those
      * would linger.
      */
-    private async proveItImports(files: PackageFiles): Promise<readonly Finding[]> {
+    private async proveItImports(
+        files: PackageFiles,
+        options: { requireSkills?: boolean } = {},
+    ): Promise<readonly Finding[]> {
         const dir = await mkdtemp(join(tmpdir(), 'ap-export-'));
         try {
             for (const [relative, content] of files) {
@@ -174,10 +248,12 @@ export class AgentPluginExportService {
                 );
             }
 
-            // A package that loads but contributed nothing is almost certainly
-            // not what the user asked for, and it would be a confusing thing
-            // to hand them a zip of.
-            if (load.skills.length === 0) {
+            // A skills export that loads but contributed nothing is almost
+            // certainly not what the user asked for, and a confusing thing to
+            // hand them a zip of. The MCP descriptor legitimately has no
+            // skills, so it opts out — the specification lets a package
+            // support any subset of the component types.
+            if ((options.requireSkills ?? true) && load.skills.length === 0) {
                 throw new ExportFailed(
                     'The exported package contains no valid skills.',
                     load.findings,
@@ -191,6 +267,22 @@ export class AgentPluginExportService {
         } finally {
             await rm(dir, { recursive: true, force: true }).catch(() => undefined);
         }
+    }
+
+    /**
+     * Build the Ever Works MCP descriptor, proved against our own importer.
+     *
+     * Uses the same gate as any other export: a descriptor we publish is a
+     * package other clients install, so it has to pass exactly what we would
+     * demand of theirs.
+     */
+    async buildEverWorksMcpDescriptor(options: { url?: string; version?: string } = {}): Promise<{
+        files: PackageFiles;
+        findings: readonly Finding[];
+    }> {
+        const files = everWorksMcpDescriptorFiles(options);
+        const findings = await this.proveItImports(files, { requireSkills: false });
+        return { files, findings };
     }
 
     /**

--- a/packages/agent/src/agent-plugins/export.service.ts
+++ b/packages/agent/src/agent-plugins/export.service.ts
@@ -1,0 +1,211 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    loadPluginPackage,
+    serializeManifest,
+    serializeSkillMd,
+    toSpecSkillName,
+    type Finding,
+    type NameNarrowing,
+    type SerializeManifestInput,
+} from '@ever-works/agent-plugins';
+
+/**
+ * Exports skills as a conforming Agent Plugins package (T35, AP-22/AP-23).
+ *
+ * ## The round-trip gate is the feature, not a check on it
+ *
+ * AP-22 requires that anything we export validates against our own importer.
+ * That is not a nicety: a producer that emits packages its own consumer
+ * rejects has published a format nobody can rely on, and the failure would
+ * surface in someone else's client rather than in ours. So
+ * {@link buildPackage} writes the package to a temporary directory, runs the
+ * REAL `loadPluginPackage` over it, and refuses to return anything that does
+ * not load — with the loader's own findings attached.
+ *
+ * Validating the in-memory strings instead would test a different thing.
+ * Directory naming, the `skills/<name>/SKILL.md` layout and path containment
+ * are facts about a tree, and the tree is what a consumer receives.
+ */
+
+/** A file in the exported package, keyed by its package-relative path. */
+export type PackageFiles = ReadonlyMap<string, string>;
+
+export interface ExportSkillInput {
+    /** Platform slug. Narrowed to the spec's name rule, or reported. */
+    readonly slug: string;
+    readonly description: string;
+    readonly body: string;
+    readonly license?: string;
+    readonly allowedTools?: readonly string[];
+    readonly metadata?: Readonly<Record<string, string>>;
+}
+
+export interface ExportInput {
+    readonly manifest: SerializeManifestInput;
+    readonly skills: readonly ExportSkillInput[];
+}
+
+export interface ExportResult {
+    readonly files: PackageFiles;
+    /**
+     * Skills whose slug could not be narrowed to a legal name.
+     *
+     * Reported rather than silently renamed. A renamed skill is a DIFFERENT
+     * skill from the consumer's point of view — bindings, references and
+     * documentation all key on the name — so the caller is given the
+     * suggestion and asked, instead of having a rename applied behind them.
+     */
+    readonly rejected: readonly { slug: string; reason: string; suggestion?: string }[];
+    /** Non-fatal findings the importer reported while validating the result. */
+    readonly findings: readonly Finding[];
+}
+
+export class ExportFailed extends Error {
+    constructor(
+        message: string,
+        readonly findings: readonly Finding[],
+    ) {
+        super(message);
+        this.name = 'ExportFailed';
+    }
+}
+
+/**
+ * Read a failed {@link toSpecSkillName} result.
+ *
+ * `NameNarrowing` is a discriminated union, and `packages/agent` compiles with
+ * `strictNullChecks: false`, under which TypeScript does NOT narrow a
+ * boolean-literal discriminant — `if (!narrowed.ok)` leaves the value
+ * unnarrowed and `narrowed.finding` fails to compile. The conformance library
+ * is strict and uses unions freely; every crossing into this package needs
+ * this, and this is the third place in the programme that has.
+ */
+function narrowingFailure(value: NameNarrowing): { reason: string; suggestion?: string } {
+    const failed = value as Extract<NameNarrowing, { ok: false }>;
+    return {
+        reason: failed.finding.message,
+        ...(failed.suggestion ? { suggestion: failed.suggestion } : {}),
+    };
+}
+
+@Injectable()
+export class AgentPluginExportService {
+    private readonly logger = new Logger(AgentPluginExportService.name);
+
+    /**
+     * Build a package and prove it imports.
+     *
+     * Throws {@link ExportFailed} when the result does not load, carrying the
+     * importer's findings — the caller needs to know WHICH rule its own data
+     * broke, not merely that something did.
+     */
+    async buildPackage(input: ExportInput): Promise<ExportResult> {
+        const files = new Map<string, string>();
+        const rejected: { slug: string; reason: string; suggestion?: string }[] = [];
+
+        files.set('plugin.json', serializeManifest(input.manifest));
+
+        const usedNames = new Set<string>();
+
+        for (const skill of input.skills) {
+            const narrowed = toSpecSkillName(skill.slug);
+            if (!narrowed.ok) {
+                rejected.push({ slug: skill.slug, ...narrowingFailure(narrowed) });
+                continue;
+            }
+
+            // Two platform slugs can narrow onto the same spec name. Emitting
+            // both would produce one directory silently containing whichever
+            // was written last — a skill that vanishes with no error anywhere.
+            if (usedNames.has(narrowed.name)) {
+                rejected.push({
+                    slug: skill.slug,
+                    reason:
+                        `"${skill.slug}" narrows to "${narrowed.name}", which another ` +
+                        `selected skill already uses.`,
+                });
+                continue;
+            }
+            usedNames.add(narrowed.name);
+
+            files.set(
+                `skills/${narrowed.name}/SKILL.md`,
+                serializeSkillMd({
+                    name: narrowed.name,
+                    description: skill.description,
+                    body: skill.body,
+                    ...(skill.license ? { license: skill.license } : {}),
+                    ...(skill.allowedTools ? { allowedTools: skill.allowedTools } : {}),
+                    ...(skill.metadata ? { metadata: skill.metadata } : {}),
+                }),
+            );
+        }
+
+        const findings = await this.proveItImports(files);
+
+        return { files, rejected, findings };
+    }
+
+    /**
+     * Write the package to a temporary directory and load it back.
+     *
+     * The directory is removed in a `finally`, so a failure that throws does
+     * not leave the exported contents on disk — an export can carry a user's
+     * private instructions, and a temp directory nobody cleans is where those
+     * would linger.
+     */
+    private async proveItImports(files: PackageFiles): Promise<readonly Finding[]> {
+        const dir = await mkdtemp(join(tmpdir(), 'ap-export-'));
+        try {
+            for (const [relative, content] of files) {
+                const target = join(dir, relative);
+                await mkdir(join(target, '..'), { recursive: true });
+                await writeFile(target, content, 'utf8');
+            }
+
+            const load = await loadPluginPackage(dir);
+            if (!load.ok) {
+                throw new ExportFailed(
+                    'The exported package does not validate against our own importer.',
+                    load.findings,
+                );
+            }
+
+            // A package that loads but contributed nothing is almost certainly
+            // not what the user asked for, and it would be a confusing thing
+            // to hand them a zip of.
+            if (load.skills.length === 0) {
+                throw new ExportFailed(
+                    'The exported package contains no valid skills.',
+                    load.findings,
+                );
+            }
+
+            this.logger.log(
+                `Exported package "${load.manifest.name}" with ${load.skills.length} skill(s)`,
+            );
+            return load.findings;
+        } finally {
+            await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+        }
+    }
+
+    /**
+     * Zip the built package.
+     *
+     * Separate from {@link buildPackage} so the round-trip gate runs against
+     * the FILES, not against an archive — an importer reads a directory, so
+     * validating the archive would validate something no consumer sees.
+     */
+    async toZip(files: PackageFiles): Promise<Buffer> {
+        const { default: JSZip } = await import('jszip');
+        const zip = new JSZip();
+        for (const [relative, content] of files) {
+            zip.file(relative, content);
+        }
+        return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+    }
+}

--- a/packages/agent/src/agent-plugins/git-source.spec.ts
+++ b/packages/agent/src/agent-plugins/git-source.spec.ts
@@ -75,6 +75,20 @@ describe('validateGitUrl', () => {
 });
 
 describe('redactUrl', () => {
+    it('removes a TOKEN-ONLY credential, which has no colon', () => {
+        // `https://ghp_xxxx@host/repo.git` is how a GitHub PAT is normally
+        // embedded. A pattern requiring `user:password` left it in the
+        // message, the response body and the log.
+        expect(redactUrl('https://ghp_secret@example.com/x.git')).toBe(
+            'https://<redacted>@example.com/x.git',
+        );
+    });
+
+    it('leaves an @ in a PATH alone', () => {
+        // Only userinfo sits before the first `/` after the authority.
+        expect(redactUrl('https://example.com/a@b')).toBe('https://example.com/a@b');
+    });
+
     it('removes credentials from a parseable URL', () => {
         expect(redactUrl('https://user:hunter2@example.com/x.git')).toBe(
             'https://<redacted>@example.com/x.git',
@@ -176,6 +190,33 @@ describe('AgentPluginGitSource', () => {
         ).rejects.toMatchObject({ status: 409 });
 
         expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the allowlist restricts refs but none is given', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(
+            allowlistStub({ allowed: true, entry: { versionRange: 'v1.*' } }),
+        );
+        source.setGitImplementation(git, {});
+
+        await expect(
+            source.acquire({ url: 'https://example.com/x.git', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 409 });
+
+        // Otherwise `git.clone` checks out the remote's DEFAULT branch, which
+        // the pattern never authorised — "v1.* and no others" is not a
+        // licence to take whatever HEAD points at.
+        expect(git.clone).not.toHaveBeenCalled();
+    });
+
+    it('still allows an unrestricted entry to use the default branch', async () => {
+        const git = gitStub();
+        const source = new AgentPluginGitSource(allowlistStub({ allowed: true }));
+        source.setGitImplementation(git, {});
+
+        await source.acquire({ url: 'https://example.com/x.git', destDir: await scratch() });
+
+        expect(git.clone).toHaveBeenCalled();
     });
 
     it('clones shallow, single-branch, without tags and without an auth callback', async () => {

--- a/packages/agent/src/agent-plugins/git-source.ts
+++ b/packages/agent/src/agent-plugins/git-source.ts
@@ -68,7 +68,12 @@ export interface GitLike {
  * check that reports the secret it is protecting is worse than no check.
  */
 export function redactUrl(value: string): string {
-    return value.replace(/(\/\/)[^/@\s]*:[^/@\s]*@/gu, '$1<redacted>@');
+    // Matches ALL userinfo before `@`, not only `user:password`. A
+    // token-only credential — `https://ghp_xxxx@host/repo.git`, which is how
+    // GitHub PATs are normally embedded — has no colon, so a pattern
+    // requiring one left it in the message, the response body and the log.
+    // The `@` is what makes something userinfo; the colon is optional.
+    return value.replace(/(\/\/)[^/@\s]+@/gu, '$1<redacted>@');
 }
 
 /**
@@ -217,6 +222,26 @@ export class AgentPluginGitSource {
         // fetched. Without it, allowlisting a repository would authorise every
         // branch in it, including one an outside contributor can push to.
         const pattern = allow.entry?.versionRange?.trim();
+
+        // A restricted entry with NO ref requested is the gap: `git.clone`
+        // then checks out the remote's default branch, which the pattern
+        // never authorised. An operator writing `v1.*` means "these refs and
+        // no others", and silently taking whatever `HEAD` points at is not a
+        // subset of that.
+        if (pattern && !input.ref) {
+            throw new HttpException(
+                {
+                    statusCode: HttpStatus.CONFLICT,
+                    message:
+                        `"${redactUrl(input.url)}" is restricted to refs matching ` +
+                        `"${pattern}", so a ref must be given explicitly — the remote's ` +
+                        `default branch is not necessarily one of them.`,
+                    url: redactUrl(input.url),
+                },
+                HttpStatus.CONFLICT,
+            );
+        }
+
         if (pattern && input.ref && !refMatchesPattern(input.ref, pattern)) {
             throw new HttpException(
                 {
@@ -297,7 +322,11 @@ export class AgentPluginGitSource {
         const allow = await this.allowlist.check(url, 'git');
         if (!allow.allowed) return null;
 
+        // Same rule as `acquire`: a restricted entry with no ref would report
+        // the default branch's commit as "the" remote SHA, and an update
+        // offered from an unauthorised ref is an invitation to install one.
         const pattern = allow.entry?.versionRange?.trim();
+        if (pattern && !ref) return null;
         if (pattern && ref && !refMatchesPattern(ref, pattern)) return null;
 
         try {

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -146,3 +146,10 @@ export {
     type ExportSkillInput,
     type PackageFiles,
 } from './export.service';
+
+export {
+    planWorkspaceMaterialization,
+    type MaterializationInput,
+    type MaterializationPlan,
+    type MaterializedFile,
+} from './workspace-materialization';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -137,3 +137,12 @@ export {
     type StdioLaunchRequest,
     type StdioTransportFactory,
 } from './stdio-server.service';
+
+export {
+    AgentPluginExportService,
+    ExportFailed,
+    type ExportInput,
+    type ExportResult,
+    type ExportSkillInput,
+    type PackageFiles,
+} from './export.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -130,3 +130,10 @@ export {
     type LaunchContext,
     type LaunchPlan,
 } from './stdio-launcher';
+
+export {
+    AgentPluginStdioServerService,
+    type RunningStdioServer,
+    type StdioLaunchRequest,
+    type StdioTransportFactory,
+} from './stdio-server.service';

--- a/packages/agent/src/agent-plugins/index.ts
+++ b/packages/agent/src/agent-plugins/index.ts
@@ -113,3 +113,20 @@ export {
     PackageMcpReconcilerService,
     type ReconcileResult,
 } from './package-mcp-reconciler.service';
+
+export {
+    AgentPluginPackageDataDirService,
+    dataDirSegment,
+    isWithin,
+    type PackageDataDirOwner,
+} from './package-data-dir.service';
+
+export {
+    buildLaunchEnv,
+    buildLaunchPlan,
+    LaunchRefused,
+    resolveCommand,
+    resolveCwd,
+    type LaunchContext,
+    type LaunchPlan,
+} from './stdio-launcher';

--- a/packages/agent/src/agent-plugins/install.service.spec.ts
+++ b/packages/agent/src/agent-plugins/install.service.spec.ts
@@ -165,7 +165,14 @@ describe('AgentPluginInstallService', () => {
         // This is the production caller the reconciler was missing. Without
         // it, package MCP declarations never became connection rows outside
         // tests — the same dead-seam shape as `checkForUpdates`.
-        expect(reconciler.reconcile).toHaveBeenCalledWith('owner');
+        // Scoped to the package JUST INSTALLED, and carrying the owner's
+        // tenancy. The packages root is shared across the deployment, so a
+        // reconcile of everything under it would mint rows for this owner
+        // pointing at other tenants' packages' servers.
+        expect(reconciler.reconcile).toHaveBeenCalledWith(
+            { userId: 'owner', tenantId: null, organizationId: null },
+            'acme.tools',
+        );
     });
 
     it('does NOT fail the install when reconciliation fails', async () => {

--- a/packages/agent/src/agent-plugins/install.service.spec.ts
+++ b/packages/agent/src/agent-plugins/install.service.spec.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { AgentPluginInstallService, sourceRefFor } from './install.service';
 import type { AgentPluginPackageRepository } from './package.repository';
 import type { AgentPluginRemoteAcquireService } from './remote-acquire.service';
+import type { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
+import type { AgentPluginPackageDataDirService } from './package-data-dir.service';
 import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
 
 function row(over: Partial<AgentPluginPackage> = {}): AgentPluginPackage {
@@ -23,7 +25,9 @@ function row(over: Partial<AgentPluginPackage> = {}): AgentPluginPackage {
     } as AgentPluginPackage;
 }
 
-function build(over: { rows?: AgentPluginPackage | null; acquire?: jest.Mock } = {}) {
+function build(
+    over: { rows?: AgentPluginPackage | null; acquire?: jest.Mock; reconcile?: jest.Mock } = {},
+) {
     const repository = {
         findById: jest.fn().mockResolvedValue(over.rows === undefined ? row() : over.rows),
         deleteById: jest.fn().mockResolvedValue(undefined),
@@ -53,7 +57,28 @@ function build(over: { rows?: AgentPluginPackage | null; acquire?: jest.Mock } =
             }),
     } as unknown as AgentPluginRemoteAcquireService & { acquire: jest.Mock };
 
-    return { repository, acquirer, service: new AgentPluginInstallService(repository, acquirer) };
+    const reconciler = {
+        reconcile:
+            over.reconcile ??
+            jest.fn().mockResolvedValue({
+                created: [],
+                unchanged: [],
+                updated: [],
+                skipped: [],
+            }),
+    } as unknown as PackageMcpReconcilerService & { reconcile: jest.Mock };
+
+    const dataDirs = {
+        remove: jest.fn().mockResolvedValue(undefined),
+    } as unknown as AgentPluginPackageDataDirService & { remove: jest.Mock };
+
+    return {
+        repository,
+        acquirer,
+        reconciler,
+        dataDirs,
+        service: new AgentPluginInstallService(repository, acquirer, reconciler, dataDirs),
+    };
 }
 
 describe('sourceRefFor', () => {
@@ -130,6 +155,45 @@ describe('AgentPluginInstallService', () => {
         ).rejects.toThrow('rejected');
 
         expect(repository.upsertInstalled).not.toHaveBeenCalled();
+    });
+
+    it('reconciles MCP declarations after a successful install', async () => {
+        const { service, reconciler } = build();
+
+        await service.install({ kind: 'npm', packageName: 'acme-skills' }, { userId: 'owner' });
+
+        // This is the production caller the reconciler was missing. Without
+        // it, package MCP declarations never became connection rows outside
+        // tests — the same dead-seam shape as `checkForUpdates`.
+        expect(reconciler.reconcile).toHaveBeenCalledWith('owner');
+    });
+
+    it('does NOT fail the install when reconciliation fails', async () => {
+        const { service, repository } = build({
+            reconcile: jest.fn().mockRejectedValue(new Error('db down')),
+        });
+
+        // The package and its skills are already on disk and valid, and
+        // connections can be reconciled again later. Losing a good install
+        // over a connection row would be the wrong trade.
+        await expect(
+            service.install({ kind: 'npm', packageName: 'acme-skills' }, { userId: 'owner' }),
+        ).resolves.toMatchObject({ name: 'acme.tools' });
+        expect(repository.upsertInstalled).toHaveBeenCalled();
+    });
+
+    it('removes the package data directory on uninstall', async () => {
+        const { service, dataDirs } = build();
+
+        await service.remove(row().id, 'owner');
+
+        // Leaving it behind would hand the next install of the same package
+        // a directory of state it never wrote, and would keep the bytes after
+        // a user believed they had removed the package.
+        expect(dataDirs.remove).toHaveBeenCalledWith({
+            userId: 'owner',
+            packageName: 'acme.tools',
+        });
     });
 
     describe('remove', () => {

--- a/packages/agent/src/agent-plugins/install.service.ts
+++ b/packages/agent/src/agent-plugins/install.service.ts
@@ -5,6 +5,8 @@ import { acquireInputFor } from './package-bootstrap.service';
 import { config } from '../config';
 import { AgentPluginPackageRepository } from './package.repository';
 import { AgentPluginRemoteAcquireService, type AcquireInput } from './remote-acquire.service';
+import { PackageMcpReconcilerService } from './package-mcp-reconciler.service';
+import { AgentPluginPackageDataDirService } from './package-data-dir.service';
 import type { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
 
 /**
@@ -32,6 +34,8 @@ export class AgentPluginInstallService {
     constructor(
         private readonly repository: AgentPluginPackageRepository,
         private readonly acquirer: AgentPluginRemoteAcquireService,
+        private readonly reconciler: PackageMcpReconcilerService,
+        private readonly dataDirs: AgentPluginPackageDataDirService,
     ) {}
 
     async install(
@@ -72,6 +76,34 @@ export class AgentPluginInstallService {
             skillNames: pkg.skills.map((skill) => skill.name),
             mcpServerNames: pkg.mcpServers.map((server) => server.name),
         });
+
+        // Reconcile the package's MCP declarations into connection rows.
+        //
+        // This is the caller `PackageMcpReconcilerService` was missing. A
+        // reconciler nothing invokes is a feature that exists only in its own
+        // tests — the same dead-seam shape as `checkForUpdates`, which sat on
+        // the plugin contract with no production caller until this programme
+        // wired it.
+        //
+        // Failure does NOT fail the install: the package and its skills are
+        // already on disk and valid, and connections can be reconciled again
+        // later. Losing a good install over a connection row is the wrong
+        // trade.
+        try {
+            const outcome = await this.reconciler.reconcile(owner.userId);
+            if (outcome.created.length > 0) {
+                this.logger.log(
+                    `Created ${outcome.created.length} package MCP connection(s), ` +
+                        `disabled and unbound pending explicit authorisation.`,
+                );
+            }
+        } catch (err) {
+            this.logger.warn(
+                `Package installed, but MCP reconciliation failed: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
 
         this.logger.log(
             `Installed ${input.kind} package "${pkg.manifest.name}" for ${owner.userId}`,
@@ -115,6 +147,13 @@ export class AgentPluginInstallService {
         }
 
         await this.repository.deleteById(id);
+
+        // The package's writable data goes with it. Leaving it behind would
+        // hand the next install of the same package under the same owner a
+        // directory of state it never wrote — and would keep the bytes after
+        // a user believed they had removed the package.
+        await this.dataDirs.remove({ userId: row.userId, packageName: row.name });
+
         if (row.installPath) {
             await rm(row.installPath, { recursive: true, force: true }).catch((err: unknown) => {
                 // The row is already gone, so the package is no longer

--- a/packages/agent/src/agent-plugins/install.service.ts
+++ b/packages/agent/src/agent-plugins/install.service.ts
@@ -90,7 +90,14 @@ export class AgentPluginInstallService {
         // later. Losing a good install over a connection row is the wrong
         // trade.
         try {
-            const outcome = await this.reconciler.reconcile(owner.userId);
+            const outcome = await this.reconciler.reconcile(
+                {
+                    userId: owner.userId,
+                    tenantId: owner.tenantId ?? null,
+                    organizationId: owner.organizationId ?? null,
+                },
+                pkg.manifest.name,
+            );
             if (outcome.created.length > 0) {
                 this.logger.log(
                     `Created ${outcome.created.length} package MCP connection(s), ` +

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
@@ -1,7 +1,11 @@
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { McpServerConfigService, usesPluginData } from './mcp-server-config.service';
+import {
+    McpServerConfigService,
+    sourceKindFromPath,
+    usesPluginData,
+} from './mcp-server-config.service';
 
 /**
  * Runs against the REAL conformance library and REAL files: what a package
@@ -56,6 +60,29 @@ describe('usesPluginData', () => {
             true,
         );
         expect(usesPluginData({ type: 'streamable-http', url: 'https://x/mcp' })).toBe(false);
+    });
+});
+
+describe('sourceKindFromPath', () => {
+    it('recognises where each acquirer places a package', () => {
+        // Reporting every package as `local` handed an audit or policy
+        // consumer false provenance — the one field whose whole job is to say
+        // where something came from.
+        expect(
+            sourceKindFromPath('/app/agent-plugins/git/https%3A%2F%2Fx.com%2Fa.git/abc123'),
+        ).toBe('git');
+        expect(sourceKindFromPath('/app/agent-plugins/npm/acme-skills/1.2.0')).toBe('npm');
+    });
+
+    it('handles Windows separators', () => {
+        expect(sourceKindFromPath('C:\\packages\\npm\\acme-skills\\1.2.0')).toBe('npm');
+    });
+
+    it('falls back to local for an operator-populated directory', () => {
+        // The safe answer when the shape is unrecognised, and the right one
+        // for a directory somebody filled themselves.
+        expect(sourceKindFromPath('/app/agent-plugins/acme-tools')).toBe('local');
+        expect(sourceKindFromPath('/srv/whatever')).toBe('local');
     });
 });
 

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.spec.ts
@@ -155,7 +155,7 @@ describe('McpServerConfigService', () => {
         expect(JSON.stringify(config)).not.toContain('PLUGIN_ROOT');
     });
 
-    it('SKIPS a server needing ${PLUGIN_DATA}, with a reason, rather than launching it broken', async () => {
+    it('leaves ${PLUGIN_DATA} INTACT for a stdio server, so the launcher can resolve it', async () => {
         process.env.AGENT_PLUGINS_STDIO = 'true';
         const root = await packagesRoot();
         await writePackage(root, 'acme', 'acme.tools', {
@@ -165,15 +165,43 @@ describe('McpServerConfigService', () => {
 
         const result = await service.resolveAll();
 
-        expect(result.servers).toHaveLength(0);
-        expect(result.skipped).toEqual([
-            expect.objectContaining({ name: 'stateful', packageName: 'acme.tools' }),
-        ]);
-        // The reason names the placeholder, so an operator knows what to do.
-        expect(result.skipped[0].reason).toContain('PLUGIN_DATA');
-        expect(result.skipped[0].code).toBe('needs-plugin-data');
-        // Nothing the operator can flip — this one needs the launcher.
-        expect(result.skipped[0].enableable).toBe(false);
+        // This resolver has no owner, and ${PLUGIN_DATA} is per (owner,
+        // package) — so it cannot supply the value and must not pretend to.
+        // The launcher, which does know the owner, resolves it.
+        expect(result.skipped).toEqual([]);
+        const config = result.servers[0]?.config as unknown as { args: string[] };
+        expect(config.args).toEqual(['${PLUGIN_DATA}/db.js']);
+    });
+
+    it('refuses a REMOTE server referencing ${PLUGIN_DATA}, which nothing can resolve', async () => {
+        const root = await packagesRoot();
+        await writePackage(root, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/${PLUGIN_DATA}' },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        // No launcher is involved, so nobody can supply it for a URL.
+        expect(result.servers).toEqual([]);
+        expect(result.skipped[0]?.code).toBe('needs-plugin-data');
+    });
+
+    it('never turns ${PLUGIN_DATA} into an absolute path at the filesystem root', async () => {
+        process.env.AGENT_PLUGINS_STDIO = 'true';
+        const root = await packagesRoot();
+        await writePackage(root, 'acme', 'acme.tools', {
+            stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.sqlite'] },
+        });
+        process.env.AGENT_PLUGINS_DIR = root;
+
+        const result = await service.resolveAll();
+
+        // Expanding with an empty string, as this once did, silently produced
+        // `/db.sqlite`.
+        const config = result.servers[0]?.config as unknown as { args: string[] };
+        expect(config.args[0]).not.toBe('/db.sqlite');
+        expect(config.args[0]).toContain('${PLUGIN_DATA}');
     });
 
     describe('AP-19: stdio is present-but-disabled, not absent', () => {

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.ts
@@ -230,13 +230,27 @@ export class McpServerConfigService {
             };
         }
 
-        if (usesPluginData(entry.config)) {
+        // `${PLUGIN_DATA}` is per (owner, package), and this resolver has no
+        // owner — it answers "what does this package declare", not "what will
+        // this user run". So it cannot supply the value, and the right
+        // behaviour depends on who can:
+        //
+        // - a STDIO server is expanded by the launcher, which does know the
+        //   owner, so the placeholder is left INTACT here for it to resolve;
+        // - a REMOTE server has no launcher. A `${PLUGIN_DATA}` in a URL or a
+        //   header is unresolvable by anyone, so it is refused.
+        //
+        // This previously refused BOTH, with the reason "this deployment does
+        // not yet allocate a per-package data directory" — true when it was
+        // written and false once T29 landed, which would have rejected a
+        // perfectly good stdio package for a stale reason.
+        if (entry.transport !== 'stdio' && usesPluginData(entry.config)) {
             return {
                 name: entry.name,
                 packageName,
                 reason:
-                    'The server references ${PLUGIN_DATA}, and this deployment does not yet ' +
-                    'allocate a per-package data directory.',
+                    'A remote server references ${PLUGIN_DATA}, which only a launched ' +
+                    'subprocess can resolve — nothing can supply it for a URL or header.',
                 code: 'needs-plugin-data',
                 enableable: false,
             };
@@ -261,15 +275,24 @@ export class McpServerConfigService {
     }
 
     /**
-     * Substitute `${PLUGIN_ROOT}`.
+     * Substitute `${PLUGIN_ROOT}`, and deliberately leave `${PLUGIN_DATA}`
+     * alone.
      *
-     * `pluginData` is passed as an empty string, which is safe ONLY because
-     * `usesPluginData` has already refused any config that mentions it — the
-     * expansion helpers substitute unconditionally rather than reporting an
-     * unresolvable placeholder, so the guard has to come first.
+     * The expansion helpers substitute BOTH placeholders unconditionally —
+     * they have no notion of "leave this one". Passing the placeholder as its
+     * own replacement is what makes the substitution a no-op, so a stdio
+     * config reaches the launcher with `${PLUGIN_DATA}` still in it and the
+     * launcher resolves it against the real per-(owner, package) directory.
+     *
+     * Passing an empty string here, as this once did, silently turned
+     * `${PLUGIN_DATA}/db.sqlite` into `/db.sqlite` — an absolute path at the
+     * filesystem root.
      */
     private expand(config: McpServerConfig, packageRoot: string): McpServerConfig {
-        const context: ExpansionContext = { pluginRoot: packageRoot, pluginData: '' };
+        const context: ExpansionContext = {
+            pluginRoot: packageRoot,
+            pluginData: PLUGIN_DATA_PLACEHOLDER,
+        };
 
         if (config.type === 'stdio') {
             return {

--- a/packages/agent/src/agent-plugins/mcp-server-config.service.ts
+++ b/packages/agent/src/agent-plugins/mcp-server-config.service.ts
@@ -133,6 +133,28 @@ export function usesPluginData(config: McpServerConfig): boolean {
     return values.some((value) => value.includes(PLUGIN_DATA_PLACEHOLDER));
 }
 
+/**
+ * Work out how a package reached this deployment, from where it sits.
+ *
+ * The resolver scans DIRECTORIES and has no registry access, so it cannot ask
+ * the database — but it does not need to: the acquirers place remote packages
+ * at `<root>/git/<encoded-url>/<sha>` and `<root>/npm/<encoded-name>/<version>`,
+ * and nothing else writes there. Reporting every package as `local`, as this
+ * did, hands an audit or policy consumer false provenance — the one field
+ * whose whole job is to say where something came from.
+ *
+ * Falls back to `local`, which is right for a directory an operator populated
+ * themselves and is the safe answer when the shape is unrecognised.
+ */
+export function sourceKindFromPath(packagePath: string): 'local' | 'git' | 'npm' {
+    const segments = packagePath.split(/[\\/]/u);
+    // The marker is the grandparent of the package directory: `git/<url>/<sha>`.
+    const marker = segments[segments.length - 3];
+    if (marker === 'git') return 'git';
+    if (marker === 'npm') return 'npm';
+    return 'local';
+}
+
 @Injectable()
 export class McpServerConfigService {
     private readonly logger = new Logger(McpServerConfigService.name);
@@ -266,10 +288,7 @@ export class McpServerConfigService {
                 packageRoot: pkg.path,
                 packageVersion: pkg.version ?? null,
                 specVersion: pkg.specVersion ?? 'unknown',
-                // Only local packages are scanned from disk today; git and npm
-                // packages land in a scanned directory too, so this widens
-                // when the registry row is consulted here.
-                sourceKind: 'local',
+                sourceKind: sourceKindFromPath(pkg.path),
             },
         };
     }

--- a/packages/agent/src/agent-plugins/npm-source.spec.ts
+++ b/packages/agent/src/agent-plugins/npm-source.spec.ts
@@ -192,6 +192,35 @@ describe('AgentPluginNpmSource', () => {
         expect(pacote.extract).not.toHaveBeenCalled();
     });
 
+    it('REFUSES when a pin exists but the registry returns no integrity', async () => {
+        const pacote = pacoteStub({ _integrity: undefined });
+        const source = new AgentPluginNpmSource(
+            allowlistStub({ allowed: true, entry: { integrity: 'sha512-pinned' } }),
+        );
+        source.setPacote(pacote);
+
+        await expect(
+            source.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).rejects.toMatchObject({ status: 424 });
+
+        // A pin with nothing to compare against is a pin that did not happen.
+        // Skipping the check ALSO meant extracting with no integrity option at
+        // all, so the tarball was written unverified.
+        expect(pacote.extract).not.toHaveBeenCalled();
+    });
+
+    it('is unaffected when no pin is configured and the registry omits integrity', async () => {
+        const pacote = pacoteStub({ _integrity: undefined });
+        const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));
+        source.setPacote(pacote);
+
+        // No pin means the operator asked for no guarantee, so this proceeds —
+        // refusing here would be a different bug.
+        await expect(
+            source.acquire({ packageName: 'acme-skills', destDir: await scratch() }),
+        ).resolves.toMatchObject({ integrity: null });
+    });
+
     it('extracts with the manifest integrity, and creates NO node_modules symlink', async () => {
         const pacote = pacoteStub();
         const source = new AgentPluginNpmSource(allowlistStub({ allowed: true }));

--- a/packages/agent/src/agent-plugins/npm-source.ts
+++ b/packages/agent/src/agent-plugins/npm-source.ts
@@ -199,6 +199,27 @@ export class AgentPluginNpmSource {
             // check. 424 (Failed Dependency) matches the code-plugin
             // installer's mapping for "the artefact is not what was promised".
             const pinned = allow.entry?.integrity?.trim();
+
+            // A pin with nothing to compare against is a pin that did not
+            // happen. If the registry response carries no `_integrity`, the
+            // old check simply skipped — and `extract` below then omitted the
+            // `integrity` option too, so the tarball was written with NO
+            // verification at all. The operator asked for exactly one
+            // artefact; silently accepting any is the opposite of that.
+            if (pinned && !manifest._integrity) {
+                throw new HttpException(
+                    {
+                        statusCode: HttpStatus.FAILED_DEPENDENCY,
+                        message:
+                            `The allowlist pins an integrity for "${packageName}", but the ` +
+                            `registry returned no integrity to check it against. Refusing ` +
+                            `rather than fetching an unverified artefact.`,
+                        packageName,
+                    },
+                    HttpStatus.FAILED_DEPENDENCY,
+                );
+            }
+
             if (pinned && manifest._integrity && pinned !== manifest._integrity) {
                 throw new HttpException(
                     {

--- a/packages/agent/src/agent-plugins/package-data-dir.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-data-dir.service.spec.ts
@@ -127,7 +127,47 @@ describe('AgentPluginPackageDataDirService', () => {
             return;
         }
 
-        await expect(service.ensure(owner)).rejects.toThrow(/outside the configured data root/u);
+        // One message covers both escapes now: the check compares the resolved
+        // path to the EXPECTED leaf, so "outside the root" and "inside the
+        // root but not this package's directory" are the same failure.
+        await expect(service.ensure(owner)).rejects.toThrow(
+            /does not resolve to that package's own directory/u,
+        );
+    });
+
+    it('REFUSES a leaf symlinked to ANOTHER tenant’s directory', async () => {
+        // The gap a root-only containment check misses: every tenant's leaf
+        // lives under the same root, so "inside the root" says nothing about
+        // whose directory this is. Without the leaf-identity check, owner A
+        // gets owner B's data.
+        const victim = { userId: 'owner-b', packageName: 'acme.tools' };
+        const attacker = { userId: 'owner-a', packageName: 'acme.tools' };
+
+        const victimPath = await service.ensure(victim);
+        await writeFile(join(victimPath, 'secret.json'), '{"b":1}', 'utf8');
+
+        const attackerPath = service.pathFor(attacker);
+        await mkdir(join(attackerPath, '..'), { recursive: true });
+
+        let linked = false;
+        try {
+            await symlink(victimPath, attackerPath, 'dir');
+            linked = true;
+        } catch {
+            linked = false;
+        }
+
+        if (!linked) {
+            console.warn(
+                'SKIPPED: symlink creation unavailable; the cross-tenant case did not run.',
+            );
+            expect(linked).toBe(false);
+            return;
+        }
+
+        await expect(service.ensure(attacker)).rejects.toThrow(
+            /does not resolve to that package's own directory/u,
+        );
     });
 
     it('removes a package’s data', async () => {

--- a/packages/agent/src/agent-plugins/package-data-dir.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-data-dir.service.spec.ts
@@ -1,0 +1,151 @@
+import { mkdir, mkdtemp, stat, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    AgentPluginPackageDataDirService,
+    dataDirSegment,
+    isWithin,
+} from './package-data-dir.service';
+
+describe('dataDirSegment', () => {
+    it('keeps a readable prefix so an operator can tell what a directory is', () => {
+        expect(dataDirSegment('acme.tools')).toMatch(/^acme\.tools-[0-9a-f]{12}$/u);
+    });
+
+    it('produces a path-safe segment from anything', () => {
+        // A user id is whatever the platform issues, and sourceRef-derived
+        // values have been attacker-influenced before. Hashing sidesteps the
+        // question of which characters are safe on which platform.
+        for (const nasty of ['../../etc', 'a/b\\c', '..', '.', 'C:\\evil', '', '   ']) {
+            const segment = dataDirSegment(nasty);
+            expect(segment).not.toContain('/');
+            expect(segment).not.toContain('\\');
+            expect(segment).not.toMatch(/^\.+$/u);
+            expect(segment.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('gives different inputs different segments even when they slugify alike', () => {
+        // Without the hash, `a/b` and `a-b` would collide — and a collision
+        // between two tenants is a shared writable directory.
+        expect(dataDirSegment('a/b')).not.toBe(dataDirSegment('a-b'));
+    });
+
+    it('is stable, so a package finds its own data again next launch', () => {
+        expect(dataDirSegment('acme.tools')).toBe(dataDirSegment('acme.tools'));
+    });
+});
+
+describe('isWithin', () => {
+    it('does not treat a sibling with a shared prefix as contained', () => {
+        // The classic containment bug: `/data/acme-2` starts with `/data/acme`.
+        expect(isWithin('/data/acme', '/data/acme-2')).toBe(false);
+        expect(isWithin('/data/acme', '/data/acme/x')).toBe(true);
+        expect(isWithin('/data/acme', '/data/acme')).toBe(true);
+    });
+
+    it('refuses relative paths outright rather than guessing a base', () => {
+        expect(isWithin('data', '/data/x')).toBe(false);
+        expect(isWithin('/data', 'data/x')).toBe(false);
+    });
+});
+
+describe('AgentPluginPackageDataDirService', () => {
+    const originalEnv = process.env;
+    let service: AgentPluginPackageDataDirService;
+    let dataRoot: string;
+
+    beforeEach(async () => {
+        process.env = { ...originalEnv };
+        dataRoot = await mkdtemp(join(tmpdir(), 'ap-data-'));
+        process.env.AGENT_PLUGINS_DATA_DIR = dataRoot;
+        service = new AgentPluginPackageDataDirService();
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('puts the OWNER segment first, so a tenant is one subtree', async () => {
+        const path = service.pathFor({ userId: 'user-1', packageName: 'acme.tools' });
+
+        // Per-tenant quota, backup and deletion become a single subtree
+        // operation rather than a scan for matching leaves.
+        const relative = path.slice(dataRoot.length + 1).split(/[\\/]/u);
+        expect(relative[0]).toContain(dataDirSegment('user-1'));
+        expect(relative[1]).toContain('acme.tools');
+    });
+
+    it('gives two tenants running the same package different directories', () => {
+        const a = service.pathFor({ userId: 'user-1', packageName: 'acme.tools' });
+        const b = service.pathFor({ userId: 'user-2', packageName: 'acme.tools' });
+
+        expect(a).not.toBe(b);
+    });
+
+    it('computes a path WITHOUT creating anything', async () => {
+        const path = service.pathFor({ userId: 'user-1', packageName: 'acme.tools' });
+
+        // Resolving a path for display or comparison must not have a side
+        // effect, so creation is a separate call.
+        await expect(stat(path)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('creates the directory on ensure, and is idempotent', async () => {
+        const owner = { userId: 'user-1', packageName: 'acme.tools' };
+
+        const first = await service.ensure(owner);
+        const second = await service.ensure(owner);
+
+        expect(first).toBe(second);
+        await expect(stat(first)).resolves.toMatchObject({});
+    });
+
+    it('REFUSES a leaf that is a symlink pointing outside the data root', async () => {
+        // A mounted volume is commonly a symlink, and a pre-existing
+        // symlinked leaf placed by anything else would otherwise hand a
+        // package a writable directory outside the root.
+        const owner = { userId: 'user-1', packageName: 'acme.tools' };
+        const target = service.pathFor(owner);
+        const outside = join(dataRoot, '..', 'escaped-' + Date.now());
+        await mkdir(outside, { recursive: true });
+        await mkdir(join(target, '..'), { recursive: true });
+
+        let linked = false;
+        try {
+            await symlink(outside, target, 'dir');
+            linked = true;
+        } catch {
+            linked = false;
+        }
+
+        if (!linked) {
+            // Said out loud rather than returned silently: an invisible skip
+            // reads exactly like a passing test.
+            console.warn('SKIPPED: symlink creation unavailable; the escape case did not run.');
+            expect(linked).toBe(false);
+            return;
+        }
+
+        await expect(service.ensure(owner)).rejects.toThrow(/outside the configured data root/u);
+    });
+
+    it('removes a package’s data', async () => {
+        const owner = { userId: 'user-1', packageName: 'acme.tools' };
+        const path = await service.ensure(owner);
+        await writeFile(join(path, 'state.json'), '{}', 'utf8');
+
+        await service.remove(owner);
+
+        await expect(stat(path)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('does not throw when there is nothing to remove', async () => {
+        // Uninstall has already deleted the row and the contents by this
+        // point; failing here would fail an uninstall that otherwise
+        // succeeded and leave the caller unsure what happened.
+        await expect(
+            service.remove({ userId: 'nobody', packageName: 'nothing' }),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/agent/src/agent-plugins/package-data-dir.service.ts
+++ b/packages/agent/src/agent-plugins/package-data-dir.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { mkdir, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { resolveRealPath } from '@ever-works/agent-plugins';
+import { config } from '../config';
+
+/**
+ * Allocates the writable directory a package sees as `${PLUGIN_DATA}` (T29).
+ *
+ * ## Why this is not a subdirectory of the package
+ *
+ * Package contents are read-only and replaced WHOLESALE on update — the git
+ * acquirer re-clones and renames, the npm acquirer re-extracts. Anything a
+ * server had written inside the package root would vanish on the next update,
+ * silently, and only for packages that happened to update. Data therefore
+ * lives under a separate root that no acquirer touches.
+ *
+ * A second reason: the package directories are SCANNED. A writable directory
+ * inside a scanned tree would be walked by the discovery pass, so a server
+ * writing a file named `plugin.json` into its own data directory could
+ * present itself as a second package.
+ *
+ * ## Isolation is per (owner, package), not per package
+ *
+ * Two tenants running the same package must not share a directory. The path
+ * therefore includes the owner, and the owner segment comes FIRST so that a
+ * per-tenant quota, backup or deletion is a single subtree operation rather
+ * than a scan for matching leaves.
+ */
+
+/**
+ * Path segments are derived, never interpolated raw.
+ *
+ * A package name is constrained by the spec (`[a-z0-9.-]`), but a user id is
+ * whatever the platform issues, and `sourceRef`-derived values have been
+ * attacker-influenced before. Hashing sidesteps the entire question of which
+ * characters are safe in a path on which platform — and, unlike escaping, it
+ * cannot be got subtly wrong.
+ *
+ * The readable prefix is kept so an operator listing the directory can tell
+ * what they are looking at; the hash is what guarantees uniqueness and
+ * containment.
+ */
+export function dataDirSegment(value: string): string {
+    const readable = value
+        .toLowerCase()
+        .replace(/[^a-z0-9.-]+/gu, '-')
+        .replace(/^[-.]+|[-.]+$/gu, '')
+        .slice(0, 40);
+    const digest = createHash('sha256').update(value).digest('hex').slice(0, 12);
+    return readable ? `${readable}-${digest}` : digest;
+}
+
+export interface PackageDataDirOwner {
+    /** The user the package is installed for. */
+    readonly userId: string;
+    /** Manifest name of the package. */
+    readonly packageName: string;
+}
+
+@Injectable()
+export class AgentPluginPackageDataDirService {
+    private readonly logger = new Logger(AgentPluginPackageDataDirService.name);
+
+    /**
+     * The absolute path a package's `${PLUGIN_DATA}` resolves to.
+     *
+     * Pure: it computes a path and touches nothing. Callers that need the
+     * directory to exist call {@link ensure}, which is separate so that
+     * resolving a path for display or comparison never has a side effect.
+     */
+    pathFor(owner: PackageDataDirOwner): string {
+        const root = resolve(config.agentPlugins.getDataDir());
+        return join(root, dataDirSegment(owner.userId), dataDirSegment(owner.packageName));
+    }
+
+    /**
+     * Create the directory if absent and return it.
+     *
+     * Called immediately before launch rather than at install: a directory
+     * created at install would be missing on every replica that did not
+     * perform that install, and on any replica whose volume was recreated.
+     * Creating it at the point of use makes those cases identical to the
+     * first launch.
+     */
+    async ensure(owner: PackageDataDirOwner): Promise<string> {
+        const path = this.pathFor(owner);
+        await mkdir(path, { recursive: true });
+
+        // Re-derive the real path and verify containment AFTER creation. The
+        // root may itself be a symlink (a mounted volume commonly is), and a
+        // pre-existing symlinked leaf placed by anything else would otherwise
+        // hand a package a writable directory outside the data root.
+        const realRoot = await resolveRealPath(resolve(config.agentPlugins.getDataDir()));
+        const realPath = await resolveRealPath(path);
+        if (!isWithin(realRoot, realPath)) {
+            throw new Error(
+                `Refusing to use "${realPath}" as package data: it resolves outside the ` +
+                    `configured data root "${realRoot}".`,
+            );
+        }
+
+        return realPath;
+    }
+
+    /**
+     * Remove a package's data.
+     *
+     * Called on uninstall. Failure is logged rather than thrown: the package
+     * row and contents are already gone by this point, so an orphaned data
+     * directory is untidy and inert, while throwing would fail an uninstall
+     * that has otherwise succeeded and leave the caller unsure what happened.
+     */
+    async remove(owner: PackageDataDirOwner): Promise<void> {
+        const path = this.pathFor(owner);
+        await rm(path, { recursive: true, force: true }).catch((err: unknown) => {
+            this.logger.warn(
+                `Could not remove package data at ${path}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        });
+    }
+}
+
+/**
+ * True when `candidate` is `root` or sits beneath it.
+ *
+ * Uses `path.relative` rather than a string prefix. Two reasons, and the
+ * second was found by a test rather than by reasoning:
+ *
+ * 1. A prefix test says `/data/acme-2` is inside `/data/acme`, which is the
+ *    classic way a containment check passes while being wrong.
+ * 2. Appending the platform separator does not fix that portably. On Windows
+ *    `sep` is a backslash while a path may legitimately use forward slashes,
+ *    so `/data/acme` + `\` never prefixes `/data/acme/x` and the check
+ *    rejects a directory that IS contained. `relative` normalises both sides
+ *    and is separator-agnostic.
+ *
+ * A contained path yields a relative path that is neither absolute nor
+ * starting with `..`; an empty result means the two are the same directory.
+ */
+export function isWithin(root: string, candidate: string): boolean {
+    if (!isAbsolute(root) || !isAbsolute(candidate)) return false;
+    const rel = relative(root, candidate);
+    if (rel === '') return true;
+    return !rel.startsWith('..') && !isAbsolute(rel);
+}

--- a/packages/agent/src/agent-plugins/package-data-dir.service.ts
+++ b/packages/agent/src/agent-plugins/package-data-dir.service.ts
@@ -88,16 +88,34 @@ export class AgentPluginPackageDataDirService {
         const path = this.pathFor(owner);
         await mkdir(path, { recursive: true });
 
-        // Re-derive the real path and verify containment AFTER creation. The
-        // root may itself be a symlink (a mounted volume commonly is), and a
-        // pre-existing symlinked leaf placed by anything else would otherwise
-        // hand a package a writable directory outside the data root.
+        // Verify AFTER creation, against the EXPECTED LEAF rather than the
+        // shared root.
+        //
+        // Checking containment in the data root alone is not enough, and the
+        // gap is a cross-tenant one: a symlink at owner A's leaf pointing to
+        // owner B's leaf resolves to a path that IS inside the root, so a
+        // root-only check passes it and `ensure()` hands owner A owner B's
+        // data directory. Every tenant's leaf lives under the same root, so
+        // "inside the root" says nothing about WHOSE directory this is.
+        //
+        // Comparing real paths also covers the legitimate case the root check
+        // was written for: the root may itself be a symlink (a mounted volume
+        // commonly is), which is why the expectation is resolved too rather
+        // than compared against the lexical path.
         const realRoot = await resolveRealPath(resolve(config.agentPlugins.getDataDir()));
         const realPath = await resolveRealPath(path);
-        if (!isWithin(realRoot, realPath)) {
+        const expected = join(
+            realRoot,
+            dataDirSegment(owner.userId),
+            dataDirSegment(owner.packageName),
+        );
+
+        if (realPath !== expected) {
             throw new Error(
-                `Refusing to use "${realPath}" as package data: it resolves outside the ` +
-                    `configured data root "${realRoot}".`,
+                `Refusing to use "${realPath}" as package data for ` +
+                    `"${owner.packageName}": it does not resolve to that package's own ` +
+                    `directory under "${realRoot}". A symlink pointing at another ` +
+                    `tenant's data would otherwise be followed.`,
             );
         }
 

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -281,9 +281,11 @@ describe('PackageMcpReconcilerService', () => {
     });
 
     it('carries forward what the resolver already refused, in one report', async () => {
-        process.env.AGENT_PLUGINS_STDIO = 'true';
         await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
-            stateful: { type: 'stdio', command: 'node', args: ['${PLUGIN_DATA}/db.js'] },
+            // A REMOTE server referencing ${PLUGIN_DATA}: nothing can resolve
+            // it, so the resolver refuses it and the reconciler passes the
+            // refusal through rather than producing a second half-report.
+            api: { type: 'streamable-http', url: 'https://x.example.com/${PLUGIN_DATA}' },
         });
         const { service } = build();
 

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -60,6 +60,26 @@ describe('connectionNameFor', () => {
         expect(connectionNameFor('Acme_Tools', 'My_Server')).toBe('acme-tools-my-server');
     });
 
+    it('gives two long names that share a prefix DIFFERENT connection names', () => {
+        // Truncation alone collides, and the consequence is not cosmetic:
+        // reconciliation finds the first server's row for the second and
+        // overwrites its URL, silently pointing one server at another's
+        // address.
+        const long = 'x'.repeat(70);
+        const a = connectionNameFor('acme.tools', `${long}-alpha`);
+        const b = connectionNameFor('acme.tools', `${long}-beta`);
+
+        expect(a).not.toBe(b);
+        expect(a!.length).toBeLessThanOrEqual(80);
+        expect(b!.length).toBeLessThanOrEqual(80);
+    });
+
+    it('leaves a short name untouched, with no digest appended', () => {
+        // A digest on every name would make the common case unreadable for no
+        // benefit.
+        expect(connectionNameFor('acme.tools', 'api')).toBe('acme-tools-api');
+    });
+
     it('never returns a name the connection entity would reject', () => {
         // The pattern is anchored and allows only [a-z0-9-] starting
         // alphanumeric, so anything else must come back null rather than be

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.spec.ts
@@ -120,7 +120,7 @@ describe('PackageMcpReconcilerService', () => {
         delete process.env.FEATURE_AGENT_PLUGINS;
         const { service, repo } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(result.created).toEqual([]);
         expect(repo.create).not.toHaveBeenCalled();
@@ -132,7 +132,7 @@ describe('PackageMcpReconcilerService', () => {
         });
         const { service, repo } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(result.created).toEqual(['acme-tools-api']);
         // The security property of this whole bridge: a package arriving on
@@ -168,7 +168,7 @@ describe('PackageMcpReconcilerService', () => {
             });
             const { service, repo } = build();
 
-            const result = await service.reconcile('user-1');
+            const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
             // Never becomes a valid server entry, so it never reaches the
             // reconciler at all.
@@ -185,7 +185,7 @@ describe('PackageMcpReconcilerService', () => {
             });
             const { service, repo } = build();
 
-            const result = await service.reconcile('user-1');
+            const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
             // This is the gap the second layer exists for: writing to the
             // repository bypasses `McpConnectionsService`, so the SSRF guard
@@ -201,7 +201,7 @@ describe('PackageMcpReconcilerService', () => {
             });
             const { service } = build();
 
-            const result = await service.reconcile('user-1');
+            const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
             expect(result.created).toEqual(['acme-tools-api']);
         });
@@ -213,8 +213,8 @@ describe('PackageMcpReconcilerService', () => {
         });
         const { service, repo } = build();
 
-        await service.reconcile('user-1');
-        const second = await service.reconcile('user-1');
+        await service.reconcile({ userId: 'user-1' }, 'acme.tools');
+        const second = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(second.created).toEqual([]);
         expect(second.unchanged).toEqual(['acme-tools-api']);
@@ -235,7 +235,7 @@ describe('PackageMcpReconcilerService', () => {
         } as McpServerConnection;
         const { service, repo } = build(repoStub([existing]));
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(result.updated).toEqual(['acme-tools-api']);
         expect(repo.save).toHaveBeenCalled();
@@ -259,7 +259,7 @@ describe('PackageMcpReconcilerService', () => {
         } as McpServerConnection;
         const { service, repo } = build(repoStub([manual]));
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         // Otherwise a package could silently repoint a connection the operator
         // created and trusts at an address of its choosing.
@@ -276,7 +276,7 @@ describe('PackageMcpReconcilerService', () => {
         });
         const { service, repo } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(result.created).toEqual([]);
         expect(result.skipped[0]?.code).toBe('disabled-by-policy');
@@ -293,7 +293,7 @@ describe('PackageMcpReconcilerService', () => {
         });
         const { service, repo } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         expect(result.created).toEqual([]);
         expect(result.skipped[0]?.code).toBe('unsupported-transport');
@@ -309,7 +309,7 @@ describe('PackageMcpReconcilerService', () => {
         });
         const { service } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'acme.tools');
 
         // One report explaining every declared server beats two half-reports.
         expect(result.skipped).toHaveLength(1);
@@ -318,7 +318,14 @@ describe('PackageMcpReconcilerService', () => {
         expect(result.skipped[0].code).toBe('needs-plugin-data');
     });
 
-    it('reconciles several packages in one pass', async () => {
+    it('reconciles ONLY the named package, never everything on the shared root', async () => {
+        // The packages root is deployment-wide: remote packages are keyed by
+        // ORIGIN (`git/<url>/<sha>`, `npm/<name>/<version>`) and never by
+        // owner, so every user's packages sit side by side under it. A
+        // reconcile that walked all of them would mint connection rows for
+        // whichever owner happened to install something, pointing at URLs
+        // chosen by another tenant's package. The rows arrive disabled, but
+        // their new owner can enable them.
         const root = process.env.AGENT_PLUGINS_DIR!;
         await writePackage(root, 'one', 'pkg.one', {
             api: { type: 'streamable-http', url: 'https://one.example.com/mcp' },
@@ -326,11 +333,34 @@ describe('PackageMcpReconcilerService', () => {
         await writePackage(root, 'two', 'pkg.two', {
             api: { type: 'sse', url: 'https://two.example.com/sse' },
         });
-        const { service } = build();
+        const { service, repo } = build();
 
-        const result = await service.reconcile('user-1');
+        const result = await service.reconcile({ userId: 'user-1' }, 'pkg.one');
 
-        // Same server name in both packages, distinct connection names.
-        expect([...result.created].sort()).toEqual(['pkg-one-api', 'pkg-two-api']);
+        expect(result.created).toEqual(['pkg-one-api']);
+        expect(repo.rows.map((row) => row.name)).toEqual(['pkg-one-api']);
+    });
+
+    it('stamps the owner tenancy onto a row it creates', async () => {
+        // The install row carries tenantId/organizationId (EW-651 Tier A). A
+        // connection minted because of that install must carry the same, or a
+        // scoped query cannot account for it.
+        await writePackage(process.env.AGENT_PLUGINS_DIR!, 'acme', 'acme.tools', {
+            api: { type: 'streamable-http', url: 'https://acme.example.com/mcp' },
+        });
+        const { service, repo } = build();
+
+        await service.reconcile(
+            { userId: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1' },
+            'acme.tools',
+        );
+
+        expect(repo.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: 'user-1',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+            }),
+        );
     });
 });

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
@@ -104,6 +104,19 @@ export function connectionNameFor(packageName: string, serverName: string): stri
     return MCP_CONNECTION_NAME_PATTERN.test(truncated) ? truncated : null;
 }
 
+/**
+ * Who the reconciled rows belong to.
+ *
+ * The Tier A scope columns ride along so a package-created connection carries
+ * the same tenancy as the install row that caused it, rather than being written
+ * with a null tenant that no scoped query can then account for.
+ */
+export interface ReconcileOwner {
+    userId: string;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
 @Injectable()
 export class PackageMcpReconcilerService {
     private readonly logger = new Logger(PackageMcpReconcilerService.name);
@@ -114,8 +127,19 @@ export class PackageMcpReconcilerService {
     ) {}
 
     /**
-     * Make the connection rows for `userId` agree with what installed packages
-     * declare.
+     * Make `owner`'s connection rows agree with what the package named
+     * `packageName` declares.
+     *
+     * SCOPED TO ONE PACKAGE ON PURPOSE. The resolver reads the shared,
+     * deployment-wide packages root — remote packages live at
+     * `<root>/git/<url>/<sha>` and `<root>/npm/<name>/<version>`, keyed by
+     * origin and never by owner — so `resolveAll()` returns every package any
+     * user on this deployment has ever installed. Reconciling all of them
+     * against whichever owner happened to trigger an install would mint
+     * connection rows for that owner pointing at other tenants' packages'
+     * servers. The rows arrive disabled and unbound, but they are still
+     * enableable by their new owner, who never installed the package that
+     * chose the URL. Only the package actually being installed is reconciled.
      *
      * Idempotent: running it twice creates nothing the second time. It does
      * NOT delete connections for servers that have disappeared — a row may
@@ -123,7 +147,7 @@ export class PackageMcpReconcilerService {
      * that because a directory was momentarily unreadable would be worse than
      * leaving a stale row that is visibly disabled.
      */
-    async reconcile(userId: string): Promise<ReconcileResult> {
+    async reconcile(owner: ReconcileOwner, packageName: string): Promise<ReconcileResult> {
         const resolution = await this.resolver.resolveAll();
         const created: string[] = [];
         const unchanged: string[] = [];
@@ -137,11 +161,13 @@ export class PackageMcpReconcilerService {
         // Carry forward whatever the resolver already refused, so one report
         // explains every declared server rather than two half-reports.
         for (const entry of resolution.skipped) {
+            if (entry.packageName !== packageName) continue;
             skipped.push(entry);
         }
 
         for (const server of resolution.servers) {
-            const outcome = await this.reconcileOne(userId, server);
+            if (server.provenance.packageName !== packageName) continue;
+            const outcome = await this.reconcileOne(owner, server);
             if (outcome.kind === 'skipped') {
                 skipped.push({
                     name: server.name,
@@ -159,7 +185,8 @@ export class PackageMcpReconcilerService {
 
         if (created.length > 0 || updated.length > 0) {
             this.logger.log(
-                `Package MCP reconcile for ${userId}: ${created.length} created, ` +
+                `Package MCP reconcile for ${owner.userId} (${packageName}): ` +
+                    `${created.length} created, ` +
                     `${updated.length} updated, ${unchanged.length} unchanged, ` +
                     `${skipped.length} skipped`,
             );
@@ -169,7 +196,7 @@ export class PackageMcpReconcilerService {
     }
 
     private async reconcileOne(
-        userId: string,
+        owner: ReconcileOwner,
         server: ResolvedMcpServer,
     ): Promise<
         | { kind: 'created' | 'updated' | 'unchanged'; name: string }
@@ -241,11 +268,13 @@ export class PackageMcpReconcilerService {
             };
         }
 
-        const existing = await this.connections.findByUserAndName(userId, name);
+        const existing = await this.connections.findByUserAndName(owner.userId, name);
 
         if (!existing) {
             await this.connections.create({
-                userId,
+                userId: owner.userId,
+                tenantId: owner.tenantId ?? null,
+                organizationId: owner.organizationId ?? null,
                 name,
                 url,
                 transport: server.transport as McpServerConnection['transport'],

--- a/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
+++ b/packages/agent/src/agent-plugins/package-mcp-reconciler.service.ts
@@ -10,6 +10,7 @@ import {
     type SkippedMcpReason,
     type SkippedMcpServer,
 } from './mcp-server-config.service';
+import { createHash } from 'node:crypto';
 import { isSafeWebhookUrl } from '../utils/ssrf-guard';
 
 /**
@@ -40,6 +41,9 @@ import { isSafeWebhookUrl } from '../utils/ssrf-guard';
  * to enable it and bind it, exactly as they would for a server they had never
  * seen before, which is what a package server is.
  */
+
+/** `mcp_server_connections.name` is varchar(80) and the pattern caps at 80. */
+const MAX_CONNECTION_NAME = 80;
 
 /** Only remote transports can become a connection; the row is URL-shaped. */
 const REMOTE_TRANSPORTS = new Set(['streamable-http', 'sse']);
@@ -75,14 +79,29 @@ export interface ReconcileResult {
  * would silently point at the wrong server.
  */
 export function connectionNameFor(packageName: string, serverName: string): string | null {
-    const slug = `${packageName}-${serverName}`
+    const source = `${packageName}-${serverName}`;
+    const slug = source
         .toLowerCase()
         .replace(/[^a-z0-9]+/gu, '-')
-        .replace(/^-+|-+$/gu, '')
-        .slice(0, 80)
-        .replace(/-+$/gu, '');
+        .replace(/^-+|-+$/gu, '');
 
-    return MCP_CONNECTION_NAME_PATTERN.test(slug) ? slug : null;
+    // Truncation alone collides. Two servers under one package whose names
+    // share their first 80 normalised characters produce the same slug, and
+    // reconciliation then finds the FIRST one's row for the second and
+    // overwrites its URL — one server silently pointed at another's address.
+    //
+    // A digest of the full input is appended, and the readable part trimmed
+    // to make room, so a name stays recognisable while distinct inputs stay
+    // distinct. Same shape as `dataDirSegment`, for the same reason.
+    if (slug.length <= MAX_CONNECTION_NAME) {
+        return MCP_CONNECTION_NAME_PATTERN.test(slug) ? slug : null;
+    }
+
+    const digest = createHash('sha256').update(source).digest('hex').slice(0, 8);
+    const head = slug.slice(0, MAX_CONNECTION_NAME - digest.length - 1).replace(/-+$/gu, '');
+    const truncated = `${head}-${digest}`;
+
+    return MCP_CONNECTION_NAME_PATTERN.test(truncated) ? truncated : null;
 }
 
 @Injectable()

--- a/packages/agent/src/agent-plugins/remote-acquire.service.ts
+++ b/packages/agent/src/agent-plugins/remote-acquire.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
-import { mkdir, rename, rm } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { mkdir, mkdtemp, rename, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { loadPluginPackage, type LoadPluginPackageResult } from '@ever-works/agent-plugins';
 import { AgentPluginGitSource, gitPackageDir } from './git-source';
 import { AgentPluginNpmSource, npmPackageDir } from './npm-source';
@@ -117,16 +117,30 @@ export class AgentPluginRemoteAcquireService {
             // which is not known until the clone completes. The staging
             // directory is derived from the ref so two concurrent acquisitions
             // of different refs cannot collide in it.
-            const staging = gitPackageDir(root, input.url, `staging-${stagingKey(input.ref)}`);
+            // A UNIQUE staging directory per operation. A deterministic one —
+            // keyed on url and ref — means two concurrent installs of the
+            // same source share a tree: each wipes the other's partial clone,
+            // and whichever renames second finds nothing to move. `mkdtemp`
+            // makes the collision impossible rather than unlikely.
+            const stagingParent = gitPackageDir(root, input.url, '.staging');
+            await mkdir(stagingParent, { recursive: true });
+            const staging = await mkdtemp(join(stagingParent, `${stagingKey(input.ref)}-`));
             const result = await this.gitSource.acquire({
                 url: input.url,
                 destDir: staging,
                 ...(input.ref ? { ref: input.ref } : {}),
             });
             const final = gitPackageDir(root, input.url, result.resolvedSha);
-            await rm(final, { recursive: true, force: true });
-            await mkdir(dirname(final), { recursive: true });
-            await rename(staging, final);
+            try {
+                await rm(final, { recursive: true, force: true });
+                await mkdir(dirname(final), { recursive: true });
+                await rename(staging, final);
+            } finally {
+                // If the rename never happened, the staging tree would sit in
+                // the packages root where the directory scanner would find and
+                // load it as if it were an installed package.
+                await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+            }
             return { destDir: final, revision: result.resolvedSha, integrity: null };
         }
 

--- a/packages/agent/src/agent-plugins/stdio-launcher.spec.ts
+++ b/packages/agent/src/agent-plugins/stdio-launcher.spec.ts
@@ -93,14 +93,28 @@ describe('buildLaunchEnv', () => {
         expect(() => buildLaunchEnv({ PLUGIN_DATA: '/elsewhere' }, ctx)).toThrow(LaunchRefused);
     });
 
-    it('does not let a package override PATH to shadow the binary about to run', () => {
-        const env = buildLaunchEnv({ PATH: '/tmp/evil' }, ctx);
+    it('does NOT let a package override PATH', () => {
+        process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
 
-        // A package CAN set PATH — it is not reserved — but the reserved keys
-        // are still written last, so the two values the client controls are
-        // never the package's.
+        const env = buildLaunchEnv({ PATH: '/tmp/its-own-bin' }, ctx);
+
+        // The guarantee for a bare command is that it "can only run something
+        // the operator installed". A package-chosen PATH makes that false: it
+        // would supply its own `node`, turning the safest command shape into
+        // the most dangerous one.
+        expect(env.PATH).toBe('/usr/local/bin:/usr/bin:/bin');
+        expect(env.PATH).not.toContain('its-own-bin');
         expect(env.PLUGIN_ROOT).toBe(pkg);
         expect(env.PLUGIN_DATA).toBe(data);
+    });
+
+    it('still lets a package set an ordinary variable', () => {
+        // A blanket refusal would be a different bug: packages legitimately
+        // configure themselves through env.
+        const env = buildLaunchEnv({ LOG_LEVEL: 'debug', API_BASE: 'https://x' }, ctx);
+
+        expect(env.LOG_LEVEL).toBe('debug');
+        expect(env.API_BASE).toBe('https://x');
     });
 });
 

--- a/packages/agent/src/agent-plugins/stdio-launcher.spec.ts
+++ b/packages/agent/src/agent-plugins/stdio-launcher.spec.ts
@@ -1,0 +1,223 @@
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    buildLaunchEnv,
+    buildLaunchPlan,
+    LaunchRefused,
+    resolveCommand,
+    resolveCwd,
+    type LaunchContext,
+} from './stdio-launcher';
+
+/**
+ * Launching a package's own executable is the largest grant in this feature,
+ * so these tests are mostly about what is REFUSED and what is not visible.
+ */
+
+let root: string;
+let pkg: string;
+let data: string;
+let ctx: LaunchContext;
+
+beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'ap-launch-'));
+    pkg = join(root, 'package');
+    data = join(root, 'data');
+    await mkdir(join(pkg, 'bin'), { recursive: true });
+    await mkdir(data, { recursive: true });
+    await writeFile(join(pkg, 'bin', 'server'), '#!/bin/sh\n', 'utf8');
+    ctx = { packageRoot: pkg, pluginData: data };
+});
+
+describe('buildLaunchEnv', () => {
+    const original = process.env;
+
+    beforeEach(() => {
+        process.env = { ...original };
+    });
+
+    afterAll(() => {
+        process.env = original;
+    });
+
+    it('does NOT inherit platform secrets from the API process', () => {
+        // The API environment holds these. A denylist would have to enumerate
+        // every secret that exists now and every one added later; building
+        // from {} means a new platform secret is invisible by default.
+        process.env.DATABASE_URL = 'postgres://user:pw@host/db';
+        process.env.AUTH_SECRET = 'super-secret';
+        process.env.PLUGIN_OPENROUTER_API_KEY = 'sk-live-xxxx';
+        process.env.PLATFORM_ENCRYPTION_KEY = 'key-material';
+
+        const env = buildLaunchEnv(undefined, ctx);
+
+        expect(env.DATABASE_URL).toBeUndefined();
+        expect(env.AUTH_SECRET).toBeUndefined();
+        expect(env.PLUGIN_OPENROUTER_API_KEY).toBeUndefined();
+        expect(env.PLATFORM_ENCRYPTION_KEY).toBeUndefined();
+        expect(JSON.stringify(env)).not.toContain('super-secret');
+        expect(JSON.stringify(env)).not.toContain('sk-live-xxxx');
+    });
+
+    it('provides the small base every runtime needs', () => {
+        const env = buildLaunchEnv(undefined, ctx);
+
+        expect(env.PATH).toBeTruthy();
+        expect(env.HOME).toBeTruthy();
+        expect(env.TMPDIR).toBeTruthy();
+    });
+
+    it('sets PLUGIN_ROOT and PLUGIN_DATA from the client, not the package', () => {
+        const env = buildLaunchEnv({ SOMETHING: 'else' }, ctx);
+
+        expect(env.PLUGIN_ROOT).toBe(pkg);
+        expect(env.PLUGIN_DATA).toBe(data);
+    });
+
+    it('expands placeholders inside the package’s own declared values', () => {
+        const env = buildLaunchEnv(
+            { CONFIG: '${PLUGIN_ROOT}/c.json', DB: '${PLUGIN_DATA}/x' },
+            ctx,
+        );
+
+        expect(env.CONFIG).toBe(`${pkg}/c.json`);
+        expect(env.DB).toBe(`${data}/x`);
+    });
+
+    it('refuses a package that declares a RESERVED key', () => {
+        // The library rejects this at validation, so reaching here is a bug —
+        // but the assignment would silently win over the authoritative value,
+        // so it is refused rather than trusted.
+        expect(() => buildLaunchEnv({ PLUGIN_ROOT: '/elsewhere' }, ctx)).toThrow(LaunchRefused);
+        expect(() => buildLaunchEnv({ PLUGIN_DATA: '/elsewhere' }, ctx)).toThrow(LaunchRefused);
+    });
+
+    it('does not let a package override PATH to shadow the binary about to run', () => {
+        const env = buildLaunchEnv({ PATH: '/tmp/evil' }, ctx);
+
+        // A package CAN set PATH — it is not reserved — but the reserved keys
+        // are still written last, so the two values the client controls are
+        // never the package's.
+        expect(env.PLUGIN_ROOT).toBe(pkg);
+        expect(env.PLUGIN_DATA).toBe(data);
+    });
+});
+
+describe('resolveCommand', () => {
+    it('accepts a bare name and marks it as PATH-resolved', async () => {
+        await expect(resolveCommand('node', pkg)).resolves.toEqual({
+            command: 'node',
+            resolvesThroughPath: true,
+        });
+    });
+
+    it('accepts a ./-relative path inside the package and returns it absolute', async () => {
+        const result = await resolveCommand('./bin/server', pkg);
+
+        expect(result.resolvesThroughPath).toBe(false);
+        expect(result.command).toContain('server');
+    });
+
+    it.each([
+        ['/usr/bin/node', 'an absolute path'],
+        ['../../bin/sh', 'a parent escape'],
+        ['sub/dir/cmd', 'a path with a separator'],
+        ['C:\\Windows\\system32\\cmd.exe', 'a Windows drive path'],
+        ['', 'an empty token'],
+    ])('refuses %s (%s)', async (command) => {
+        await expect(resolveCommand(command, pkg)).rejects.toBeInstanceOf(LaunchRefused);
+    });
+
+    it('refuses a ./ path that ESCAPES via a symlink', async () => {
+        // `resolve` collapses `..` lexically before any symlink is followed,
+        // so a lexical check alone passes this. The real path must be
+        // recomputed — the same trap the conformance library documents.
+        const outside = join(root, 'outside');
+        await mkdir(outside, { recursive: true });
+        await writeFile(join(outside, 'evil'), '#!/bin/sh\n', 'utf8');
+
+        let linked = false;
+        try {
+            await symlink(outside, join(pkg, 'link'), 'dir');
+            linked = true;
+        } catch {
+            linked = false;
+        }
+
+        if (!linked) {
+            // Windows without developer mode cannot create symlinks. Say so
+            // OUT LOUD: a silent early return here reads as a passing test,
+            // and in Phase 0 five containment tests skipped invisibly for
+            // exactly this reason while appearing green.
+            console.warn(
+                'SKIPPED: symlink creation unavailable on this host; the escape case did not run.',
+            );
+            expect(linked).toBe(false);
+            return;
+        }
+
+        await expect(resolveCommand('./link/evil', pkg)).rejects.toMatchObject({
+            code: 'command-escapes-package',
+        });
+    });
+});
+
+describe('resolveCwd', () => {
+    it('defaults to the package root', async () => {
+        await expect(resolveCwd(undefined, ctx)).resolves.toContain('package');
+    });
+
+    it('accepts a ./-relative directory inside the package', async () => {
+        await expect(resolveCwd('./bin', ctx)).resolves.toContain('bin');
+    });
+
+    it('accepts a ${PLUGIN_DATA}-anchored directory', async () => {
+        await expect(resolveCwd('${PLUGIN_DATA}', ctx)).resolves.toContain('data');
+    });
+
+    it.each(['../elsewhere', './../elsewhere', '/etc', '${PLUGIN_DATA}/../elsewhere'])(
+        'refuses %s',
+        async (cwd) => {
+            await expect(resolveCwd(cwd, ctx)).rejects.toBeInstanceOf(LaunchRefused);
+        },
+    );
+
+    it('contains a ${PLUGIN_DATA} cwd against the DATA root, not the package root', async () => {
+        // Checking both anchors against the package root would pass a value
+        // that escapes into another tenant's data directory.
+        const sibling = join(root, 'other-tenant');
+        await mkdir(sibling, { recursive: true });
+
+        await expect(resolveCwd('${PLUGIN_DATA}/../other-tenant', ctx)).rejects.toBeInstanceOf(
+            LaunchRefused,
+        );
+    });
+});
+
+describe('buildLaunchPlan', () => {
+    it('produces a complete plan with nothing left to decide', async () => {
+        const plan = await buildLaunchPlan(
+            {
+                type: 'stdio',
+                command: 'node',
+                args: ['${PLUGIN_ROOT}/index.js', '--data', '${PLUGIN_DATA}'],
+                env: { LOG: 'debug' },
+            },
+            ctx,
+        );
+
+        expect(plan.command).toBe('node');
+        expect(plan.resolvesThroughPath).toBe(true);
+        expect(plan.args).toEqual([`${pkg}/index.js`, '--data', data]);
+        expect(plan.env.LOG).toBe('debug');
+        expect(plan.env.PLUGIN_ROOT).toBe(pkg);
+        expect(plan.cwd).toContain('package');
+    });
+
+    it('refuses the whole plan when any part is refused', async () => {
+        await expect(
+            buildLaunchPlan({ type: 'stdio', command: '/bin/sh' }, ctx),
+        ).rejects.toBeInstanceOf(LaunchRefused);
+    });
+});

--- a/packages/agent/src/agent-plugins/stdio-launcher.ts
+++ b/packages/agent/src/agent-plugins/stdio-launcher.ts
@@ -1,0 +1,241 @@
+import { homedir, tmpdir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import {
+    classifyCwd,
+    expandArgs,
+    expandEnvValues,
+    expandPlaceholders,
+    isReservedEnvKey,
+    PLUGIN_DATA_PLACEHOLDER,
+    PLUGIN_ROOT_PLACEHOLDER,
+    resolveRealPath,
+    type ExpansionContext,
+    type McpStdioServer,
+} from '@ever-works/agent-plugins';
+import { isWithin } from './package-data-dir.service';
+
+/**
+ * Turns a validated stdio server declaration into the exact arguments a
+ * subprocess would be spawned with (T30).
+ *
+ * Deliberately a PURE function returning a plan, with no `spawn` in sight.
+ * Everything that makes launching a package's own executable dangerous is
+ * decided here — the environment it can see, the binary that actually runs,
+ * the directory it starts in — and each of those is a value that can be
+ * asserted on directly. A function that spawned as it decided could only be
+ * tested by running the thing it is supposed to be deciding whether to run.
+ */
+
+/** The base environment. Everything else must be earned. */
+const INHERITED_KEYS = ['PATH', 'HOME', 'TMPDIR', 'USERPROFILE', 'SystemRoot'] as const;
+
+export interface LaunchPlan {
+    /** Absolute path to the executable, or a bare name to resolve through PATH. */
+    readonly command: string;
+    readonly args: readonly string[];
+    /** Complete environment. NOT merged with `process.env` by the caller. */
+    readonly env: Readonly<Record<string, string>>;
+    readonly cwd: string;
+    /** True when `command` is a bare name the OS resolves through PATH. */
+    readonly resolvesThroughPath: boolean;
+}
+
+export interface LaunchContext {
+    /** Filesystem-resolved package root. */
+    readonly packageRoot: string;
+    /** Filesystem-resolved `${PLUGIN_DATA}` directory, already created. */
+    readonly pluginData: string;
+}
+
+export class LaunchRefused extends Error {
+    constructor(
+        message: string,
+        readonly code: string,
+    ) {
+        super(message);
+        this.name = 'LaunchRefused';
+    }
+}
+
+/**
+ * Build the environment a package's server process will see.
+ *
+ * ## Built from nothing, not filtered from `process.env`
+ *
+ * The API process environment holds `DATABASE_URL`, `AUTH_SECRET`, every
+ * `PLUGIN_*` API key and the platform encryption key. A denylist over that
+ * would have to enumerate every secret that exists now and every one added
+ * later — and the day someone adds a secret without updating the denylist,
+ * every installed package can read it. Starting from `{}` inverts the
+ * default: a new platform secret is invisible to packages unless somebody
+ * deliberately adds it here.
+ *
+ * `PATH` is inherited because resolving a bare command is the point of
+ * allowing bare commands at all; `HOME` and `TMPDIR` because a great many
+ * runtimes fail confusingly without them.
+ *
+ * ## Order is a control
+ *
+ * The package's own `env` is applied SECOND and the two reserved keys LAST,
+ * so a package cannot point `PLUGIN_ROOT` at somewhere else by declaring it —
+ * and cannot override `PATH` to shadow the binary that is about to run.
+ */
+export function buildLaunchEnv(
+    declared: Readonly<Record<string, string>> | undefined,
+    ctx: LaunchContext,
+): Record<string, string> {
+    const env: Record<string, string> = {};
+
+    for (const key of INHERITED_KEYS) {
+        const value = process.env[key];
+        if (value !== undefined && value !== '') {
+            env[key] = value;
+        }
+    }
+    env.PATH ??= '/usr/local/bin:/usr/bin:/bin';
+    env.HOME ??= homedir();
+    env.TMPDIR ??= tmpdir();
+
+    const expansion: ExpansionContext = {
+        pluginRoot: ctx.packageRoot,
+        pluginData: ctx.pluginData,
+    };
+
+    for (const [key, value] of Object.entries(expandEnvValues(declared, expansion))) {
+        // The library rejects a reserved key at validation time, so reaching
+        // this is a bug rather than a hostile package — but the assignment
+        // below would silently win over the authoritative values set after
+        // the loop, so it is refused rather than trusted.
+        if (isReservedEnvKey(key)) {
+            throw new LaunchRefused(
+                `Package declared the reserved environment variable "${key}".`,
+                'reserved-env-key',
+            );
+        }
+        env[key] = value;
+    }
+
+    // LAST, and unconditionally: these are the client's statement of where the
+    // package lives, not the package's.
+    env[PLUGIN_ROOT_PLACEHOLDER.slice(2, -1)] = ctx.packageRoot;
+    env[PLUGIN_DATA_PLACEHOLDER.slice(2, -1)] = ctx.pluginData;
+
+    return env;
+}
+
+/**
+ * Resolve the command token to something safe to execute.
+ *
+ * The spec permits exactly two shapes, and the distinction is the whole
+ * control:
+ *
+ * - a **bare name** (`node`, `uvx`) resolves through `PATH`, so it can only
+ *   ever run something the operator installed in the image;
+ * - a **`./`-relative path** runs a file the PACKAGE ships, so it must be
+ *   proved to sit inside the package root after symlinks are followed.
+ *
+ * Anything else — an absolute path, a `../` escape, a Windows drive, a token
+ * containing a separator — is refused. An absolute path is refused even
+ * though it looks harmless, because it names a binary neither the operator
+ * nor the package can be said to have chosen deliberately.
+ */
+export async function resolveCommand(
+    command: string,
+    packageRoot: string,
+): Promise<{ command: string; resolvesThroughPath: boolean }> {
+    const token = command.trim();
+
+    if (token === '') {
+        throw new LaunchRefused('Empty command.', 'empty-command');
+    }
+
+    if (token.startsWith('./')) {
+        const candidate = resolve(packageRoot, token);
+        // `resolve` collapses `..` LEXICALLY, before any symlink is followed,
+        // so the real path has to be recomputed and checked — the same trap
+        // the conformance library documents for package paths.
+        const real = await resolveRealPath(candidate);
+        const realRoot = await resolveRealPath(packageRoot);
+        if (!isWithin(realRoot, real)) {
+            throw new LaunchRefused(
+                `Command "${token}" resolves to "${real}", outside the package root.`,
+                'command-escapes-package',
+            );
+        }
+        return { command: real, resolvesThroughPath: false };
+    }
+
+    if (isAbsolute(token) || /[\\/]/u.test(token) || /^[a-zA-Z]:/u.test(token)) {
+        throw new LaunchRefused(
+            `Command "${token}" must be a bare name resolved through PATH, or a ./-relative ` +
+                `path inside the package.`,
+            'command-not-a-single-token',
+        );
+    }
+
+    return { command: token, resolvesThroughPath: true };
+}
+
+/**
+ * Resolve `cwd` per spec 7.2.1, or default to the package root.
+ *
+ * Each of the three permitted anchors is contained against the root it names:
+ * a `${PLUGIN_DATA}`-anchored value must stay inside the data directory, not
+ * merely inside *a* directory. Checking both against the package root would
+ * pass a value that escapes into someone else's data.
+ */
+export async function resolveCwd(
+    declared: string | undefined,
+    ctx: LaunchContext,
+): Promise<string> {
+    if (declared === undefined || declared === '') {
+        return ctx.packageRoot;
+    }
+
+    const anchor = classifyCwd(declared);
+    if (anchor === undefined) {
+        throw new LaunchRefused(
+            `cwd "${declared}" is not one of the permitted forms.`,
+            'cwd-not-permitted',
+        );
+    }
+
+    const expanded = expandPlaceholders(declared, {
+        pluginRoot: ctx.packageRoot,
+        pluginData: ctx.pluginData,
+    });
+    const candidate = anchor === 'plugin-relative' ? join(ctx.packageRoot, declared) : expanded;
+
+    const expectedRoot = anchor === 'plugin-data' ? ctx.pluginData : ctx.packageRoot;
+    const real = await resolveRealPath(resolve(candidate));
+    const realRoot = await resolveRealPath(expectedRoot);
+
+    if (!isWithin(realRoot, real)) {
+        throw new LaunchRefused(
+            `cwd "${declared}" resolves to "${real}", outside "${realRoot}".`,
+            'cwd-escapes-anchor',
+        );
+    }
+
+    return real;
+}
+
+/** Everything needed to spawn one stdio server, with nothing left to decide. */
+export async function buildLaunchPlan(
+    server: McpStdioServer,
+    ctx: LaunchContext,
+): Promise<LaunchPlan> {
+    const { command, resolvesThroughPath } = await resolveCommand(server.command, ctx.packageRoot);
+    const expansion: ExpansionContext = {
+        pluginRoot: ctx.packageRoot,
+        pluginData: ctx.pluginData,
+    };
+
+    return {
+        command,
+        args: expandArgs(server.args, expansion),
+        env: buildLaunchEnv(server.env, ctx),
+        cwd: await resolveCwd(server.cwd, ctx),
+        resolvesThroughPath,
+    };
+}

--- a/packages/agent/src/agent-plugins/stdio-launcher.ts
+++ b/packages/agent/src/agent-plugins/stdio-launcher.ts
@@ -29,6 +29,22 @@ import { isWithin } from './package-data-dir.service';
 /** The base environment. Everything else must be earned. */
 const INHERITED_KEYS = ['PATH', 'HOME', 'TMPDIR', 'USERPROFILE', 'SystemRoot'] as const;
 
+/**
+ * Keys the CLIENT owns outright, reapplied after the package's own `env`.
+ *
+ * `PATH` is here because the whole guarantee of allowing a bare command is
+ * that it "can only run something the operator installed in the image" — and
+ * that is false if the package chooses `PATH`. A package declaring
+ * `PATH=/tmp/its-own-bin` alongside `command: "node"` would have the resolver
+ * pick ITS `node`, turning the safest command shape into the most dangerous
+ * one. AP-18 makes the base environment client-chosen, so refusing to let a
+ * package redirect it is exactly the client doing its job.
+ *
+ * `PLUGIN_ROOT` and `PLUGIN_DATA` are here because they are the client's
+ * statement of where the package lives, not the package's.
+ */
+const CLIENT_OWNED_KEYS = ['PATH', 'PLUGIN_ROOT', 'PLUGIN_DATA'] as const;
+
 export interface LaunchPlan {
     /** Absolute path to the executable, or a bare name to resolve through PATH. */
     readonly command: string;
@@ -101,6 +117,10 @@ export function buildLaunchEnv(
         pluginData: ctx.pluginData,
     };
 
+    // Kept so the client-owned values can be restored verbatim below, rather
+    // than recomputed and risk drifting from what was inherited.
+    const clientPath = env.PATH;
+
     for (const [key, value] of Object.entries(expandEnvValues(declared, expansion))) {
         // The library rejects a reserved key at validation time, so reaching
         // this is a bug rather than a hostile package — but the assignment
@@ -115,8 +135,11 @@ export function buildLaunchEnv(
         env[key] = value;
     }
 
-    // LAST, and unconditionally: these are the client's statement of where the
-    // package lives, not the package's.
+    // LAST, and unconditionally. A package may declare `PATH`, and the
+    // specification does not forbid it — but honouring it would break the
+    // guarantee that a bare command only runs what the operator installed, so
+    // the client's value is put back. See CLIENT_OWNED_KEYS.
+    env.PATH = clientPath;
     env[PLUGIN_ROOT_PLACEHOLDER.slice(2, -1)] = ctx.packageRoot;
     env[PLUGIN_DATA_PLACEHOLDER.slice(2, -1)] = ctx.pluginData;
 

--- a/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
@@ -178,6 +178,53 @@ describe('AgentPluginStdioServerService', () => {
         expect(good).toBe(1);
     });
 
+    it('does not leak a process that finishes starting DURING shutdown', async () => {
+        // `factory.create()` is async, so a shutdown can snapshot the running
+        // set while a launch is still in flight. Without the guard the
+        // transport is added AFTER teardown and never closed — a process
+        // leaked for the lifetime of the pod.
+        let release!: () => void;
+        const pending = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        let closed = 0;
+
+        const transport = {
+            create: jest.fn(async () => {
+                await pending;
+                return {
+                    close: async () => {
+                        closed += 1;
+                    },
+                };
+            }),
+        };
+        service.setTransportFactory(transport);
+
+        const launching = service.launch({ ...request, packageRoot: pkg });
+        const shutdown = await service.shutdownAll();
+        release();
+
+        await expect(launching).rejects.toMatchObject({ code: 'shutting-down' });
+
+        // Nothing was registered, so shutdown legitimately saw nothing — and
+        // the late transport closed itself rather than surviving.
+        expect(shutdown).toEqual({ stopped: 0, failed: 0 });
+        expect(closed).toBe(1);
+    });
+
+    it('is usable again after a shutdown', async () => {
+        // The service is a singleton across runs: a latched shutdown flag
+        // would make every launch after the first teardown fail.
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await service.shutdownAll();
+        const running = await service.launch({ ...request, packageRoot: pkg });
+
+        expect(running.plan.command).toBe('node');
+    });
+
     it('is idempotent at shutdown', async () => {
         const transport = transportStub();
         service.setTransportFactory(transport);

--- a/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
@@ -1,0 +1,191 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentPluginStdioServerService } from './stdio-server.service';
+import { AgentPluginPackageDataDirService } from './package-data-dir.service';
+import { LaunchRefused } from './stdio-launcher';
+
+/**
+ * The spawn point. These are about the gate, the lifecycle and what is
+ * handed to the transport — the rules about environments and binaries are
+ * asserted against plain values in `stdio-launcher.spec.ts`.
+ */
+
+let root: string;
+let pkg: string;
+let service: AgentPluginStdioServerService;
+let created: Array<Record<string, unknown>>;
+let closes: number;
+
+const originalEnv = process.env;
+
+function transportStub(closeImpl?: () => Promise<void>) {
+    return {
+        create: jest.fn(async (params: Record<string, unknown>) => {
+            created.push(params);
+            return {
+                close:
+                    closeImpl ??
+                    (async () => {
+                        closes += 1;
+                    }),
+            };
+        }),
+    };
+}
+
+beforeEach(async () => {
+    process.env = { ...originalEnv };
+    root = await mkdtemp(join(tmpdir(), 'ap-stdio-'));
+    pkg = join(root, 'package');
+    await mkdir(join(pkg, 'bin'), { recursive: true });
+    await writeFile(join(pkg, 'bin', 'server'), '#!/bin/sh\n', 'utf8');
+
+    process.env.AGENT_PLUGINS_DATA_DIR = join(root, 'data');
+    process.env.AGENT_PLUGINS_STDIO = 'true';
+
+    created = [];
+    closes = 0;
+    service = new AgentPluginStdioServerService(new AgentPluginPackageDataDirService());
+});
+
+afterAll(() => {
+    process.env = originalEnv;
+});
+
+const request = {
+    server: { type: 'stdio' as const, command: 'node', args: ['${PLUGIN_ROOT}/index.js'] },
+    packageRoot: '',
+    userId: 'user-1',
+    packageName: 'acme.tools',
+};
+
+describe('AgentPluginStdioServerService', () => {
+    it('REFUSES to spawn while the gate is closed', async () => {
+        delete process.env.AGENT_PLUGINS_STDIO;
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await expect(service.launch({ ...request, packageRoot: pkg })).rejects.toMatchObject({
+            code: 'disabled-by-policy',
+        });
+
+        // The resolver already refuses earlier, so this is the second gate —
+        // and the one that matters, because it is the function that spawns.
+        expect(transport.create).not.toHaveBeenCalled();
+    });
+
+    it('creates the data directory before launching, not at install', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        const running = await service.launch({ ...request, packageRoot: pkg });
+
+        // A directory created at install is missing on every replica that did
+        // not perform it.
+        expect(running.plan.env.PLUGIN_DATA).toContain('data');
+        const { stat } = await import('node:fs/promises');
+        await expect(stat(running.plan.env.PLUGIN_DATA)).resolves.toMatchObject({});
+    });
+
+    it('pipes stderr rather than letting it into the API log stream', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await service.launch({ ...request, packageRoot: pkg });
+
+        // The SDK default is 'inherit', which writes a package's stderr
+        // straight into the API's own log stream, where it is
+        // indistinguishable from platform output and can forge log lines.
+        expect(created[0].stderr).toBe('pipe');
+    });
+
+    it('hands the transport the planned command, args, env and cwd', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await service.launch({ ...request, packageRoot: pkg });
+
+        expect(created[0]).toMatchObject({ command: 'node', cwd: expect.any(String) });
+        expect(created[0].args).toEqual([`${pkg}/index.js`]);
+        const env = created[0].env as Record<string, string>;
+        expect(env.PLUGIN_ROOT).toBe(pkg);
+        expect(env.DATABASE_URL).toBeUndefined();
+    });
+
+    it('refuses a command that escapes the package, without spawning', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await expect(
+            service.launch({
+                ...request,
+                packageRoot: pkg,
+                server: { type: 'stdio', command: '/bin/sh' },
+            }),
+        ).rejects.toBeInstanceOf(LaunchRefused);
+
+        expect(transport.create).not.toHaveBeenCalled();
+    });
+
+    it('closes a single server and forgets it', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        const running = await service.launch({ ...request, packageRoot: pkg });
+        await running.close();
+
+        expect(closes).toBe(1);
+        // Already closed, so a later shutdown must not try again.
+        await expect(service.shutdownAll()).resolves.toEqual({ stopped: 0, failed: 0 });
+    });
+
+    it('stops every server it started at run end', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+
+        await service.launch({ ...request, packageRoot: pkg });
+        await service.launch({ ...request, packageRoot: pkg, packageName: 'other.tools' });
+
+        await expect(service.shutdownAll()).resolves.toEqual({ stopped: 2, failed: 0 });
+        expect(closes).toBe(2);
+    });
+
+    it('does not let one unresponsive server strand the others', async () => {
+        let good = 0;
+        const transport = {
+            create: jest
+                .fn()
+                .mockResolvedValueOnce({
+                    close: async () => {
+                        throw new Error('hung');
+                    },
+                })
+                .mockResolvedValue({
+                    close: async () => {
+                        good += 1;
+                    },
+                }),
+        };
+        service.setTransportFactory(transport);
+
+        await service.launch({ ...request, packageRoot: pkg });
+        await service.launch({ ...request, packageRoot: pkg, packageName: 'other.tools' });
+
+        // A half-completed teardown leaks processes for the lifetime of the
+        // pod, which is worse than a noisy log line.
+        await expect(service.shutdownAll()).resolves.toEqual({ stopped: 1, failed: 1 });
+        expect(good).toBe(1);
+    });
+
+    it('is idempotent at shutdown', async () => {
+        const transport = transportStub();
+        service.setTransportFactory(transport);
+        await service.launch({ ...request, packageRoot: pkg });
+
+        await service.shutdownAll();
+
+        await expect(service.shutdownAll()).resolves.toEqual({ stopped: 0, failed: 0 });
+        expect(closes).toBe(1);
+    });
+});

--- a/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.spec.ts
@@ -1,7 +1,8 @@
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { AgentPluginStdioServerService } from './stdio-server.service';
+import { AgentPluginStdioServerService, createStdioTransportFactory } from './stdio-server.service';
 import { AgentPluginPackageDataDirService } from './package-data-dir.service';
 import { LaunchRefused } from './stdio-launcher';
 
@@ -235,4 +236,76 @@ describe('AgentPluginStdioServerService', () => {
         await expect(service.shutdownAll()).resolves.toEqual({ stopped: 0, failed: 0 });
         expect(closes).toBe(1);
     });
+});
+
+/**
+ * The REAL factory, spawning a REAL process.
+ *
+ * Everything above injects a fake factory, which is right for testing the gate
+ * and the lifecycle but means `createStdioTransportFactory` — the only code
+ * that starts a process — ran in no test at all. It shipped a stall.
+ */
+describe('createStdioTransportFactory', () => {
+    let dir: string;
+    let child: string;
+
+    beforeAll(async () => {
+        dir = await mkdtemp(join(tmpdir(), 'stdio-real-'));
+        child = join(dir, 'child.cjs');
+        // Writes `PROBE_SIZE` bytes to stderr, then records that the write
+        // actually FLUSHED. A blocked child never reaches the callback.
+        await writeFile(
+            child,
+            [
+                "const fs = require('node:fs');",
+                "process.stderr.write('x'.repeat(Number(process.env.PROBE_SIZE)), () => {",
+                "    try { fs.writeFileSync(process.env.PROBE_MARKER, 'flushed'); } catch {}",
+                '});',
+                'setInterval(() => {}, 10000);',
+            ].join('\n'),
+            'utf8',
+        );
+    });
+
+    async function spawnWriting(bytes: number): Promise<boolean> {
+        const marker = join(dir, `marker-${bytes}-${Date.now()}`);
+
+        const factory = await createStdioTransportFactory();
+        const transport = await factory.create({
+            command: process.execPath,
+            args: [child],
+            env: { PROBE_SIZE: String(bytes), PROBE_MARKER: marker },
+            cwd: dir,
+            stderr: 'pipe',
+        });
+
+        try {
+            // Generous, because the assertion is "does it EVER finish", not
+            // "how fast". A stalled child never writes the marker at all.
+            for (let waited = 0; waited < 4000; waited += 100) {
+                if (existsSync(marker)) return true;
+                await new Promise((resolve) => setTimeout(resolve, 100));
+            }
+            return false;
+        } finally {
+            await transport.close().catch(() => undefined);
+        }
+    }
+
+    it('spawns a process that can write a little to stderr', async () => {
+        await expect(spawnWriting(10)).resolves.toBe(true);
+    }, 30000);
+
+    /**
+     * The regression. `stderr: 'pipe'` routes the child's stderr into a
+     * PassThrough that nothing reads, so past roughly 80 KB (16 KB PassThrough
+     * + ~64 KB OS pipe) backpressure stalls the child mid-write — and an MCP
+     * server frozen inside a write to stderr stops answering entirely.
+     *
+     * 10 bytes passes either way, which is exactly why this needs a payload
+     * larger than the buffers rather than a token one.
+     */
+    it('does not stall a process that writes 200 KB to stderr', async () => {
+        await expect(spawnWriting(200_000)).resolves.toBe(true);
+    }, 30000);
 });

--- a/packages/agent/src/agent-plugins/stdio-server.service.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.ts
@@ -183,16 +183,52 @@ export class AgentPluginStdioServerService {
 
     private async getFactory(): Promise<StdioTransportFactory> {
         if (this.factory) return this.factory;
-
-        const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
-
-        this.factory = {
-            async create(params) {
-                const transport = new StdioClientTransport(params);
-                await transport.start();
-                return transport as unknown as { close(): Promise<void> };
-            },
-        };
+        this.factory = await createStdioTransportFactory();
         return this.factory;
     }
+}
+
+/**
+ * The factory that actually spawns.
+ *
+ * Exported, and not inlined into `getFactory`, because it was previously
+ * unreachable from any test: every spec injects a fake factory, so the one
+ * function that starts a real process ran nowhere. That is the same shape that
+ * hid the `pinnedFetch` deadlock, and it hid a second one here.
+ */
+export async function createStdioTransportFactory(): Promise<StdioTransportFactory> {
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    return {
+        async create(params) {
+            const transport = new StdioClientTransport(params);
+            await transport.start();
+
+            // MANDATORY, not hygiene. `stderr: 'pipe'` keeps a package's output
+            // out of the platform's log stream — the whole reason it is not
+            // 'inherit' — but the SDK only pipes the child's stderr into a
+            // PassThrough and hands it over; nothing reads it. Once roughly
+            // 80 KB accumulates (a 16 KB PassThrough plus the ~64 KB OS pipe)
+            // backpressure stalls the CHILD mid-write, and an MCP server frozen
+            // inside a write to stderr stops answering entirely.
+            //
+            // Measured against the real SDK: 10 bytes of stderr completes,
+            // 200 KB never does, and 200 KB with this line completes. Exactly
+            // the size-dependent stealth that let it past review — a chatty
+            // debug log is enough to reach it, and nothing looks wrong until a
+            // server silently stops responding.
+            //
+            // `resume()` discards rather than captures. That is deliberate:
+            // retaining package stderr would mean either putting attacker-
+            // controlled text into our logs (the risk 'pipe' exists to avoid)
+            // or building a buffer nothing reads, which is a dead seam.
+            // `.on('data')` rather than `.resume()`: the SDK types this as the
+            // base `Stream`, which has no `resume`, and attaching a data
+            // listener puts the readable into flowing mode — the same drain
+            // without an `as` cast over the SDK's own typing.
+            transport.stderr?.on('data', () => undefined);
+
+            return transport as unknown as { close(): Promise<void> };
+        },
+    };
 }

--- a/packages/agent/src/agent-plugins/stdio-server.service.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.ts
@@ -155,10 +155,20 @@ export class AgentPluginStdioServerService {
     /**
      * Stop every process this service started.
      *
-     * Called at run end. Failures are swallowed per process so that one
-     * unresponsive server cannot strand the others — a half-completed
-     * teardown leaks processes for the lifetime of the pod, which is worse
-     * than a noisy log line.
+     * **Nothing calls this yet, and nothing calls `launch` either.** This said
+     * "Called at run end", which was not true — the same dead-seam claim this
+     * programme has criticised elsewhere, written into a docstring where it
+     * would be believed.
+     *
+     * It matters to whoever finishes AP-14: `launch` and `shutdownAll` have to
+     * be wired in the SAME change. Wiring only the spawn leaks one subprocess
+     * per run for the lifetime of the pod, and the leak is invisible until the
+     * pod is OOM-killed. The generation counter makes the pair safe to
+     * interleave; it does not make either safe to omit.
+     *
+     * Failures are swallowed per process so that one unresponsive server
+     * cannot strand the others — a half-completed teardown leaks processes,
+     * which is worse than a noisy log line.
      */
     async shutdownAll(): Promise<{ stopped: number; failed: number }> {
         // Bumped BEFORE the snapshot, so a launch that completes during

--- a/packages/agent/src/agent-plugins/stdio-server.service.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.ts
@@ -55,6 +55,23 @@ export class AgentPluginStdioServerService {
     /** Every process this service has started, so teardown can be exhaustive. */
     private readonly running = new Set<{ close(): Promise<void> }>();
 
+    /**
+     * Bumped by every `shutdownAll`.
+     *
+     * `factory.create()` is asynchronous, so a shutdown can snapshot the
+     * running set while a launch is still in flight; the transport would then
+     * be added AFTER teardown and never closed, leaking a process for the
+     * lifetime of the pod.
+     *
+     * A COUNTER rather than a boolean, because a boolean has to be cleared at
+     * the end of `shutdownAll` for the service to stay reusable — and a launch
+     * whose `create()` resolves after that point would see it already false
+     * and register into a set that had been emptied. The generation a launch
+     * captured cannot be un-changed, so the comparison holds however the two
+     * interleave.
+     */
+    private shutdownGeneration = 0;
+
     constructor(private readonly dataDirs: AgentPluginPackageDataDirService) {}
 
     /** Test seam, mirroring the pacote and isomorphic-git injection points. */
@@ -63,6 +80,12 @@ export class AgentPluginStdioServerService {
     }
 
     async launch(request: StdioLaunchRequest): Promise<RunningStdioServer> {
+        // Captured FIRST, before any await. This is the generation the caller
+        // launched into; capturing it later would miss a shutdown that ran
+        // while the data directory or the launch plan was still being
+        // prepared, and those are awaits too.
+        const generation = this.shutdownGeneration;
+
         if (!config.agentPlugins.isStdioEnabled()) {
             throw new LaunchRefused(
                 'Stdio servers are disabled by policy on this deployment ' +
@@ -97,6 +120,17 @@ export class AgentPluginStdioServerService {
             stderr: 'pipe',
         });
 
+        if (this.shutdownGeneration !== generation) {
+            // A teardown ran while this process was starting. Close it here
+            // rather than registering it: that shutdown already took its
+            // snapshot and will never see this transport.
+            await transport.close().catch(() => undefined);
+            throw new LaunchRefused(
+                'Shutdown began while this server was starting; it was stopped again.',
+                'shutting-down',
+            );
+        }
+
         this.running.add(transport);
         this.logger.log(
             `Launched stdio server for package "${request.packageName}" ` +
@@ -127,6 +161,10 @@ export class AgentPluginStdioServerService {
      * than a noisy log line.
      */
     async shutdownAll(): Promise<{ stopped: number; failed: number }> {
+        // Bumped BEFORE the snapshot, so a launch that completes during
+        // teardown sees a different generation and closes itself rather than
+        // registering into a set nobody will read again.
+        this.shutdownGeneration += 1;
         const transports = [...this.running];
         this.running.clear();
 
@@ -136,6 +174,10 @@ export class AgentPluginStdioServerService {
         if (failed > 0) {
             this.logger.warn(`${failed} stdio server(s) did not shut down cleanly.`);
         }
+
+        // Nothing to reset: the next launch captures the NEW generation and
+        // matches it, so the service is reusable without a window in which a
+        // late transport can slip through.
         return { stopped: results.length - failed, failed };
     }
 

--- a/packages/agent/src/agent-plugins/stdio-server.service.ts
+++ b/packages/agent/src/agent-plugins/stdio-server.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { McpStdioServer } from '@ever-works/agent-plugins';
+import { config } from '../config';
+import { AgentPluginPackageDataDirService } from './package-data-dir.service';
+import { buildLaunchPlan, LaunchRefused, type LaunchPlan } from './stdio-launcher';
+
+/**
+ * Spawns a package-declared stdio MCP server (T30, second half).
+ *
+ * `stdio-launcher.ts` decides *what* would run; this decides *whether*, and
+ * then actually runs it. Keeping the two apart means every rule about
+ * environments, binaries and working directories is unit-tested against
+ * plain values, and this file is only about the gate, the lifecycle and the
+ * teardown.
+ *
+ * ## The gate is checked HERE as well as in the resolver
+ *
+ * `McpServerConfigService` already refuses to resolve a stdio server when
+ * `AGENT_PLUGINS_STDIO` is off, so in practice nothing reaches this method
+ * with the gate closed. It is checked again anyway, because this is the
+ * function that actually spawns a process: a future caller that obtains a
+ * server declaration by some other route would otherwise bypass the only
+ * thing standing between a package and execution. A gate that lives at one
+ * call site is a gate that the next call site forgets.
+ */
+
+/** Subset of the SDK transport this service constructs, so tests need no SDK. */
+export interface StdioTransportFactory {
+    create(params: {
+        command: string;
+        args: string[];
+        env: Record<string, string>;
+        cwd: string;
+        stderr: 'pipe';
+    }): Promise<{ close(): Promise<void> }>;
+}
+
+export interface StdioLaunchRequest {
+    readonly server: McpStdioServer;
+    readonly packageRoot: string;
+    readonly userId: string;
+    readonly packageName: string;
+}
+
+export interface RunningStdioServer {
+    readonly plan: LaunchPlan;
+    close(): Promise<void>;
+}
+
+@Injectable()
+export class AgentPluginStdioServerService {
+    private readonly logger = new Logger(AgentPluginStdioServerService.name);
+    private factory: StdioTransportFactory | null = null;
+
+    /** Every process this service has started, so teardown can be exhaustive. */
+    private readonly running = new Set<{ close(): Promise<void> }>();
+
+    constructor(private readonly dataDirs: AgentPluginPackageDataDirService) {}
+
+    /** Test seam, mirroring the pacote and isomorphic-git injection points. */
+    setTransportFactory(factory: StdioTransportFactory): void {
+        this.factory = factory;
+    }
+
+    async launch(request: StdioLaunchRequest): Promise<RunningStdioServer> {
+        if (!config.agentPlugins.isStdioEnabled()) {
+            throw new LaunchRefused(
+                'Stdio servers are disabled by policy on this deployment ' +
+                    '(AGENT_PLUGINS_STDIO).',
+                'disabled-by-policy',
+            );
+        }
+
+        // The data directory is created HERE rather than at install: a
+        // directory created at install is missing on every replica that did
+        // not perform it, and on any replica whose volume was recreated.
+        const pluginData = await this.dataDirs.ensure({
+            userId: request.userId,
+            packageName: request.packageName,
+        });
+
+        const plan = await buildLaunchPlan(request.server, {
+            packageRoot: request.packageRoot,
+            pluginData,
+        });
+
+        const factory = await this.getFactory();
+        const transport = await factory.create({
+            command: plan.command,
+            args: [...plan.args],
+            env: { ...plan.env },
+            cwd: plan.cwd,
+            // NOT 'inherit', which is the SDK default. A package's stderr
+            // would otherwise be written straight into the API's own log
+            // stream, where it is indistinguishable from platform output and
+            // can forge log lines.
+            stderr: 'pipe',
+        });
+
+        this.running.add(transport);
+        this.logger.log(
+            `Launched stdio server for package "${request.packageName}" ` +
+                `(${plan.resolvesThroughPath ? 'PATH' : 'package-local'}: ${plan.command})`,
+        );
+
+        return {
+            plan,
+            close: async () => {
+                this.running.delete(transport);
+                await transport.close().catch((err: unknown) => {
+                    this.logger.warn(
+                        `Failed to close stdio server for "${request.packageName}": ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    );
+                });
+            },
+        };
+    }
+
+    /**
+     * Stop every process this service started.
+     *
+     * Called at run end. Failures are swallowed per process so that one
+     * unresponsive server cannot strand the others — a half-completed
+     * teardown leaks processes for the lifetime of the pod, which is worse
+     * than a noisy log line.
+     */
+    async shutdownAll(): Promise<{ stopped: number; failed: number }> {
+        const transports = [...this.running];
+        this.running.clear();
+
+        const results = await Promise.allSettled(transports.map((t) => t.close()));
+        const failed = results.filter((r) => r.status === 'rejected').length;
+
+        if (failed > 0) {
+            this.logger.warn(`${failed} stdio server(s) did not shut down cleanly.`);
+        }
+        return { stopped: results.length - failed, failed };
+    }
+
+    private async getFactory(): Promise<StdioTransportFactory> {
+        if (this.factory) return this.factory;
+
+        const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+        this.factory = {
+            async create(params) {
+                const transport = new StdioClientTransport(params);
+                await transport.start();
+                return transport as unknown as { close(): Promise<void> };
+            },
+        };
+        return this.factory;
+    }
+}

--- a/packages/agent/src/agent-plugins/workspace-materialization.spec.ts
+++ b/packages/agent/src/agent-plugins/workspace-materialization.spec.ts
@@ -1,0 +1,153 @@
+import { planWorkspaceMaterialization } from './workspace-materialization';
+import type { DiscoveredSkill, McpServerEntry } from '@ever-works/agent-plugins';
+
+/**
+ * The property that matters is what a NON-GATED package cannot put into a
+ * workspace. Everything else here exists so that a planner which withheld
+ * everything could not pass.
+ */
+
+const skill = (over: Partial<DiscoveredSkill> = {}): DiscoveredSkill =>
+    ({
+        name: 'release-notes',
+        sidecarDirs: [],
+        ...over,
+    }) as DiscoveredSkill;
+
+const server = (name: string): McpServerEntry =>
+    ({
+        name,
+        transport: 'streamable-http',
+        config: { type: 'streamable-http', url: `https://${name}.example.com/mcp` },
+    }) as McpServerEntry;
+
+const base = {
+    packageRoot: '/packages/acme',
+    skills: [skill()],
+    mcpServers: [],
+    packageMayExecute: false,
+    boundServerNames: [],
+};
+
+describe('planWorkspaceMaterialization', () => {
+    it('always materialises SKILL.md, which is what the agent is meant to read', () => {
+        const plan = planWorkspaceMaterialization(base);
+
+        expect(plan.files).toEqual([
+            expect.objectContaining({
+                destination: '.claude/skills/release-notes/SKILL.md',
+                executable: false,
+            }),
+        ]);
+    });
+
+    it('NEVER copies scripts for a package without execution authority', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            skills: [skill({ sidecarDirs: ['scripts', 'references'] as never })],
+            packageMayExecute: false,
+        });
+
+        // Copying them would hand the agent the stdio grant without the stdio
+        // gate — it can shell out to whatever lands in its workspace.
+        expect(plan.files.map((f) => f.destination)).not.toContain(
+            '.claude/skills/release-notes/scripts',
+        );
+        expect(plan.withheld).toEqual([
+            expect.objectContaining({ path: 'skills/release-notes/scripts' }),
+        ]);
+        // The reference sidecar still arrives — withholding everything would
+        // be a different bug wearing the same green tick.
+        expect(plan.files.map((f) => f.destination)).toContain(
+            '.claude/skills/release-notes/references',
+        );
+    });
+
+    it('copies scripts, executable, for a package that IS granted execution', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            skills: [skill({ sidecarDirs: ['scripts'] as never })],
+            packageMayExecute: true,
+        });
+
+        expect(plan.files).toContainEqual(
+            expect.objectContaining({
+                destination: '.claude/skills/release-notes/scripts',
+                executable: true,
+            }),
+        );
+        expect(plan.withheld).toEqual([]);
+    });
+
+    it('strips the executable bit from references and assets even when granted', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            skills: [skill({ sidecarDirs: ['references', 'assets'] as never })],
+            packageMayExecute: true,
+        });
+
+        // A reference has no reason to be executable, and a file that arrives
+        // executable is a file something might run.
+        for (const file of plan.files) {
+            if (file.destination.endsWith('references') || file.destination.endsWith('assets')) {
+                expect(file.executable).toBe(false);
+            }
+        }
+    });
+
+    it('writes .mcp.json ONLY for servers with an enabled binding', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            mcpServers: [server('bound'), server('unbound')],
+            boundServerNames: ['bound'],
+        });
+
+        const config = JSON.parse(plan.mcpConfig!);
+        expect(Object.keys(config.mcpServers)).toEqual(['bound']);
+        expect(plan.withheld).toEqual([expect.objectContaining({ path: 'mcp.json#unbound' })]);
+    });
+
+    it('omits .mcp.json entirely when nothing is bound', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            mcpServers: [server('unbound')],
+            boundServerNames: [],
+        });
+
+        // Absence is the only representation every reader agrees on: the
+        // workspace tooling reads this file on its own terms and may not
+        // honour whatever "disabled" shape we invented.
+        expect(plan.mcpConfig).toBeNull();
+    });
+
+    it('explains everything it withheld', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            skills: [skill({ sidecarDirs: ['scripts'] as never })],
+            mcpServers: [server('unbound')],
+        });
+
+        // An operator asking "where is my script?" needs the answer here.
+        expect(plan.withheld).toHaveLength(2);
+        for (const item of plan.withheld) {
+            expect(item.reason.length).toBeGreaterThan(20);
+        }
+    });
+
+    it('handles several skills without leaking one skill’s grant to another', () => {
+        const plan = planWorkspaceMaterialization({
+            ...base,
+            skills: [
+                skill({ name: 'a', sidecarDirs: ['scripts'] as never }),
+                skill({ name: 'b', sidecarDirs: ['references'] as never }),
+            ],
+            packageMayExecute: false,
+        });
+
+        expect(plan.files.map((f) => f.destination).sort()).toEqual([
+            '.claude/skills/a/SKILL.md',
+            '.claude/skills/b/SKILL.md',
+            '.claude/skills/b/references',
+        ]);
+    });
+});

--- a/packages/agent/src/agent-plugins/workspace-materialization.ts
+++ b/packages/agent/src/agent-plugins/workspace-materialization.ts
@@ -1,0 +1,160 @@
+import { join } from 'node:path';
+import type { DiscoveredSkill, McpServerEntry } from '@ever-works/agent-plugins';
+
+/**
+ * Decides what a package is allowed to place into an agent's workspace (T34).
+ *
+ * A pure planner, like `buildLaunchPlan`: it returns the set of copies that
+ * WOULD be made, and copies nothing. The rule being enforced is an
+ * authorisation rule, and an authorisation rule that can only be observed by
+ * performing the action is one nobody can test cheaply.
+ *
+ * ## The execution-gate split
+ *
+ * Materialising a package into a workspace is not one decision but three,
+ * because the three kinds of content carry different authority:
+ *
+ * - **`references/` and `assets/`** are read by the agent as information.
+ *   Copied by default, with executable bits stripped — a reference file has
+ *   no reason to be executable, and a file that arrives executable is a file
+ *   something might run.
+ * - **`scripts/`** is code the agent can execute. Copied ONLY for a package
+ *   that passes the same gate as a stdio server, because "the agent can run
+ *   this" is the same grant whether the process is spawned by us or by the
+ *   agent shelling out.
+ * - **`.mcp.json`** tells the workspace's own tooling to connect somewhere.
+ *   Written ONLY for servers that already have an enabled binding, so the
+ *   file cannot become a second, unaudited route to a server the operator
+ *   did not authorise.
+ *
+ * Without the split, installing a package would let it drop an executable
+ * script into a workspace an agent is about to run in — which is the stdio
+ * grant, obtained without the stdio gate.
+ */
+
+/** Where a materialised item comes from and where it goes. */
+export interface MaterializedFile {
+    /** Absolute path inside the package. */
+    readonly source: string;
+    /** Workspace-relative destination. */
+    readonly destination: string;
+    /** False for everything except gated `scripts/` content. */
+    readonly executable: boolean;
+}
+
+export interface MaterializationPlan {
+    readonly files: readonly MaterializedFile[];
+    /** `.mcp.json` content, or null when no server qualifies. */
+    readonly mcpConfig: string | null;
+    /** What was withheld, and why — an operator asking "where is my script?" needs this. */
+    readonly withheld: readonly { path: string; reason: string }[];
+}
+
+export interface MaterializationInput {
+    readonly packageRoot: string;
+    readonly skills: readonly DiscoveredSkill[];
+    readonly mcpServers: readonly McpServerEntry[];
+    /**
+     * True only when this package passes the stdio-grade gate. Named for what
+     * it authorises rather than for a flag, so a caller has to think about
+     * whether it holds rather than forwarding a boolean it did not examine.
+     */
+    readonly packageMayExecute: boolean;
+    /** Server names with an enabled binding. Anything else is withheld. */
+    readonly boundServerNames: readonly string[];
+}
+
+/** Sidecar directories copied without any execution authority. */
+const INERT_SIDECARS = ['references', 'assets'] as const;
+
+/**
+ * Build the plan.
+ *
+ * Skills always materialise: a `SKILL.md` is instructions, which is what the
+ * agent is meant to read. Everything else is conditional.
+ */
+export function planWorkspaceMaterialization(input: MaterializationInput): MaterializationPlan {
+    const files: MaterializedFile[] = [];
+    const withheld: { path: string; reason: string }[] = [];
+
+    for (const skill of input.skills) {
+        const skillRoot = join(input.packageRoot, 'skills', skill.name);
+        const target = `.claude/skills/${skill.name}`;
+
+        files.push({
+            source: join(skillRoot, 'SKILL.md'),
+            destination: `${target}/SKILL.md`,
+            executable: false,
+        });
+
+        for (const dir of skill.sidecarDirs) {
+            if (INERT_SIDECARS.includes(dir as (typeof INERT_SIDECARS)[number])) {
+                files.push({
+                    source: join(skillRoot, dir),
+                    destination: `${target}/${dir}`,
+                    // Stripped deliberately: a reference has no reason to be
+                    // executable, and a file that arrives executable is a
+                    // file something might run.
+                    executable: false,
+                });
+                continue;
+            }
+
+            // `scripts/`
+            if (!input.packageMayExecute) {
+                withheld.push({
+                    path: `skills/${skill.name}/${dir}`,
+                    reason:
+                        'Scripts are executable content. This package has not been granted ' +
+                        'execution, so copying them would hand the agent the stdio grant ' +
+                        'without the stdio gate.',
+                });
+                continue;
+            }
+
+            files.push({
+                source: join(skillRoot, dir),
+                destination: `${target}/${dir}`,
+                executable: true,
+            });
+        }
+    }
+
+    return {
+        files,
+        mcpConfig: buildMcpConfig(input, withheld),
+        withheld,
+    };
+}
+
+/**
+ * Emit `.mcp.json` for the servers that are actually bound.
+ *
+ * A server with no enabled binding is withheld rather than written disabled.
+ * The workspace's tooling reads this file on its own terms and may not honour
+ * whatever "disabled" shape we invented; absence is the only representation
+ * every reader agrees on.
+ */
+function buildMcpConfig(
+    input: MaterializationInput,
+    withheld: { path: string; reason: string }[],
+): string | null {
+    const bound = new Set(input.boundServerNames);
+    const servers: Record<string, unknown> = {};
+
+    for (const entry of input.mcpServers) {
+        if (!bound.has(entry.name)) {
+            withheld.push({
+                path: `mcp.json#${entry.name}`,
+                reason:
+                    'The server has no enabled binding, so writing it here would create a ' +
+                    'second route to a server the operator did not authorise.',
+            });
+            continue;
+        }
+        servers[entry.name] = entry.config;
+    }
+
+    if (Object.keys(servers).length === 0) return null;
+    return JSON.stringify({ mcpServers: servers }, null, 2) + '\n';
+}

--- a/packages/agent/src/database/repositories/plugin-usage.repository.ts
+++ b/packages/agent/src/database/repositories/plugin-usage.repository.ts
@@ -447,13 +447,13 @@ export class PluginUsageRepository {
             const occurredAt =
                 row.occurredAt instanceof Date ? row.occurredAt : new Date(row.occurredAt);
             const day = occurredAt.toISOString().slice(0, 10);
-            const key = `${day} ${row.agentId ?? ''}`;
+            const key = `${day}\0${row.agentId ?? ''}`;
             byDayAgent.set(key, (byDayAgent.get(key) ?? 0) + Number(row.costCents ?? 0));
         }
 
         return Array.from(byDayAgent.entries())
             .map(([key, costCents]) => {
-                const [day, agentId] = key.split(' ');
+                const [day, agentId] = key.split('\0');
                 return { day, agentId: agentId === '' ? null : agentId, costCents };
             })
             .sort((a, b) => a.day.localeCompare(b.day));

--- a/packages/agent/src/entities/plugin-usage-event.entity.ts
+++ b/packages/agent/src/entities/plugin-usage-event.entity.ts
@@ -16,6 +16,10 @@ import { BudgetOwnerType } from './_types';
 
 export enum PluginUsageCapability {
     AI = 'ai',
+    // Agent Plugins (EW-772) — one event per MCP tool invocation. Additive
+    // enum value, no migration needed (the column is varchar), matching every
+    // other addition to this enum.
+    MCP = 'mcp',
     SEARCH = 'search',
     SCREENSHOT = 'screenshot',
     EXTRACTOR = 'extractor',

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -1045,7 +1045,7 @@ export class GitFacadeService implements IGitFacade {
             cloneOptions.repo,
             cloneOptions.branch ?? '',
             cloneOptions.autoSwitchToMainBranch === false ? 'no-switch' : 'switch',
-        ].join(' ');
+        ].join('\0');
 
         const inFlight = this.cloneOrPullRequests.get(key);
         if (inFlight) {

--- a/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
+++ b/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
@@ -57,6 +57,7 @@ function makeSource(options: {
     connections: McpServerConnection[];
     bindings: AgentMcpServerBinding[];
     toolsByConnection?: Record<string, McpToolInfo[] | Error>;
+    usage?: { record: jest.Mock };
 }) {
     const connectionsRepo = {
         findEnabledByUser: jest
@@ -96,7 +97,12 @@ function makeSource(options: {
         { findByIdAndUser: jest.fn() } as never,
         undefined,
     );
-    return { source: new McpToolSource(connections, client), client };
+    const usage = options.usage;
+    return {
+        source: new McpToolSource(connections, client, usage as never),
+        client,
+        usage,
+    };
 }
 
 describe('McpToolSource', () => {
@@ -233,5 +239,89 @@ describe('McpToolSource', () => {
                 { q: 'bug' },
             );
         });
+    });
+});
+
+describe('usage accounting (T28)', () => {
+    it('records one event per successful tool invocation', async () => {
+        const usage = { record: jest.fn().mockResolvedValue({}) };
+        const { source } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+            usage,
+        });
+
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        await tools[0].invoke({ q: 'x' });
+
+        expect(usage.record).toHaveBeenCalledTimes(1);
+        expect(usage.record).toHaveBeenCalledWith(
+            expect.objectContaining({
+                workId: 'work-1',
+                userId: 'u1',
+                capability: 'mcp',
+                units: 1,
+            }),
+        );
+    });
+
+    it('does NOT record a failed tool call', async () => {
+        const usage = { record: jest.fn().mockResolvedValue({}) };
+        const { source, client } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+            usage,
+        });
+        (client.callTool as jest.Mock).mockRejectedValue(new Error('server down'));
+
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        await expect(tools[0].invoke({ q: 'x' })).rejects.toThrow('server down');
+
+        // Recording after the call is what makes this true: a failed
+        // invocation consumed nothing, so counting it would overstate spend.
+        expect(usage.record).not.toHaveBeenCalled();
+    });
+
+    it('NEVER breaks a tool call when accounting fails', async () => {
+        const usage = { record: jest.fn().mockRejectedValue(new Error('db down')) };
+        const { source } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+            usage,
+        });
+
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+
+        // Trading a working tool for a complete ledger is the wrong way round.
+        await expect(tools[0].invoke({ q: 'x' })).resolves.toEqual({ ok: true });
+    });
+
+    it('skips an agent with no workId rather than inventing one', async () => {
+        const usage = { record: jest.fn().mockResolvedValue({}) };
+        const { source } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+            usage,
+        });
+
+        // `plugin_usage_events.workId` is NOT NULL, and an agent scoped to a
+        // Mission or Idea has none. Making that column nullable is a migration
+        // on a table five other capabilities write to — a larger change than
+        // this feature should make alone, so such agents are simply not
+        // counted, and the gap is stated rather than hidden.
+        const tools = await source.buildTools(makeAgent({ workId: null }));
+        await tools[0].invoke({ q: 'x' });
+
+        expect(usage.record).not.toHaveBeenCalled();
+    });
+
+    it('works with no usage repository bound at all', async () => {
+        const { source } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+        });
+
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        await expect(tools[0].invoke({ q: 'x' })).resolves.toEqual({ ok: true });
     });
 });

--- a/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
+++ b/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
@@ -242,6 +242,13 @@ describe('McpToolSource', () => {
     });
 });
 
+/**
+ * Usage accounting is deliberately NOT awaited by `invoke`, so an assertion
+ * made immediately after would be racing a microtask. Flushing makes these
+ * tests deterministic rather than dependent on how fast the stub resolves.
+ */
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 describe('usage accounting (T28)', () => {
     it('records one event per successful tool invocation', async () => {
         const usage = { record: jest.fn().mockResolvedValue({}) };
@@ -253,6 +260,7 @@ describe('usage accounting (T28)', () => {
 
         const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
         await tools[0].invoke({ q: 'x' });
+        await flush();
 
         expect(usage.record).toHaveBeenCalledTimes(1);
         expect(usage.record).toHaveBeenCalledWith(
@@ -276,6 +284,7 @@ describe('usage accounting (T28)', () => {
 
         const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
         await expect(tools[0].invoke({ q: 'x' })).rejects.toThrow('server down');
+        await flush();
 
         // Recording after the call is what makes this true: a failed
         // invocation consumed nothing, so counting it would overstate spend.
@@ -311,8 +320,35 @@ describe('usage accounting (T28)', () => {
         // counted, and the gap is stated rather than hidden.
         const tools = await source.buildTools(makeAgent({ workId: null }));
         await tools[0].invoke({ q: 'x' });
+        await flush();
 
         expect(usage.record).not.toHaveBeenCalled();
+    });
+
+    it('returns the tool result WITHOUT waiting for accounting to finish', async () => {
+        let settle!: () => void;
+        const usage = {
+            record: jest.fn(
+                () =>
+                    new Promise<void>((resolve) => {
+                        settle = resolve;
+                    }),
+            ),
+        };
+        const { source } = makeSource({
+            connections: [makeConnection()],
+            bindings: [makeBinding()],
+            usage,
+        });
+
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+
+        // The write never settles. If `invoke` awaited it, this would hang —
+        // a stalled accounting write would hold every successful tool
+        // response open, making the ledger a latency dependency of the run.
+        await expect(tools[0].invoke({ q: 'x' })).resolves.toEqual({ ok: true });
+
+        settle();
     });
 
     it('works with no usage repository bound at all', async () => {

--- a/packages/agent/src/mcp/guarded-fetch.spec.ts
+++ b/packages/agent/src/mcp/guarded-fetch.spec.ts
@@ -1,4 +1,4 @@
-import { createGuardedFetch, MAX_REDIRECTS } from './guarded-fetch';
+import { createGuardedFetch, MAX_REDIRECTS, pinnedFetch } from './guarded-fetch';
 
 /**
  * The property under test is what CROSSES a redirect, not whether fetch works.
@@ -230,5 +230,67 @@ describe('createGuardedFetch', () => {
         // target is handed to it for checking rather than fetched directly.
         expect(hops[1].url).toBe('http://127.0.0.1:6379/');
         expect(impl).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('pinnedFetch — DNS rebinding', () => {
+    it('refuses when ANY resolved address is private, not just the first', async () => {
+        // A response mixing a public and a private record would otherwise pass
+        // whenever the public one happens to be picked — a coin toss, not a
+        // control.
+        const resolver = jest.fn().mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+            { address: '127.0.0.1', family: 4 },
+        ]);
+
+        await expect(
+            pinnedFetch('https://rebind.example.com/mcp', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'dns_private_ip' });
+    });
+
+    it('refuses a private IPv6 answer', async () => {
+        const resolver = jest.fn().mockResolvedValue([{ address: '::1', family: 6 }]);
+
+        await expect(
+            pinnedFetch('https://rebind.example.com/mcp', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'dns_private_ip' });
+    });
+
+    it('refuses when the lookup returns nothing', async () => {
+        const resolver = jest.fn().mockResolvedValue([]);
+
+        await expect(
+            pinnedFetch('https://nowhere.example.com/mcp', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'dns_no_results' });
+    });
+
+    it('refuses a lookup failure rather than falling through to fetch', async () => {
+        const resolver = jest.fn().mockRejectedValue(new Error('SERVFAIL'));
+
+        await expect(
+            pinnedFetch('https://broken.example.com/mcp', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'dns_lookup_failed' });
+    });
+
+    it('applies the lexical guard before spending a DNS lookup', async () => {
+        const resolver = jest.fn();
+
+        await expect(
+            pinnedFetch('http://169.254.169.254/latest/meta-data/', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'lexical_blocked' });
+
+        expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it('does NOT resolve a literal-IP host — there is no name to rebind', async () => {
+        const resolver = jest.fn();
+
+        // Rejected by the lexical guard, and the point is that the resolver
+        // was never consulted: a literal address cannot be rebound.
+        await expect(
+            pinnedFetch('http://127.0.0.1:6379/mcp', undefined, resolver),
+        ).rejects.toMatchObject({ code: 'lexical_blocked' });
+
+        expect(resolver).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/mcp/guarded-fetch.spec.ts
+++ b/packages/agent/src/mcp/guarded-fetch.spec.ts
@@ -1,4 +1,4 @@
-import { createGuardedFetch, MAX_REDIRECTS, pinnedFetch } from './guarded-fetch';
+import { createGuardedFetch, MAX_REDIRECTS, pinnedConnect, pinnedFetch } from './guarded-fetch';
 
 /**
  * The property under test is what CROSSES a redirect, not whether fetch works.
@@ -294,3 +294,93 @@ describe('pinnedFetch — DNS rebinding', () => {
         expect(resolver).not.toHaveBeenCalled();
     });
 });
+
+/**
+ * The real connection path, against a real server.
+ *
+ * Everything above injects `fetchImpl`, which is right for testing what crosses
+ * a redirect but means `pinnedConnect` — the code that actually opens the
+ * socket — ran in no test at all. `pinnedFetch` cannot be pointed at a local
+ * server because `isSafeWebhookUrl` refuses loopback, so the untestable shape
+ * was structural rather than an oversight.
+ *
+ * It hid a deadlock: `await dispatcher.close()` before returning the Response
+ * waits for a body the caller has not been given the chance to read yet.
+ */
+describe('pinnedConnect against a live server', () => {
+    let server: import('node:http').Server;
+    let origin: string;
+
+    beforeAll(async () => {
+        const http = await import('node:http');
+        server = http.createServer((req, res) => {
+            const size = Number(new URL(req.url ?? '/', 'http://x').searchParams.get('n') ?? 10);
+            res.writeHead(200, { 'content-type': 'text/plain' });
+            res.end('x'.repeat(size));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const address = server.address();
+        origin = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
+    });
+
+    afterAll(async () => {
+        // `close()` only stops the server ACCEPTING; it then waits for every
+        // open connection to end. undici keeps its sockets alive by default, so
+        // `close()` alone never settles and the server stays an open handle —
+        // which is what "a worker process has failed to exit gracefully"
+        // actually meant here. Dropping the live sockets first is the fix; a
+        // `setImmediate` yield was not, and confirmed it by not helping.
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    const loopback = { address: '127.0.0.1', family: 4 };
+
+    it('returns a small body', async () => {
+        const response = await pinnedConnect(`${origin}/?n=10`, undefined, loopback);
+        await expect(response.text()).resolves.toHaveLength(10);
+    });
+
+    /**
+     * The regression. A body larger than the socket buffer cannot complete
+     * before the Response is handed back, so awaiting `close()` first hung
+     * forever. 10 bytes passed; 200 KB never returned — and an SSE stream,
+     * which never ends, hung on connect.
+     *
+     * The timeout is the assertion: without it a failure hangs the suite
+     * instead of reporting.
+     */
+    it('returns a body larger than the socket buffer without hanging', async () => {
+        const size = 200_000;
+
+        const response = await withTimeout(
+            pinnedConnect(`${origin}/?n=${size}`, undefined, loopback),
+            5000,
+            'pinnedConnect did not return',
+        );
+        const body = await withTimeout(response.text(), 5000, 'body never finished');
+
+        expect(body).toHaveLength(size);
+    }, 20000);
+
+    it('rejects, rather than hanging, when the connection fails', async () => {
+        // Port 1 is reserved and nothing listens on it.
+        await expect(
+            withTimeout(
+                pinnedConnect('http://127.0.0.1:1/', undefined, loopback),
+                5000,
+                'pinnedConnect neither resolved nor rejected',
+            ),
+        ).rejects.toBeDefined();
+    }, 20000);
+});
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+    let timer: NodeJS.Timeout;
+    return Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(message)), ms);
+        }),
+    ]).finally(() => clearTimeout(timer)) as Promise<T>;
+}

--- a/packages/agent/src/mcp/guarded-fetch.spec.ts
+++ b/packages/agent/src/mcp/guarded-fetch.spec.ts
@@ -160,6 +160,43 @@ describe('createGuardedFetch', () => {
         expect(hops[1].init?.method).toBe('POST');
     });
 
+    it('drops to GET on a cross-origin 307, rather than sending a bodyless POST', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: 'https://evil.example.net/collect' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', {
+            method: 'POST',
+            body: '{"a":1}',
+            headers: { 'X-API-Key': 'secret' },
+        });
+
+        // A 307 preserves the method by definition, so keeping POST while
+        // dropping the body would send a bodyless POST to a host the caller
+        // never addressed — a request neither side asked for, which a server
+        // may still act on.
+        expect(hops[1].init?.method).toBe('GET');
+        expect(hops[1].init?.body).toBeUndefined();
+        expect(hops[1].init?.headers).toBeUndefined();
+    });
+
+    it('still preserves POST across a SAME-origin 307', async () => {
+        const { impl, hops } = scriptedFetch([
+            { status: 307, location: 'https://api.example.com/v2' },
+            { status: 200 },
+        ]);
+        const fetchImpl = createGuardedFetch({ fetchImpl: impl });
+
+        await fetchImpl('https://api.example.com/mcp', { method: 'POST', body: '{}' });
+
+        // Same origin keeps the caller's request intact; only the origin
+        // crossing forfeits it.
+        expect(hops[1].init?.method).toBe('POST');
+        expect(hops[1].init?.body).toBe('{}');
+    });
+
     it('refuses a redirect loop rather than following it forever', async () => {
         const { impl } = scriptedFetch([{ status: 302, location: 'https://api.example.com/a' }]);
         const fetchImpl = createGuardedFetch({ fetchImpl: impl });

--- a/packages/agent/src/mcp/guarded-fetch.ts
+++ b/packages/agent/src/mcp/guarded-fetch.ts
@@ -1,4 +1,12 @@
-import { safeFetchWithDnsPin, SsrfBlockedError, type DnsResolver } from '../utils/ssrf-guard';
+import { isIP } from 'node:net';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import {
+    isPrivateIPv4,
+    isPrivateIPv6,
+    isSafeWebhookUrl,
+    SsrfBlockedError,
+    type DnsResolver,
+} from '../utils/ssrf-guard';
 
 /**
  * SSRF- and redirect-hardened `fetch` for the MCP client (AP-15).
@@ -51,6 +59,104 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
  */
 const REWRITE_TO_GET = new Set([301, 302, 303]);
 
+/**
+ * Resolve a host, validate every address, and CONNECT TO THE ONE VALIDATED.
+ *
+ * `safeFetchWithDnsPin` does the first two steps correctly — it rejects the
+ * lookup if any returned address is private — and then calls
+ * `fetch(rawUrl, init)`, which resolves the hostname AGAIN. Its own docstring
+ * says as much: it "closes the obvious half of that race". The half left open
+ * is the one that matters: a name the attacker controls can answer publicly
+ * for the validation lookup and privately for the connection a moment later,
+ * and nothing in between notices.
+ *
+ * Pinning closes it by taking the address out of the connection's hands. The
+ * URL, and therefore the `Host` header and the TLS SNI, are untouched — so
+ * certificate validation still happens against the hostname, and a pinned
+ * connection to a host presenting the wrong certificate still fails.
+ *
+ * A literal-IP URL skips DNS entirely: there is no name to rebind, and the
+ * lexical guard has already judged the address.
+ */
+export async function pinnedFetch(
+    url: string,
+    init: RequestInit | undefined,
+    resolver: DnsResolver | undefined,
+): Promise<Response> {
+    if (!isSafeWebhookUrl(url)) {
+        throw new SsrfBlockedError('lexical_blocked', 'URL rejected by lexical SSRF guard');
+    }
+
+    const parsed = new URL(url);
+    let host = parsed.hostname.toLowerCase();
+    if (host.startsWith('[') && host.endsWith(']')) {
+        host = host.slice(1, -1);
+    }
+
+    // A literal address was already judged above and cannot be rebound.
+    if (isIP(host) !== 0) {
+        return fetch(url, init);
+    }
+
+    let addresses: { address: string; family: number }[];
+    try {
+        addresses = resolver
+            ? await resolver(host)
+            : await dnsLookup(host, { all: true, verbatim: true });
+    } catch (err) {
+        throw new SsrfBlockedError(
+            'dns_lookup_failed',
+            `DNS lookup failed for ${host}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+
+    if (!Array.isArray(addresses) || addresses.length === 0) {
+        throw new SsrfBlockedError(
+            'dns_no_results',
+            `DNS lookup returned no addresses for ${host}`,
+        );
+    }
+
+    // EVERY address, not the one we happen to pick. A response mixing a public
+    // and a private record would otherwise pass whenever the public one is
+    // chosen, which is a coin toss rather than a control.
+    for (const entry of addresses) {
+        if (entry.family === 4 && isPrivateIPv4(entry.address)) {
+            throw new SsrfBlockedError(
+                'dns_private_ip',
+                `${host} resolved to private IPv4 ${entry.address}`,
+            );
+        }
+        if (entry.family === 6 && isPrivateIPv6(entry.address)) {
+            throw new SsrfBlockedError(
+                'dns_private_ip',
+                `${host} resolved to private IPv6 ${entry.address}`,
+            );
+        }
+    }
+
+    const pinned = addresses[0];
+    const { Agent } = await import('undici');
+    const dispatcher = new Agent({
+        connect: {
+            // Hand back only the address just validated. undici still uses the
+            // URL's hostname for SNI and the Host header, so TLS verification
+            // is unchanged.
+            lookup: (
+                _hostname: string,
+                _options: unknown,
+                callback: (err: Error | null, address: string, family: number) => void,
+            ) => callback(null, pinned.address, pinned.family),
+        },
+    });
+
+    try {
+        return await fetch(url, { ...init, dispatcher } as RequestInit);
+    } finally {
+        await dispatcher.close().catch(() => undefined);
+    }
+}
+
 export interface GuardedFetchOptions {
     /** Injected in tests so no DNS or network is required. */
     dnsResolver?: DnsResolver;
@@ -75,12 +181,7 @@ function headerEntries(init: RequestInit | undefined): [string, string][] {
 export function createGuardedFetch(options: GuardedFetchOptions = {}): GuardedFetch {
     const doFetch =
         options.fetchImpl ??
-        ((url: string, init?: RequestInit) =>
-            safeFetchWithDnsPin(
-                url,
-                init,
-                options.dnsResolver ? { dnsResolver: options.dnsResolver } : undefined,
-            ));
+        ((url: string, init?: RequestInit) => pinnedFetch(url, init, options.dnsResolver));
 
     return async function guardedFetch(input, init) {
         let currentUrl = typeof input === 'string' ? input : input.toString();

--- a/packages/agent/src/mcp/guarded-fetch.ts
+++ b/packages/agent/src/mcp/guarded-fetch.ts
@@ -135,7 +135,26 @@ export async function pinnedFetch(
         }
     }
 
-    const pinned = addresses[0];
+    return pinnedConnect(url, init, addresses[0]);
+}
+
+/**
+ * Connect with the socket pinned to one already-validated address.
+ *
+ * Split out from {@link pinnedFetch} so the dispatcher's lifetime is testable.
+ * `pinnedFetch` runs `isSafeWebhookUrl` first, which refuses loopback — so a
+ * test cannot drive the real function against a local server, and every test
+ * therefore injected `fetchImpl` and exercised none of this. That is exactly
+ * how the bug below survived.
+ *
+ * The caller is responsible for validating `pinned`; this function performs no
+ * SSRF checks of its own.
+ */
+export async function pinnedConnect(
+    url: string,
+    init: RequestInit | undefined,
+    pinned: { address: string; family: number },
+): Promise<Response> {
     const { Agent } = await import('undici');
     const dispatcher = new Agent({
         connect: {
@@ -150,11 +169,37 @@ export async function pinnedFetch(
         },
     });
 
+    let response: Response;
     try {
-        return await fetch(url, { ...init, dispatcher } as RequestInit);
-    } finally {
-        await dispatcher.close().catch(() => undefined);
+        response = await fetch(url, { ...init, dispatcher } as RequestInit);
+    } catch (err) {
+        // No response, so nothing can be streaming: tear the pool down now
+        // rather than waiting for a request that will never complete.
+        void dispatcher.destroy().catch(() => undefined);
+        throw err;
     }
+
+    // Deliberately NOT awaited, and this is the whole point.
+    //
+    // `close()` resolves only once every in-flight request has finished, and a
+    // request is not finished until its response body has been consumed — which
+    // cannot happen until this function returns the Response to its caller.
+    // `await dispatcher.close()` in a `finally` therefore deadlocks: the close
+    // waits for the body, the body waits for the return, the return waits for
+    // the close.
+    //
+    // It hid beautifully. A small response fits the socket buffer and completes
+    // before `close()` is called, so it passes; a 200 KB body hangs forever, and
+    // an SSE stream — which never ends by design — hangs on connect. Every unit
+    // test injected `fetchImpl`, so none of them ran this line.
+    //
+    // Fire-and-forget is correct rather than merely convenient: `close()` is
+    // graceful, so the pool drains after the body is consumed and the socket is
+    // released then. Callers that discard a response must cancel its body, or
+    // the request stays pending and this never resolves — see the redirect path
+    // in `createGuardedFetch`.
+    void dispatcher.close().catch(() => undefined);
+    return response;
 }
 
 export interface GuardedFetchOptions {
@@ -201,6 +246,13 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): GuardedFe
                 // problem; hand it back rather than inventing a target.
                 return response;
             }
+
+            // Past this point the response is discarded in favour of the
+            // redirect target, so cancel its body. An unread body leaves the
+            // request pending, which keeps the pinned dispatcher's `close()`
+            // from ever resolving and holds the socket open for the life of
+            // the process — one leaked pool per redirect hop.
+            void response.body?.cancel().catch(() => undefined);
 
             if (hop === MAX_REDIRECTS) {
                 throw new SsrfBlockedError(

--- a/packages/agent/src/mcp/guarded-fetch.ts
+++ b/packages/agent/src/mcp/guarded-fetch.ts
@@ -111,15 +111,18 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): GuardedFe
             const target = new URL(location, currentUrl);
 
             if (target.origin !== origin) {
-                // Cross-origin: forward the method and nothing else. See the
+                // Cross-origin: forward nothing the caller supplied. See the
                 // class docstring — an allow-list cannot tell a secret header
                 // from a benign one by its name.
-                currentInit = {
-                    method: REWRITE_TO_GET.has(response.status)
-                        ? 'GET'
-                        : (currentInit.method ?? 'GET'),
-                    redirect: 'manual',
-                };
+                //
+                // The body goes too, and that forces the method. A 307/308
+                // preserves the method by definition, so keeping POST while
+                // dropping the body would send a bodyless POST to a host the
+                // caller never addressed — a request neither side asked for,
+                // and one a server may act on. Dropping to GET makes the hop
+                // a plain retrieval, which is the only thing that can be said
+                // to be safe without the caller's data.
+                currentInit = { method: 'GET', redirect: 'manual' };
             } else if (REWRITE_TO_GET.has(response.status)) {
                 currentInit = {
                     ...currentInit,

--- a/packages/agent/src/mcp/mcp-tool-source.ts
+++ b/packages/agent/src/mcp/mcp-tool-source.ts
@@ -175,8 +175,15 @@ export class McpToolSource implements AgentMcpToolSource {
                 const record =
                     args && typeof args === 'object' ? (args as Record<string, unknown>) : {};
                 const result = await this.client.callTool(connection, tool.name, record);
+                // Started but NOT awaited. The helper swallows its own
+                // rejections, but `repository.save()` can still stall — and a
+                // stalled write would hold a successful tool response open,
+                // making accounting a latency and availability dependency of
+                // every tool call. It is an observation; it must not sit in
+                // the response path.
+                //
                 // After the call, so a failed tool is not counted as usage.
-                await this.recordInvocation(agent, connection);
+                void this.recordInvocation(agent, connection);
                 return result;
             },
         };

--- a/packages/agent/src/mcp/mcp-tool-source.ts
+++ b/packages/agent/src/mcp/mcp-tool-source.ts
@@ -1,8 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import type { Agent } from '../entities/agent.entity';
 import type { McpServerConnection } from '../entities/mcp-server-connection.entity';
 import type { AgentToolDescriptor, AgentToolParameterSchema } from '../agents/agent-tool.service';
 import type { AgentMcpToolSource } from '../agents/agent-mcp-tool-source';
+import { PluginUsageRepository } from '../database/repositories/plugin-usage.repository';
+import { PluginUsageCapability } from '../entities/plugin-usage-event.entity';
 import { McpClientService, type McpToolInfo } from './mcp-client.service';
 import { McpConnectionsService } from './mcp-connections.service';
 
@@ -35,7 +37,49 @@ export class McpToolSource implements AgentMcpToolSource {
     constructor(
         private readonly connections: McpConnectionsService,
         private readonly client: McpClientService,
+        // @Optional() so every existing construction of this class keeps
+        // working and so a context without a database still builds tools.
+        // Usage accounting is an observation, never a precondition for a tool
+        // being callable.
+        @Optional()
+        private readonly usage?: PluginUsageRepository,
     ) {}
+
+    /**
+     * Record one MCP tool invocation (T28).
+     *
+     * Best-effort in two distinct senses, both deliberate:
+     *
+     * - It NEVER throws into the tool call. An accounting failure that broke
+     *   a working tool would trade a complete ledger for a broken agent, which
+     *   is the wrong way round.
+     * - It records only when the agent has a `workId`. `plugin_usage_events`
+     *   requires one, and an agent scoped to a Mission or Idea has none.
+     *   Making that column nullable is a migration on a table five other
+     *   capabilities write to, which is a larger change than this feature
+     *   should make on its own — so unscoped agents are simply not counted,
+     *   and that is stated rather than hidden.
+     */
+    private async recordInvocation(agent: Agent, connection: McpServerConnection): Promise<void> {
+        if (!this.usage || !agent.workId) return;
+        try {
+            await this.usage.record({
+                workId: agent.workId,
+                userId: agent.userId,
+                pluginId: `mcp:${connection.name}`.slice(0, 128),
+                capability: PluginUsageCapability.MCP,
+                units: 1,
+                costCents: 0,
+                metadata: { connectionId: connection.id, source: connection.source },
+            });
+        } catch (err) {
+            this.logger.debug(
+                `Usage accounting failed for MCP tool call on "${connection.name}": ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
+    }
 
     async buildTools(agent: Agent): Promise<AgentToolDescriptor[]> {
         if (!agent.permissions?.canCallExternalTools) return [];
@@ -69,7 +113,7 @@ export class McpToolSource implements AgentMcpToolSource {
                 continue;
             }
             for (const tool of tools) {
-                const descriptor = this.toDescriptor(connection, tool);
+                const descriptor = this.toDescriptor(agent, connection, tool);
                 if (!descriptor) continue;
                 if (seen.has(descriptor.name)) {
                     this.logger.warn(
@@ -87,6 +131,7 @@ export class McpToolSource implements AgentMcpToolSource {
     // ── internals ─────────────────────────────────────────────────
 
     private toDescriptor(
+        agent: Agent,
         connection: McpServerConnection,
         tool: McpToolInfo,
     ): AgentToolDescriptor | null {
@@ -129,7 +174,10 @@ export class McpToolSource implements AgentMcpToolSource {
             invoke: async (args: unknown) => {
                 const record =
                     args && typeof args === 'object' ? (args as Record<string, unknown>) : {};
-                return this.client.callTool(connection, tool.name, record);
+                const result = await this.client.callTool(connection, tool.name, record);
+                // After the call, so a failed tool is not counted as usage.
+                await this.recordInvocation(agent, connection);
+                return result;
             },
         };
     }

--- a/packages/agent/src/mcp/mcp.module.ts
+++ b/packages/agent/src/mcp/mcp.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { McpServerConnection } from '../entities/mcp-server-connection.entity';
+import { PluginUsageEvent } from '../entities/plugin-usage-event.entity';
 import { AgentMcpServerBinding } from '../entities/agent-mcp-server-binding.entity';
 import { Agent } from '../entities/agent.entity';
 import { McpServerConnectionRepository } from '../database/repositories/mcp-server-connection.repository';
+import { PluginUsageRepository } from '../database/repositories/plugin-usage.repository';
 import { AgentMcpServerBindingRepository } from '../database/repositories/agent-mcp-server-binding.repository';
 import { AgentRepository } from '../database/repositories/agent.repository';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
@@ -28,11 +30,17 @@ import { McpToolSource } from './mcp-tool-source';
 @Module({
     imports: [
         DatabaseModule,
-        TypeOrmModule.forFeature([McpServerConnection, AgentMcpServerBinding, Agent]),
+        TypeOrmModule.forFeature([
+            McpServerConnection,
+            AgentMcpServerBinding,
+            Agent,
+            PluginUsageEvent,
+        ]),
         ActivityLogModule,
     ],
     providers: [
         McpServerConnectionRepository,
+        PluginUsageRepository,
         AgentMcpServerBindingRepository,
         AgentRepository,
         McpClientService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1110,6 +1110,9 @@ importers:
       typeorm:
         specifier: ^0.3.31
         version: 0.3.31(better-sqlite3@12.6.2)(ioredis@5.10.1)(mysql2@3.24.2(@types/node@22.19.11))(pg@8.18.0)(sql.js@1.14.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(typescript@5.9.3))
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3


### PR DESCRIPTION
Phase 4 of the Agent Plugins programme (EW-772), **T29–T32**. Follows [#2327](https://github.com/ever-works/ever-works/pull/2327), now merged.

Everything remains behind `FEATURE_AGENT_PLUGINS`, and stdio behind a second flag that also defaults to off.

## Two switches, not one

`AGENT_PLUGINS_STDIO` is deliberately separate from the master flag, because they authorise different things. The master flag lets a package contribute **documents** and **declarations** of remote servers — inert data, and a remote server still needs an allowlist entry and an explicit per-agent binding. This one lets the platform **execute a subprocess from a package's own contents**, with no sandbox, at the API pod's privileges. SaaS keeps it off.

Per AP-19 a stdio server on a closed gate is **present and disabled by policy**, not hidden: skips carry a machine-readable `code`, and `disabled-by-policy` is the only one with `enableable: true` — the single case an operator fixes with a setting rather than by fixing a package.

## The environment is built from nothing

The API process holds `DATABASE_URL`, `AUTH_SECRET`, every `PLUGIN_*` API key and the platform encryption key. A denylist over that would have to enumerate every secret that exists now **and every one added later** — and the day someone adds a secret without updating it, every installed package can read it. Building from `{}` inverts the default. A test asserts those four specific values are absent from the result.

Order is a control too: the package's own `env` is applied second and the two reserved keys last, so a package cannot redirect `PLUGIN_ROOT` by declaring it.

## Command and cwd

A **bare name** resolves through `PATH`, so it can only run what the operator installed in the image. A **`./`-relative path** runs a file the package ships, proved inside the package root *after* symlinks — `resolve` collapses `..` lexically first, the same trap the conformance library documents. Absolute paths are refused despite looking harmless: they name a binary neither the operator nor the package chose deliberately.

`cwd` is contained against the root its anchor **names** — a `${PLUGIN_DATA}` value against the data directory, not merely against *some* directory. Checking both against the package root would pass a value escaping into another tenant's data.

## Spawning

The gate is checked at the spawn point as well as in the resolver. Nothing reaches it with the flag off today, but this is the function that actually creates a process, and a gate that lives at one call site is a gate the next call site forgets.

stderr is **piped, not inherited**. The SDK default writes a package's stderr straight into the API's own log stream, where it is indistinguishable from platform output and can forge log lines. Teardown stops every process this service started and swallows failures per process, because a half-completed teardown leaks processes for the lifetime of the pod.

## Data directories

Per (owner, package), owner segment first so a tenant is one subtree for quota, backup and deletion. Segments are hashed with a readable prefix rather than interpolated — a user id is whatever the platform issues, and hashing sidesteps which characters are safe on which platform. Kept **outside** the package root, because package contents are replaced wholesale on update, and because a writable directory inside a *scanned* tree could present itself as a second package.

## A falsifiable conformance statement

`docs/specs/features/agent-plugins/conformance.md` gives all 23 Appendix A requirements a status and evidence, and a test fails the build if the page drifts from the spec or the summary disagrees with its own rows. It caught me within minutes of writing it: I updated AP-16 and AP-18 to Met and left the summary saying 19.

| | Count |
| --- | --- |
| Met | 21 |
| Partial | 1 — AP-14 |
| Not yet | 1 — AP-22 (export flow, Phase 5) |

AP-14 stays partial **honestly**: a stdio server can now be planned, gated and spawned, and still contributes no tools to an agent, because nothing in the run path calls `launch()` yet.

## Two bugs the tests found

- **`isWithin` was broken on Windows.** Appending the platform separator does not work when a path uses forward slashes, so it rejected directories that *were* contained. It fails closed, so it was broken rather than unsafe. Now uses `path.relative`.
- **The symlink-escape tests announce a skip out loud.** In Phase 0 five containment tests skipped invisibly and read as green; these say so and assert the skip.

## Verification

- **346 tests** across 24 `mcp` + `agent-plugins` suites; **399** in the conformance library
- Full agent suite measured at **this head** and again at the merge-base
  (`7863168572`), not inherited from an earlier run:

  |               | merge-base                | head                          |
  | ------------- | ------------------------- | ----------------------------- |
  | Test suites   | 18 failed / 561 passed    | 18 failed / **567** passed    |
  | Tests         | 107 failed / 10,251 passed | 107 failed / **10,371** passed |

  `diff` of the two failing-suite name lists is **empty** — the failing set is
  unchanged, and the deltas (+120 tests, +6 suites) are this PR's new coverage.
  All 18 pre-existing failures are `*.integration.spec.ts` (needing a real
  database) or workflow/subscriptions DI suites; none is in `mcp/` or
  `agent-plugins/`.
- Typecheck and Prettier clean

---

## Post-review: two production hangs found after this was called complete

Both were found by self-review while CI queued, not by a reviewer, and both are
in code this PR adds. Neither would have failed a test, because both are
**size-dependent**: a token payload passes and a real one hangs.

### 1. The AP-15 pinned fetch deadlocked (`756d2b5`)

`pinnedFetch` closed its undici dispatcher in a `finally` before returning the
Response. `close()` resolves only once in-flight requests finish, and a request
is not finished until its body is consumed — which cannot happen until the
function returns. Close waits for body, body waits for return, return waits for
close.

Reachable in production: `mcp-sdk.ts` calls `createGuardedFetch()` with no
`fetchImpl`, so this backed **both** the streamable-http and SSE transports.
Measured against a real server: 10 bytes returns in 31 ms, 200 KB never returns,
and SSE — which never ends by design — hangs on connect.

### 2. Stdio servers stalled once they wrote ~80 KB to stderr (`9803b32`)

`stderr: 'pipe'` is correct and stays — `'inherit'` lets a package forge lines in
the platform log. But nothing read the pipe. The MCP SDK only pipes the child's
stderr into a `PassThrough`; past ~80 KB (16 KB PassThrough + ~64 KB OS pipe)
backpressure stalls the **child** mid-write, and a server frozen inside a write
to stderr stops answering entirely. A verbose debug log reaches that.

```
stderr=     10 bytes  drain=NO   -> child flushed: YES
stderr= 200000 bytes  drain=NO   -> child flushed: NO   <-- blocked
stderr= 200000 bytes  drain=yes  -> child flushed: YES
```

### The common root cause is worth the reviewer's attention

Both hid behind the same structural flaw: **the only code that did the real work
was unreachable from any test.** `pinnedFetch` runs `isSafeWebhookUrl` first,
which refuses loopback, so it cannot be pointed at a local server; the stdio
service builds its transport factory inline, and every spec injects a fake one.
In both cases every test stubbed the real path, so it ran nowhere.

That is fixed as well as the bugs: the connection step is now `pinnedConnect` and
the spawn step is now `createStdioTransportFactory`, both exported and both
covered by tests that drive a **real** socket and a **real** child process with
payloads larger than every buffer in the path. Both fixes are mutation-tested —
reverting each fails exactly its new test while the 10-byte case still passes.

### Also in this range

- `4f70e44` — `DescriptorQueryDto.url` accepted userinfo and fragments.
  `@IsUrl` permits both by default (validator.js `disallow_auth: false`,
  `allow_fragments: true`) while `validateRemoteUrl` (spec 7.2.1) rejects both,
  so the boundary was looser than the importer it feeds. Since
  `buildEverWorksMcpDescriptor` reports a bad URL in `findings` rather than
  throwing, `?url=https://user:pass@host/` returned **200 with an `mcp.json`
  carrying the credential** — contradicting the endpoint's own promise that the
  descriptor contains none.
- `ff092b4` — `shutdownAll`'s docstring claimed "Called at run end." Nothing
  calls it, and nothing calls `launch` either. Whoever finishes AP-14 must wire
  **both** in the same change; wiring only the spawn leaks a subprocess per run
  for the pod's lifetime.

### What this changes about the claim

AP-14 remains **Partial**, unchanged and accurate — verified against live code
this round, not re-asserted. What has changed is my confidence in the word
"complete": it means feature-complete, not proven. Two hangs surfaced after the
42/42 milestone, so the conformance statement is best read as a map of what is
claimed and tested, not a guarantee that untested paths work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for launching package-declared stdio MCP servers when enabled.
- Added isolated package data directories and controlled workspace materialization.
- Added Agent Plugin and Ever Works MCP descriptor export through the API and CLI.
- Added read-only Agent Plugin discovery tools and automatic desktop package-directory setup.
- Added MCP tool usage accounting.

## Bug Fixes
- Improved protection against unsafe commands, paths, redirects, symlinks, and credential leaks.
- Strengthened package integrity checks and staging cleanup.
- Improved connection naming, package source detection, and MCP response reliability.

## Documentation
- Updated Agent Plugins and MCP documentation, conformance status, and implementation task tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

