### PR TITLE
test(e2e): update assertions pinning contracts the product deliberately changed

### DIFF
--- a/apps/web/e2e/flow-ai-conversation-work-scoped.spec.ts
+++ b/apps/web/e2e/flow-ai-conversation-work-scoped.spec.ts
@@ -26,10 +26,11 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  * ── Verified API contracts (conversation entity vs. works) ───────────────────
  *
  * The Conversation entity (packages/agent/.../conversation.entity.ts) has NO
- * `workId` column. `CreateConversationDto` whitelists ONLY { title, providerId };
- * `UpdateConversationDto` whitelists ONLY { title } — both under the hardened
- * global ValidationPipe (`forbidNonWhitelisted:true`, apps/api/src/main.ts). So
- * the ONLY durable conversation⇄work linkage today is the TITLE ENCODING
+ * `workId` column. `CreateConversationDto` whitelists ONLY
+ * { title, providerId, model }; `UpdateConversationDto` whitelists ONLY
+ * { title, model } — both under the hardened global ValidationPipe
+ * (`forbidNonWhitelisted:true`, apps/api/src/main.ts). So the ONLY durable
+ * conversation⇄work linkage today is the TITLE ENCODING
  * (`work:<workId>` convention). The contracts that govern that linkage:
  *
  * GET /api/conversations?limit&offset[&workId]   (conversation.controller.list)
@@ -39,11 +40,13 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *   NO native server-side work filter. Clients filter by the `work:<id>` title
  *   prefix on the projection. `limit` is clamped to [1,200] (DoS cap).
  *
- * POST /api/conversations { title?, providerId? } → 201 row (no `messages`).
+ * POST /api/conversations { title?, providerId?, model? } → 201 row (no `messages`).
  *   title>200 → 400 maxLength; providerId>100 → 400 maxLength.
  *
- * PATCH /api/conversations/:id { title } → 204 (re-scopes the title linkage).
- *   title is REQUIRED + maxLength 200; a non-whitelisted `workId` in the body →
+ * PATCH /api/conversations/:id { title?, model? } → 204 (re-scopes the title
+ *   linkage). Since #2103 this is a PARTIAL update: BOTH fields are optional and
+ *   each write is guarded independently, so an EMPTY body is a valid 204 no-op.
+ *   title keeps its maxLength 200; a non-whitelisted `workId` in the body →
  *   400 ["property workId should not exist"] (forbidNonWhitelisted on UPDATE too).
  *
  * POST /api/conversations/:id/messages { messages } → 201 { success:true }.
@@ -326,7 +329,7 @@ test.describe('AI conversation entity — work-scoping linkage (title-encoded; n
         ).toEqual([]);
     });
 
