### PR TITLE
fix(web): compare the BFF Referer against the configured public origin

### DIFF
--- a/apps/web/src/lib/api/bff-scope.ts
+++ b/apps/web/src/lib/api/bff-scope.ts
@@ -15,9 +15,38 @@ function scopesMatch(left: WorkspaceScope, right: WorkspaceScope): boolean {
 }
 
 /**
+ * The origin this deployment is served to browsers on.
+ *
+ * This MUST NOT be derived from the incoming `Request`. Inside a Next server
+ * `request.url` is the server's own view of itself, never the browser-facing
+ * URL: `attachRequestMeta` builds it from the bind hostname and port
+ * (`http://<hostname>:<port>`), or leaves it relative — so it resolves against
+ * Next's dummy `http://n` base — unless `experimental.trustHostHeader` is on,
+ * which it is not. In production the app binds `process.env.HOSTNAME || 0.0.0.0`
+ * and serves `https://app.ever.works` through an ingress, so comparing a browser
+ * Referer against `new URL(request.url).origin` could never match and rejected
+ * EVERY call to every guarded route (EW e2e shards 16 and 27, red since
+ * 2026-08-23).
+ *
+ * `WEB_URL` / `NEXT_PUBLIC_WEB_URL` is the deployment's public origin and is
+ * already set wherever this runs (prod k8s manifest, the e2e workflow). Read it
+ * per call rather than at module load so tests and env changes are honoured.
+ */
+function trustedBrowserOrigin(): string | null {
+    const configured = process.env.NEXT_PUBLIC_WEB_URL || process.env.WEB_URL;
+    if (!configured) return null;
+    try {
+        return new URL(configured).origin;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Convert the browser's explicit, per-tab selector into the API contract.
- * Referer is optional, but when present it must be same-origin and agree with
- * the selector. Both browser and API scope headers are always overwritten.
+ * Referer is optional, but when present it must come from this deployment's own
+ * public origin and agree with the selector. Both browser and API scope headers
+ * are always overwritten.
  */
 export function applyBffWorkspaceScope(request: Request, baseHeaders: HeadersInit): Headers {
     try {
@@ -27,7 +56,8 @@ export function applyBffWorkspaceScope(request: Request, baseHeaders: HeadersIni
         const referer = request.headers.get('referer');
         if (referer) {
             const refererUrl = new URL(referer);
-            if (refererUrl.origin !== new URL(request.url).origin) {
+            const trusted = trustedBrowserOrigin();
+            if (trusted !== null && refererUrl.origin !== trusted) {
                 throw new Error('Cross-origin Referer');
             }
             if (!scopesMatch(selected, parseWorkspacePath(refererUrl.pathname))) {

--- a/apps/web/src/lib/api/bff-scope.unit.spec.ts
+++ b/apps/web/src/lib/api/bff-scope.unit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
     API_SCOPE_HEADER,
     BROWSER_WORKSPACE_SCOPE_HEADER,
@@ -6,16 +6,45 @@ import {
 } from '../workspace-scope';
 import { applyBffWorkspaceScope } from './bff-scope';
 
+/**
+ * The browser-facing origin, as the deployment configures it.
+ */
+const PUBLIC_ORIGIN = 'https://app.example';
+
+/**
+ * The origin a Next server reports for its OWN requests. This is deliberately
+ * different from PUBLIC_ORIGIN, because in every real deployment it is: Next
+ * builds `request.url` from the bind hostname and port, so behind an ingress it
+ * is the pod address, and under `next start` with no `-H` it is not even
+ * absolute. An earlier version of this guard compared the Referer against
+ * `new URL(request.url).origin` and therefore rejected every browser call to
+ * every guarded route in production and in e2e. These fixtures exist to make
+ * that class of mistake impossible to reintroduce: nothing here may pass by
+ * virtue of the request's own URL.
+ */
+const SERVER_SELF_ORIGIN = 'http://0.0.0.0:3000';
+
 function request(selector?: string, referer?: string): Request {
     const headers = new Headers({
         [API_SCOPE_HEADER]: 'attacker-supplied-yo',
     });
     if (selector !== undefined) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
     if (referer !== undefined) headers.set('referer', referer);
-    return new Request('https://app.example/api/missions', { method: 'POST', headers });
+    return new Request(`${SERVER_SELF_ORIGIN}/api/missions`, { method: 'POST', headers });
 }
 
 describe('BFF workspace scope boundary', () => {
+    const previous = process.env.NEXT_PUBLIC_WEB_URL;
+
+    beforeEach(() => {
+        process.env.NEXT_PUBLIC_WEB_URL = PUBLIC_ORIGIN;
+    });
+
+    afterEach(() => {
+        if (previous === undefined) delete process.env.NEXT_PUBLIC_WEB_URL;
+        else process.env.NEXT_PUBLIC_WEB_URL = previous;
+    });
+
     it('accepts an explicit Organization selector without Referer and overwrites the API header', () => {
         const upstream = applyBffWorkspaceScope(request('org:ever'), {
             Authorization: 'Bearer test',
@@ -26,22 +55,60 @@ describe('BFF workspace scope boundary', () => {
         expect(upstream.get('authorization')).toBe('Bearer test');
     });
 
-    it('accepts explicit personal only with an unprefixed same-origin Referer', () => {
+    it('accepts explicit personal only with an unprefixed Referer from the public origin', () => {
         const upstream = applyBffWorkspaceScope(
-            request('personal', 'https://app.example/missions/new'),
+            request('personal', `${PUBLIC_ORIGIN}/missions/new`),
             {},
         );
 
         expect(upstream.get(API_SCOPE_HEADER)).toBe(PERSONAL_SCOPE_SENTINEL);
     });
 
+    it('accepts a Referer from the configured public origin even though the request URL is the server address', () => {
+        // The regression pin. The Referer's origin and the request's own origin
+        // disagree here exactly as they do in production; only the configured
+        // public origin decides.
+        const upstream = applyBffWorkspaceScope(
+            request('org:ever', `${PUBLIC_ORIGIN}/org/ever/missions`),
+            {},
+        );
+
+        expect(upstream.get(API_SCOPE_HEADER)).toBe('ever');
+    });
+
+    it("rejects a Referer that matches the server's own address but not the public origin", () => {
+        expect(() =>
+            applyBffWorkspaceScope(
+                request('org:ever', `${SERVER_SELF_ORIGIN}/org/ever/missions`),
+                {},
+            ),
+        ).toThrow('Invalid workspace scope');
+    });
+
+    it('still enforces the selector when no public origin is configured', () => {
+        delete process.env.NEXT_PUBLIC_WEB_URL;
+        delete process.env.WEB_URL;
+
+        // Unverifiable origin: the Referer's path must still agree with the
+        // selector, so a stale tab is caught even without the origin leg.
+        expect(() =>
+            applyBffWorkspaceScope(
+                request('org:ever', 'https://anywhere.example/org/yo/missions'),
+                {},
+            ),
+        ).toThrow('Invalid workspace scope');
+    });
+
     it.each([
-        ['missing selector', request(undefined, 'https://app.example/org/ever/missions')],
-        ['invalid selector', request('org:@personal', 'https://app.example/org/ever/missions')],
-        ['stale tab selector', request('org:ever', 'https://app.example/org/yo/missions')],
-        ['personal downgrade', request('personal', 'https://app.example/org/ever/missions')],
-        ['cross-origin Referer', request('org:ever', 'https://evil.example/org/ever/missions')],
-    ] as const)('fails closed for %s', (_label, input) => {
-        expect(() => applyBffWorkspaceScope(input, {})).toThrow('Invalid workspace scope');
+        ['missing selector', () => request(undefined, `${PUBLIC_ORIGIN}/org/ever/missions`)],
+        ['invalid selector', () => request('org:@personal', `${PUBLIC_ORIGIN}/org/ever/missions`)],
+        ['stale tab selector', () => request('org:ever', `${PUBLIC_ORIGIN}/org/yo/missions`)],
+        ['personal downgrade', () => request('personal', `${PUBLIC_ORIGIN}/org/ever/missions`)],
+        [
+            'cross-origin Referer',
+            () => request('org:ever', 'https://evil.example/org/ever/missions'),
+        ],
+    ] as const)('fails closed for %s', (_label, build) => {
+        expect(() => applyBffWorkspaceScope(build(), {})).toThrow('Invalid workspace scope');
     });
 });


### PR DESCRIPTION
## What this fixes

`applyBffWorkspaceScope` compared the browser's `Referer` against the server's own
idea of its origin:

```ts
if (refererUrl.origin !== new URL(request.url).origin) {
    throw new Error('Cross-origin Referer');
}
```

**Inside a Next server `request.url` is never the browser-facing URL.** From
`attachRequestMeta` in the pinned Next 16.2.11 (`next-server.js:1266`):

```js
const initUrl = this.fetchHostname && this.port
  ? `${protocol}://${this.fetchHostname}:${this.port}${req.url}`
  : this.nextConfig.experimental.trustHostHeader
    ? `https://${req.headers.host || 'localhost'}${req.url}`
    : req.url;
```

Only the middle branch yields the browser's origin, and it needs
`experimental.trustHostHeader`, which `apps/web/next.config.ts` does not set. So:

| Environment | Browser origin | Next's self-reported origin |
| --- | --- | --- |
| Production | `https://app.ever.works` | `https://<pod-name>:3000` |
| e2e CI | `http://127.0.0.1:3000` | `http://n` (url stays relative) |

Production builds standalone (`NEXT_BUILD_OUTPUT=standalone`, `CMD ["node","server.js"]`)
and Next's standalone server binds `process.env.HOSTNAME || '0.0.0.0'`, which Kubernetes
sets to the pod name. The two can never be equal, so **every** browser call to a guarded
route was answered with `400 {"error":"Invalid workspace scope"}`.

Ten routes call the guard: organization create, rename, switch and listing, org
templates, company import, company register, upgrade-from-account, the user scope
endpoint, and the three agent-terminal routes.

## CI evidence

Introduced by `8f28edca0` (2026-08-23). First red e2e run `32753184043` (2026-08-24);
last green before it `32651261833` (2026-08-23). Red on every run since.

From e2e shard 27's Playwright trace — same page, same browser, same Referer:

```
GET  /api/organizations            -> 400
GET  /api/org-templates            -> 400
POST /api/organizations            -> 400
GET  /api/organizations/check-slug -> 200   <- the only one that does not call the guard
```

The 400 body is `{"error":"Invalid workspace scope"}`. The error-context snapshot shows
the Create Organization dialog still open with that string rendered under the Name field,
so `createOrganizationViaUI` then blocks forever waiting for a dashboard navigation that
never happens.

## The fix

`WEB_URL` / `NEXT_PUBLIC_WEB_URL` already holds the deployment's public origin, and is
set in both places that matter — `https://app.ever.works` in the prod manifest,
`http://127.0.0.1:3000` in the e2e workflow. Compare against that. The CSRF property the
guard was written for is preserved and starts actually holding.

When no public origin is configured the origin leg is skipped rather than failing closed,
so a dev server without `WEB_URL` still works; the Referer's path must still agree with
the selector, so a stale tab is caught either way.

**Deliberately not done:** pointing the e2e harness at `localhost:3000` so Next's
self-view happens to match. That would turn the shards green while leaving production
broken, and the harness uses `127.0.0.1` on purpose (`e2e.yml:426`, IPv6 resolution).

## Why review and CI missed it

`bff-scope.unit.spec.ts` built its fixture with
`new Request('https://app.example/api/missions', …)` and paired it with a Referer on that
same origin. A `Request` constructed from an absolute URL reports exactly that URL, so
the two origins matched **by construction** — the one condition a real Next server can
never satisfy. The test encoded the assumption the bug depended on.

Fixtures now use a `SERVER_SELF_ORIGIN` that deliberately differs from the public origin,
so nothing can pass by virtue of the request's own URL. Two new tests:

- a Referer from the configured public origin is accepted even though the request URL is
  the server address (the regression pin);
- a Referer forged to the server's own address is rejected — **the old code accepted it**,
  so this was not only blocking legitimate traffic but admitting the wrong thing.

## Verification

- `bff-scope.unit.spec.ts` 10/10 pass.
- Reverted to the old guard and re-ran: 3 of the 10 fail, and they are the right three.
- `bff-scope` + `browser-api` + `server-api` + `workspace-scope` unit specs: 40/40 pass.
- `npx tsc --noEmit` in `apps/web`: clean.
- Prettier clean.

## Not verified

Nobody has executed this against production. The repo evidence is unambiguous and there
is no configuration under which the check can pass, but the confirming click has not been
made — **log into the app and try to create an organization**. If the modal shows
"Invalid workspace scope", this has been broken for real users since 2026-08-23.

Refs EW-783. Wider context, including the eight other groups of e2e failures, in
Workspace `knowledge/notes/2026-09-04-stage-e2e-gate-diagnosis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
