### PR TITLE
fix(web): forward workspace scope from the Memory BFF routes

### DIFF
--- a/apps/api/src/works/org-memory.controller.ts
+++ b/apps/api/src/works/org-memory.controller.ts
@@ -249,10 +249,13 @@ export class ListMemoryUploadsDto {
  *
  * **Org resolution + security.** Unlike the per-Work KB routes, Memory
  * is session-scoped: the Organization comes from the request SCOPE
- * CONTEXT (`ScopeContextService.getOrganizationId()`), which the
- * `SessionScopeGuard` seeds from the authenticated user's validated
- * last-active Org on these legacy un-prefixed routes — never from a
- * query/body param. When no Organization is resolvable (bare-Tenant
+ * CONTEXT (`ScopeContextService.getOrganizationId()`) — never from a
+ * query/body param. That scope is resolved from the `/api/<slug>/…` path
+ * param or the `x-scope-slug` header, BOTH CALLER-SUPPLIED. It is NOT
+ * seeded from the user's last-active Org: commit 8f28edca0 (2026-08-23)
+ * retired that fallback so two tabs in different Orgs cannot race, and
+ * `SessionScopeGuard` now seeds `organizationId: null` on an unprefixed
+ * request. When no Organization is resolvable (bare-Tenant
  * "personal" surface, or an un-upgraded user) the endpoint returns an
  * EMPTY aggregation — there is no unscoped or cross-tenant scan (spec
  * §2.1 / §7). As defense-in-depth we also assert org membership via the
@@ -353,11 +356,15 @@ export class OrgMemoryController {
             };
         }
 
-        // Defense-in-depth: the caller must belong to the Tenant that owns
-        // the active org. The scope was seeded from the user's own
-        // validated last-active Org, so this is normally a formality — but
-        // it keeps the authorization explicit and consistent with the
-        // sibling org-KB routes. Throws NotFound (not Forbidden) on a
+        // NOT defence-in-depth, and NOT a formality. This comment used to say
+        // the check was "normally a formality" because "the scope was seeded
+        // from the user's own validated last-active Org" — that seeding was
+        // retired by 8f28edca0. `organizationId` now comes from the caller's
+        // own `x-scope-slug` header (or path param), so ANY authenticated user
+        // can name ANY Organization here. This `ensureMember` call is the
+        // load-bearing authorization check standing between them and another
+        // Organization's Memory, and it must not be weakened or reordered
+        // after the aggregation. Throws NotFound (not Forbidden) on a
         // cross-tenant mismatch, matching the existence-leak contract.
         await this.membership.ensureMember(organizationId, auth.userId);
 

--- a/apps/web/src/app/api/memory/consolidate/route.ts
+++ b/apps/web/src/app/api/memory/consolidate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Memory Consolidation — same-origin proxy for the consolidation pass
@@ -13,16 +14,30 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * (cookie JWT → `Authorization: Bearer`, API base URL stays
  * server-side). Mirrors the sibling GET proxy (`app/api/memory/route.ts`).
  *
- * The active Organization is resolved by the API from the request scope
- * context (the session's last-active Org), not a param — so there is
- * nothing org-specific to forward here.
+ * The active Organization MUST be forwarded as `x-scope-slug`, via
+ * `applyBffWorkspaceScope`. This docblock used to claim the opposite — that the
+ * API resolves the Org from "the session's last-active Org", so there was
+ * "nothing org-specific to forward here". Commit 8f28edca0 (2026-08-23) retired
+ * that fallback: `SessionScopeGuard` now seeds `organizationId: null` on an
+ * unprefixed request and refuses the user's mutable last-active preference.
+ *
+ * This one is worse than the sibling GET: consolidation WRITES. Without the
+ * header the `{ apply: true }` pass ran in PERSONAL scope, so it could never
+ * persist into the Organization the user was looking at — it silently
+ * consolidated the wrong workspace.
  */
 export async function POST(request: NextRequest) {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
-    headers.set('Accept', 'application/json');
-    headers.set('Content-Type', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
     if (token) {
         headers.set('Authorization', `Bearer ${token}`);
     }

--- a/apps/web/src/app/api/memory/consolidate/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/consolidate/route.unit.spec.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { POST } from './route';
+
+/**
+ * Same live bug as the sibling GET, but this one WRITES. Without a forwarded
+ * scope the `{ apply: true }` pass ran in PERSONAL scope, so a consolidation
+ * started from `/org/<slug>/memory` could never persist into that Organization
+ * — it silently operated on the wrong workspace and reported success.
+ */
+function request(body: unknown, selector?: string, referer?: string) {
+    const headers = new Headers({
+        'content-type': 'application/json',
+        'x-scope-slug': 'attacker-supplied-yo',
+    });
+    if (selector) headers.set('x-ever-workspace', selector);
+    if (referer) headers.set('referer', referer);
+    return new Request('http://web.example/api/memory/consolidate', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+    }) as Parameters<typeof POST>[0];
+}
+
+describe('POST /api/memory/consolidate workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        process.env.WEB_URL = 'http://web.example';
+        fetchMock = vi.fn(
+            async () => new Response(JSON.stringify({ scanned: 0 }), { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        delete process.env.WEB_URL;
+    });
+
+    it('forwards the Organization selector on the dry-run pass', async () => {
+        const response = await POST(request({ apply: false }, 'org:ever'));
+
+        expect(response.status).toBe(200);
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+    });
+
+    it('forwards the Organization selector on the APPLYING pass', async () => {
+        // The write. Getting this wrong consolidates into the wrong workspace.
+        await POST(request({ apply: true }, 'org:ever'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+        expect(init.body).toBe(JSON.stringify({ apply: true }));
+    });
+
+    it('overwrites a spoofed x-scope-slug and strips the browser selector', async () => {
+        await POST(request({ apply: true }, 'org:ever'));
+
+        const headers = new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers);
+        expect(headers.get('x-scope-slug')).toBe('ever');
+        expect(headers.get('x-ever-workspace')).toBeNull();
+    });
+
+    it('refuses to WRITE at all when no selector is present', async () => {
+        const response = await POST(request({ apply: true }));
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a selector that disagrees with the Referer path', async () => {
+        const response = await POST(
+            request({ apply: true }, 'org:ever', 'http://web.example/org/yo/memory'),
+        );
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps the JSON content type and the bearer token', async () => {
+        await POST(request({ apply: false }, 'org:ever'));
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://api.example/memory/consolidate');
+        const headers = new Headers(init.headers);
+        expect(headers.get('Content-Type')).toBe('application/json');
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+    });
+});

--- a/apps/web/src/app/api/memory/route.ts
+++ b/apps/web/src/app/api/memory/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Org-wide Memory (Cortex P1) — read-only same-origin proxy for the
@@ -13,15 +14,32 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * forwarded verbatim. Mirrors the per-Work KB list proxy
  * (`app/api/works/[id]/kb/documents/route.ts`).
  *
- * The active Organization is resolved by the API from the request scope
- * context (the session's last-active Org), not a param — so there is
- * nothing org-specific to forward here.
+ * The active Organization MUST be forwarded as `x-scope-slug`, via
+ * `applyBffWorkspaceScope`. This docblock used to claim the opposite — that the
+ * API resolves the Org from "the session's last-active Org", so there was
+ * "nothing org-specific to forward here". Commit 8f28edca0 (2026-08-23) retired
+ * that fallback: `SessionScopeGuard` now seeds `organizationId: null` on an
+ * unprefixed request and deliberately refuses to read the user's mutable
+ * last-active preference, because two tabs in different Orgs would otherwise
+ * race. Org scope arrives ONLY from an `/api/<slug>/…` param or this header.
+ *
+ * Nothing else supplies it: Next middleware (`proxy.ts`) stamps the browser
+ * selector, but its matcher excludes `/api`, so a BFF route never sees it unless
+ * the caller sends it — hence `browserApiFetch` on the client side.
+ *
+ * Until this was fixed, `/org/<slug>/memory` rendered correctly server-side and
+ * then emptied on the first keystroke or chip click, because this proxy ran the
+ * query in PERSONAL scope.
  */
 export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
-    headers.set('Accept', 'application/json');
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, { Accept: 'application/json' });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
     if (token) {
         headers.set('Authorization', `Bearer ${token}`);
     }

--- a/apps/web/src/app/api/memory/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/route.unit.spec.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET } from './route';
+
+/**
+ * Regression cover for a LIVE production bug: this proxy forwarded no workspace
+ * scope at all. Commit 8f28edca0 retired `SessionScopeGuard`'s last-active-Org
+ * fallback, so an unscoped call resolves to PERSONAL — meaning `/org/<slug>/memory`
+ * rendered correctly server-side and then emptied on the first keystroke, because
+ * the client-side refetch came through here.
+ *
+ * Nothing upstream can compensate: Next middleware stamps the browser selector but
+ * its matcher excludes `/api`, so the header only arrives if the caller sends it
+ * and this route forwards it.
+ */
+function request(selector?: string, referer?: string) {
+    // A spoofed upstream header is present on purpose: the BFF must overwrite it
+    // rather than pass a caller-chosen scope through to the API.
+    const headers = new Headers({ 'x-scope-slug': 'attacker-supplied-yo' });
+    if (selector) headers.set('x-ever-workspace', selector);
+    if (referer) headers.set('referer', referer);
+
+    const url = 'http://web.example/api/memory?q=notes';
+    const req = new Request(url, { method: 'GET', headers });
+    // A real Request carries the headers the scope guard reads; `nextUrl` is the
+    // one thing NextRequest adds that this route uses (for the query string).
+    Object.defineProperty(req, 'nextUrl', { value: new URL(url) });
+    return req as unknown as Parameters<typeof GET>[0];
+}
+
+describe('GET /api/memory workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        process.env.WEB_URL = 'http://web.example';
+        fetchMock = vi.fn(
+            async () => new Response(JSON.stringify({ documents: [] }), { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        delete process.env.WEB_URL;
+    });
+
+    it('forwards the per-tab Organization selector as x-scope-slug', async () => {
+        const response = await GET(request('org:ever'));
+
+        expect(response.status).toBe(200);
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+    });
+
+    it('overwrites a spoofed x-scope-slug rather than trusting the caller', async () => {
+        await GET(request('org:ever'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        // 'attacker-supplied-yo' was set by the caller and must not survive.
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('ever');
+    });
+
+    it('does not leak the browser selector header upstream', async () => {
+        await GET(request('org:ever'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-ever-workspace')).toBeNull();
+    });
+
+    it('forwards the personal sentinel when the tab is in personal scope', async () => {
+        await GET(request('personal'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get('x-scope-slug')).toBe('@personal');
+    });
+
+    it('fails closed before calling upstream when no selector is present', async () => {
+        const response = await GET(request());
+
+        // Silently defaulting to personal is exactly the bug this fixes: the user
+        // sees an empty Org feed and no error. A 400 makes the mistake loud.
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a selector that disagrees with the Referer path', async () => {
+        const response = await GET(request('org:ever', 'http://web.example/org/yo/memory'));
+
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('still carries the bearer token and the query string', async () => {
+        await GET(request('org:ever'));
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://api.example/memory?q=notes');
+        expect(new Headers(init.headers).get('Authorization')).toBe('Bearer fake-jwt');
+    });
+});

--- a/apps/web/src/components/memory/MemoryShell.tsx
+++ b/apps/web/src/components/memory/MemoryShell.tsx
@@ -13,6 +13,7 @@ import {
     Sparkles,
 } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import { MemoryUploadsPanel } from './MemoryUploadsPanel';
@@ -119,7 +120,14 @@ export function MemoryShell({ initial, meetings }: MemoryShellProps) {
         inflightRef.current = controller;
         setIsLoading(true);
         try {
-            const res = await fetch(`/api/memory${qs}`, {
+            // `browserApiFetch`, not bare `fetch`: it stamps the per-tab
+            // `x-ever-workspace` selector from window.location.pathname, which
+            // the BFF route forwards upstream as `x-scope-slug`. Next middleware
+            // cannot do this for us — its matcher excludes `/api`. With a bare
+            // fetch this request carried no scope, so the API resolved PERSONAL
+            // and the feed emptied on the first keystroke while the SSR render
+            // above it stayed correctly org-scoped.
+            const res = await browserApiFetch(`/api/memory${qs}`, {
                 method: 'GET',
                 headers: { Accept: 'application/json' },
                 cache: 'no-store',
@@ -182,7 +190,11 @@ export function MemoryShell({ initial, meetings }: MemoryShellProps) {
             setIsConsolidating(true);
             setConsolidateFailed(false);
             try {
-                const res = await fetch('/api/memory/consolidate', {
+                // Scope-aware for the same reason as the feed query, and it
+                // matters more here: this WRITES when `apply` is true, so
+                // without the selector a consolidation could never land in the
+                // Organization the user was looking at.
+                const res = await browserApiFetch('/api/memory/consolidate', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
                     cache: 'no-store',


### PR DESCRIPTION
## The bug

On `/org/<slug>/memory` the page rendered correctly and then **emptied on the first keystroke**. The SSR pass forwards the workspace selector, but the client-side refetch goes through `/api/memory`, and that BFF route built its headers by hand and forwarded no scope at all. `POST /api/memory/consolidate` was worse — it **writes**, so `{ apply: true }` could never persist into the Organization the user was looking at, and reported success anyway.

Commit `8f28edca0` retired `SessionScopeGuard`'s last-active-Org fallback: an unprefixed request now seeds `organizationId: null` and deliberately refuses to read the user's mutable preference, because two tabs in different Orgs would otherwise race. So an unscoped call does not "default sensibly" — it resolves to **personal**, and `getMemory` returns its empty payload.

**Nothing upstream could compensate.** Next middleware stamps the browser selector, but its matcher is `/((?!api|trpc|_next|_vercel|…).*)` — it **excludes `/api`**. The header only arrives if the caller sends it, which is why `MemoryShell` now uses `browserApiFetch` rather than bare `fetch`. Fixing only the route, or only the client, would have left it broken.

## Behaviour change, stated plainly

These routes now **fail closed with 400** when no selector is present, matching the ten routes that already forward scope. Silently running personal *is* the bug; a 400 makes it loud.

Verified safe before accepting it: the only callers are the two `MemoryShell` sites (both fixed in this PR), and the e2e suite hits `API_BASE` — the Nest API on `:3100` — directly, bypassing the BFF entirely.

## Tests

13 new specs, following the existing `route.unit.spec.ts` convention. **Mutation-tested:** reverting the two routes fails **10 of 13**; the 3 survivors are the bearer-token and query-string assertions that don't depend on scope.

They cover forwarding, overwriting a spoofed `x-scope-slug`, stripping the browser header, the personal sentinel, fail-closed with no selector, and rejecting a selector that disagrees with the Referer path.

## Docblocks

Both routes claimed the **opposite** of the truth — *"the session's last-active Org … so there is nothing org-specific to forward here."* Corrected rather than deleted, so the next reader sees why.

One in `org-memory.controller.ts` was wrong in a **security-relevant direction**: it called `membership.ensureMember` *"normally a formality"* because *"the scope was seeded from the user's own validated last-active Org."* That seeding is gone — `organizationId` now arrives from the caller's own `x-scope-slug` header, so **`ensureMember` is the load-bearing authorization check**, not a formality.

## The audit: 19 of 68 unscoped routes are bugs

Task 2 asked for an enumeration, not a mass fix. All 68 `route.ts` files that don't call `applyBffWorkspaceScope` were classified against their Nest handler: **19 bugs, 49 correct, 0 unclear.** This PR fixes 2.

### Memory family (11 more)

| Route | Impact |
| --- | --- |
| `memory/health` | Health panel permanently shows "not measurable" — rates render `—` for every org |
| `memory/review` | Review queue returns `[]`, and the panel hides itself when empty, so proposed merges are **invisible and unacceptable** |
| `memory/review/[docId]/accept` · `reject` | Hard 422 "No active Organization" |
| `memory/consolidation/settings` | Settings read/write miss the org |
| `memory/files` · `upload` · `move` · `folders/[id]/sync` | Org files invisible; **`sync` commits a silently incomplete snapshot** and reports clean success with a commit SHA |
| `memory/files/[id]/download` | Org file downloads 404 |
| `memory/uploads` | Panel always empty; upload fails 422 while standing inside the org |

### Beyond Memory (6)

- **`uploads`, `uploads/file`, `skills/[id]/files`** — writes are stamped **personal** while the parent (Work/Skill) is stamped org, so attachments don't travel with the Organization
- **`uploads/[userId]/[filename]`** — org-stamped uploads return an opaque 404 on download. Note this is the *mirror* of the three above: fixing the writes without this one makes every attachment link 404
- **`chat`** — every chat tool fails with "Invalid workspace scope"; turns aren't persisted; attachments never reach org Memory
- **`credits/usage/export`** — the CSV isn't filtered to the viewed org

### One correction to the audit, and one design constraint

The analysis flagged `credits/usage/export` as "exactly the cross-org billing read the Swagger promises against." **That overstates it.** The repository's `userId` filter is *always* applied — a caller only ever exports their **own** events. With no org scope the export widens to that user's account-wide history across orgs **they already belong to**. That is a correctness bug (the CSV can't be reconciled against on-screen org spend), **not a data breach**, and it's documented behaviour in `findPageForUserExport`.

**The constraint that matters for the follow-up:** several of these are reached by plain `<a href download>` navigation (`credits/usage/export`, `memory/files/[id]/download`) or a bare XHR. A browser navigation **cannot carry a custom header**, so dropping `applyBffWorkspaceScope` in would make them *worse* — `parseWorkspaceSelector(null)` throws, so every download would 4xx. Those need a scope query param or an org-prefixed URL, not this PR's pattern.

## Verified

- `apps/web` **2350 tests pass** (252 files)
- `pnpm lint` **byte-identical** to the pre-existing 42-error baseline — none in a file this PR touches
- `pnpm format:check` clean over the root glob `**/*.{ts,tsx,jsx,json,css,md}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)