### PR TITLE
fix(node): stop the mock-registry race that randomly reddens CI

### DIFF
--- a/apps/node/src/core/runtime.spec.ts
+++ b/apps/node/src/core/runtime.spec.ts
@@ -420,7 +420,19 @@ describe('createNodeRuntime — agent-task publish fence', () => {
 			await runtime.worker?.drained();
 			await runtime.worker?.stop();
 		} finally {
-			vi.doUnmock('./executors/agent-task');
+			// NOT `vi.doUnmock` here. In vitest 4 both doMock and doUnmock are
+			// fire-and-forget: each queues a DIFFERENT RPC and applies its side
+			// effect in completion order, not call order. So this teardown's
+			// pending unmock could land AFTER the next test's doMock and delete
+			// the stub it had just registered — the dynamic import then bound the
+			// REAL runAgentTaskJob, which throws AgentTaskPayloadError on the
+			// harness's stepless payload, so the loop POSTed /complete and
+			// `completedBodies` was non-empty. Failed ~1 run in 4 locally, and
+			// reddened lint-and-test on stage, develop and main at random.
+			//
+			// Dropping it is safe: resetModules() below discards the module graph,
+			// and the next withStubbedExecutor call issues its own doMock for this
+			// same path, which replaces the registration outright.
 			vi.resetModules();
 		}
 		return harness;


### PR DESCRIPTION
## The symptom

`lint-and-test (22.x)` has been failing at random on **stage, develop and main** with exactly one failing test in `apps/node`:

```
runtime.spec.ts > agent-task publish fence >
  "reports nothing to the platform when the run withheld its publish"
expected [ { ... } ] to deeply equal []
```

It looked like infrastructure — same commit green on a re-run, identical turbo input hash on passing and failing runs. It is neither infra nor a product defect.

## The cause

`withStubbedExecutor` tore down with `vi.doUnmock('./executors/agent-task')` in a `finally`, and the next invocation re-registered with `vi.doMock`. **In vitest 4 both are fire-and-forget** — they queue two *different* RPCs and apply their side effects in completion order, not call order. When one test's pending unmock landed after the next test's `doMock`, it deleted the stub that had just been registered, and the dynamic `import('./runtime')` bound the **real** `runAgentTaskJob`.

The real executor throws `AgentTaskPayloadError` on the harness's stepless payload, so the worker loop POSTed `/complete` and `completedBodies` was no longer empty. The error string in the failure output is the tell: it is emitted only by `executors/agent-task.ts`, the module the test believed it had replaced.

## The fix

Drop the unmock. It is safe because `vi.resetModules()` already discards the module graph, and the next `withStubbedExecutor` issues its own `doMock` for the same path, which replaces the registration outright.

## Measured, not assumed

| | failures |
| --- | --- |
| before | **3 / 12** runs |
| after | **0 / 24** runs |
| after, whole file | **0 / 8** runs |

The whole `apps/node` suite is **679 passing**. Its one failure — `windows-job-helper-trust.windows.spec.ts`, an Authenticode signature check — reproduces identically with this change stashed, so it is a pre-existing local Windows-environment failure, not related.

## Why it matters now

This is the check that made `stage` look red during a production cascade. Diagnosing it as "flaky infra, just re-run" was wrong in a way that costs real time on every promotion, and it would have kept recurring at roughly one run in four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)