### PR TITLE
fix(migrations): renumber CreateAgentPluginPackages off a colliding timestamp

### DIFF
--- a/apps/api/src/migrations/1787750000000-CreateAgentPluginPackages.ts
+++ b/apps/api/src/migrations/1787750000000-CreateAgentPluginPackages.ts
@@ -30,8 +30,8 @@ import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } f
  * `down` drops both tables. They hold no financial or audit record, and a
  * package is re-discoverable from its source, so a clean rollback is safe.
  */
-export class CreateAgentPluginPackages1787700000000 implements MigrationInterface {
-    name = 'CreateAgentPluginPackages1787700000000';
+export class CreateAgentPluginPackages1787750000000 implements MigrationInterface {
+    name = 'CreateAgentPluginPackages1787750000000';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (!(await queryRunner.hasTable('agent_plugin_packages'))) {


### PR DESCRIPTION
**develop is currently red on this**, and so is the develop → stage cascade (#2330).

## What happened

Two migrations landed on the same timestamp:

```
1787700000000-AddFleetJobCancelRequestedAt.ts   (#2298, fleet stack)
1787700000000-CreateAgentPluginPackages.ts      (#2325, agent plugins)
```

Neither branch could see the other. Both were green alone; they collided only once both reached develop. `migrations-directory-contract.spec.ts` caught it on the first run where both were present.

This is the composite-failure class that per-branch CI structurally cannot catch — and worth noting that #2298 was one of the stacked PRs that had **no CI at all** while it targeted a feature branch.

## Why it matters

TypeORM orders migrations by timestamp. Two sharing one have no defined order between them, so a deploy can run them in either sequence, and a `migrations` table written in one order does not describe the other.

## Why renamed rather than grandfathered

`LEGACY_DUPLICATE_TIMESTAMPS` exists because renaming an **already-deployed** migration makes TypeORM treat it as new and re-run it, so historical collisions are frozen rather than fixed. But the spec's own comment says *"only genuinely new collisions should fail the contract below"* — grandfathering one created hours ago would defeat the guard on its first real catch.

`CreateAgentPluginPackages` is the safe one to move, and deliberately so: every step of its `up()` and `down()` is guarded with `hasTable(...)`, so even if it has already run on the dev database, a re-run under the new name finds the tables present and skips. `AddFleetJobCancelRequestedAt` carries no such guard, which would have made moving it the riskier choice.

`1787750000000` sits between the fleet migration and `1787800000000-AddTaskLinkedPullRequests`, and the new tables depend on nothing else, so the ordering is free.

## Verification

| Check | Result |
| --- | --- |
| `apps/api src/migrations` | 141 passed (33 suites), contract spec included |
| `prettier --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)