### PR TITLE
docs(scope): correct docblocks still describing the retired last-active-Org seeding

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -453,6 +453,10 @@ jobs:
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
 
       - name: Sanitize branch tag for artifact names
+        # Must run even when the test step failed: the upload steps below
+        # are `if: always()`, so without this the artifacts from a FAILING
+        # run — exactly the ones someone needs — are named with an empty tag.
+        if: always()
         # GitHub Actions expressions have no `replace()` function, and
         # actions/upload-artifact rejects `/` (and other path chars) in
         # artifact names. Branch names like `session/<id>-e2e-followup`
@@ -621,6 +625,10 @@ jobs:
           E2E_PROD_BUILD: '1'
 
       - name: Sanitize branch tag for artifact names
+        # Must run even when the test step failed: the upload steps below
+        # are `if: always()`, so without this the artifacts from a FAILING
+        # run — exactly the ones someone needs — are named with an empty tag.
+        if: always()
         # Same rationale as the sharded e2e job above â€” `github.ref_name`
         # is `<PR#>/merge` on pull_request events, which actions/upload-
         # artifact rejects.

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -311,10 +311,12 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // EW-664 (Phase 12) — runs AFTER AuthSessionGuard (guard order
         // matches providers-array order) so request.user is set, and
         // BEFORE ScopeOwnershipGuard so the ownership check sees the
