### PR TITLE
test(e2e): carry the Organization scope on requests that act inside an Org

### DIFF
--- a/apps/web/e2e/flow-memory-consolidation-deep.spec.ts
+++ b/apps/web/e2e/flow-memory-consolidation-deep.spec.ts
@@ -21,8 +21,8 @@
  *     configured provider projects synthesized=1 in the dry-run PLAN, but the
  *     APPLY path downgrades a failing/keyless provider to a note and reports 0;
  *     assertions tolerate synthesized ∈ {0, 1}
- *   • no active Organization ⇒ an empty report (never a cross-tenant scan); the
- *     Organization is resolved from the request SCOPE CONTEXT, not a param
+ *   • no active Organization ⇒ an empty report (never a cross-tenant scan); an
+ *     unprefixed bare-Bearer call IS that case — see the scope contract below
  *   • validation: `apply` must be boolean (400), unknown body props rejected (400)
  *   • auth gating (401) on both /api/memory and /api/memory/consolidate
  *   • org isolation: a second user's active org is never consolidated against the
@@ -35,12 +35,31 @@
  *    to the inheritable classes (legal / style / seo); those are what the pass
  *    scans here (org docs carry workId === null in the feed).
  *
+ * ── Scope contract (8f28edca0). Both routes resolve their Organization from the
+ *    request SCOPE CONTEXT, never from a param — and that context is only ever
+ *    established by an explicit `X-Scope-Slug: <org-slug>` header or an
+ *    `/api/<slug>/…` path. `SessionScopeGuard` deliberately refuses to infer one
+ *    from the user's mutable last-active-Org preference (that refusal is what
+ *    keeps two tabs on two different Orgs isolated), so an unprefixed
+ *    bare-Bearer request runs in the PERSONAL scope, where both handlers
+ *    early-return their canned EMPTY payload with HTTP 200 — an org-stamped row
+ *    is simply invisible to it. Every test that means "act inside this org"
+ *    therefore builds its headers with `orgScopedHeaders(token, org.slug)`; the
+ *    two places that mean "personal scope / no active Organization" keep the
+ *    bare `authedHeaders` set on purpose.
+ *
  * Isolation discipline: every test builds a FRESH registerUserViaAPI() owner and
  * a lazily-minted org. Fully API-orchestrated (safe `flow-` prefix, not matched
  * by the no-auth testIgnore regex), so it never contends on the UI.
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI, type RegisteredUser } from './helpers/api';
+import {
+    API_BASE,
+    authedHeaders,
+    orgScopedHeaders,
+    registerUserViaAPI,
+    type RegisteredUser,
+} from './helpers/api';
 import { createOrganizationViaAPI } from './helpers/organizations';
 
 const CONSOLIDATE_URL = `${API_BASE}/api/memory/consolidate`;