-    test('Flow 4: PATCH is title-only — a smuggled `workId` is rejected (forbidNonWhitelisted on UPDATE), proving there is no FK re-link path', async ({
+    test('Flow 4: PATCH is whitelist-only — a smuggled `workId` is rejected (forbidNonWhitelisted on UPDATE), proving there is no FK re-link path', async ({
         request,
     }) => {
         test.setTimeout(60_000);
@@ -356,13 +359,24 @@ test.describe('AI conversation entity — work-scoping linkage (title-encoded; n
             'rejected smuggle did not change the title',
         ).toBe(`work:${fakeWorkId(4)}`);
 
-        // title is REQUIRED on update (an empty body is rejected, not a no-op).
+        // CONTRAST — the whitelist rejects, but it does not make any member of
+        // it mandatory. Since #2103 made PATCH a partial update (`title` and
+        // `model` both optional, each write guarded by `!== undefined`), an
+        // empty body is a valid no-op, NOT a 400. The point that matters for
+        // the work linkage: a body carrying nothing cannot re-scope anything.
         const empty = await request.patch(`${API_BASE}/api/conversations/${conv.id}`, {
             headers: authedHeaders(token),
             data: {},
         });
-        expect(empty.status(), 'PATCH with no title → 400 (title required)').toBe(400);
-        expect(flatMessage((await empty.json()) as ValidationError)).toContain('title');
+        expect(empty.status(), 'PATCH with an empty body → 204 (partial-update no-op)').toBe(204);
+
+        const afterNoOp = await request.get(`${API_BASE}/api/conversations/${conv.id}`, {
+            headers: authedHeaders(token),
+        });
+        expect(
+            ((await afterNoOp.json()) as ConversationRow).title,
+            'the empty no-op PATCH left the work linkage untouched',
+        ).toBe(`work:${fakeWorkId(4)}`);
     });
 
     test('Flow 5: conversation title/providerId length caps bound the work-linkage payload (create + update)', async ({

--- a/apps/web/e2e/flow-chat-provider-switch.spec.ts
+++ b/apps/web/e2e/flow-chat-provider-switch.spec.ts
@@ -701,9 +701,22 @@ test.describe('Chat provider switch — configured gate, switch routing, record 
         // the confusion this gate removes. Most accounts activate exactly one
         // provider, so "hidden" is the common case and the assertions below
         // branch on the real count rather than assuming the chip is there.
+        // The dropdown header is the i18n `title` = exactly "AI Assistant". Match it
+        // EXACTLY: the panel also renders `welcomeTitle` ("Welcome to AI Assistant 👋"),
+        // so a substring match counts the welcome heading as a dropdown that is not there.
         if (seededProviders.length < 2) {
+            // The header only exists while the menu is OPEN, so its absence alone
+            // would also hold for a wrongly-rendered chip nobody clicked. Assert the
+            // TRIGGER is absent too — that is the control the gate removes (same
+            // pairing as flow-chat-roundtrip-adaptive.spec.ts).
             await expect(
-                page.getByText('AI Assistant', { exact: false }),
+                page.getByRole('button', {
+                    name: new RegExp(orForSeeded?.name ?? 'OpenRouter', 'i'),
+                }),
+                'a single-provider account gets no selector trigger',
+            ).toHaveCount(0);
+            await expect(
+                page.getByText('AI Assistant', { exact: true }),
                 'a single-provider account gets no provider dropdown at all',
             ).toHaveCount(0);
             return;
@@ -720,8 +733,10 @@ test.describe('Chat provider switch — configured gate, switch routing, record 
         await expect(triggerOrLabel.first()).toBeVisible({ timeout: 30_000 });
 
         // Open the dropdown (DEV hydration race: the first click can be swallowed
-        // pre-hydration — retry until the menu's section header is visible).
-        const menuHeader = page.getByText('AI Assistant', { exact: false }).first();
+        // pre-hydration — retry until the menu's section header is visible). Exact
+        // again: the always-visible "Welcome to AI Assistant 👋" heading would
+        // satisfy a substring match before the menu ever opened.
+        const menuHeader = page.getByText('AI Assistant', { exact: true }).first();
         await expect(async () => {
             await triggerOrLabel
                 .first()

--- a/apps/web/e2e/flow-chat-roundtrip-adaptive.spec.ts
+++ b/apps/web/e2e/flow-chat-roundtrip-adaptive.spec.ts
@@ -39,11 +39,16 @@ import {
  *      "History". resetChat() → setMessages([]) + clears active conversation.
  *  ChatToolbar.tsx / ChatProviderSelector.tsx
  *    - "New chat" / "History" buttons (i18n newChat="New chat", history="History").
- *    - selector button shows the active provider name (or "Provider"); the
- *      dropdown header is the i18n `title` ("AI Assistant"); each provider row is
- *      a <button>; if `!provider.configured` it is `disabled` with a
- *      "Not configured" badge. Selection persists to localStorage
- *      key `chat-ai-provider`.
+ *    - the selector renders ONLY when 2+ AI providers are activated for the
+ *      account (`if (providers.length < 2) return null`) — a one-option dropdown
+ *      is not a choice. With a single provider there is no trigger and no
+ *      dropdown anywhere in the panel; the model chip beside the composer is
+ *      then the only picker.
+ *    - when it DOES render: the trigger shows the active provider name (or
+ *      "Provider"); the dropdown header is the i18n `title` ("AI Assistant");
+ *      each provider row is a <button>; if `!provider.configured` it is
+ *      `disabled` with a "Not configured" badge. Selection persists to
+ *      localStorage key `chat-ai-provider`.
  *  ChatProvider.tsx
  *    - providers + their `configured` flags come from getGlobalFormSchema()
  *      → GET /api/generator-form → providers.ai[] (ProviderOption:
@@ -300,6 +305,34 @@ test.describe('AI Chat — round-trip adaptive (composer + reset + selector)', (
             aiProviders[0]?.name;
         expect(activeName, 'an active provider name is derivable').toBeTruthy();
 
+        // CONTRACT: the selector is a CHOICE, so ChatProviderSelector renders
+        // NOTHING while fewer than two AI providers are activated — a lone provider
+        // chip is decoration, and beside the composer's model picker it read as a
+        // second, competing control. CI activates exactly ONE provider, so "no
+        // selector at all" is the real contract there; branch on the true provider
+        // count the way the assertions below branch on the true `configured` flags.
+        // The model chip is asserted first so the absence below is read against a
+        // composer whose controls have actually mounted. It is NOT a fetch gate:
+        // `selectedProvider` is seeded from localStorage with DEFAULT_AI_PROVIDER,
+        // so ChatModelSelector renders before providers.ai[] lands. The absence is
+        // sound anyway — with one provider the selector never renders at any point,
+        // so there is no later state for this to race against.
+        if (aiProviders.length < 2) {
+            await expect(
+                page.getByTestId('chat-model-selector'),
+                'the composer control row has mounted',
+            ).toBeVisible({ timeout: 30_000 });
+            await expect(
+                page.getByRole('button', { name: new RegExp(escapeRegExp(activeName!), 'i') }),
+                'a single-provider account gets no selector trigger',
+            ).toHaveCount(0);
+            await expect(
+                page.getByText('AI Assistant', { exact: true }),
+                'and no provider dropdown to open',
+            ).toHaveCount(0);
+            return;
+        }
+
         const selectorTrigger = page
             .getByRole('button', { name: new RegExp(escapeRegExp(activeName!), 'i') })
             .first();
@@ -330,14 +363,14 @@ test.describe('AI Chat — round-trip adaptive (composer + reset + selector)', (
                 page.getByText(PROVIDER_NOT_CONFIGURED_BADGE).first(),
                 'an unconfigured provider shows the Not-configured badge',
             ).toBeVisible({ timeout: 10_000 });
-            // Scope to the dropdown ROW, never the selector TRIGGER. In CI the only
-            // AI provider (openrouter) is BOTH unconfigured AND the active provider, so
-            // its name ("OpenRouter") labels two buttons: the trigger (DOM-first, only
-            // `pointer-events-none` while streaming — never the HTML `disabled` attr) and
-            // the disabled dropdown row. A bare `.first()` resolves to the enabled trigger,
-            // so `toBeDisabled()` fails ("unconfigured provider row is disabled"). Only the
-            // row carries the "Not configured" badge text inside the same <button>, so
-            // requiring that text uniquely targets the actual disabled row.
+            // Scope to the dropdown ROW, never the selector TRIGGER. When no provider is
+            // configured the ACTIVE provider is itself unconfigured, so its name labels two
+            // buttons: the trigger (DOM-first, only `pointer-events-none` while streaming —
+            // never the HTML `disabled` attr) and the disabled dropdown row. A bare
+            // `.first()` resolves to the enabled trigger, so `toBeDisabled()` fails
+            // ("unconfigured provider row is disabled"). Only the row carries the
+            // "Not configured" badge text inside the same <button>, so requiring that text
+            // uniquely targets the actual disabled row.
             const disabledRow = page
                 .getByRole('button', {
                     name: new RegExp(escapeRegExp(unconfiguredProviders[0].name), 'i'),

--- a/apps/web/e2e/flow-mission-attachments.spec.ts
+++ b/apps/web/e2e/flow-mission-attachments.spec.ts
@@ -53,9 +53,10 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *   DELETE malformed attachmentId        -> 400 "Validation failed (uuid is
  *                                         expected)" (ParseUUIDPipe)
  *   anon list/attach/delete              -> 401 "Unauthorized"
- *   uppercase-hex uploadId               -> 201 (regex is /i); stored verbatim
- *                                         so it is a DISTINCT row from the
- *                                         lowercase form (case-sensitive index)
+ *   uppercase-hex uploadId               -> 201 (regex is /i); canonicalised
+ *                                         to lowercase before persistence, so
+ *                                         it COLLAPSES onto the lowercase row
+ *                                         (same edge id, list stays length 1)
  *
  * NON-DUPLICATION:
  *   - missions.spec.ts owns the Mission CRUD + lifecycle (pause/resume/
@@ -311,7 +312,7 @@ test.describe('FLOW: mission attachments — validation + ownership', () => {
         expect(messages.some((m) => m.includes('must match'))).toBe(true);
     });
 
-    test('uppercase-hex uploadId is accepted (regex /i) and stored verbatim as a distinct row', async ({
+    test('uppercase-hex uploadId is accepted (regex /i) and canonicalised onto the lowercase row', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
@@ -326,19 +327,29 @@ test.describe('FLOW: mission attachments — validation + ownership', () => {
             data: { uploadId: lower },
         });
         expect(a.status()).toBe(201);
+        const lowerEdge = await a.json();
+
         const b = await request.post(`${API_BASE}/api/me/missions/${missionId}/attachments`, {
             headers,
             data: { uploadId: upper },
         });
-        // Same /i regex passes; the stored varchar(64) differs by case, so the
-        // unique (missionId, uploadId) index does NOT collapse them.
+        // The same /i regex passes, but MissionsService.addAttachment folds the
+        // input with `uploadId.toLowerCase()` before BOTH the upload-ownership
+        // lookup and persistence: `user_uploads.sha256` is stored lowercase, so
+        // an uppercase edge would be one the upload join could never resolve.
+        // The canonical value therefore collides with the lowercase row on the
+        // unique (missionId, uploadId) index and takes the idempotent
+        // re-attach path — 201 with the SAME edge, not a second row.
         expect(b.status(), `uppercase attach body=${await b.text()}`).toBe(201);
-        expect((await b.json()).uploadId).toBe(upper);
+        const upperEdge = await b.json();
+        expect(upperEdge.uploadId).toBe(lower);
+        expect(upperEdge.id).toBe(lowerEdge.id);
 
         const list = await (
             await request.get(`${API_BASE}/api/me/missions/${missionId}/attachments`, { headers })
         ).json();
-        expect(list).toHaveLength(2);
+        expect(list).toHaveLength(1);
+        expect(list[0].uploadId).toBe(lower);
     });
 
     test('malformed missionId on attach -> 400 ParseUUIDPipe (uuid expected)', async ({

--- a/apps/web/e2e/flow-mission-clone-deep.spec.ts
+++ b/apps/web/e2e/flow-mission-clone-deep.spec.ts
@@ -46,13 +46,13 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *      a partial field set; this pins schedule/cap/autoBuild/guardrails both
  *      ways and re-GETs both rows after each direction).
  *   5. NO acceptedWork / idea / work linkage is carried over — the cloned
- *      mission DTO carries EXACTLY the 16 modeled columns and no extra linkage
+ *      mission DTO carries EXACTLY the 18 modeled columns and no extra linkage
  *      key, its Mission-scoped Idea list is empty, and it gets its OWN
  *      zero-state budget bucket keyed on the CLONE's id (a cross-feature angle
  *      the budget spec, which never clones, does not cover).
  *
  * ── PROBED LIVE (http://127.0.0.1:3100, 2026-06-12) ──
- *   POST /api/me/missions                       → 201 MissionDto (16 keys)
+ *   POST /api/me/missions                       → 201 MissionDto (18 keys)
  *   POST /api/me/missions/:id/clone  {title?}    → 201 { mission, ideasCloned, ideasSkipped }
  *     · copies: description,type,schedule,autoBuildWorks,outstandingIdeasCap(-1 too),
  *               guardrailsOverride,missionTemplateRepo  (verbatim)
@@ -73,10 +73,12 @@ const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
 
 // The complete modeled mission-DTO key set — used to prove the clone carries
 // NO extra linkage column (acceptedWork / ideaIds / workIds / etc.).
-// This is the FULL 16-key projection emitted by `toMissionDto`
+// This is the FULL 18-key projection emitted by `toMissionDto`
 // (packages/agent/src/missions/types.ts) — the `outcome` + `completedAt`
 // pair was added by the PR-3 domain-model evolution and is present on every
-// mission DTO (null until a human records a conclusion at Complete).
+// mission DTO (null until a human records a conclusion at Complete); the
+// `organizationId` + `tenantId` pair was added by "fix(api): expose and
+// enforce organization ownership" and is null for personal-scope missions.
 const MISSION_KEYS = [
     'autoBuildWorks',
     'completedAt',
@@ -86,11 +88,13 @@ const MISSION_KEYS = [
     'id',
     'missionRepo',
     'missionTemplateRepo',
+    'organizationId',
     'outcome',
     'outstandingIdeasCap',
     'schedule',
     'sourceMissionId',
     'status',
+    'tenantId',
     'title',
     'type',
     'updatedAt',
@@ -98,6 +102,8 @@ const MISSION_KEYS = [
 
 interface MissionDto {
     id: string;
+    tenantId: string | null;
+    organizationId: string | null;
     title: string;
     description: string;
     type: 'one-shot' | 'scheduled';
@@ -626,7 +632,7 @@ test.describe('Mission clone — deep copy-vs-reset semantics', () => {
 
     /**
      * NO acceptedWork / idea / work linkage is carried over: the cloned mission
-     * DTO carries EXACTLY the 16 modeled columns (no linkage key), and its
+     * DTO carries EXACTLY the 18 modeled columns (no linkage key), and its
      * Mission-scoped Idea list is empty (the owner's standalone unlinked Idea
      * never surfaces on it).
      */

--- a/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
+++ b/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
@@ -37,9 +37,12 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *  POST /api/me/goals {title,metricSource:{pluginId,metricId},comparator,targetValue,
  *       unit,window} → 201 GoalDto status:'draft', nextCheckAt/currentValue/
  *       baselineValue/deadline/outcome all null, checkFrequencyMinutes:60. The DTO
- *       NEVER leaks userId/tenantId/organizationId.
+ *       NEVER leaks the owning userId, but it DOES carry the ownership scope pair
+ *       (tenantId/organizationId) it is stamped with.
  *  POST /api/me/missions/:id/goals {goalId,isPrimary?} → 201 MissionGoalLinkDto
- *       { id, missionId, goalId, isPrimary, createdAt, goal:GoalDto } — ALWAYS 201,
+ *       { id, tenantId, organizationId, missionId, goalId, isPrimary, createdAt,
+ *       goal:GoalDto } — the edge carries the same ownership scope pair as the
+ *       Goal it nests (e49936d8) — ALWAYS 201,
  *       even when it merely updates an existing edge's isPrimary (idempotent).
  *       Promoting a second primary demotes the incumbent (one-primary-per-mission).
  *       Unknown goal → 404 "Goal not found"; foreign/unknown mission → 404
@@ -121,6 +124,13 @@ interface LinkRow {
 
 const GOAL_DTO_KEYS = [
     'id',
+    // Ownership scope: the DTO deliberately surfaces the tenant/Organization
+    // pair a Goal is stamped with (e49936d8 "fix(api): expose and enforce
+    // organization ownership"), so a client can tell a personal Goal from an
+    // Organization-scoped one. Either may be null, but the keys are always
+    // present — `toGoalDto` writes both unconditionally.
+    'tenantId',
+    'organizationId',
     'title',
     'description',
     'metricSource',
@@ -332,7 +342,7 @@ test.describe('Mission goal-portfolio composition', () => {
         }
     });
 
-    test('each link nests a full GoalDto projection that mirrors the standalone Goal and leaks no owner/scope', async ({
+    test('each link nests a full GoalDto projection that mirrors the standalone Goal and leaks no owning userId', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -358,11 +368,12 @@ test.describe('Mission goal-portfolio composition', () => {
             params: { currency: 'usd' },
         });
         expect(nested.status).toBe('draft');
-        // …exposing exactly the GoalDto surface — no userId/tenantId/organizationId.
+        // …exposing exactly the GoalDto surface — the ownership scope pair is part
+        // of that surface, the owning userId is not.
         expect(Object.keys(nested).sort()).toEqual([...GOAL_DTO_KEYS].sort());
         expect(nested).not.toHaveProperty('userId');
-        expect(nested).not.toHaveProperty('tenantId');
-        expect(nested).not.toHaveProperty('organizationId');
+        expect(nested).toHaveProperty('tenantId');
+        expect(nested).toHaveProperty('organizationId');
     });
 
     test('promoting a second Goal to primary demotes the incumbent — one-primary holds across a 3-goal set', async ({

--- a/apps/web/e2e/flow-oauth-callback-security.spec.ts
+++ b/apps/web/e2e/flow-oauth-callback-security.spec.ts
@@ -44,15 +44,34 @@ import { API_BASE } from './helpers/api';
  *      state query, no cookie      → 400 "...failed: missing state cookie"
  *      cookie len ≠ state len      → 400 "...failed: state length mismatch"
  *      cookie ≠ state (same len)   → 400 "...failed: state value mismatch"
- *      cookie === state, supported → 500 (code exchange vs fake provider creds)
+ *      cookie === state, supported → 400 or 502 (code exchange fails against
+ *                                    the real provider — see the note below)
  *      cookie === state, bad prov  → 400 "Unsupported OAuth provider: <id>"
  *      EVERY outcome               → Set-Cookie ew_oauth_state=; Max-Age=0 ...
  *   GET /api/oauth/bogus/url        → 400 "Unsupported OAuth provider: bogus"
  *
  * This env wires up github + google social login with FAKE client ids, so the
  * authorize URL forms correctly and the code-exchange step reaches a real but
- * unauthorised provider (→ 500). Upstream github.com / accounts.google.com are
- * NEVER contacted — every assertion is platform-side behaviour.
+ * unauthorised provider. NOTE: on the guard-PASSES paths the API really does
+ * make a SERVER-SIDE POST to the provider's token endpoint (github.com /
+ * oauth2.googleapis.com) — Playwright's route() cannot intercept an outbound
+ * call made by the API process, so those cases depend on the runner having
+ * egress and on the provider refusing the fake client id. Every OTHER
+ * assertion in this file is purely platform-side.
+ *
+ * Since be0148efc ("fix(api): map upstream OAuth failures to 400/502 instead
+ * of a raw 500") SocialAuthService.callUpstream converts that AxiosError
+ * rather than letting it escape to Nest's ExceptionsHandler: an upstream 4xx
+ * other than 401/408/429 → 400 "<Provider> rejected the OAuth <step>", while
+ * 401/408/429, 5xx and no-response-at-all → 502. The guard-PASSES branch lands
+ * on whichever of the two the runner produces — it is 400 where github.com is
+ * reachable (it answers the fake client id, and a 200-with-error body is
+ * already a 400 "Missing access_token"), and 502 where it is not (the sibling
+ * flow-oauth-git-providers.spec.ts calls the provider "unreachable", and the
+ * e2e job can run on an in-network ARC pool) — so the case accepts EITHER
+ * mapped status and pins the distinction that matters by REASON instead: the
+ * failure must not be the state-verification one, which is also a 400. What
+ * the pair still excludes is the raw unmapped 500 be0148efc removed.
  */
 
 const OAUTH_STATE_COOKIE = 'ew_oauth_state';
@@ -119,7 +138,10 @@ test.describe('flow: OAuth callback single-use clear-cookie is the replay defenc
             provider: string;
             query: string;
             cookie?: string;
-            expectStatus: number;
+            /** One status, or the accepted set where the outcome is upstream-dependent. */
+            expectStatus: number | number[];
+            /** True for the one case that gets PAST the state gate. */
+            pastGate?: boolean;
         }> = [
             {
                 name: 'missing state query',
@@ -148,11 +170,19 @@ test.describe('flow: OAuth callback single-use clear-cookie is the replay defenc
                 expectStatus: 400,
             },
             {
+                // Past the gate, so the API really posts to github.com's token
+                // endpoint from the SERVER. Which of the two mapped failures
+                // comes back depends on the runner's egress (see the note in the
+                // file docblock): a refusal from github.com → 400, an
+                // unreachable/rate-limited/5xx provider → 502. Both are
+                // callUpstream's mapping; the raw 500 be0148efc removed is
+                // excluded by this pair, and `pastGate` pins the REASON.
                 name: 'guard PASSES → code exchange fails (matching cookie+state)',
                 provider: 'github',
                 query: `?code=e2e-invalid-code&state=${minted.state}`,
                 cookie: `${OAUTH_STATE_COOKIE}=${minted.state}`,
-                expectStatus: 500,
+                expectStatus: [400, 502],
+                pastGate: true,
             },
         ];
 
@@ -165,7 +195,18 @@ test.describe('flow: OAuth callback single-use clear-cookie is the replay defenc
                     headers,
                 },
             );
-            expect(res.status(), `${o.name} → status ${o.expectStatus}`).toBe(o.expectStatus);
+            const accepted = Array.isArray(o.expectStatus) ? o.expectStatus : [o.expectStatus];
+            expect(accepted, `${o.name} → status ${accepted.join('/')}`).toContain(res.status());
+            if (o.pastGate) {
+                // 400 is ALSO a state-gate rejection status, so the status alone
+                // no longer separates "gate passed" from "gate rejected". Pin the
+                // distinction by reason: this case must fail at the exchange,
+                // never at the state guard.
+                expect(
+                    await jsonMessage(res),
+                    `${o.name} failed past the state gate, not at it`,
+                ).not.toMatch(/OAuth state verification failed/i);
+            }
             // The defence: the cookie is cleared on this very response.
             const sc = setCookieString(res.headers()['set-cookie']);
             expect(sc, `${o.name} emits a Set-Cookie`).toContain(OAUTH_STATE_COOKIE);

--- a/apps/web/e2e/flow-work-deploy-state.spec.ts
+++ b/apps/web/e2e/flow-work-deploy-state.spec.ts
@@ -51,8 +51,12 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *       unauthenticated            → 401 { message:'Unauthorized', statusCode:401 }
  *
  *   - Web Next.js route GET /api/works/:id/deploy/status reads the SAME work and projects
- *     { deploymentState, deploymentStartedAt, website, deployProvider }; unauth → 500 { error:'Unauthorized' }
- *     (the route wraps the upstream 401 as 500). With the seeded session cookie it returns the projection.
+ *     { deploymentState, deploymentStartedAt, website, deployProvider }; unauth → 401 { error:'Unauthorized' }
+ *     (its own cookie guard, before any upstream call). It reaches the platform through `serverFetch`,
+ *     which since 8f28edca0 fails closed — 500 { error:'failed_to_load_deploy_status' } — unless the
+ *     request carries the browser's per-tab `x-ever-workspace` selector ('personal' | 'org:<slug>');
+ *     the real client sends it via `browserApiFetch`. With the seeded session cookie AND that selector
+ *     it returns the projection.
  *
  * ADAPTIVITY: these flows assert the UNCONFIGURED branch (the CI reality) as the primary path
  * but tolerate a configured stack (a real Vercel/k8s token) by widening the accepted status set
@@ -72,6 +76,15 @@ const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
 /** Status classes accepted for a deploy POST: the CI-real 400 refusal, OR a configured success. */
 const DEPLOY_OUTCOMES = [200, 201, 202, 400, 401, 403, 409, 422, 500];
+
+/**
+ * The per-tab workspace selector the real client attaches to every BFF call via
+ * `browserApiFetch` (apps/web/src/lib/api/browser-api.ts), derived from the visible URL.
+ * Web route handlers reach the platform through `serverFetch`, which fails closed without
+ * it. Works here are created with `organization:false`, so the URL a real client would be
+ * on is unprefixed and the selector it serializes is `personal`.
+ */
+const BROWSER_PERSONAL_SCOPE_HEADERS = { 'x-ever-workspace': 'personal' };
 
 interface WorkDeployFields {
     id: string;
@@ -488,13 +501,16 @@ test.describe('Work deploy state machine (deep integration)', () => {
 
         const origin = baseURL ?? 'http://localhost:3000';
 
-        // The page-fixture `request` here carries the storageState session cookie, so the web route
+        // The page-fixture `request` here carries the storageState session cookie, and the GET
+        // below adds the workspace selector the browser sends for itself, so the web route
         // resolves the work. Poll it (next-dev cold compile of the route handler can be slow).
         let body: Record<string, unknown> | null = null;
         await expect
             .poll(
                 async () => {
-                    const res = await request.get(`${origin}/api/works/${workId}/deploy/status`);
+                    const res = await request.get(`${origin}/api/works/${workId}/deploy/status`, {
+                        headers: BROWSER_PERSONAL_SCOPE_HEADERS,
+                    });
                     if (res.status() === 200) {
                         body = (await res.json()) as Record<string, unknown>;
                         return 200;


### PR DESCRIPTION
Part of restoring the `stage` e2e gate (EW-784). Companion to
[#2335](https://github.com/ever-works/ever-works/pull/2335), which fixes the one
**production** defect the red gate was hiding.

## The rule I worked to

Some failures in this suite are the tests correctly reporting real behaviour changes, and
rewriting those erases the signal. So every assertion here was verified against product
source **before** being touched — the commit, the code comment, or a sibling unit spec
that pins the new behaviour. Where a failure looked like a real bug, it was left alone and
ticketed as EW-785 instead.

Nothing is skipped, no timeout is raised, no exact key match was loosened into a subset,
and no assertion was deleted rather than updated.

## The eight

| Spec | Why it was failing | Proof the new behaviour is deliberate |
| --- | --- | --- |
| `flow-oauth-callback-security` | expected a raw 500 from a failed code exchange | `be0148efc` maps upstream OAuth failures to 400/502; `social-auth.service.spec.ts:735-887` pins nine cases |
| `flow-work-deploy-state` | raw HTTP probe sent no scope header | the route's own `route.unit.spec.ts` has a test named for failing closed without one |
| `flow-ai-conversation-work-scoped` | expected `PATCH {}` → 400 | `#2103` made it a whitelist partial update, `@HttpCode(204)`, both writes behind `!== undefined`; sibling `flow-conversations-crud-deep.spec.ts:204` already pins 204 |
| `flow-chat-roundtrip-adaptive` | waited for a provider selector | `ChatProviderSelector.tsx:51` returns null below 2 providers; CI activates one |
| `flow-chat-provider-switch` | `getByText('AI Assistant', { exact: false })` | `en.json` has two such strings; only `ChatProviderSelector` renders `title` |
| `flow-mission-clone-deep` | DTO gained 2 keys | `e49936d83`; `toMissionDto` emits exactly 18 |
| `flow-mission-goals-evaluation-chain` | same | `ownership-observability.spec.ts:20` is named for it |
| `flow-mission-attachments` | expected the uppercase SHA back | `missions.service.ts` lowercases because `user_uploads.sha256` is stored lowercase |

## Three things worth reading before approving

**1. The OAuth row leaves the platform boundary, and `e2e.yml` says it does not.**
`exchangeCodeForTokens` POSTs to `https://github.com/login/oauth/access_token` from the
**API process**. Playwright's `route()` intercepts the browser context, so it cannot touch
this. The comment near `e2e.yml:386` claiming "each spec mocks the upstream provider at
the Playwright route() layer so the real provider never sees the request" is false for
this spec and for the cross-provider Google case.

That makes the mapped status environment-dependent: a refusal maps to 400, but a 429 from
a shared runner egress IP or a lost egress maps to 502. So this row asserts the **pair**
`[400, 502]` rather than a single number. That is deliberate, not laziness — and the pair
still excludes the raw 500 that `be0148efc` removed, which is what the case is actually
for. A reason assertion was added so the row still tells "past the state gate" from
"rejected at it", now that 400 is shared with the gate.

The real fix is to stop this row depending on a live provider. Not done here.

**2. One edit fixes a latent false pass.** In `flow-chat-provider-switch`, the loose
locator meant the `toPass` retry loop could go green on the chat welcome heading without
the provider menu ever opening. That assertion was not merely failing, it was capable of
passing for the wrong reason.

**3. Coverage is genuinely thinner in one place, and cannot be otherwise.** The provider
persistence assertion (`localStorage` `chat-ai-provider`) does not execute while CI
activates a single AI provider, because the control does not render. If that coverage
matters, the fix is a second provider in the CI fixture, not a looser spec.

## Verification

- `prettier --check`: clean on all eight.
- `npx tsc --noEmit` in `apps/web`: clean. Its `include` is `**/*.ts`, so this does cover
  `e2e/`.

**Not verified:** the suite cannot be run locally — it needs service containers plus
production builds of two apps. These changes are unproven until a push to `stage`.

## Known remaining, deliberately out of scope

Same family, still red, not touched here: `flow-mission-ideas-isolation-deep.spec.ts:526`
(needs the EW-785 ruling — it exists specifically to forbid what now happens),
`flow-credits-billing-contract.spec.ts:96`, `flow-teams-list-org-chart-contract.spec.ts:341`,
and stale "title only" prose in `flow-chat-work-scoped.spec.ts:40`. The large group-2 set
(30 tests still sending a bare Bearer where an org scope now needs an explicit header) is
also untouched and is the bulk of EW-784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
