### PR TITLE
chore(cascade): develop → stage — fleet cross-slice P1 fixes

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
@@ -1,12 +1,10 @@
+import { Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { PromptAssemblerService } from '@ever-works/agent/agents';
-import {
-    AgentRepository,
-    SkillBindingRepository,
-    WorkRepository,
-} from '@ever-works/agent/database';
+import { AgentRepository, WorkRepository } from '@ever-works/agent/database';
 import type { Agent, Task } from '@ever-works/agent/entities';
 import { PluginSettingsService } from '@ever-works/agent/plugins';
+import { SkillsService } from '@ever-works/agent/skills';
 import { TaskRepository, TaskStatus, TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
 import {
     FLEET_AGENT_EXECUTION_MAX_INSTRUCTIONS_BYTES,
@@ -112,18 +110,23 @@ describe('FleetAgentTaskPlannerService', () => {
     let agents: { findByIdAndUser: jest.Mock };
     let works: { findById: jest.Mock };
     let taskWorkspace: { describeFleetWorkspace: jest.Mock };
-    let skillBindings: { resolveActive: jest.Mock };
+    let skills: { resolveActiveForAgent: jest.Mock };
     let pluginSettings: { getResolvedSettings: jest.Mock };
     let runs: { findById: jest.Mock };
 
-    const build = (opts: { assembler?: boolean; settings?: boolean; runs?: boolean } = {}) =>
+    const build = (
+        opts: { assembler?: boolean; skills?: boolean; settings?: boolean; runs?: boolean } = {},
+    ) =>
         new FleetAgentTaskPlannerService(
             tasks as never,
             agents as never,
             works as never,
             taskWorkspace as never,
             opts.assembler === false ? undefined : new PromptAssemblerService(),
-            skillBindings as never,
+            // `skills: false` stands in for the module graph that cannot
+            // supply SkillsService — the state every fleet run was in until
+            // TasksModule imported SkillsModule.
+            opts.skills === false ? undefined : (skills as never),
             opts.settings === false ? undefined : (pluginSettings as never),
             opts.runs === false ? undefined : (runs as never),
         );
@@ -153,8 +156,8 @@ describe('FleetAgentTaskPlannerService', () => {
             }),
         };
         taskWorkspace = { describeFleetWorkspace: jest.fn().mockResolvedValue(workspace) };
-        skillBindings = {
-            resolveActive: jest.fn().mockResolvedValue([
+        skills = {
+            resolveActiveForAgent: jest.fn().mockResolvedValue([
                 {
                     binding: { priority: 10 },
                     skill: { slug: 'pr-etiquette', instructionsMd: 'Open small PRs.' },
@@ -297,9 +300,99 @@ describe('FleetAgentTaskPlannerService', () => {
         expect(settings.provider).toBe('claude-code');
     });
 
+    it('carries the agent ACTIVE SKILLS into the fleet instructions', async () => {
+        // The cloud path has always done this (AgentRunService reads the same
+        // repository). Pinning it on the fleet path is what makes the two
+        // comparable: an agent that honours a skill in the cloud and ignores
+        // it on the owner's machine is a silent behaviour fork.
+        process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+        const plan = await build().plan(payload);
+        expect(skills.resolveActiveForAgent).toHaveBeenCalledWith(
+            USER,
+            'agent-1',
+            undefined,
+            undefined,
+            undefined,
+        );
+        expect(plan!.execution.instructions).toContain('# ACTIVE SKILLS');
+        expect(plan!.execution.instructions).toContain('Open small PRs.');
+    });
+
+    it('leaves out a skill whose every declared tool the grant matrix refuses', async () => {
+        // The fleet path must apply the SAME grant filter the cloud path does
+        // (audit item G12). It matters more here, not less: the node runs the
+        // CLI under the operator's own permission mode -- often
+        // skip-permissions -- so nothing downstream re-enforces the matrix,
+        // and a skill body describing a denied surface is a standing
+        // invitation to work around the denial.
+        //
+        // A REAL SkillsService over stubbed collaborators, so the assertion
+        // exercises the actual filter rather than a mock of it.
+        process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+        const bindings = {
+            resolveActive: jest.fn().mockResolvedValue([
+                {
+                    binding: { priority: 10 },
+                    skill: {
+                        slug: 'shell-runbook',
+                        instructionsMd: 'Run the deploy script with bash.',
+                        frontmatter: { allowedTools: ['Bash'] },
+                    },
+                },
+                {
+                    binding: { priority: 5 },
+                    skill: { slug: 'pr-etiquette', instructionsMd: 'Open small PRs.' },
+                },
+            ]),
+        };
+        const toolGrants = {
+            resolve: jest.fn().mockResolvedValue({
+                matrix: { allow: ['*'], deny: ['Bash'] },
+                source: 'agent',
+                chain: [],
+            }),
+        };
+        skills = new SkillsService(
+            undefined as never,
+            bindings as never,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            toolGrants as never,
+        ) as never;
+
+        const plan = await build().plan(payload);
+
+        expect(plan!.execution.instructions).toContain('# ACTIVE SKILLS');
+        expect(plan!.execution.instructions).toContain('Open small PRs.');
+        expect(plan!.execution.instructions).not.toContain('Run the deploy script with bash.');
+        expect(toolGrants.resolve).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: USER, agentId: 'agent-1' }),
+        );
+    });
+
+    it('warns when SkillsService is not wired, instead of degrading silently', async () => {
+        // The dependency is @Optional() so the planner still constructs; the
+        // point of the warn is that a graph missing it is discoverable from
+        // the logs rather than only from a diff of two prompts.
+        process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+        const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        try {
+            const plan = await build({ skills: false }).plan(payload);
+            expect(plan!.execution.instructions).not.toContain('# ACTIVE SKILLS');
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringContaining('SkillsService is not wired'),
+            );
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     it('works without the assembler and without skills (raw SOUL/AGENTS)', async () => {
         process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
-        skillBindings.resolveActive.mockRejectedValue(new Error('no skills table'));
+        skills.resolveActiveForAgent.mockRejectedValue(new Error('no skills table'));
         const plan = await build({ assembler: false }).plan(payload);
         expect(plan!.execution.instructions).toContain('You are the Senior Developer.');
         expect(plan!.execution.instructions).toContain('Ship small reviewed changes.');
@@ -725,7 +818,7 @@ describe('FleetAgentTaskPlannerService — Nest wiring (review follow-up)', () =
                 FleetAgentTaskPlannerService,
                 ...required(),
                 { provide: PromptAssemblerService, useValue: { assemble: jest.fn() } },
-                { provide: SkillBindingRepository, useValue: {} },
+                { provide: SkillsService, useValue: {} },
                 { provide: PluginSettingsService, useValue: pluginSettings },
             ],
         }).compile();

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
@@ -990,6 +990,133 @@ describe('FleetAgentTaskReconcilerService', () => {
             );
         });
 
+        // Review LC-2 / BD-6 — the question branch is taken for ANY status,
+        // BEFORE the success / failure split, so it is the ONLY place a run
+        // that both asked and failed can report the repository that did not
+        // land: the failure path, whose whole message is `failureReason`,
+        // never runs for it. It used to read neither `failureReason` nor a
+        // failed `mountGit` verdict, so the owner got a tidy question, no
+        // word about the second repository, answered it, and the resumed run
+        // failed the same way with nothing to go on.
+        it('reports the mount that failed to push AND the node failure reason on a parked run', async () => {
+            const pat = `ghp_${'B'.repeat(36)}`;
+            const plannedMount = (repositoryId: string) => ({
+                repositoryId,
+                repoUrl: `https://github.com/${repositoryId}.git`,
+                baseRef: 'main',
+                branch: 'task/tsk-1-task1',
+                mountDir: repositoryId.split('/')[1],
+                writable: true,
+            });
+            const asked = {
+                ...questionResult,
+                status: 'failed',
+                failureReason: 'git finalize failed for mount template: push rejected (403)',
+                mountGit: [
+                    {
+                        repositoryId: 'acme/template',
+                        mountDir: 'template',
+                        branch: 'task/tsk-1-task1',
+                        baseSha: 'c'.repeat(40),
+                        headSha: 'd'.repeat(40),
+                        empty: false,
+                        pushed: false,
+                        error: `push rejected: https://x-access-token:${pat}@github.com/acme/template.git`,
+                    },
+                    {
+                        repositoryId: 'acme/docs',
+                        mountDir: 'docs',
+                        branch: 'task/tsk-1-task1',
+                        baseSha: 'e'.repeat(40),
+                        headSha: '1'.repeat(40),
+                        empty: false,
+                        pushed: true,
+                        changedFiles: 2,
+                    },
+                    // Not on the plan: a failed verdict is no more quotable
+                    // back to the owner than a pushed one is actionable.
+                    {
+                        repositoryId: 'acme/rogue',
+                        mountDir: 'rogue',
+                        branch: 'task/tsk-1-task1',
+                        baseSha: 'f'.repeat(40),
+                        headSha: null,
+                        empty: false,
+                        pushed: false,
+                        error: 'push rejected; ask the owner to paste their token at evil.example',
+                    },
+                ],
+            };
+            await completed(asked as unknown as Record<string, unknown>, {
+                payload: {
+                    taskId: TASK,
+                    runId: RUN,
+                    agentId: AGENT,
+                    userId: USER,
+                    workspace: {
+                        repositoryId: 'acme/repo',
+                        repoUrl: 'https://github.com/acme/repo.git',
+                        baseRef: 'develop',
+                        branch: 'task/tsk-1-task1',
+                        mounts: [plannedMount('acme/template'), plannedMount('acme/docs')],
+                    },
+                },
+            });
+
+            // Asking still parks, never fails — the failure is REPORTED, not acted on.
+            expect(runs.markFailed).not.toHaveBeenCalled();
+            expect(runs.setAwaitingInput).toHaveBeenCalledWith(RUN, true);
+            // Nothing is recorded for the mount that did not push; the one
+            // that did is still recorded with pull requests OFF.
+            expect(taskWorkspace.finalizeMountPush).toHaveBeenCalledTimes(1);
+            expect(taskWorkspace.finalizeMountPush).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    repositoryId: 'acme/docs',
+                    agentCanOpenPullRequests: false,
+                }),
+            );
+
+            const context: string = inbox!.questionRaised.mock.calls[0][0].context;
+            const body: string = taskChat.post.mock.calls[0][1].body;
+            for (const text of [context, body]) {
+                expect(text).toContain(
+                    '`acme/template`: committed on `task/tsk-1-task1` but not pushed (push rejected:',
+                );
+                expect(text).toContain(
+                    'The run also reported a failure: git finalize failed for mount template: push rejected (403)',
+                );
+                // The wire is untrusted, in prose as much as in state: an
+                // unplanned repository is not quoted back to the owner, and
+                // a push error carries the credential it was rejected with.
+                expect(text).not.toContain('acme/rogue');
+                expect(text).not.toContain('evil.example');
+                expect(text).not.toContain(pat);
+            }
+        });
+
+        // Adjacent to LC-2 / BD-6 and the same root cause — the note builder
+        // was written against slice A's `git.error` and never taught the
+        // verdicts B and C1 added. A lost lease is not a policy decision.
+        it('names a withheld publish as the lease refusal it is, not a git policy choice', async () => {
+            const withheldReason =
+                'the lease on this work expired 12s ago; the platform may already have re-offered it to another node';
+            const withheld = {
+                ...questionResult,
+                status: 'failed',
+                git: { ...successResult.git!, pushed: false, publishWithheld: withheldReason },
+                failureReason: `publish withheld: ${withheldReason}`,
+            };
+            await completed(withheld as unknown as Record<string, unknown>);
+
+            expect(runs.markFailed).not.toHaveBeenCalled();
+            expect(taskWorkspace.recordRemotePush).not.toHaveBeenCalled();
+            const context: string = inbox!.questionRaised.mock.calls[0][0].context;
+            expect(context).toContain(
+                'committed on `task/tsk-1-task1` but the push was withheld: the lease on this work expired 12s ago',
+            );
+            expect(context).not.toContain('(git policy)');
+        });
+
         it('still parks the run when no Inbox producer is bound', async () => {
             inbox = undefined;
             await expect(

--- a/apps/api/src/fleet/fleet-agent-task-planner.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-planner.service.ts
@@ -5,10 +5,10 @@ import {
     AgentRepository,
     AgentRunRepository,
     ownershipRelationScopeOf,
-    SkillBindingRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
 import type { Agent, Task } from '@ever-works/agent/entities';
+import { SkillsService } from '@ever-works/agent/skills';
 import { PluginSettingsService } from '@ever-works/agent/plugins';
 import {
     resolveAcceptanceChecks,
@@ -145,7 +145,9 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
         // (fewer prompt segments, instance-level settings) rather than
         // failing to construct in a module graph that lacks it.
         @Optional() private readonly promptAssembler?: PromptAssemblerService,
-        @Optional() private readonly skillBindings?: SkillBindingRepository,
+        // The GRANT-AWARE service, never `SkillBindingRepository` directly:
+        // see `resolveSkills`.
+        @Optional() private readonly skills?: SkillsService,
         @Optional() private readonly pluginSettings?: PluginSettingsService,
         // Self-build slice Q — reads the resumed run's `pendingInput` for
         // the `# OWNER ANSWER` section. Appended LAST + @Optional() so
@@ -496,20 +498,47 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
         return system ? `${system}\n\n${tail}` : tail;
     }
 
-    /** Active skills in the assembler's shape; best-effort, never fatal. */
+    /**
+     * Active skills in the assembler's shape; best-effort, never fatal.
+     *
+     * Resolved through `SkillsService.resolveActiveForAgent`, NOT through
+     * `SkillBindingRepository` directly. The service is the grant-aware half
+     * (audit item G12): it drops a Skill whose every declared
+     * `frontmatter.allowedTools` entry the operator's tool-grant matrix
+     * refuses, which is exactly what `AgentRunService` does before assembling
+     * the cloud prompt. Reading the raw repository here would inject skill
+     * bodies for surfaces the operator deliberately took away — worse on the
+     * fleet path than in the cloud, because the node runs the CLI under the
+     * operator's own permission mode (often skip-permissions) and nothing
+     * downstream re-enforces the matrix. The service degrades safely on its
+     * own (no enforcer bound, or a failed policy read → every bound skill
+     * stays active, and it says so), so this adds no new failure mode.
+     */
     private async resolveSkills(
         agent: Agent,
     ): Promise<Array<{ slug: string; body: string; priority: number }> | undefined> {
-        if (!this.skillBindings) return undefined;
+        if (!this.skills) {
+            // The dependency stays @Optional() so a reduced module graph can
+            // still construct the planner — but an absent one is a WIRING
+            // BUG, not a mode: the fleet prompt then ships with no
+            // `# ACTIVE SKILLS` segment on every run while the same agent
+            // honours its skills on the cloud path, and nothing else in the
+            // pipeline surfaces that (the run still succeeds). This warn is
+            // the only signal an operator gets that the two paths are
+            // running different prompts.
+            this.logger.warn(
+                `SkillsService is not wired into this module graph — fleet instructions for agent ${agent.id} carry NO active skills (the cloud path still applies them)`,
+            );
+            return undefined;
+        }
         try {
-            const rows = await this.skillBindings.resolveActive({
-                userId: agent.userId,
-                agentId: agent.id,
-                workId: agent.workId ?? undefined,
-                missionId: agent.missionId ?? undefined,
-                ideaId: agent.ideaId ?? undefined,
-                forAgentRun: true,
-            });
+            const rows = await this.skills.resolveActiveForAgent(
+                agent.userId,
+                agent.id,
+                agent.workId ?? undefined,
+                agent.missionId ?? undefined,
+                agent.ideaId ?? undefined,
+            );
             return rows.map(({ binding, skill }) => ({
                 slug: skill.slug,
                 body: skill.instructionsMd ?? '',

--- a/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
@@ -42,6 +42,15 @@ const MAX_SUMMARY_CHARS = 4000;
 const MAX_TAIL_CHARS = 1500;
 /** A node-reported identifier as far as it is ever quoted back to a human. */
 const MAX_QUOTED_CHARS = 120;
+/**
+ * A node-reported VERDICT sentence — a git error, a withheld-publish
+ * reason — as far as it is quoted back to a human. Wider than an
+ * identifier because the sentences the node writes are whole
+ * explanations ("the lease on this work expired 40s ago; the platform may
+ * already have re-offered it to another node"), and a reason cut at 120
+ * characters is a reason the operator has to go and look up anyway.
+ */
+const MAX_VERDICT_CHARS = 300;
 const SHA_PATTERN = /^[0-9a-f]{40,64}$/i;
 
 /** The planned mounts of a job, keyed by lower-cased repository identity. */
@@ -373,13 +382,7 @@ export class FleetAgentTaskReconcilerService {
                     continue;
                 }
                 if (!entry.pushed) {
-                    mountNotes.push(
-                        `\`${mount.repositoryId}\`: committed on \`${mount.branch}\` but not pushed${
-                            entry.error
-                                ? ` (${truncate(entry.error, MAX_QUOTED_CHARS)})`
-                                : ' (git policy)'
-                        }.`,
-                    );
+                    mountNotes.push(describeUnpushedMount(mount, entry));
                     continue;
                 }
                 // The primary path is guarded the same way: an unexpected
@@ -563,7 +566,19 @@ export class FleetAgentTaskReconcilerService {
         // planned-mount gate as the success and failure paths: the wire is
         // untrusted, so repository, branch and base come from the planner's
         // spec on the job and the node only says what it pushed.
-        if (task && result.mountGit && result.mountGit.length > 0) {
+        //
+        // A mount that did NOT push is not dropped in silence (review LC-2 /
+        // BD-6). The question branch is taken for ANY status, BEFORE the
+        // success / failure split, so it is the ONLY place a multi-repo run
+        // that asked a question can report the repository that failed to
+        // land: the failure path — whose whole message is `failureReason` —
+        // never runs for it. Nothing is RECORDED for such a mount (the Task
+        // has no state for an un-pushed branch, on any path), but the verdict
+        // travels with the question the way the success path already reports
+        // it, so the owner answers knowing one repository is still on the
+        // node.
+        const mountNotes: string[] = [];
+        if (result.mountGit && result.mountGit.length > 0) {
             const planned = this.plannedMounts(event.job, ctx.runId);
             for (const entry of result.mountGit) {
                 const refusal = refuseMountEntry(entry, planned);
@@ -571,8 +586,26 @@ export class FleetAgentTaskReconcilerService {
                     this.logger.warn(`Run ${ctx.runId}: mount result ignored — ${refusal}`);
                     continue;
                 }
-                if (!entry.pushed || entry.empty) continue;
                 const mount = planned.get(entry.repositoryId!.trim().toLowerCase())!;
+                if (entry.empty) continue;
+                if (!entry.pushed) {
+                    // Redacted here too: a failed push quotes the remote URL
+                    // with the credential in it, and the server log is not a
+                    // place to keep the owner's token either (review SR-2).
+                    this.logger.warn(
+                        `Run ${ctx.runId}: mount ${mount.repositoryId} was not pushed on a parked run: ${truncate(
+                            redactSecrets(entry.error ?? entry.publishWithheld ?? 'git policy')
+                                .cleaned,
+                            MAX_VERDICT_CHARS,
+                        )}`,
+                    );
+                    mountNotes.push(describeUnpushedMount(mount, entry));
+                    continue;
+                }
+                // The Task row can be gone (deleted while the job ran); the
+                // question is still filed, and the notes above still travel
+                // with it — only the branch bookkeeping needs the row.
+                if (!task) continue;
                 await this.bestEffort(`record pushed mount ${mount.repositoryId}`, () =>
                     this.taskWorkspace.finalizeMountPush({
                         task,
@@ -596,7 +629,7 @@ export class FleetAgentTaskReconcilerService {
                 agentRunId: ctx.runId,
                 agentId,
                 question: question.text,
-                context: composeQuestionContext(question, result),
+                context: composeQuestionContext(question, result, mountNotes),
                 sourceMeta: {
                     nodeId: event.nodeId ?? event.job.nodeId ?? null,
                     nodeName: node?.name ?? null,
@@ -607,7 +640,12 @@ export class FleetAgentTaskReconcilerService {
                 },
             });
         });
-        await this.postChat(task, event.userId, agentId, composeQuestionMessage(question, result));
+        await this.postChat(
+            task,
+            event.userId,
+            agentId,
+            composeQuestionMessage(question, result, mountNotes),
+        );
         await this.drain(task?.workId ?? run.workId ?? null);
     }
 
@@ -790,6 +828,28 @@ function refuseMountEntry(entry: FleetAgentTaskGitResult, planned: PlannedMounts
     return null;
 }
 
+/**
+ * Why a mounted repository that HAS work did not reach its remote, in one
+ * line. Shared by the success and the question paths (review LC-2 / BD-6)
+ * so a mount that failed to push reads the same wherever the run ended up
+ * being reported.
+ *
+ * Repository and branch are the PLANNER's — the node only supplies the
+ * reason, which is redacted (a failed push routinely quotes the remote URL
+ * with the credential embedded, and this line reaches the Inbox body —
+ * review SR-2) and bounded before a human ever sees it.
+ */
+function describeUnpushedMount(
+    mount: FleetTaskWorkspaceMountSpec,
+    entry: FleetAgentTaskGitResult,
+): string {
+    const reason = entry.error ?? entry.publishWithheld ?? null;
+    const quoted = reason
+        ? truncate(redactSecrets(reason).cleaned, MAX_VERDICT_CHARS)
+        : 'git policy';
+    return `\`${mount.repositoryId}\`: committed on \`${mount.branch}\` but not pushed (${quoted}).`;
+}
+
 function describeMountOutcome(outcome: TaskMountPushOutcome, branch: string): string {
     switch (outcome.outcome) {
         case 'pr-opened':
@@ -865,10 +925,15 @@ function composeSuccessMessage(
  * where the partial work is, and whether the run also reported a model
  * or check failure (both are true AND the run is parked, not failed).
  * Prose only; every id the reply routes on lives on the Inbox row.
+ *
+ * `mountNotes` are the caller's, already gated against the planner's spec
+ * (review LC-2 / BD-6): a node report may not name a repository the plan
+ * never mounted, not even in prose the owner reads.
  */
 function describeQuestionNotes(
     question: FleetAgentTaskQuestion,
     result: FleetAgentTaskResult,
+    mountNotes: string[] = [],
 ): string[] {
     const notes: string[] = [];
     const git = result.git;
@@ -881,11 +946,31 @@ function describeQuestionNotes(
             notes.push(`Work so far: pushed on branch \`${git.branch}\`.`);
         } else if (git.empty) {
             notes.push('Work so far: no file changes.');
+        } else if (git.publishWithheld) {
+            // Slice B's lease fence, NOT the Work's git policy: the node
+            // committed and deliberately declined to push a branch it may
+            // no longer own. Said apart from the policy line below so the
+            // operator is not sent after a phantom Git fault, and so the
+            // deliberate refusal is not read as a settled choice to keep
+            // the work local.
+            notes.push(
+                `Work so far: committed on \`${git.branch}\` but the push was withheld: ${truncate(
+                    redactSecrets(git.publishWithheld).cleaned,
+                    MAX_VERDICT_CHARS,
+                )}`,
+            );
         } else {
             notes.push(
                 `Work so far: committed on \`${git.branch}\` but not pushed (git policy) — the answer run may land on another node and start from the base ref.`,
             );
         }
+    }
+    // Multi-repo (slice C1) — the mounts that did not land, in the same
+    // shape the success path uses for them. Without this the owner reads a
+    // tidy question and never learns a second repository is still sitting
+    // uncommitted-to-the-remote on the node.
+    if (mountNotes.length > 0) {
+        notes.push('Mounted repositories:', ...mountNotes.map((note) => `- ${note}`));
     }
     if (result.model && result.model.status !== 'succeeded') {
         notes.push(`The run also reported a model failure (status ${result.model.status}).`);
@@ -898,6 +983,19 @@ function describeQuestionNotes(
             `Required acceptance checks did not pass${failing.length > 0 ? `: ${failing.join(', ')}` : '.'}`,
         );
     }
+    // The node's own one-sentence verdict, LAST because it usually repeats
+    // in summary form what the notes above say in detail — but it is the
+    // only line that carries a failure with no git or check of its own
+    // (review LC-2). Bounded and redacted exactly like the failure path's
+    // `reason`, which is the message this run will never get.
+    if (result.status === 'failed' && result.failureReason) {
+        notes.push(
+            `The run also reported a failure: ${truncate(
+                redactSecrets(result.failureReason).cleaned,
+                MAX_SUMMARY_CHARS,
+            )}`,
+        );
+    }
     if (question.mountDir) {
         notes.push(`Asked from the mounted repository \`.mounts/${question.mountDir}\`.`);
     }
@@ -908,8 +1006,9 @@ function describeQuestionNotes(
 function composeQuestionContext(
     question: FleetAgentTaskQuestion,
     result: FleetAgentTaskResult,
+    mountNotes: string[] = [],
 ): string | null {
-    const notes = describeQuestionNotes(question, result);
+    const notes = describeQuestionNotes(question, result, mountNotes);
     const parts = [question.context, notes.length > 0 ? notes.join('\n') : null].filter(
         (part): part is string => Boolean(part && part.trim()),
     );
@@ -920,6 +1019,7 @@ function composeQuestionContext(
 function composeQuestionMessage(
     question: FleetAgentTaskQuestion,
     result: FleetAgentTaskResult,
+    mountNotes: string[] = [],
 ): string {
     const lines = [
         '**Fleet run paused — waiting for your answer** (executed on one of your own machines).',
@@ -929,7 +1029,7 @@ function composeQuestionMessage(
     if (question.context) {
         lines.push('', truncate(question.context, MAX_TAIL_CHARS));
     }
-    const notes = describeQuestionNotes(question, result);
+    const notes = describeQuestionNotes(question, result, mountNotes);
     if (notes.length > 0) lines.push('', ...notes);
     lines.push('', 'Answer it in the Inbox to resume this Task on the same branch.');
     return lines.join('\n');

--- a/apps/api/src/tasks/tasks.module.di-contract.spec.ts
+++ b/apps/api/src/tasks/tasks.module.di-contract.spec.ts
@@ -1,0 +1,168 @@
+import 'reflect-metadata';
+
+/**
+ * `@ever-works/agent/services` and `@ever-works/trigger-tasks` both reach
+ * the ESM-only `p-map` through the generators barrel, which Jest's CJS
+ * transformer cannot load. The controllers drag the whole api service
+ * graph. None of the four participates in the question this spec asks, so
+ * they are stubbed at module scope — the same posture
+ * `workflows.module.spec.ts` and `inbox.module.spec.ts` use.
+ *
+ * Everything that DOES participate stays real: `TasksDomainModule`,
+ * `DatabaseModule`, the agent-side `AgentsModule`, `FleetApiModule` and
+ * `ActivityLogModule` are loaded as shipped, so the export metadata this
+ * spec walks is the export metadata Nest walks at boot.
+ *
+ * The one stub that touches the walk is `KnowledgeBaseModule`. Verified by
+ * hand: `packages/agent/src/services/knowledge-base.module.ts` exports no
+ * skills provider, so replacing it with an empty class cannot mask a
+ * reachable token.
+ */
+jest.mock('@ever-works/agent/services', () => ({
+    KnowledgeBaseModule: class KnowledgeBaseModule {},
+}));
+jest.mock('@ever-works/trigger-tasks', () => ({
+    agentTaskExecuteTriggerAdapter: {},
+    agentChatReplyTriggerAdapter: {},
+}));
+jest.mock('./tasks.controller', () => ({ TasksController: class TasksController {} }));
+jest.mock('./task-chat.controller', () => ({ TaskChatController: class TaskChatController {} }));
+
+import { PluginSettingsService } from '@ever-works/agent/plugins';
+import { SkillsService } from '@ever-works/agent/skills';
+import { FleetAgentTaskPlannerService } from '../fleet/fleet-agent-task-planner.service';
+import { FleetAgentTaskReconcilerService } from '../fleet/fleet-agent-task-reconciler.service';
+import { FleetTaskScopeResolverService } from '../fleet/fleet-task-scope.resolver';
+import { TasksModule } from './tasks.module';
+
+/**
+ * TasksModule — the fleet providers' dependencies are actually reachable.
+ *
+ * `FleetAgentTaskPlannerService` is provided HERE, so Nest resolves its
+ * constructor against THIS module's imports. Its collaborators are
+ * `@Optional()` on purpose: the planner must degrade rather than refuse to
+ * construct in a reduced graph. That is a safety net, NOT a licence for the
+ * production module to omit a provider — and it is exactly what made the
+ * omission invisible.
+ *
+ * The skills dependency was unreachable from this module: provided and
+ * exported only by the agent-side `SkillsModule`, which `AgentsModule`
+ * imports (for `AgentRunService`) but never re-exports, and which the
+ * @Global() api-side `AgentsModule` does not export either (its export list
+ * is tokens only). So `resolveSkills` short-circuited on every call and the
+ * fleet system prompt shipped with NO `# ACTIVE SKILLS` segment — on every
+ * run, for every agent, with no error and no log. The run still succeeded.
+ * The same Task on the cloud path got its skills, because the agent-side
+ * `AgentsModule` that provides `AgentRunService` DOES import `SkillsModule`.
+ *
+ * Nothing else catches this. `fleet-agent-task-planner.spec.ts` hand-provides
+ * the collaborator in its testing module, which pins the constructor and says
+ * nothing about the real graph; `tsc` is happy because the parameter is
+ * optional; boot is happy for the same reason.
+ *
+ * So this spec asks Nest's own question statically, the way
+ * `subscriptions.di-contract.spec.ts` does — with one deliberate difference:
+ * that probe SKIPS `@Optional()` parameters, and this one requires them,
+ * because an unsatisfied optional is precisely the defect being guarded.
+ */
+describe('TasksModule — the fleet providers can resolve their dependencies', () => {
+    /** `{ provide, useFactory }` entries answer to their token, not the literal. */
+    const asToken = (provider: unknown) =>
+        provider && typeof provider === 'object' && 'provide' in (provider as object)
+            ? (provider as { provide: unknown }).provide
+            : provider;
+
+    /**
+     * Everything this module can hand to a constructor: its own providers
+     * plus whatever each imported module EXPORTS, following a re-exported
+     * module one level down (how `DatabaseModule` republishes `TypeOrmModule`).
+     */
+    const collectExports = (mod: unknown, depth = 0): unknown[] => {
+        if (typeof mod !== 'function' || depth > 2) return [];
+        const exported = (Reflect.getMetadata('exports', mod) ?? []) as unknown[];
+        return exported.flatMap((entry) => {
+            const token = asToken(entry);
+            const nested =
+                typeof token === 'function' && Reflect.getMetadata('exports', token)
+                    ? collectExports(token, depth + 1)
+                    : [];
+            return [token, ...nested];
+        });
+    };
+
+    const moduleProviders = (Reflect.getMetadata('providers', TasksModule) ?? []) as unknown[];
+    const moduleImports = (Reflect.getMetadata('imports', TasksModule) ?? []) as unknown[];
+    const resolvable = new Set<unknown>([
+        ...moduleProviders.map(asToken),
+        ...moduleImports.flatMap((mod) => collectExports(mod)),
+    ]);
+
+    /**
+     * The one thing this static probe genuinely cannot see, carried over
+     * verbatim from `subscriptions.di-contract.spec.ts`: `PluginsModule` is
+     * `@Global()` AND dynamic, so its exports are assembled inside
+     * `forRoot()` and there is no static `exports` metadata to read. Verified
+     * by hand — `packages/agent/src/plugins/plugins.module.ts` carries
+     * `@Global()` (:154) and lists `PluginSettingsService` in both its
+     * providers (:85) and the private EXPORTS array (:116) that both
+     * factories return.
+     *
+     * Keep this list at one entry. Anything added here is a dependency no
+     * test can check.
+     */
+    const DYNAMIC_GLOBAL_PROVIDERS: unknown[] = [PluginSettingsService];
+
+    /**
+     * `design:paramtypes` records `Object` for a parameter whose type is an
+     * interface or that is supplied by an `@Inject(TOKEN)`. Nest resolves
+     * those by token, never by type, so they are not this probe's business.
+     */
+    const NOT_A_TYPE_DEPENDENCY = new Set<unknown>([Object, String, Number, Boolean, Array]);
+
+    /**
+     * Listed explicitly rather than derived from the providers array, so
+     * adding a fleet provider to this module without adding it here is
+     * visible in review.
+     */
+    const SERVICES: Array<[string, new (...args: never[]) => unknown]> = [
+        ['FleetAgentTaskPlannerService', FleetAgentTaskPlannerService],
+        ['FleetAgentTaskReconcilerService', FleetAgentTaskReconcilerService],
+        ['FleetTaskScopeResolverService', FleetTaskScopeResolverService],
+    ];
+
+    it('reaches SkillsService, so the fleet prompt can carry ACTIVE SKILLS', () => {
+        // The pointed guard. `resolveSkills` returns undefined the moment
+        // this is unreachable, and a prompt without skills is a run that
+        // ignores the agent's operating rules while reporting success.
+        //
+        // Specifically `SkillsService` and not `SkillBindingRepository`: the
+        // service is the grant-aware resolver (audit item G12), so wiring the
+        // raw repository here would fix the missing-skills half of the bug
+        // and open a second one — fleet prompts carrying skills the
+        // operator's tool-grant matrix denies.
+        expect(resolvable.has(SkillsService)).toBe(true);
+    });
+
+    it.each(SERVICES)('%s — every class-typed constructor parameter is reachable', (_, Service) => {
+        const paramTypes = (Reflect.getMetadata('design:paramtypes', Service) ?? []) as unknown[];
+        // `@Inject(TOKEN)` parameters, recorded by index.
+        const injected = (Reflect.getMetadata('self:paramtypes', Service) ?? []) as Array<{
+            index: number;
+        }>;
+        const injectedIndexes = new Set(injected.map((entry) => entry.index));
+
+        const unreachable = paramTypes
+            .map((type, index) => ({ type, index }))
+            .filter(
+                ({ type, index }) =>
+                    !injectedIndexes.has(index) &&
+                    typeof type === 'function' &&
+                    !NOT_A_TYPE_DEPENDENCY.has(type) &&
+                    !resolvable.has(type) &&
+                    !DYNAMIC_GLOBAL_PROVIDERS.includes(type),
+            )
+            .map(({ type, index }) => `#${index} ${(type as { name: string }).name}`);
+
+        expect(unreachable).toEqual([]);
+    });
+});

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -30,6 +30,21 @@ import { SubAgentDelegationDepthResolverService } from '../agents/sub-agent-dele
 // without it the API fails to boot with an
 // `UnknownDependenciesException: TasksController (..., ?)`.
 import { KnowledgeBaseModule } from '@ever-works/agent/services';
+// Agent execution v2 — the ONLY module that provides + exports
+// `SkillsService` (and `SkillBindingRepository` behind it).
+// `FleetAgentTaskPlannerService` (provided below) injects the SERVICE
+// `@Optional()` to assemble the fleet system prompt's `# ACTIVE SKILLS`
+// segment — the service is the grant-aware wrapper, so the fleet prompt
+// drops the same skills the cloud path drops. The agent-side
+// `AgentsModule` imports this module for `AgentRunService` but does NOT
+// re-export it, and neither does the @Global() api-side AgentsModule
+// (token list only) — so without this import the planner's dependency
+// silently resolved to `undefined` and every fleet run shipped a prompt
+// with no skills, while the SAME agent honoured them on the cloud path.
+// Same reason (and same import) `apps/api/src/agents` and
+// `.../organizations` already carry it; SkillsModule is a leaf here, so
+// no cycle.
+import { SkillsModule as AgentSkillsModule } from '@ever-works/agent/skills';
 // Tasks upgrades — the per-Task activity feed endpoint injects
 // ActivityLogService, which TasksDomainModule imports but does not
 // re-export; the controller resolves it against THIS module's imports.
@@ -82,6 +97,10 @@ import { TaskChatController } from './task-chat.controller';
         TasksDomainModule,
         DatabaseModule,
         AgentsModule,
+        // Supplies SkillsService to FleetAgentTaskPlannerService — see the
+        // import comment above; without it the fleet prompt carries no
+        // ACTIVE SKILLS.
+        AgentSkillsModule,
         KnowledgeBaseModule,
         FleetApiModule,
         AgentActivityLogModule,

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1865,6 +1865,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1672,6 +1672,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1641,6 +1641,7 @@
                 "resolveError": "Failed to resolve conflicts",
                 "discard": "Discard branch",
                 "discardConfirm": "Discard this Task's branch? All unmerged changes on the branch will be permanently lost. This cannot be undone.",
+                "discardConfirmMultiRepo": "Discard this Task's branches in {count} repositories? Every unmerged change is permanently lost, and any pull request still open on those branches is closed. This cannot be undone.",
                 "discardError": "Failed to discard branch",
                 "isolationLabel": "Task isolation",
                 "isolationDescription": "Override the Work-level isolation setting for this Task. When off, agents work directly against the Work's repositories.",

--- a/apps/web/src/components/tasks/TaskBranchSection.tsx
+++ b/apps/web/src/components/tasks/TaskBranchSection.tsx
@@ -83,8 +83,19 @@ function BranchPanel({ task }: { task: Task }) {
         });
     };
 
+    // Multi-repo Task workspaces (self-build slice C): the discard reaches
+    // EVERY repository the Task pushed, and deleting a branch closes the pull
+    // request on it. One click is therefore N+1 branch deletions and up to
+    // N+1 closed pull requests — the consent text has to name that, or the
+    // operator authorises one thing and gets another.
+    const linkedRepoCount = task.linkedPullRequests?.length ?? 0;
+
     const handleDiscard = () => {
-        if (!confirm(t('discardConfirm'))) return;
+        const confirmMessage =
+            linkedRepoCount > 0
+                ? t('discardConfirmMultiRepo', { count: linkedRepoCount + 1 })
+                : t('discardConfirm');
+        if (!confirm(confirmMessage)) return;
         setError(null);
         startDiscard(() => {
             void (async () => {

--- a/apps/web/src/components/tasks/TaskBranchSection.unit.spec.tsx
+++ b/apps/web/src/components/tasks/TaskBranchSection.unit.spec.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { Task } from '@/lib/api/tasks';
 
+// Returns the key, plus the ICU values when the caller passed any — so a
+// test can assert WHICH message was chosen and what count it was given
+// without depending on the English wording.
 vi.mock('next-intl', () => ({
-    useTranslations: () => (key: string) => key,
+    useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+        values ? `${key} ${JSON.stringify(values)}` : key,
 }));
 vi.mock('next/navigation', () => ({
     useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
@@ -22,6 +26,7 @@ vi.mock('@/app/actions/tasks', () => ({
     updateTaskAction: vi.fn(),
 }));
 
+import { discardTaskBranchAction } from '@/app/actions/tasks';
 import { TaskBranchSection } from './TaskBranchSection';
 
 /**
@@ -142,5 +147,69 @@ describe('TaskBranchSection — linked pull requests', () => {
             'href',
             'https://github.com/acme/repo/pull/10',
         );
+    });
+});
+
+/**
+ * Discard is an irreversible, credentialed, cross-repository action. Since the
+ * discard learned to reach every repository the Task pushed, one click deletes
+ * N+1 branches and closes every pull request open on them — so the sentence the
+ * operator actually gives consent against has to describe that, not the
+ * single-branch action it used to be.
+ */
+describe('TaskBranchSection - the discard confirmation matches what discard does', () => {
+    const linked = (repositoryId: string) => ({
+        repositoryId,
+        branch: 'task/t-1-add-field-x',
+        baseRef: 'main',
+        headSha: 'b'.repeat(40),
+        prNumber: 7,
+        prUrl: `https://github.com/${repositoryId}/pull/7`,
+        state: 'pr-open' as const,
+        error: null,
+        updatedAt: '2026-09-03T00:00:00.000Z',
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.mocked(discardTaskBranchAction).mockClear();
+    });
+
+    it('names every repository it will delete a branch in, counting the primary', () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        render(
+            <TaskBranchSection
+                task={make({
+                    linkedPullRequests: [linked('acme/template'), linked('acme/docs')],
+                })}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('task-discard-branch'));
+
+        // Two mounts plus the Task's own branch: three branches, three
+        // pull requests. The single-branch wording would understate it.
+        expect(confirmSpy).toHaveBeenCalledWith('discardConfirmMultiRepo {"count":3}');
+        expect(discardTaskBranchAction).toHaveBeenCalledWith('t1');
+    });
+
+    it('keeps the single-branch wording for a Task that spans one repository', () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        render(<TaskBranchSection task={make({ linkedPullRequests: null })} />);
+
+        fireEvent.click(screen.getByTestId('task-discard-branch'));
+
+        expect(confirmSpy).toHaveBeenCalledWith('discardConfirm');
+    });
+
+    it('discards nothing when the operator declines', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        render(
+            <TaskBranchSection task={make({ linkedPullRequests: [linked('acme/template')] })} />,
+        );
+
+        fireEvent.click(screen.getByTestId('task-discard-branch'));
+
+        expect(discardTaskBranchAction).not.toHaveBeenCalled();
     });
 });

--- a/docs/features/task-isolation.md
+++ b/docs/features/task-isolation.md
@@ -47,7 +47,7 @@ Once a Task has a branch, the panel replaces the selector with the branch cockpi
 - the **branch name** with a copy button, and the short **base SHA** it was cut from,
 - a **state** pill — `created` → `pushed` → `pr-open` → `merged`, plus `conflict`, `discarded` and `cleaned`,
 - a link to the **pull request** when one is open,
-- **Discard branch**, which deletes the remote branch and resets the Task's workspace identity so the next run starts clean. This is irreversible and asks for confirmation.
+- **Discard branch**, which deletes the remote branch and resets the Task's workspace identity so the next run starts clean. On a Task that spans several repositories it discards the branch in _every_ repository the Task pushed, not only the primary, and clears the linked pull requests with it. A repository whose branch could not be deleted — a refused token, a protected branch, or a plain `git` remote, which has no delete-branch API — keeps its entry, marked `failed`, so the branch and the pull request it left open are still on the record. This is irreversible and asks for confirmation.
 
 The same branch state appears as a chip on the Task's card on the [board](../api/tasks.md).
 
@@ -60,11 +60,11 @@ If the base branch moves on and the Task branch can no longer merge, the branch 
 | Action            | API                                     | Result                                                                                         |
 | ----------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Resolve conflicts | `POST /api/tasks/:id/resolve-conflicts` | 200 — branch back to `pushed`, Task back to `in_progress`. 409 if the Task is not in conflict. |
-| Discard branch    | `POST /api/tasks/:id/discard-branch`    | 200 — branch deleted, workspace identity reset. Idempotent.                                    |
+| Discard branch    | `POST /api/tasks/:id/discard-branch`    | 200 — branch deleted in every repository the Task spans, workspace identity reset. Idempotent. |
 
 ## Cleanup
 
-With `taskBranchCleanup: on-merge`, a nightly sweep deletes the remote branches of Tasks that reached a terminal state (done or cancelled), plus any abandoned branch past a hard staleness cutoff. With `manual`, branches are never auto-deleted — use **Discard branch**.
+With `taskBranchCleanup: on-merge`, a nightly sweep deletes the remote branches of Tasks that reached a terminal state (done or cancelled), plus any abandoned branch past a hard staleness cutoff — in every repository the Task spans, so a multi-repo Task does not leave one branch behind per extra repository. With `manual`, branches are never auto-deleted — use **Discard branch**.
 
 ## Related
 

--- a/packages/agent/src/tasks-domain/__tests__/task-workspace-mounts.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-workspace-mounts.spec.ts
@@ -563,3 +563,309 @@ describe('TaskWorkspaceService.finalizeMountPush', () => {
         );
     });
 });
+
+/**
+ * Multi-repo Task workspaces (self-build slice C) meet the M6 "Discard
+ * branch" escape hatch.
+ *
+ * `taskBranchName` is a pure function of the Task id and slug, so the next
+ * run recomputes the SAME branch in EVERY repository the Task spans. A
+ * discard that resets only the primary therefore leaves the mount branch
+ * AND its recorded `pr-open` entry alive, and the next run's mount commits
+ * land straight back in the pull request the operator threw away.
+ */
+describe('TaskWorkspaceService discard reaches every repository the Task pushed', () => {
+    type Doubles = {
+        works: { findById: jest.Mock };
+        tasks: {
+            findByIdAndUser: jest.Mock;
+            findById: jest.Mock;
+            updateById: jest.Mock;
+            findBranchCleanupCandidates: jest.Mock;
+        };
+        gitFacade: { deleteBranch: jest.Mock };
+        attachments: { listEnabledForAgentWithRepos: jest.Mock };
+        repoConnections: { findByIdAndUser: jest.Mock };
+    };
+
+    let d: Doubles;
+
+    /** Primary PR #10 open, mount PR #3 open, a second mount only pushed. */
+    const multiRepoTask = () =>
+        makeTask({
+            agentId: 'agent-1',
+            branchState: 'pr-open',
+            prNumber: 10,
+            prUrl: 'https://github.com/ever-works/ever-works/pull/10',
+            extraRepos: [{ repoConnectionId: 'conn-2' }],
+            linkedPullRequests: [
+                {
+                    repositoryId: 'ever-works/directory-web-template',
+                    branch: 'task/tsk-9-task1',
+                    baseRef: 'develop',
+                    headSha: 'a'.repeat(40),
+                    prNumber: 3,
+                    prUrl: 'https://github.com/ever-works/directory-web-template/pull/3',
+                    state: 'pr-open',
+                    error: null,
+                    updatedAt: '2026-09-01T00:00:00.000Z',
+                },
+                {
+                    repositoryId: 'ever-works/workspace',
+                    branch: 'task/tsk-9-task1',
+                    baseRef: 'main',
+                    headSha: 'b'.repeat(40),
+                    prNumber: null,
+                    prUrl: null,
+                    state: 'pushed',
+                    error: null,
+                    updatedAt: '2026-09-01T00:00:00.000Z',
+                },
+            ],
+        });
+
+    const build = () =>
+        new TaskWorkspaceService(
+            d.works as unknown as ServiceArgs[0],
+            d.tasks as unknown as ServiceArgs[1],
+            {} as unknown as ServiceArgs[2],
+            {} as unknown as ServiceArgs[3],
+            d.gitFacade as unknown as ServiceArgs[4],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            d.attachments as unknown as ServiceArgs[9],
+            d.repoConnections as unknown as ServiceArgs[10],
+        );
+
+    const deleted = () =>
+        d.gitFacade.deleteBranch.mock.calls.map((call: unknown[]) => [
+            `${call[0]}/${call[1]}`,
+            call[2],
+            (call[3] as { providerId: string }).providerId,
+        ]);
+
+    beforeEach(() => {
+        const task = multiRepoTask();
+        d = {
+            works: {
+                findById: jest
+                    .fn()
+                    .mockResolvedValue({ ...makeWork(), taskBranchCleanup: 'on-merge' }),
+            },
+            tasks: {
+                findByIdAndUser: jest.fn().mockResolvedValue(task),
+                findById: jest.fn().mockResolvedValue(task),
+                updateById: jest.fn().mockResolvedValue(undefined),
+                findBranchCleanupCandidates: jest.fn().mockResolvedValue([task]),
+            },
+            gitFacade: { deleteBranch: jest.fn().mockResolvedValue(undefined) },
+            // The template mount is an agent attachment (provider `github`)…
+            attachments: {
+                listEnabledForAgentWithRepos: jest.fn().mockResolvedValue([attachment()]),
+            },
+            // …and `ever-works/workspace` is a Task extra on a GENERIC git
+            // connection, so its own provider must be used, not the Work's.
+            repoConnections: {
+                findByIdAndUser: jest.fn().mockResolvedValue({
+                    id: 'conn-2',
+                    url: 'https://github.com/ever-works/workspace.git',
+                    provider: 'git',
+                }),
+            },
+        };
+    });
+
+    it('deletes every mount branch through its own provider and clears the links with the primary reset', async () => {
+        await build().discardBranch('user-1', 'task-1');
+
+        expect(deleted()).toEqual([
+            ['ever-works/ever-works', 'task/tsk-9-task1', 'github'],
+            ['ever-works/directory-web-template', 'task/tsk-9-task1', 'github'],
+            ['ever-works/workspace', 'task/tsk-9-task1', 'git'],
+        ]);
+        expect(d.tasks.updateById).toHaveBeenCalledWith('task-1', {
+            branchRef: null,
+            branchState: 'discarded',
+            baseSha: null,
+            prNumber: null,
+            prUrl: null,
+            conflictPaths: null,
+            linkedPullRequests: null,
+        });
+    });
+
+    it('keeps going when one remote refuses, and still resets the Task', async () => {
+        d.gitFacade.deleteBranch.mockImplementation((_owner: string, repo: string) =>
+            repo === 'directory-web-template'
+                ? Promise.reject(new Error('403: resource not accessible'))
+                : Promise.resolve(undefined),
+        );
+
+        await expect(build().discardBranch('user-1', 'task-1')).resolves.toBeUndefined();
+
+        expect(deleted().map((call) => call[0])).toEqual([
+            'ever-works/ever-works',
+            'ever-works/directory-web-template',
+            'ever-works/workspace',
+        ]);
+        // The refused branch is STILL on its remote and its pull request is
+        // still open — deleting the branch is what would have closed it. The
+        // row is the only record of either, so clearing it here would trade a
+        // recoverable leak for an unrecoverable one: after this patch
+        // `branchRef` is null, so the branch cockpit is gone from the Task
+        // page and `findBranchCleanupCandidates` will never look at the row
+        // again. It survives, downgraded to `failed` with its PR link intact.
+        expect(d.tasks.updateById).toHaveBeenCalledWith(
+            'task-1',
+            expect.objectContaining({
+                branchState: 'discarded',
+                linkedPullRequests: [
+                    expect.objectContaining({
+                        repositoryId: 'ever-works/directory-web-template',
+                        branch: 'task/tsk-9-task1',
+                        state: 'failed',
+                        prNumber: 3,
+                        prUrl: 'https://github.com/ever-works/directory-web-template/pull/3',
+                        error: expect.stringContaining('403: resource not accessible'),
+                    }),
+                ],
+            }),
+        );
+    });
+
+    it('refuses to reuse the pull request of a branch whose delete failed', async () => {
+        // The fence BD-1 exists for: the survivor above must not become the
+        // `pr-open` entry a later run's mount push lands in. `failed` is the
+        // one state `findOpenLinkedPullRequest` never matches.
+        d.gitFacade.deleteBranch.mockRejectedValue(new Error('403: resource not accessible'));
+
+        await build().discardBranch('user-1', 'task-1');
+
+        const [, patch] = d.tasks.updateById.mock.calls[0] as [
+            string,
+            { linkedPullRequests: Array<{ state: string }> },
+        ];
+        expect(patch.linkedPullRequests).toHaveLength(2);
+        expect(patch.linkedPullRequests.map((entry) => entry.state)).toEqual(['failed', 'failed']);
+    });
+
+    it('keeps no record for a mount branch that was already gone', async () => {
+        // The common case, not an error: a mount branch merged under
+        // auto-delete-on-merge, or a discard retried after a partial
+        // failure. GitHub answers `deleteRef` for a missing ref with
+        // "Reference does not exist" — that is a completed discard, and
+        // leaving a `failed` entry behind would tell the operator a branch
+        // is still live when it is not.
+        d.gitFacade.deleteBranch.mockRejectedValue(
+            new Error('Reference does not exist - https://docs.github.com/rest'),
+        );
+
+        await build().discardBranch('user-1', 'task-1');
+
+        expect(d.tasks.updateById).toHaveBeenCalledWith(
+            'task-1',
+            expect.objectContaining({ linkedPullRequests: null }),
+        );
+    });
+
+    it('keeps the record when the remote answers 404, which is also what a revoked token looks like', async () => {
+        // The deliberate asymmetry: GitHub answers 404 both for "no such
+        // branch" and for "your token cannot see this repository". Only the
+        // second is a branch left behind, and the two are indistinguishable
+        // from here — so an ambiguous failure keeps its record rather than
+        // silently dropping a live branch and its open pull request.
+        d.gitFacade.deleteBranch.mockRejectedValue(new Error('Not Found'));
+
+        await build().discardBranch('user-1', 'task-1');
+
+        const [, patch] = d.tasks.updateById.mock.calls[0] as [
+            string,
+            { linkedPullRequests: Array<{ state: string }> | null },
+        ];
+        expect(patch.linkedPullRequests).toHaveLength(2);
+    });
+
+    it('sweeps mount branches too, so a multi-repo Task cannot leak one branch per extra repository', async () => {
+        const result = await build().sweepStaleBranches({ staleDays: 30 });
+
+        expect(result).toEqual({ cleaned: 1 });
+        expect(deleted()).toEqual([
+            ['ever-works/ever-works', 'task/tsk-9-task1', 'github'],
+            ['ever-works/directory-web-template', 'task/tsk-9-task1', 'github'],
+            ['ever-works/workspace', 'task/tsk-9-task1', 'git'],
+        ]);
+        expect(d.tasks.updateById).toHaveBeenCalledWith('task-1', {
+            branchState: 'cleaned',
+            linkedPullRequests: null,
+        });
+    });
+
+    it('leaves a malformed linked entry to a human instead of stranding the reset', async () => {
+        const task = makeTask({
+            agentId: 'agent-1',
+            linkedPullRequests: [
+                {
+                    repositoryId: 'directory-web-template',
+                    branch: 'task/tsk-9-task1',
+                    baseRef: 'develop',
+                    headSha: null,
+                    prNumber: null,
+                    prUrl: null,
+                    state: 'pushed',
+                    error: null,
+                    updatedAt: '2026-09-01T00:00:00.000Z',
+                },
+            ],
+        });
+        d.tasks.findByIdAndUser.mockResolvedValue(task);
+
+        await build().discardBranch('user-1', 'task-1');
+
+        expect(deleted()).toEqual([['ever-works/ever-works', 'task/tsk-9-task1', 'github']]);
+        // "Leaving it to a human" only works if the human can still see it:
+        // the entry the discard could not parse is kept, marked failed, with
+        // the reason in `error`.
+        expect(d.tasks.updateById).toHaveBeenCalledWith(
+            'task-1',
+            expect.objectContaining({
+                linkedPullRequests: [
+                    expect.objectContaining({
+                        repositoryId: 'directory-web-template',
+                        state: 'failed',
+                        error: expect.stringContaining('not a deletable'),
+                    }),
+                ],
+            }),
+        );
+    });
+
+    it('sweeps only what it actually deleted, so a refused branch keeps its record', async () => {
+        // Worse here than in the interactive discard: the sweep KEEPS
+        // `branchRef` and only flips the state to `cleaned`, so an
+        // over-clearing sweep would leave the Task page rendering a branch
+        // cockpit whose linked-pull-request list had just been emptied while
+        // the branch and its PR were still live.
+        d.gitFacade.deleteBranch.mockImplementation((_owner: string, repo: string) =>
+            repo === 'workspace'
+                ? Promise.reject(new Error('Delete branch not supported by this provider'))
+                : Promise.resolve(undefined),
+        );
+
+        await expect(build().sweepStaleBranches({ staleDays: 30 })).resolves.toEqual({
+            cleaned: 1,
+        });
+
+        expect(d.tasks.updateById).toHaveBeenCalledWith('task-1', {
+            branchState: 'cleaned',
+            linkedPullRequests: [
+                expect.objectContaining({
+                    repositoryId: 'ever-works/workspace',
+                    state: 'failed',
+                    error: expect.stringContaining('Delete branch not supported by this provider'),
+                }),
+            ],
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -528,6 +528,46 @@ export class TaskWorkspaceService {
     }
 
     /**
+     * Git-facade options for ONE mounted repository of a multi-repo Task
+     * (self-build slice C): attachment first, then the Task's own extra
+     * repositories (PR C2), then the Work's provider — the same precedence
+     * the plan used to mount it.
+     *
+     * ONE definition, shared by `finalizeMountPush` (which opens the pull
+     * request) and `discardMountBranches` (which deletes the branch behind
+     * it). They must not drift: a discard that resolved a different provider
+     * than the push would delete nothing on the remote that actually holds
+     * the branch, while telling the operator the branch is gone.
+     */
+    private async resolveMountGitOptions(
+        task: Task,
+        repositoryId: string,
+        userId: string,
+        agentId?: string | null,
+    ): Promise<{ userId: string; providerId: string; workId: string }> {
+        const attached =
+            this.agentRepoAttachments && agentId
+                ? await resolveAttachedReposForAgent(
+                      this.agentRepoAttachments,
+                      agentId,
+                      userId,
+                  ).catch(() => [])
+                : [];
+        const attachment = attached.find(
+            (candidate) =>
+                repositoryIdFromCloneUrl(candidate.url)?.toLowerCase() ===
+                repositoryId.toLowerCase(),
+        );
+        const work = task.workId ? await this.works.findById(task.workId) : null;
+        const providerId =
+            attachment?.provider ??
+            (await this.extraRepoProvider(task, repositoryId, userId)) ??
+            work?.gitProvider ??
+            'github';
+        return { userId, providerId, workId: task.workId ?? '' };
+    }
+
+    /**
      * Multi-repo Task workspaces (self-build slice C) — a fleet run pushed
      * a branch in one of the Task's MOUNTED repositories; open its pull
      * request and record it on the Task next to the primary.
@@ -596,27 +636,13 @@ export class TaskWorkspaceService {
                 'no git facade is available to open the pull request',
             );
         }
-        const attached = this.agentRepoAttachments
-            ? await resolveAttachedReposForAgent(
-                  this.agentRepoAttachments,
-                  input.agentId,
-                  userId,
-              ).catch(() => [])
-            : [];
-        const attachment = attached.find(
-            (candidate) =>
-                repositoryIdFromCloneUrl(candidate.url)?.toLowerCase() ===
-                repositoryId.toLowerCase(),
+        const gitOptions = await this.resolveMountGitOptions(
+            task,
+            repositoryId,
+            userId,
+            input.agentId,
         );
-        const work = task.workId ? await this.works.findById(task.workId) : null;
-        // Attachment first, then the Task's own extra repositories (PR C2),
-        // then the Work's provider — the same precedence the plan used.
-        const providerId =
-            attachment?.provider ??
-            (await this.extraRepoProvider(task, repositoryId, userId)) ??
-            work?.gitProvider ??
-            'github';
-        const gitOptions = { userId, providerId, workId: task.workId ?? '' };
+        const { providerId } = gitOptions;
 
         if (!input.agentCanOpenPullRequests || providerId === 'git') {
             await this.recordLinkedPullRequest(task, {
@@ -1510,16 +1536,20 @@ export class TaskWorkspaceService {
      * M6 — "Discard branch" escape hatch: delete the remote task branch
      * and reset the Task's workspace identity so the next run starts
      * clean. Irreversible for the branch (the UI confirms first).
+     *
+     * Multi-repo Tasks (self-build slice C) discard EVERY repository the
+     * Task pushed, not just the primary: see `discardMountBranches`.
      */
     async discardBranch(userId: string, taskId: string): Promise<void> {
         const task = await this.tasks.findByIdAndUser(taskId, userId);
         if (!task) {
             throw new Error('TASK_NOT_FOUND');
         }
-        if (!task.branchRef) {
+        const mounts = Array.isArray(task.linkedPullRequests) ? task.linkedPullRequests : [];
+        if (!task.branchRef && mounts.length === 0) {
             return; // nothing to discard — idempotent
         }
-        if (task.workId && this.gitFacade) {
+        if (task.branchRef && task.workId && this.gitFacade) {
             const work = await this.works.findById(task.workId);
             if (work) {
                 try {
@@ -1540,6 +1570,7 @@ export class TaskWorkspaceService {
                 }
             }
         }
+        const survivingMounts = await this.discardMountBranches(task, userId, mounts);
         await this.tasks.updateById(task.id, {
             branchRef: null,
             branchState: 'discarded',
@@ -1547,6 +1578,18 @@ export class TaskWorkspaceService {
             prNumber: null,
             prUrl: null,
             conflictPaths: null,
+            // Cleared in the SAME patch as the primary reset — but only for
+            // the branches that really went. A surviving `pr-open` entry is
+            // what `findOpenLinkedPullRequest` matches to push a later run's
+            // commits back into the discarded pull request, so a deleted
+            // branch must lose its entry. A branch whose delete did NOT take
+            // is the opposite case: it is still on its remote with its pull
+            // request still open, and this row is the only record of it, so
+            // dropping the entry would strand both with nothing left
+            // pointing at them. Those are kept, downgraded to `failed` —
+            // never matched by `findOpenLinkedPullRequest`, so the reuse
+            // fence stays shut either way.
+            linkedPullRequests: survivingMounts.length > 0 ? survivingMounts : null,
         });
     }
 
@@ -1590,9 +1633,136 @@ export class TaskWorkspaceService {
                 } catch {
                     // already gone — fine
                 }
-                await this.tasks.updateById(task.id, { branchState: 'cleaned' });
+                // Same reach as the interactive discard: without this, every
+                // multi-repo Task leaks one branch per extra repository on
+                // every remote, forever — the GC only ever saw the primary.
+                const survivingMounts = await this.discardMountBranches(
+                    task,
+                    task.userId,
+                    Array.isArray(task.linkedPullRequests) ? task.linkedPullRequests : [],
+                );
+                await this.tasks.updateById(task.id, {
+                    branchState: 'cleaned',
+                    // Same rule as the interactive discard: only the branches
+                    // that really went lose their entry. The sweep is worse
+                    // than the discard when it over-clears, because it keeps
+                    // `branchRef` — so the row would still show a branch
+                    // cockpit while the only record of a live mount branch
+                    // and its open pull request had just been erased, and no
+                    // later sweep would look at this Task again.
+                    linkedPullRequests: survivingMounts.length > 0 ? survivingMounts : null,
+                });
             }
         }
+    }
+
+    /**
+     * Multi-repo Task workspaces (self-build slice C) — delete the branch
+     * this Task opened in each MOUNTED repository, through the same provider
+     * path that opened it (`resolveMountGitOptions`).
+     *
+     * Why discard has to reach this far: `taskBranchName` is a pure function
+     * of the Task id and slug, so the next run recomputes the SAME branch in
+     * every repository. Leave a mount branch behind and its recorded
+     * `pr-open` entry keeps matching in `findOpenLinkedPullRequest`, so the
+     * next run's mount commits land silently in the pull request the
+     * operator believed they had thrown away.
+     *
+     * Best-effort, exactly like the primary: a branch may already be gone
+     * (merged + auto-deleted) and one unreachable remote must not strand the
+     * other repositories or the Task's own reset. Failures are warned, never
+     * thrown — the caller has already told the operator the branch is going.
+     *
+     * Returns the entries whose branch is STILL on its remote — a refused
+     * delete (403, protected branch, revoked token) or a provider with no
+     * delete-branch surface at all, which is every `git` mount, since only
+     * the github plugin implements it. The caller keeps those on the row so
+     * a branch the discard could not reach does not lose the one record
+     * pointing at it and at the pull request it left open.
+     */
+    private async discardMountBranches(
+        task: Task,
+        userId: string,
+        entries: readonly TaskLinkedPullRequest[],
+    ): Promise<TaskLinkedPullRequest[]> {
+        if (entries.length === 0) return [];
+        if (!this.gitFacade) {
+            return entries.map((entry) =>
+                this.mountBranchSurvived(
+                    entry,
+                    'no git provider was available to delete this branch',
+                ),
+            );
+        }
+        const survivors: TaskLinkedPullRequest[] = [];
+        for (const entry of entries) {
+            const repositoryId =
+                typeof entry?.repositoryId === 'string' ? entry.repositoryId.trim() : '';
+            const branch = typeof entry?.branch === 'string' ? entry.branch.trim() : '';
+            const [owner, repo] = repositoryId.split('/') as [string, string | undefined];
+            if (!owner || !repo || repositoryId.split('/').length !== 2 || !branch) {
+                this.logger.warn(
+                    `Task ${task.id}: linked entry '${repositoryId}' / '${branch}' is not a deletable <owner>/<repository> + branch; leaving it to a human.`,
+                );
+                survivors.push(
+                    this.mountBranchSurvived(
+                        entry,
+                        'this linked entry is not a deletable <owner>/<repository> + branch; delete the branch by hand',
+                    ),
+                );
+                continue;
+            }
+            try {
+                const gitOptions = await this.resolveMountGitOptions(
+                    task,
+                    repositoryId,
+                    userId,
+                    task.agentId,
+                );
+                await this.gitFacade.deleteBranch(owner, repo, branch, gitOptions);
+                this.logger.log(
+                    `Task ${task.id}: discarded mount branch ${branch} in ${repositoryId}.`,
+                );
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if (mountBranchAlreadyGone(message)) {
+                    // Nothing to keep a record of: the branch is gone, which
+                    // is what the discard wanted. The primary path has always
+                    // treated this as success ("discard stays idempotent") —
+                    // a merged branch under auto-delete-on-merge, or a
+                    // discard retried after a partial failure.
+                    this.logger.log(
+                        `Task ${task.id}: mount ${repositoryId} branch ${branch} was already gone.`,
+                    );
+                    continue;
+                }
+                this.logger.warn(
+                    `Task ${task.id}: mount ${repositoryId} branch ${branch} delete failed (continuing): ${message}`,
+                );
+                survivors.push(this.mountBranchSurvived(entry, message));
+            }
+        }
+        return survivors;
+    }
+
+    /**
+     * A mount branch the discard could not delete, rewritten for the row it
+     * stays on. `failed` rather than its old state on purpose: it is the one
+     * state `findOpenLinkedPullRequest` never matches, so the next run cannot
+     * push into a pull request the operator has already tried to throw away,
+     * while `prNumber` / `prUrl` are kept because that link is the only way
+     * the operator can go and close it by hand.
+     */
+    private mountBranchSurvived(
+        entry: TaskLinkedPullRequest,
+        reason: string,
+    ): TaskLinkedPullRequest {
+        return {
+            ...entry,
+            state: 'failed',
+            error: `branch delete failed — the branch is still on the remote: ${reason}`,
+            updatedAt: new Date().toISOString(),
+        };
     }
 
     private async postSystemMessage(
@@ -1615,6 +1785,23 @@ export class TaskWorkspaceService {
             );
         }
     }
+}
+
+/**
+ * Did a mount-branch delete fail because the branch was ALREADY gone?
+ *
+ * Deliberately narrow: ONLY GitHub's literal `deleteRef` answer for a ref
+ * that is not there (HTTP 422, "Reference does not exist"). A bare status
+ * is not enough to decide — GitHub answers 404 both for "no such branch"
+ * and for "your token cannot see this repository", and the second case is
+ * precisely the one whose record must survive the discard. Anything this
+ * predicate is unsure about is therefore treated as "still on the remote",
+ * because keeping a stale entry costs the operator a line on a row, while
+ * dropping a live one costs them a branch and an open pull request that
+ * nothing points at any more.
+ */
+function mountBranchAlreadyGone(message: string): boolean {
+    return message.toLowerCase().includes('reference does not exist');
 }
 
 /**


### PR DESCRIPTION
Second cascade, following #2330. Carries **#2332**, which fixes two P1 defects in fleet code that #2330 already put on stage.

## Why this should not wait

**BD-1 — "Discard branch" only reset the primary row.** Mount branches, their `linkedPullRequests` entries and their open pull requests all survived. Because `taskBranchName` is a pure function of Task id and slug, the next run recomputed the same branch, matched the surviving `pr-open` entry, and **pushed the discarded commits back into the pull request the operator believed they had thrown away.** Discard and the nightly sweep now reach every repository. A delete that was *refused* keeps its record, downgraded to `failed`, which the reuse fence never matches.

**LC-2 — the fleet question path dropped push failures.** A run that asks the owner a question routes through `reconcileQuestion` *before* the success/failure split, and that path read neither `result.failureReason` nor the per-mount git verdicts. A multi-repo run that asked a question and failed to push produced a tidy Inbox question and silently dropped the failure.

**IB-2 — the fleet planner could not resolve its skills dependency.** It is `@Optional()`, so it degraded in silence: no `# ACTIVE SKILLS` in any fleet prompt, on every run, for every agent, while the same agent honoured its skills on the cloud path. Now wired through the **grant-aware** `SkillsService.resolveActiveForAgent` rather than the raw repository — wiring the repository would have fixed the missing-skills half and opened a permissions leak, since the node runs the CLI under the operator's own permission mode and nothing downstream re-enforces the tool-grant matrix.

## Review

Reviewed adversarially. One low-severity finding, and its verifier corrected the severity *down*: where a mount delete is refused and the entry is kept as `failed` to preserve the pull-request link, a subsequent run can overwrite that entry and lose the link to a PR the discard could not close. Worth a follow-up; it does not undermine the fix, and the state it leaves is strictly better than the pre-fix behaviour.

`lint-and-test (22.x)` green on #2332 with 14 checks passing and none failing.

## Known follow-up, deliberately not in scope

BD-1's second half: the node's persistent worktree still holds discarded commits and will push them into a *new* pull request on the next run. Closing that needs a `branchGeneration` column, a field on the fleet workspace wire contract, and a tightened stamp-reuse gate — a persisted column plus a contract change plus an invariant that slices A and B pin with their own tests. Scoped in the #2297 review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)