-        // seeded scope. Falls back to the authenticated user's default
-        // scope (their Tenant + last-active Org) on legacy un-prefixed
-        // routes where no slug resolved a scope. No-op for slug routes
-        // (scope already set) and unauthenticated requests.
+        // seeded scope. On unprefixed routes where no slug resolved a
+        // scope it seeds the authenticated user's Tenant and leaves the
+        // Organization NULL — since 8f28edca0 it deliberately does not
+        // fall back to their last-active Org, so an unprefixed request is
+        // the personal contract. No-op for slug routes (scope already set)
+        // and unauthenticated requests.
         {
             provide: APP_GUARD,
             useClass: SessionScopeGuard,

--- a/apps/api/src/digest/digest.controller.ts
+++ b/apps/api/src/digest/digest.controller.ts
@@ -37,10 +37,12 @@ import { UpdateDigestSettingsDto, type DigestSettingsResponse } from './dto/dige
  * ready-made cross-tenant activity oracle.
  *
  * The organization scope keeps the same posture. The org id is NEVER
- * read from the request; it comes from the request SCOPE CONTEXT
- * (`ScopeContextService.getOrganizationId()`), which `SessionScopeGuard`
- * seeds from the authenticated user's validated last-active Org on
- * these legacy un-prefixed routes. As defense in depth every org access
+ * read from the request BODY; it comes from the request SCOPE CONTEXT
+ * (`ScopeContextService.getOrganizationId()`), which since 8f28edca0 is
+ * populated only from an explicit `X-Scope-Slug` header or an
+ * `/api/<slug>/…` path — `SessionScopeGuard` deliberately does NOT fall
+ * back to the user's last-active Org, so an unprefixed call to this
+ * controller runs in the personal scope. As defense in depth every org access
  * is then re-authorized through the shared
  * `OrganizationMembershipService`, which 404s (never 403s) on a
  * cross-tenant mismatch so foreign org ids stay opaque. Mirrors

--- a/apps/api/src/scope/scope-context.service.ts
+++ b/apps/api/src/scope/scope-context.service.ts
@@ -81,14 +81,21 @@ export class ScopeContextService {
      * EW-664 (Tenants & Organizations Phase 12) — re-seed the active
      * scope IN PLACE within the current `runWith` frame.
      *
-     * Used by [`SessionScopeGuard`](./session-scope.guard.ts) to fall
-     * back to an authenticated user's default scope (their Tenant +
-     * last-active Org) on legacy un-prefixed routes, where the Phase 7
+     * Used by [`SessionScopeGuard`](./session-scope.guard.ts) to seed the
+     * authenticated user's Tenant — and ONLY their Tenant — on unprefixed
+     * routes, where the Phase 7
      * [`ScopeResolverMiddleware`](./scope-resolver.middleware.ts) ran
      * the request under `EMPTY_SCOPE` because no slug was present. The
      * middleware can't do this itself — it runs BEFORE `AuthSessionGuard`
-     * populates `request.user`, so it has no user to read a default
-     * scope from.
+     * populates `request.user`, so it has no user to read a Tenant from.
+     *
+     * It does NOT seed an Organization. Since 8f28edca0 the guard
+     * deliberately refuses to read the user's mutable last-Organization
+     * preference: that value is a fresh-login navigation default, not
+     * request authorization, and reading it here would let two tabs on
+     * different Orgs act on each other's data. An Organization scope comes
+     * only from an explicit `X-Scope-Slug` header or an `/api/<slug>/…`
+     * path, so an unprefixed request is the PERSONAL contract.
      *
      * Mutates the holder the middleware created via `runWith`, so every
      * later reader in the same async context (the controller, the

--- a/apps/web/e2e/flow-org-memory-page-deep.spec.ts
+++ b/apps/web/e2e/flow-org-memory-page-deep.spec.ts
@@ -33,9 +33,12 @@
  *
  * ── Verified live against http://127.0.0.1:3100 (sqlite in-memory — the CI
  *    driver) before assertions were written. The Organization is taken from the
- *    request scope context: on these legacy un-prefixed routes it is seeded from
- *    the user's last-active Org, or resolved from the `X-Scope-Slug` header. We
- *    drive the header explicitly so scope is deterministic.
+ *    request scope context, which since 8f28edca0 is populated ONLY from an
+ *    explicit `X-Scope-Slug` header or an `/api/<slug>/…` path — the guard
+ *    deliberately refuses to fall back to the user's last-active Org, so an
+ *    unprefixed bare-Bearer call runs in the personal scope and these handlers
+ *    early-return an empty payload with HTTP 200. We drive the header
+ *    explicitly, which is now required rather than merely deterministic.
  *
  * Isolation discipline: every test builds a FRESH registerUserViaAPI() owner +
  * a lazily-minted org. Fully API-orchestrated (safe `flow-` prefix, not matched
@@ -66,9 +69,10 @@ function stamp(): string {
 }
 
 /**
- * An owner + their org, with both a plain-authed header set and a
- * scope-pinned header set (`X-Scope-Slug`) so the legacy /api/memory route
- * resolves this exact org regardless of the user's last-active pointer.
+ * An owner + their org, with both a plain-authed header set (the PERSONAL
+ * contract — it resolves no Organization at all) and a scope-pinned header set
+ * (`X-Scope-Slug`) which is the only way an unprefixed /api/memory call can
+ * reach this org.
  */
 interface OrgCtx {
     user: RegisteredUser;


### PR DESCRIPTION
Small, comment-only, and independent of the other three PRs in this series
([#2335](https://github.com/ever-works/ever-works/pull/2335),
[#2336](https://github.com/ever-works/ever-works/pull/2336),
[#2337](https://github.com/ever-works/ever-works/pull/2337)). Merge in any order.

## Why prose is worth a PR

Four comments still stated, as current fact, that `SessionScopeGuard` falls back to the
user's last-active Organization on unprefixed routes. Since `8f28edca0` it deliberately
does not — it seeds the Tenant and leaves the Organization `null`:

```ts
// An unprefixed request is the personal route contract. Never read the
// user's mutable last-Organization preference here: that value is only
// a fresh-login navigation default, not request authorization. This is
// what keeps simultaneous Ever and Yo tabs isolated.
```

The stale version is not harmless. In two of the four sites it reads as *rationale* —
"the API resolves the active Organization from the session's last-active Org, so there is
nothing org-specific to forward here." That sentence tells the next engineer not to
forward a scope, which is exactly the mistake behind
[EW-783](https://github.com/ever-works/ever-works/pull/2335) and EW-786, and behind thirty
e2e failures that went unexplained for twelve days.

Sites corrected:

- `apps/api/src/scope/scope-context.service.ts`
- `apps/api/src/api.module.ts` (the `SessionScopeGuard` provider comment)
- `apps/api/src/digest/digest.controller.ts`
- `apps/web/e2e/flow-org-memory-page-deep.spec.ts` (two paragraphs)

Verified there is **no runtime read of `lastScopeOrganizationId` left anywhere** outside
the migration that created the column.

## Also: artifacts from failing runs were named with an empty tag

Both `Sanitize branch tag for artifact names` steps in `e2e.yml` had no `if:`, so they are
skipped whenever the test step fails — while the upload steps below them run with
`if: always()`. The result is that every artifact from a **failing** run is named
`server-logs--shard13-1` rather than `server-logs-stage-shard13-1`. Nothing is lost, but
the names look broken exactly when someone is under pressure to read them. I hit this
while pulling the logs for the gate diagnosis.

Both steps now carry `if: always()`.

## Verification

- Comment-only: filtering each diff to non-comment lines yields **zero** for all four
  source files. The only executable change in the PR is the two `if: always()` lines.
- `e2e.yml` parses as valid YAML.
- Prettier clean on the four source files.

**One thing to know:** `.github/workflows/e2e.yml` is *already* prettier-dirty on
`develop`, before this change — I checked by stashing and re-running. I deliberately did
not run `--write`, because that would bundle a large unrelated reformat into a
three-line fix. Worth a separate cleanup if the team wants workflows prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EW-783]: https://evertech.atlassian.net/browse/EW-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