@@ -51,12 +70,18 @@ function stamp(): string {
     return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
-/** A fresh owner + their lazily-minted org, with pre-built auth headers. */
+/**
+ * A fresh owner + their lazily-minted org, with pre-built headers PINNED to
+ * that org's slug. The pin is what puts the request in this Organization's
+ * scope; without it the same bearer is a personal-scope caller that cannot see
+ * a single one of the rows seeded below.
+ */
 interface OrgCtx {
     user: RegisteredUser;
     token: string;
-    headers: { Authorization: string };
+    headers: { Authorization: string; 'X-Scope-Slug': string };
     orgId: string;
+    orgSlug: string;
 }
 
 async function buildOrgCtx(request: APIRequestContext): Promise<OrgCtx> {
@@ -65,8 +90,9 @@ async function buildOrgCtx(request: APIRequestContext): Promise<OrgCtx> {
     return {
         user,
         token: user.access_token,
-        headers: authedHeaders(user.access_token),
+        headers: orgScopedHeaders(user.access_token, org.slug),
         orgId: org.id,
+        orgSlug: org.slug,
     };
 }
 
@@ -106,7 +132,7 @@ interface ConsolidationReport {
 
 async function consolidate(
     request: APIRequestContext,
-    headers: { Authorization: string },
+    headers: Record<string, string>,
     apply?: boolean,
 ): Promise<ConsolidationReport> {
     const res = await request.post(CONSOLIDATE_URL, {
@@ -119,7 +145,7 @@ async function consolidate(
 
 async function getMemory(
     request: APIRequestContext,
-    headers: { Authorization: string },
+    headers: Record<string, string>,
     qs = '',
 ): Promise<{
     documents: Array<{ id: string; class: string; workId: string | null; consolidation: unknown }>;
@@ -179,7 +205,10 @@ test.describe('Memory Consolidation — dry-run preview (writes nothing)', () =>
     });
 
     test('no active Organization ⇒ an empty report with the no-org note', async ({ request }) => {
-        const user = await registerUserViaAPI(request); // never creates an org
+        // DELIBERATELY bare `authedHeaders` — this test pins the PERSONAL-scope
+        // contract, so it must NOT carry an X-Scope-Slug. The user also never
+        // creates an org, so there is nothing a slug could resolve to anyway.
+        const user = await registerUserViaAPI(request);
         const report = await consolidate(request, authedHeaders(user.access_token), true);
         expect(report).toMatchObject({ scanned: 0, promoted: 0, synthesized: 0, superseded: 0 });
         expect(report.details.promotedIds).toEqual([]);
@@ -188,12 +217,19 @@ test.describe('Memory Consolidation — dry-run preview (writes nothing)', () =>
     });
 
     test('an org with zero documents scans nothing', async ({ request }) => {
+        // The scope pin matters here even though every count is 0: it is the
+        // difference between "the org really is empty" and "the request never
+        // reached an org", which the no-org branch above answers with the same
+        // zeros. Only the pinned call asserts the former.
         const ctx = await buildOrgCtx(request);
         const report = await consolidate(request, ctx.headers);
         expect(report.scanned).toBe(0);
         expect(report.promoted).toBe(0);
         expect(report.superseded).toBe(0);
         expect(report.dryRun).toBe(true);
+        // …and it is NOT the no-org early return: that branch always emits its
+        // own note, which a genuinely-empty org never does.
+        expect(report.notes.some((n) => /no active organization/i.test(n))).toBe(false);
     });
 
     test('two distinct documents → nothing superseded, both promoted', async ({ request }) => {
@@ -453,6 +489,11 @@ test.describe('Memory Consolidation — validation & auth', () => {
     });
 });
 
+// Each ctx below pins ITS OWN org slug. Sharing one slug between the two users
+// would collapse the very boundary these tests exist to prove — and a spoofed
+// slug is not the attack under test either (`ScopeOwnershipGuard` 403s that;
+// see flow-org-memory-page-deep.spec.ts). What is under test is that a caller
+// legitimately scoped to org B never sees org A's rows.
 test.describe('Memory Consolidation — org isolation (scope-context bound)', () => {
     test("a second user's org is never consolidated against the first user's documents", async ({
         request,
@@ -474,7 +515,8 @@ test.describe('Memory Consolidation — org isolation (scope-context bound)', ()
         expect(aliceReport.superseded).toBe(1);
         const aliceSurvivor = aliceReport.details.supersededPairs[0][1];
 
-        // Bob's own active org sees only his own (empty) memory — never Alice's docs.
+        // Bob's own org, pinned by Bob's OWN slug, sees only his own (empty)
+        // memory — never Alice's docs.
         const bob = await buildOrgCtx(request);
         const bobReport = await consolidate(request, bob.headers, true);
         expect(bobReport.scanned).toBe(0);

--- a/apps/web/e2e/flow-memory-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-memory-ui-journey.spec.ts
@@ -1,27 +1,28 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
 import { loadSeededTestUser } from './helpers/seeded-test-user';
-import { API_BASE } from './helpers/api';
+import { API_BASE, authedHeaders, orgScopedHeaders } from './helpers/api';
 
 /**
- * Org-wide Memory (Cortex P1) — the `/memory` PAGE, driven through the real
+ * Org-wide Memory (Cortex P1) — the Memory PAGE, driven through the real
  * authenticated UI (storageState), DEEP + ASSERTIVE.
  *
  * The sibling `flow-org-memory-page-deep.spec.ts` pins the `GET /api/memory`
  * + `POST /api/memory/consolidate` CONTRACT at the REST layer with fresh,
  * scope-pinned users. This file is the complementary UI journey: it lands
- * the shared seeded user on `/en/memory` (which 307s to `/memory`) and pins
- * the actual rendered `MemoryShell` surface — nothing here overlaps the API
- * spec. Coverage:
+ * the shared seeded user on the canonical Organization route
+ * `/org/<slug>/memory` and pins the actual rendered `MemoryShell` surface —
+ * nothing here overlaps the API spec. Coverage:
  *
  *   • page chrome: `memory-shell` mounts, the "Memory" heading + subtitle
  *     render, the document <title> comes from `generateMetadata`, the search
- *     box + "Consolidate" action + "documents indexed" header count render
- *   • seeded KB docs authored in the session user's active Org surface as
+ *     box + "Consolidate" action + "documents indexed" header count render.
+ *     These are scope-agnostic, so they stay on the unprefixed `/en/memory`
+ *     → `/memory` route and also pin that locale-prefix collapse.
+ *   • seeded KB docs authored in the session user's Organization surface as
  *     `memory-doc-<id>` rows with their title, class chip, and a link to the
- *     source Work (workName) — seeded via the API into the SAME session-scope
- *     Org the page reads (verified live: creating a Work/KB doc with a bare
- *     Bearer token, no scope header, lands in the user's active Org and the
- *     bare `GET /api/memory` returns it — exactly the BFF proxy's path)
+ *     source Work (workName) — seeded through the API with an explicit
+ *     `X-Scope-Slug: <org-slug>` so the rows are stamped into the SAME
+ *     Organization the `/org/<slug>/memory` page reads
  *   • filter chips render per facet (type / work / status / source) with the
  *     titleCased labels the shell computes; clicking a Type chip flips
  *     aria-pressed and narrows the feed (a non-matching seeded row drops out),
@@ -33,16 +34,44 @@ import { API_BASE } from './helpers/api';
  *     Cancel closes it; Apply persists and swaps in the applied summary, after
  *     which a reload shows at least one promoted/superseded doc badge
  *
- * ── Probed live against http://127.0.0.1:3100 / :3000 before assertions:
- *      - `/en/memory` → 307 `/memory`; unauth `/memory` → 307 `/login`
- *      - bare `GET /api/memory` (no X-Scope-Slug) returns the session Org's
- *        aggregation; a seeded brand/active doc surfaces with the full
- *        OrgMemoryDocumentItem projection (workName resolved, source=user,
- *        lastIndexedAt/consolidation null)
- *      - `POST /api/memory/consolidate {}` → dryRun report (scanned N,
- *        promoted≥1, superseded≥1 for a populated Org); `{apply:true}` stamps
- *        promoted/superseded markers (synthesis is env-adaptive: 0 with no LLM
- *        key + a MODEL_AUTHENTICATION note, so counts are asserted tolerantly)
+ * ── SCOPE CONTRACT (since 8f28edca0 — `apps/api/src/scope/session-scope.guard.ts`)
+ *      An Organization scope requires EITHER an explicit `X-Scope-Slug:
+ *      <org-slug>` header OR an `/api/<slug>/…` path. The guard deliberately
+ *      refuses to infer one from the user's mutable last-Organization
+ *      preference ("Never read the user's mutable last-Organization
+ *      preference here … This is what keeps simultaneous Ever and Yo tabs
+ *      isolated"), so an unprefixed bare-Bearer call is the PERSONAL
+ *      contract. Two consequences shape this file:
+ *        - Seeding sends `X-Scope-Slug` (see `orgScopedHeaders` in
+ *          `helpers/api.ts`). Without it the Work + KB docs are stamped
+ *          `organizationId: null` and Memory can never see them.
+ *        - The browser must be on `/org/<slug>/memory`. `apps/web/src/proxy.ts`
+ *          stamps `x-ever-workspace` from `parseWorkspacePath(pathname)` and
+ *          `lib/api/server-api.ts` turns that into `X-Scope-Slug` on the SSR
+ *          fetch; an unprefixed `/memory` is `personal`, and
+ *          `OrgMemoryController.getMemory` early-returns the EMPTY aggregation
+ *          with HTTP 200 when no Organization resolves — so an unprefixed
+ *          journey renders zero rows instead of failing loudly.
+ *
+ * ── KNOWN PRODUCT GAP — the interactive assertions below
+ *      SSR is Organization-scoped, but the shell's client-side re-query
+ *      (`MemoryShell.runFetch`) and the Consolidate POST go to the
+ *      same-origin BFF routes `apps/web/src/app/api/memory/route.ts` and
+ *      `apps/web/src/app/api/memory/consolidate/route.ts`. Both forward a
+ *      bare Bearer with NO scope header — neither calls
+ *      `applyBffWorkspaceScope` the way `app/api/organizations/route.ts`
+ *      does, and `MemoryShell` uses raw `fetch` rather than
+ *      `lib/api/browser-api.ts`'s `browserApiFetch`. So the first search
+ *      keystroke / chip click / Consolidate lands in PERSONAL scope and
+ *      empties the feed. The chip / search / consolidation assertions below
+ *      are the correct Organization behaviour and are left asserting it —
+ *      they stay RED until the product is fixed; do NOT "repair" them by
+ *      loosening what they check or by moving them back to `/memory`.
+ *      The gap is the whole `app/api/memory/*` BFF subtree, not just those
+ *      two routes: none of `files/*`, `health`, `review` (incl. the accept
+ *      / reject WRITES), `uploads` or `consolidation/settings` forwards the
+ *      scope either — only 10 of the 78 BFF route files under `app/api`
+ *      call `applyBffWorkspaceScope` at all.
  *
  * Seeding uses the shared `loadSeededTestUser()` creds (written by
  * global-setup) so the API-seeded Work is owned by the SAME account whose
@@ -65,14 +94,25 @@ interface SeededDoc {
 // Populated once in beforeAll; consumed by the seeded-content tests.
 let seedOk = false;
 let seedError = '';
+let orgSlug = '';
 let workId = '';
 let workName = '';
 let brandDoc: SeededDoc; // class brand / active — title token "alpha"
 let personaDoc: SeededDoc; // class personas / active — title token "bravo"
 let legalDoc: SeededDoc; // class legal / draft — title token "charlie"
 
-function authHeaders(token: string): Record<string, string> {
-    return { authorization: `Bearer ${token}`, 'content-type': 'application/json' };
+/** Auth only — for the Organization endpoints, which key off the user id. */
+function jsonAuthHeaders(token: string): Record<string, string> {
+    return { ...authedHeaders(token), 'content-type': 'application/json' };
+}
+
+/**
+ * Auth + the `X-Scope-Slug` pin at `orgSlug`. Every seed write goes through
+ * this: without the pin the row is stamped `organizationId: null` and the
+ * Organization-scoped Memory page can never read it back.
+ */
+function jsonOrgHeaders(token: string): Record<string, string> {
+    return { ...orgScopedHeaders(token, orgSlug), 'content-type': 'application/json' };
 }
 
 async function createDoc(
@@ -81,7 +121,7 @@ async function createDoc(
 ): Promise<SeededDoc> {
     const res = await fetch(`${API_BASE}/api/works/${workId}/kb/documents`, {
         method: 'POST',
-        headers: authHeaders(token),
+        headers: jsonOrgHeaders(token),
         body: JSON.stringify({
             path: input.path,
             title: input.title,
@@ -99,10 +139,14 @@ async function createDoc(
 }
 
 /**
- * Seed the session user's active Org with a Work + a spread of KB docs so
- * the page has deterministic rows to render, filter, and consolidate. Uses a
- * bare Bearer token with NO scope header — verified live to land in the same
- * active Org the BFF proxy (and therefore the page) reads.
+ * Seed ONE Organization of the session user with a Work + a spread of KB docs
+ * so the page has deterministic rows to render, filter, and consolidate.
+ *
+ * Every write is pinned with `X-Scope-Slug: <orgSlug>` and the browser is then
+ * pointed at `/org/<orgSlug>/memory`, so seed and page agree on exactly one
+ * Organization. `GET`/`POST /api/organizations` are the two calls that stay
+ * bare-Bearer on purpose: both resolve from the user id (`listForUser` /
+ * `createOrganization`), not from the request scope.
  */
 test.beforeAll(async () => {
     test.setTimeout(120_000);
@@ -118,27 +162,33 @@ test.beforeAll(async () => {
         }
         const token = ((await loginRes.json()) as { access_token: string }).access_token;
 
-        // Ensure the account has an active Org (global-setup lazy-creates one;
-        // be defensive in case a bespoke env skipped it).
+        // Resolve the Organization slug to pin every seed write (and the page
+        // URL) to. global-setup lazy-creates one; be defensive in case a
+        // bespoke env skipped it.
         const orgsRes = await fetch(`${API_BASE}/api/organizations`, {
-            headers: { authorization: `Bearer ${token}` },
+            headers: authedHeaders(token),
         });
-        const orgs = orgsRes.ok ? ((await orgsRes.json()) as unknown[]) : [];
-        if (!Array.isArray(orgs) || orgs.length === 0) {
+        const orgs = orgsRes.ok ? ((await orgsRes.json()) as { slug?: string }[]) : [];
+        orgSlug = (Array.isArray(orgs) ? (orgs[0]?.slug ?? '') : '').trim();
+        if (!orgSlug) {
             const createOrg = await fetch(`${API_BASE}/api/organizations`, {
                 method: 'POST',
-                headers: authHeaders(token),
+                headers: jsonAuthHeaders(token),
                 body: JSON.stringify({ name: `MemUI Org ${RUN}` }),
             });
             if (!createOrg.ok) {
                 throw new Error(`org create failed ${createOrg.status}: ${await createOrg.text()}`);
             }
+            orgSlug = (((await createOrg.json()) as { slug?: string }).slug ?? '').trim();
+        }
+        if (!orgSlug) {
+            throw new Error('no Organization slug resolved for the seeded test user');
         }
 
         workName = `MemUI Journey ${RUN}`;
         const wkRes = await fetch(`${API_BASE}/api/works`, {
             method: 'POST',
-            headers: authHeaders(token),
+            headers: jsonOrgHeaders(token),
             body: JSON.stringify({
                 name: workName,
                 slug: `mem-ui-journey-${RUN}`,
@@ -199,8 +249,27 @@ test.beforeAll(async () => {
     }
 });
 
+/**
+ * Land on the PERSONAL Memory route. Used by the page-chrome tests, whose
+ * assertions are scope-agnostic — the shell, heading, search box and
+ * Consolidate action all render on an empty payload, and the header count
+ * falls through to the `documentsIndexed` zero-state ("No documents
+ * indexed"). Going in unprefixed also keeps the `/en/memory` → `/memory`
+ * locale collapse under test.
+ */
 async function gotoMemory(page: Page): Promise<void> {
     await page.goto('/en/memory', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('memory-shell')).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Land on the canonical Organization Memory route. `proxy.ts` strips the
+ * `/org/<slug>` prefix for the internal App Router match and stamps
+ * `x-ever-workspace: org:<slug>`, which `serverFetch` forwards to the API as
+ * `X-Scope-Slug` — the only way the SSR aggregation sees the seeded rows.
+ */
+async function gotoOrgMemory(page: Page): Promise<void> {
+    await page.goto(`/org/${orgSlug}/memory`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('memory-shell')).toBeVisible({ timeout: 30_000 });
 }
 
@@ -317,7 +386,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     test('a seeded KB doc surfaces as a row with its title', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         const row = page.getByTestId(`memory-doc-${brandDoc.id}`);
         await expect(row).toBeVisible({ timeout: 15_000 });
         await expect(row).toContainText(`MemUI Brand ${RUN} alpha`);
@@ -326,7 +395,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     test('a seeded doc row shows its class chip and links to the source Work', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         const row = page.getByTestId(`memory-doc-${brandDoc.id}`);
         await expect(row).toBeVisible({ timeout: 15_000 });
         // Class chip carries the exact class text (rendered lowercase in the
@@ -343,7 +412,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
 
         const typeBrand = page.getByTestId('memory-filter-chip-type:brand');
         await expect(typeBrand).toBeVisible({ timeout: 15_000 });
@@ -365,7 +434,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     test('clicking a Type chip flips aria-pressed and narrows the feed', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
 
         const brandRow = page.getByTestId(`memory-doc-${brandDoc.id}`);
         const legalRow = page.getByTestId(`memory-doc-${legalDoc.id}`);
@@ -384,7 +453,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     test('multi-selecting two Type chips is OR within the facet', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
 
         const brandRow = page.getByTestId(`memory-doc-${brandDoc.id}`);
         const personaRow = page.getByTestId(`memory-doc-${personaDoc.id}`);
@@ -403,7 +472,7 @@ test.describe('Org Memory UI — seeded documents & facets', () => {
     test('"Clear all" restores the full feed and un-presses the chips', async ({ page }) => {
         test.setTimeout(90_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
 
         const brandRow = page.getByTestId(`memory-doc-${brandDoc.id}`);
         const legalRow = page.getByTestId(`memory-doc-${legalDoc.id}`);
@@ -438,7 +507,7 @@ test.describe('Org Memory UI — search', () => {
     test('typing a title token narrows the feed to the matching seeded doc', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
 
         const brandRow = page.getByTestId(`memory-doc-${brandDoc.id}`);
         const legalRow = page.getByTestId(`memory-doc-${legalDoc.id}`);
@@ -457,7 +526,7 @@ test.describe('Org Memory UI — search', () => {
     test('a no-match query renders the real "no results" empty-state', async ({ page }) => {
         test.setTimeout(60_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         await expect(page.getByTestId(`memory-doc-${brandDoc.id}`)).toBeVisible({
             timeout: 15_000,
         });
@@ -477,7 +546,7 @@ test.describe('Org Memory UI — consolidation', () => {
     test('Consolidate opens the dry-run confirm panel and Cancel closes it', async ({ page }) => {
         test.setTimeout(90_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         await expect(page.getByTestId(`memory-doc-${brandDoc.id}`)).toBeVisible({
             timeout: 15_000,
         });
@@ -511,7 +580,7 @@ test.describe('Org Memory UI — consolidation', () => {
     test('Applying the consolidation swaps in the applied summary', async ({ page }) => {
         test.setTimeout(90_000);
         requireSeed();
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         await expect(page.getByTestId(`memory-doc-${brandDoc.id}`)).toBeVisible({
             timeout: 15_000,
         });
@@ -543,7 +612,7 @@ test.describe('Org Memory UI — consolidation', () => {
         // The previous test applied consolidation to this Org (near-duplicate
         // research pair guarantees markers). A fresh load re-reads the feed
         // with the persisted promoted/superseded markers.
-        await gotoMemory(page);
+        await gotoOrgMemory(page);
         await expect(page.getByTestId(`memory-doc-${brandDoc.id}`)).toBeVisible({
             timeout: 15_000,
         });

--- a/apps/web/e2e/flow-multi-tenant-isolation.spec.ts
+++ b/apps/web/e2e/flow-multi-tenant-isolation.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from './helpers/api';
+import {
+    API_BASE,
+    authedHeaders,
+    orgScopedHeaders,
+    registerUserViaAPI,
+    createWorkViaAPI,
+} from './helpers/api';
 import { createOrganizationViaAPI } from './helpers/organizations';
 import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
 
@@ -49,10 +55,20 @@ import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
  *     - A fresh user's works/tasks are born tenantId:null, organizationId:null.
  *     - Creating the user's FIRST organization lazily mints a Tenant. Minting
  *       RETROACTIVELY backfills that tenantId onto the user's pre-existing
- *       scoped rows (work + task) — but leaves their organizationId null (the
- *       org becomes the active scope only for NEW writes, not a retro member).
- *     - Every subsequent scoped write (work, task) is auto-stamped with that
- *       org's tenantId AND organizationId.
+ *       scoped rows (work + task) — but leaves their organizationId null: the
+ *       backfill covers tenantId only, nothing is retro-joined to an Org.
+ *     - Every subsequent scoped write inherits the SCOPE OF THE REQUEST, and
+ *       an unprefixed bare-Bearer call is the PERSONAL contract — tenantId
+ *       stamped, organizationId null. To land a row inside an Organization the
+ *       write must carry that Org's scope explicitly, via `X-Scope-Slug:
+ *       <org-slug>` (see `orgScopedHeaders`) or an `/api/<slug>/…` path. The
+ *       API deliberately refuses to infer one from the user's last-active
+ *       Organization — that refusal is what keeps two tabs on different Orgs
+ *       isolated. See `apps/api/src/scope/session-scope.guard.ts`.
+ *     - Reads follow the same rule: `TasksService.getOne` filters by the active
+ *       scope (`ownershipScopeMatches`), so an Org-stamped Task is a 404 to a
+ *       bare-Bearer read. `GET /api/works/:id` is owner-gated rather than
+ *       scope-filtered, but is still read here under the Org it belongs to.
  *     - A user has exactly ONE Tenant: a 2nd org reuses the same tenantId.
  *     - Two distinct users get two distinct tenantIds.
  *
@@ -60,6 +76,14 @@ import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
  * registerUserViaAPI() users (never the shared seeded user) so the in-memory
  * DB stays clean for other specs, and list assertions tolerate pre-existing
  * rows (toContain / not.toContain on ids), never exact global counts.
+ *
+ * Scope discipline: most requests here are bare-Bearer ON PURPOSE. Flows 1
+ * and 2 prove that per-USER ownership holds inside one shared personal scope
+ * (two users, identical request shape, neither sees the other's rows), and
+ * flow 3's pre-tenant and post-backfill probes are personal-scope reads by
+ * definition. Only the writes/reads whose subject IS Organization membership
+ * carry `X-Scope-Slug`. Do not add scope headers to the rest: it would swap
+ * the isolation boundary under test for a different one.
  *
  * Filename uses the safe `flow-` prefix (NOT matched by the no-auth testIgnore
  * regex in playwright.config.ts) and is fully API-orchestrated, so it does not
@@ -88,6 +112,37 @@ async function createMission(
     expect(body.id).toMatch(UUID_RE);
     expect(body.status).toBe('active');
     return body.id as string;
+}
+
+/**
+ * Create a Work that lands INSIDE the given Organization.
+ *
+ * The shared `createWorkViaAPI` helper sends a bare Bearer, which is the
+ * personal contract — the row would be stamped `organizationId: null`. An
+ * Organization write has to name its Org, so this posts the identical body
+ * with {@link orgScopedHeaders}. Same shape as the sibling org-scoped create
+ * in `flow-kb-lifecycle-consolidate-memory-chain.spec.ts`.
+ */
+async function createWorkInOrgViaAPI(
+    request: APIRequestContext,
+    token: string,
+    orgSlug: string,
+    payload: { name: string; slug: string },
+): Promise<string> {
+    const res = await request.post(`${API_BASE}/api/works`, {
+        headers: orgScopedHeaders(token, orgSlug),
+        data: {
+            name: payload.name,
+            slug: payload.slug,
+            description: `e2e ${payload.name}`,
+            organization: false,
+        },
+    });
+    expect(res.status(), `org-scoped work create body=${await res.text()}`).toBe(200);
+    const body = await res.json();
+    const id = body?.work?.id ?? body?.id ?? '';
+    expect(id).toMatch(UUID_RE);
+    return id as string;
 }
 
 /** GET /api/works and return the parsed page (status:'success', works:[…]). */
@@ -141,7 +196,11 @@ async function buildTenant(request: APIRequestContext, label: string): Promise<T
     const token = user.access_token;
     const s = stamp();
 
-    // First org → lazily mints the Tenant and makes it the active scope.
+    // First org → lazily mints the Tenant. It does NOT become the ambient
+    // scope: every write below is bare-Bearer, i.e. the PERSONAL contract
+    // (tenantId stamped, organizationId null), which is exactly the shared
+    // scope this test wants both users in so the boundary it proves is
+    // per-USER ownership rather than per-Organization partitioning.
     const org = await createOrganizationViaAPI(request, token, `${label} Org ${s}`);
     expect(org.tenantId).toMatch(UUID_RE);
 
@@ -328,26 +387,41 @@ test.describe('Multi-tenant isolation (deep)', () => {
         const tenantId = org.tenantId;
         expect(tenantId).toMatch(UUID_RE);
 
-        // ── 3. POST-tenant scoped writes are auto-stamped with tenantId +
-        //       organizationId (the active scope). Probed: BOTH works AND
-        //       tasks expose these fields and carry the org's tenant. ───────
-        const { id: postWorkId } = await createWorkViaAPI(request, token, {
+        // ── 3. A write that CARRIES the org's scope is auto-stamped with that
+        //       org's tenantId + organizationId. The scope must be explicit —
+        //       `X-Scope-Slug: <org-slug>` — because a bare-Bearer call is the
+        //       personal contract and would stamp organizationId:null. Probed:
+        //       BOTH works AND tasks expose these fields. ──────────────────
+        const orgHeaders = orgScopedHeaders(token, org.slug);
+        const postWorkId = await createWorkInOrgViaAPI(request, token, org.slug, {
             name: `Post Work ${s}`,
             slug: `post-work-${s}`,
         });
-        const postTask = await createTaskViaAPI(request, token, { title: `Post Task ${s}` });
+        const postTask = await createTaskViaAPI(
+            request,
+            token,
+            { title: `Post Task ${s}` },
+            org.slug,
+        );
 
-        // Read each back via GET-by-id and assert tenant consistency.
+        // Read each back via GET-by-id — under the SAME org scope they were
+        // written in. `TasksService.getOne` filters by the active scope, so an
+        // org-stamped Task is a deliberate 404 to a bare-Bearer read.
         const postWorkBody = await (
-            await request.get(`${API_BASE}/api/works/${postWorkId}`, { headers })
+            await request.get(`${API_BASE}/api/works/${postWorkId}`, { headers: orgHeaders })
         ).json();
         const postWork = postWorkBody.work ?? postWorkBody;
         expect(postWork.tenantId).toBe(tenantId);
         expect(postWork.organizationId).toBe(org.id);
 
-        const postTaskBody = await (
-            await request.get(`${API_BASE}/api/tasks/${postTask.id}`, { headers })
-        ).json();
+        const postTaskRead = await request.get(`${API_BASE}/api/tasks/${postTask.id}`, {
+            headers: orgHeaders,
+        });
+        expect(
+            postTaskRead.status(),
+            `org-scoped task read body=${await postTaskRead.text().catch(() => '')}`,
+        ).toBe(200);
+        const postTaskBody = await postTaskRead.json();
         expect(postTaskBody.tenantId).toBe(tenantId);
         expect(postTaskBody.organizationId).toBe(org.id);
 
@@ -369,8 +443,10 @@ test.describe('Multi-tenant isolation (deep)', () => {
         // ── 5. Minting the tenant RETROACTIVELY backfills tenantId onto the
         //       user's pre-existing work (probed) so the whole tenant shares
         //       ONE namespace — but organizationId stays null on that earlier
-        //       row (the org is the active scope for NEW writes, not a retro
-        //       membership). This is the truthful, probed behavior. ─────────
+        //       row: the backfill covers tenantId only, and a row joins an
+        //       Organization solely when the write itself carried that org's
+        //       scope. Read back bare-Bearer ON PURPOSE — the personal scope
+        //       is exactly where an organizationId:null row belongs. ────────
         const preWorkAfter = await (
             await request.get(`${API_BASE}/api/works/${preWorkId}`, { headers })
         ).json();

--- a/apps/web/e2e/flow-org-upgrade-from-account.spec.ts
+++ b/apps/web/e2e/flow-org-upgrade-from-account.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+import {
+    API_BASE,
+    authedHeaders,
+    createWorkViaAPI,
+    orgScopedHeaders,
+    registerUserViaAPI,
+} from './helpers/api';
 import { createOrganizationViaAPI, listOrganizationsViaAPI } from './helpers/organizations';
 import { createTaskViaAPI } from './helpers/agents-tasks';
 
@@ -74,6 +80,21 @@ import { createTaskViaAPI } from './helpers/agents-tasks';
  *    org). Every flow asserts a deterministic, driver-stable status
  *    (2xx/409/404/400/401).
  *
+ * ── SCOPE CONTRACT (since 8f28edca0): an unprefixed bare-Bearer request runs in
+ *    the PERSONAL scope. `SessionScopeGuard` deliberately refuses to infer an
+ *    Organization from the user's mutable last-Organization preference, so an
+ *    Organization scope needs an explicit `X-Scope-Slug: <org-slug>` header (or
+ *    an `/api/<slug>/…` path). `TasksService.getOne` then matches the row through
+ *    `ownershipScopeMatches`, which in personal scope requires
+ *    `organizationId IS NULL`. Consequences for the reads below:
+ *      - Pre-upgrade reads stay BARE on purpose: those rows really are personal
+ *        (tenantId stamped at most), and asserting that is the point.
+ *      - register-company (flow 2) stamps tenantId ONLY — organizationId stays
+ *        null — so its follow-up read is correctly bare too.
+ *      - The read AFTER `upgrade-from-account` (flow 5) is the one row that has
+ *        just been stamped `organizationId = org.id`, so it MUST carry the org
+ *        scope; a bare-Bearer GET there 404s ("Task … not found.").
+ *
  * Cross-spec isolation: every flow runs on a FRESH registerUserViaAPI() user
  * (Date.now()-unique) so the shared in-memory DB stays clean for sibling specs;
  * the seeded storageState user is never mutated. Counts use toContain, never
@@ -108,10 +129,22 @@ async function upgradeRaw(request: APIRequestContext, token: string | undefined,
     });
 }
 
-/** GET /api/tasks/:id (returns the bare task row; tenantId/organizationId are exposed). */
-async function getTask(request: APIRequestContext, token: string, taskId: string) {
+/**
+ * GET /api/tasks/:id (returns the bare task row; tenantId/organizationId are exposed).
+ *
+ * Pass `orgSlug` to read inside an Organization — required for any row whose
+ * `organizationId` is stamped, because a bare-Bearer GET runs in the personal
+ * scope and `TasksService.getOne` 404s such a row there. Omit it while the row
+ * is still unstamped: that bare read IS the personal contract, not an oversight.
+ */
+async function getTask(
+    request: APIRequestContext,
+    token: string,
+    taskId: string,
+    orgSlug?: string,
+) {
     const res = await request.get(`${API_BASE}/api/tasks/${taskId}`, {
-        headers: authedHeaders(token),
+        headers: orgSlug ? orgScopedHeaders(token, orgSlug) : authedHeaders(token),
     });
     expect(res.status(), `getTask body=${await res.text().catch(() => '')}`).toBe(200);
     return res.json();
@@ -200,7 +233,9 @@ test.describe('Organization register-company — registered Company path mints t
 
         // 3. The task's tenantId is now the company's tenantId; organizationId
         //    STAYS null (the backfill stamps tenantId only — pulling rows into the
-        //    org is a SEPARATE upgrade-from-account step, see flow 5/6).
+        //    org is a SEPARATE upgrade-from-account step, see flow 5/6). The read
+        //    is therefore BARE by design: the row is still personal, and the
+        //    personal scope is exactly where it has to remain visible.
         const afterTask = await getTask(request, token, task.id);
         expect(afterTask.tenantId, 'register-company backfilled the task tenantId').toBe(
             org.tenantId,
@@ -337,12 +372,16 @@ test.describe('Organization upgrade-from-account — first-org guard + driver-co
         //    "ready to upgrade" pre-state the endpoint expects.
         const org = await createOrganizationViaAPI(request, token, `Upgrade Org ${s}`);
         expect(org.tenantId).toMatch(UUID_RE);
+        // The post-upgrade read below resolves its scope through this slug.
+        expect(org.slug, 'the org must have a slug to scope reads with').toBeTruthy();
         const { id: workId } = await createWorkViaAPI(request, token, {
             name: `Upgrade Work ${s}`,
             slug: `upgrade-work-${s}`,
         });
         expect(workId).toMatch(UUID_RE);
 
+        // Deliberately a BARE read: createOrganization stamps tenantId only, so
+        // the row is still personal and must be visible in the personal scope.
         const preUpgradeTask = await getTask(request, token, task.id);
         expect(preUpgradeTask.tenantId, 'createOrg backfilled tenantId').toBe(org.tenantId);
         expect(preUpgradeTask.organizationId, 'but NOT yet pulled into the org').toBeNull();
@@ -369,7 +408,9 @@ test.describe('Organization upgrade-from-account — first-org guard + driver-co
 
         // The task is now pulled INTO the org (organizationId stamped) while its
         // tenantId is unchanged — the migration ran end-to-end under sqlite.
-        const afterTask = await getTask(request, token, task.id);
+        // This read carries the Organization scope: the row is no longer personal,
+        // and a bare-Bearer GET would 404 it rather than show the migrated stamp.
+        const afterTask = await getTask(request, token, task.id, org.slug);
         expect(afterTask.organizationId, 'upgrade pulled the task into the org').toBe(org.id);
         expect(afterTask.tenantId, 'tenantId unchanged by the upgrade').toBe(org.tenantId);
 

--- a/apps/web/e2e/flow-org-vision-company-import-chain.spec.ts
+++ b/apps/web/e2e/flow-org-vision-company-import-chain.spec.ts
@@ -52,7 +52,16 @@
  *   GET  /api/organizations/:id/teams | /:id/teams/:tid | /:id/teams/:tid/members
  *      | /:id/org-chart                           → 200 for the OWNER,
  *      404-not-leak for a non-owner (OrganizationOwnershipGuard).
- *   GET  /api/agents                              → 200 {data:[…]} tenant-wide.
+ *   GET  /api/agents                              → 200 {data:[…]} filtered by
+ *      the REQUEST scope, NOT tenant-wide. The importer materializes every
+ *      agent inside `ScopeContextService.runWith({tenantId, organizationId})`,
+ *      so the rows are Organization-stamped; an unprefixed bare-Bearer read is
+ *      the PERSONAL contract (`organizationId IS NULL`) and returns none of
+ *      them — 200 with an EMPTY `data`, never an error. The verification read
+ *      therefore carries `X-Scope-Slug: <imported-org-slug>` via
+ *      `orgScopedHeaders`. The org-NESTED endpoints above are unaffected: they
+ *      resolve off the `:orgId` path + OrganizationOwnershipGuard and never
+ *      consult the ambient scope.
  *
  * Env-adaptive: the catalog is fetched over the network from ever-works/orgs;
  * an env that can't reach it returns `[]` (wizard skips its step) and every
@@ -68,7 +77,7 @@
  * testMatch/testIgnore regexes; contends on no shared UI state.
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { API_BASE, authedHeaders, orgScopedHeaders, registerUserViaAPI } from './helpers/api';
 
 const ORGS_BASE = `${API_BASE}/api/organizations`;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -691,8 +700,16 @@ test.describe('Vision × Import chain — materialized structure asserted with t
 
         await patchOrgOk(request, token, orgId, { vision: `Agent-staffed vision ${s}` });
 
-        // This fresh user's tenant holds exactly this one import's agents.
-        const res = await request.get(`${API_BASE}/api/agents`, { headers: authedHeaders(token) });
+        // The importer materializes agents inside
+        // `ScopeContextService.runWith({tenantId, organizationId: <new org>})`,
+        // so every row is stamped with THIS org. `GET /api/agents` filters by
+        // the request scope, and an unprefixed bare-Bearer call is the PERSONAL
+        // contract (`organizationId IS NULL`) — it would 200 with an EMPTY list.
+        // Pin the read to the imported org, where this run's agents live and
+        // where this fresh user's tenant holds exactly this one import's agents.
+        const res = await request.get(`${API_BASE}/api/agents`, {
+            headers: orgScopedHeaders(token, report.organization.slug),
+        });
         expect(res.status()).toBe(200);
         const agents = (await res.json()).data as Array<{
             scope: string;

--- a/apps/web/e2e/flow-task-scope-linkage.spec.ts
+++ b/apps/web/e2e/flow-task-scope-linkage.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from './helpers/api';
+import {
+    API_BASE,
+    authedHeaders,
+    orgScopedHeaders,
+    registerUserViaAPI,
+    createWorkViaAPI,
+} from './helpers/api';
 import { createTaskViaAPI } from './helpers/agents-tasks';
 import { createOrganizationViaAPI } from './helpers/organizations';
 import { loadSeededTestUser } from './helpers/seeded-test-user';
@@ -34,6 +40,9 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *       user-scoped first; the scope filter narrows within the caller's own
  *       Tasks. An orphan (unscoped) Task appears in NONE of the three.
  *       An unknown scope id → 200 with an empty page (never 4xx/5xx).
+ *       The list is additionally filtered by the REQUEST's active scope
+ *       (personal vs Organization) and drops rows whose referenced Work is
+ *       unreachable in it — see the tenant-stamping section below.
  *   PATCH /api/tasks/:id                                              → 200
  *       `UpdateTaskDto` whitelists the six owner keys alongside the mutable
  *       fields, so owners are RE-FILEABLE: one PATCH may detach an owner
@@ -49,12 +58,26 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *     - A fresh user's Tasks are born tenantId:null, organizationId:null.
  *     - Creating the user's FIRST org lazily mints a Tenant and
  *       RETROACTIVELY backfills that tenantId onto the user's pre-existing
- *       Task rows — but leaves their organizationId null (the org is the
- *       active scope for NEW writes, not a retro membership). [The isolation
- *       spec only verified this backfill for WORKS; here we pin it for the
- *       TASK row, and additionally for a SCOPE-linked task.]
- *     - Every subsequent scoped write carries the org's tenantId AND
- *       organizationId SIMULTANEOUSLY with its own missionId/ideaId/workId.
+ *       Task rows — but leaves their organizationId null: the backfill covers
+ *       tenantId only, and nothing is retro-joined to an Organization. [The
+ *       isolation spec only verified this backfill for WORKS; here we pin it
+ *       for the TASK row, and additionally for a SCOPE-linked task.]
+ *     - A later write lands INSIDE the Organization only when the REQUEST
+ *       carries that Org's scope — `X-Scope-Slug: <org-slug>` (see
+ *       `orgScopedHeaders`) or an `/api/<slug>/…` path. An unprefixed
+ *       bare-Bearer call is the PERSONAL contract: tenantId stamped,
+ *       organizationId null. The API deliberately refuses to infer the scope
+ *       from the user's last-active Organization preference, and that refusal
+ *       is what keeps two tabs on different Orgs isolated. See
+ *       `apps/api/src/scope/session-scope.guard.ts`.
+ *     - An org-scoped write carries the org's tenantId AND organizationId
+ *       SIMULTANEOUSLY with its own missionId/ideaId/workId.
+ *     - Scope linkage and request scope must AGREE: `TasksService.getOne`
+ *       (and the list's `filterTasksByReachableWork`) re-checks the referenced
+ *       Work against the active scope, and `assertScopeReachable` does the
+ *       same at create time via `ownershipScopeMatches`. So a Work-scoped Task
+ *       inside an Organization requires its Work to live in that same
+ *       Organization, and both are written and read under that Org's scope.
  *
  * AI/build/research linkage (Idea→Mission auto-link, agent dispatch) needs a
  * provider + Trigger.dev — absent on the e2e stack — so it is out of scope.
@@ -125,14 +148,52 @@ async function createIdea(
     return (await res.json()).id;
 }
 
-/** Page through the full task list filtered by one scope param; return ids. */
+/**
+ * Create a Work that lands INSIDE the given Organization.
+ *
+ * The shared `createWorkViaAPI` helper sends a bare Bearer, which is the
+ * personal contract — the row would be stamped `organizationId: null`. An
+ * Organization write has to name its Org, so this posts the identical body
+ * with {@link orgScopedHeaders}. Same shape as the sibling org-scoped create
+ * in `flow-multi-tenant-isolation.spec.ts`.
+ */
+async function createWorkInOrgViaAPI(
+    request: APIRequestContext,
+    token: string,
+    orgSlug: string,
+    payload: { name: string; slug: string },
+): Promise<string> {
+    const res = await request.post(`${API_BASE}/api/works`, {
+        headers: orgScopedHeaders(token, orgSlug),
+        data: {
+            name: payload.name,
+            slug: payload.slug,
+            description: `e2e ${payload.name}`,
+            organization: false,
+        },
+    });
+    expect(res.status(), `org-scoped work create body=${await res.text()}`).toBe(200);
+    const body = await res.json();
+    const id = body?.work?.id ?? body?.id ?? '';
+    expect(id).toMatch(UUID_RE);
+    return id as string;
+}
+
+/**
+ * Page through the full task list filtered by one scope param; return ids.
+ *
+ * `scopeSlug` pins the request to an Organization (`X-Scope-Slug`); omitting it
+ * is the PERSONAL contract, which is what every pre-org test below wants. An
+ * Organization-stamped Task is deliberately invisible to the personal list.
+ */
 async function listTaskIds(
     request: APIRequestContext,
     token: string,
     query: string,
+    scopeSlug?: string,
 ): Promise<{ ids: string[]; total: number }> {
     const res = await request.get(`${API_BASE}/api/tasks?${query}`, {
-        headers: authedHeaders(token),
+        headers: scopeSlug ? orgScopedHeaders(token, scopeSlug) : authedHeaders(token),
     });
     expect(res.status(), `list ${query} body=${await res.text().catch(() => '')}`).toBe(200);
     const body = await res.json();
@@ -501,33 +562,57 @@ test.describe('Task ↔ scope linkage (Mission / Idea / Work)', () => {
         expect(preAfter.workId).toBe(preWorkId); // scope preserved through backfill
 
         // ── POST-org: a NEW work + a work-scoped Task carry the org's tenant
-        //    AND organizationId SIMULTANEOUSLY with their own scope id. ─────
-        const { id: postWorkId } = await createWorkViaAPI(request, token, {
+        //    AND organizationId SIMULTANEOUSLY with their own scope id.
+        //
+        //    Both writes must NAME the org: an unprefixed bare-Bearer call is
+        //    the personal contract and would stamp organizationId:null. The
+        //    Work is org-scoped too because scope linkage and request scope
+        //    have to agree — `assertScopeReachable` re-checks the referenced
+        //    Work through `ownershipScopeMatches`, so an org-scoped Task
+        //    pinned to a PERSONAL Work is a 400 "Work <id> not found." ──────
+        const orgHeaders = orgScopedHeaders(token, org.slug);
+        const postWorkId = await createWorkInOrgViaAPI(request, token, org.slug, {
             name: `Post Work ${s}`,
             slug: `post-work-${s}`,
         });
-        const postScopedTask = await createTaskViaAPI(request, token, {
-            title: `Post-org scoped ${s}`,
-            workId: postWorkId,
-        });
+        const postScopedTask = await createTaskViaAPI(
+            request,
+            token,
+            {
+                title: `Post-org scoped ${s}`,
+                workId: postWorkId,
+            },
+            org.slug,
+        );
         expect(asScoped(postScopedTask).tenantId).toBe(tenantId);
         expect(asScoped(postScopedTask).organizationId).toBe(org.id);
         expect(asScoped(postScopedTask).workId).toBe(postWorkId);
 
         // tenantId is one shared namespace across the org row, the work, and
-        // both scoped tasks.
+        // both scoped tasks. Read the work back under the SAME org scope it
+        // was written in.
         const postWorkBody = await (
-            await request.get(`${API_BASE}/api/works/${postWorkId}`, { headers })
+            await request.get(`${API_BASE}/api/works/${postWorkId}`, { headers: orgHeaders })
         ).json();
         const postWork = postWorkBody.work ?? postWorkBody;
+        expect(postWork.organizationId).toBe(org.id);
         expect(
             new Set([org.tenantId, postWork.tenantId, asScoped(postScopedTask).tenantId]).size,
         ).toBe(1);
 
         // The work filter still finds the post-org scoped task even though it
         // is now tenant+org-stamped — stamping is orthogonal to scope linkage.
-        const byPostWork = await listTaskIds(request, token, `workId=${postWorkId}`);
+        // The list is scope-filtered like every other read, so it runs under
+        // the org the row belongs to.
+        const byPostWork = await listTaskIds(request, token, `workId=${postWorkId}`, org.slug);
         expect(byPostWork.ids).toContain(postScopedTask.id);
+
+        // …and the SAME filter under the personal scope returns nothing: an
+        // Organization row is invisible to a bare-Bearer call. That isolation
+        // is the point of the explicit-scope contract, so pin it here rather
+        // than leaving the org read as the only evidence.
+        const byPostWorkPersonal = await listTaskIds(request, token, `workId=${postWorkId}`);
+        expect(byPostWorkPersonal.ids).not.toContain(postScopedTask.id);
     });
 
     test('UI: a Work-scoped Task renders on the work /tasks tab (filtered by workId)', async ({

--- a/apps/web/e2e/helpers/api.ts
+++ b/apps/web/e2e/helpers/api.ts
@@ -82,9 +82,30 @@ export async function loginViaAPI(
 
 /**
  * Authenticated GET request shortcut.
+ *
+ * This carries NO scope header, which since 8f28edca0 means the request runs in
+ * the PERSONAL scope — that is the contract for an unprefixed bare-Bearer call,
+ * not an oversight. Reads will not see Organization-stamped rows and writes land
+ * unstamped. When a request is meant to act inside an Organization, use
+ * {@link orgScopedHeaders} instead of adding a header at the call site.
  */
 export function authedHeaders(token: string): { Authorization: string } {
     return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Authenticated request headers bound to an Organization scope.
+ *
+ * An Organization scope requires either this explicit `X-Scope-Slug` header or an
+ * `/api/<slug>/…` path; the API deliberately refuses to infer one from the user's
+ * last-active Organization, which is what keeps two tabs on different Orgs
+ * isolated. See `apps/api/src/scope/session-scope.guard.ts`.
+ */
+export function orgScopedHeaders(
+    token: string,
+    orgSlug: string,
+): { Authorization: string; 'X-Scope-Slug': string } {
+    return { ...authedHeaders(token), 'X-Scope-Slug': orgSlug };
 }
 
 /**


### PR DESCRIPTION
The bulk of EW-784. Third of three: [#2335](https://github.com/ever-works/ever-works/pull/2335)
fixes the production defect the red gate was hiding, [#2336](https://github.com/ever-works/ever-works/pull/2336)
covers the smaller stale-contract groups, this one covers the scope group.

## The contract that moved

`8f28edca0` (2026-08-23) deleted the `lastScopeOrganizationId` seeding from
`session-scope.guard.ts`. An Organization scope now comes **only** from an explicit
`X-Scope-Slug` header or an `/api/<slug>/…` path. The guard says why:

> An unprefixed request is the personal route contract. Never read the user's mutable
> last-Organization preference here … This is what keeps simultaneous Ever and Yo tabs
> isolated.

That is right, and it is not what these specs assumed. They sent a bare Bearer while
asserting Organization behaviour, so reads saw none of the org-stamped rows and writes
landed unstamped. The reads are the confusing half: the handlers early-return an **empty
payload with HTTP 200**, which is why the failures read `Expected: 1, Received: 0` rather
than surfacing a status.

## What changed

`orgScopedHeaders(token, orgSlug)` added to `e2e/helpers/api.ts`, promoting a pattern 14
spec files already hand-rolled. `authedHeaders` now documents that carrying no scope
header *means* personal scope rather than meaning nothing.

Six specs updated. Each agent had to prove from source that the behaviour was deliberate
before editing, and an independent auditor then read the whole diff looking specifically
for scope headers added where a test was probing the personal contract.

## What was deliberately left alone

**Both isolation flows in `flow-multi-tenant-isolation` are byte-for-byte untouched.**
They prove per-user ownership inside one shared personal scope, with attacker and owner
using the identical request shape. Adding a scope header there would have turned a real
isolation proof into a tautology that passes for the wrong reason. Only flow 3, a
single-user tenant-stamping probe with no isolation claim, gained the scope.

Also untouched: requests that deliberately probe the personal contract, the no-auth
401 probe, and the two failures that are real behaviour changes rather than stale tests
(EW-785).

## Two tests were strengthened, not merely repaired

- The zero-documents memory test **previously passed for the wrong reason** — the
  personal-scope early return emits the same zeros a genuinely empty org does. It now
  also asserts the no-org note is absent, which is the only signal that distinguishes
  the two.
- `flow-task-scope-linkage` gained a negative probe: the same `?workId=` filter under the
  personal scope must return nothing.

## A second production defect found on the way — not fixed here

`flow-memory-ui-journey` stays partly red on purpose, because the Org Memory UI cannot
work today:

- `apps/web/src/components/memory/MemoryShell.tsx:122` and `:185` call raw `fetch()`
  rather than `browserApiFetch`, so no `x-ever-workspace` selector is sent.
- `app/api/memory/route.ts` and `app/api/memory/consolidate/route.ts` build a fresh header
  set carrying only `Accept` and the bearer, forwarding no scope.

A viewer on `/org/<slug>/memory` gets a correctly scoped SSR render and then an **empty
feed on the first keystroke or chip click**, and Consolidate can never persist anything.
The same gap covers the write paths (`review/[docId]/accept`, `reject`, `uploads`,
`consolidation/settings`). Only **12 of 78** BFF route files call `applyBffWorkspaceScope`
at all — most legitimately, but that surface deserves an audit.

This is the same family as #2335 and the same root commit. Left unfixed here because it is
a product bug, not a test defect, and the spec asserting the correct behaviour is the
right thing to leave red until it lands. The three docblocks that stated the retired
contract as fact are corrected, since that prose is precisely what would send the next
person to add headers in the wrong place.

## Verification

- `prettier --check`: clean on all ten files.
- `npx tsc --noEmit` in `apps/web`: clean, and its `include` covers `e2e/`.
- Product code touched is **comment-only** — verified by filtering the diff to
  non-comment lines, which is empty for all three files.

**Not verified:** the suite cannot be run locally. Unproven until a stage push.

## Follow-ups noted, not done

Stale prose still asserting the retired last-active-Org seeding:
`flow-org-memory-page-deep.spec.ts` (~36 and ~68), `apps/api/src/scope/scope-context.service.ts:86`,
`apps/api/src/api.module.ts:315`, `apps/api/src/digest/digest.controller.ts:42`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how personal and organization scopes are selected for API requests.
  * Documented authorization checks and organization membership requirements.
  * Updated end-to-end test guidance to distinguish personal-scope requests from organization-scoped requests.

* **Tests**
  * Expanded coverage for organization-scoped memory, work, task, and agent operations.
  * Added validation that organization data remains isolated from personal-scope results.
  * Updated organization memory journeys and upgrade flows to verify scoped reads and writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->