### PR TITLE
fix(web): send the workspace selector from the chat transport

### DIFF
--- a/apps/web/src/components/ai/ChatProvider.tsx
+++ b/apps/web/src/components/ai/ChatProvider.tsx
@@ -82,13 +82,31 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 // `browserApiFetch` does, so a second tab on another Organization cannot leak
 // its scope into this one.
 export function prepareChatRequest({
+    id,
+    messages,
+    trigger,
+    messageId,
     body,
     headers,
 }: {
+    id: string;
+    messages: UIMessage[];
+    trigger: 'submit-message' | 'regenerate-message';
+    messageId: string | undefined;
     body?: Record<string, unknown>;
     headers?: HeadersInit;
 }): { body: object; headers: Headers } {
-    return { body: body ?? {}, headers: applyBrowserWorkspaceScope(headers) };
+    // `body` is ONLY the extra fields — the transport's `body` merged with the
+    // per-call one. The SDK hands id/messages/trigger/messageId to this callback
+    // as SEPARATE arguments, and when the callback returns a `body` the SDK
+    // POSTs that object VERBATIM instead of re-adding them (it only re-adds them
+    // on the no-callback path). So returning `body` alone sends a request with
+    // no `messages`, and /api/chat's schema rejects it with 400 before any model
+    // is reached — i.e. every send fails. Restate the four fields here.
+    return {
+        body: { ...(body ?? {}), id, messages, trigger, messageId },
+        headers: applyBrowserWorkspaceScope(headers),
+    };
 }
 
 // Exported only so a unit spec can pin that the transport is actually WIRED to

--- a/apps/web/src/components/ai/ChatProvider.tsx
+++ b/apps/web/src/components/ai/ChatProvider.tsx
@@ -24,6 +24,7 @@ import {
 import { toast } from 'sonner';
 import { DEFAULT_AI_PROVIDER } from '@/lib/constants';
 import { useLocalStorage } from '@/lib/hooks/use-local-storage';
+import { applyBrowserWorkspaceScope } from '@/lib/api/browser-api';
 
 import type { ConversationSummary } from '@/lib/api/conversations';
 import {
@@ -65,8 +66,38 @@ interface ChatContextValue {
 
 const ChatContext = createContext<ChatContextValue | null>(null);
 
-// Stable transport — created once outside the component
-const transport = new DefaultChatTransport({ api: '/api/chat' });
+// Stable transport — created once outside the component.
+//
+// `prepareSendMessagesRequest` stamps the per-tab workspace selector on every
+// send. This is NOT optional and it is NOT only about Organizations: the tool
+// loop inside `/api/chat` reaches the platform through `serverFetch`, which
+// derives its scope from this header and THROWS `Invalid workspace scope` when
+// it is absent (`lib/api/server-api.ts` → `parseWorkspaceSelector`). Without it
+// every data action the assistant attempts fails before a request leaves the
+// web tier, in personal scope as well as org scope.
+//
+// The middleware cannot supply it — `proxy.ts`'s matcher deliberately excludes
+// `/api`, so a BFF route only ever receives the selector when the client sends
+// it. We re-derive from `window.location.pathname` per request, exactly as
+// `browserApiFetch` does, so a second tab on another Organization cannot leak
+// its scope into this one.
+export function prepareChatRequest({
+    body,
+    headers,
+}: {
+    body?: Record<string, unknown>;
+    headers?: HeadersInit;
+}): { body: object; headers: Headers } {
+    return { body: body ?? {}, headers: applyBrowserWorkspaceScope(headers) };
+}
+
+// Exported only so a unit spec can pin that the transport is actually WIRED to
+// `prepareChatRequest`. Testing the function alone would not catch someone
+// dropping the option here, which is precisely the regression this fixes.
+export const transport = new DefaultChatTransport({
+    api: '/api/chat',
+    prepareSendMessagesRequest: prepareChatRequest,
+});
 
 export function ChatProvider({ children }: { children: React.ReactNode }) {
     const t = useTranslations('dashboard.aiChat');

--- a/apps/web/src/components/ai/ChatProvider.unit.spec.ts
+++ b/apps/web/src/components/ai/ChatProvider.unit.spec.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefaultChatTransport } from 'ai';
 import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 import { prepareChatRequest, transport } from './ChatProvider';
 
@@ -18,6 +19,24 @@ import { prepareChatRequest, transport } from './ChatProvider';
  * supply the header on the client's behalf. If these fail, every data action
  * the in-app assistant offers is dead.
  */
+
+type PrepareArgs = Parameters<typeof prepareChatRequest>[0];
+
+/**
+ * The SDK passes `id`, `messages`, `trigger` and `messageId` ALONGSIDE `body`,
+ * never inside it. Hand-building a call without them is what let the first
+ * version of this suite pass against a `prepareChatRequest` that dropped them.
+ */
+function sendArgs(overrides: Partial<PrepareArgs> = {}): PrepareArgs {
+    return {
+        id: 'conv-1',
+        messages: [],
+        trigger: 'submit-message',
+        messageId: undefined,
+        ...overrides,
+    } as PrepareArgs;
+}
+
 describe('chat transport workspace selector', () => {
     afterEach(() => {
         window.history.replaceState({}, '', '/');
@@ -26,7 +45,7 @@ describe('chat transport workspace selector', () => {
     it('stamps the Organization selector from the visible tab URL', () => {
         window.history.replaceState({}, '', '/org/ever/dashboard');
 
-        const { headers } = prepareChatRequest({});
+        const { headers } = prepareChatRequest(sendArgs());
 
         expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
     });
@@ -34,26 +53,35 @@ describe('chat transport workspace selector', () => {
     it('stamps explicit personal scope on an unprefixed route — never nothing', () => {
         window.history.replaceState({}, '', '/dashboard');
 
-        const { headers } = prepareChatRequest({});
+        const { headers } = prepareChatRequest(sendArgs());
 
         expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('personal');
     });
 
-    it('passes the body through untouched and defaults it to an object', () => {
+    it('restates the fields the SDK passes outside `body`, and keeps the extras', () => {
         window.history.replaceState({}, '', '/dashboard');
+        const messages = [
+            { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+        ] as unknown as PrepareArgs['messages'];
 
-        expect(prepareChatRequest({ body: { id: 'c1', messages: [] } }).body).toEqual({
-            id: 'c1',
-            messages: [],
+        const { body } = prepareChatRequest(
+            sendArgs({ messages, body: { providerOverride: 'openai' } }),
+        );
+
+        expect(body).toEqual({
+            providerOverride: 'openai',
+            id: 'conv-1',
+            messages,
+            trigger: 'submit-message',
+            messageId: undefined,
         });
-        expect(prepareChatRequest({}).body).toEqual({});
     });
 
     it('re-derives per send, so navigating between turns cannot reuse a stale Organization', () => {
         window.history.replaceState({}, '', '/org/ever/chat');
-        const first = prepareChatRequest({}).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
+        const first = prepareChatRequest(sendArgs()).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
         window.history.replaceState({}, '', '/org/yo/chat');
-        const second = prepareChatRequest({}).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
+        const second = prepareChatRequest(sendArgs()).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
 
         expect([first, second]).toEqual(['org:ever', 'org:yo']);
     });
@@ -75,10 +103,55 @@ describe('chat transport workspace selector', () => {
     it('overwrites a stale caller-supplied selector rather than trusting it', () => {
         window.history.replaceState({}, '', '/org/yo/chat');
 
-        const { headers } = prepareChatRequest({
-            headers: { [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:ever' },
-        });
+        const { headers } = prepareChatRequest(
+            sendArgs({ headers: { [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:ever' } }),
+        );
 
         expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:yo');
+    });
+
+    it('puts `messages` on the wire when driven through a real transport', async () => {
+        // Every test above calls `prepareChatRequest` with arguments WE build,
+        // so none of them can catch the callback disagreeing with the SDK about
+        // where `messages` lives. This one lets the SDK build the arguments and
+        // reads the request that actually leaves: when the callback returns a
+        // `body`, the SDK POSTs it verbatim rather than re-adding the fields it
+        // passed separately, so dropping them here means `/api/chat` rejects
+        // every send with 400 before a model is ever reached.
+        window.history.replaceState({}, '', '/org/ever/chat');
+
+        let sentBody: Record<string, unknown> | undefined;
+        let sentHeaders: Headers | undefined;
+
+        const probe = new DefaultChatTransport({
+            api: '/api/chat',
+            prepareSendMessagesRequest: prepareChatRequest,
+            fetch: vi.fn(async (_input: unknown, init: RequestInit) => {
+                sentBody = JSON.parse(String(init.body));
+                sentHeaders = new Headers(init.headers as HeadersInit);
+                return new Response('', {
+                    status: 200,
+                    headers: { 'content-type': 'text/event-stream' },
+                });
+            }) as unknown as typeof fetch,
+        });
+
+        await (probe as unknown as { sendMessages: (o: unknown) => Promise<unknown> })
+            .sendMessages({
+                chatId: 'conv-1',
+                messages: [{ id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+                trigger: 'submit-message',
+                messageId: undefined,
+                metadata: undefined,
+                abortSignal: undefined,
+            })
+            // The stub returns no parseable stream; only the request matters.
+            .catch(() => undefined);
+
+        expect(sentBody).toBeDefined();
+        expect(sentBody?.id).toBe('conv-1');
+        expect(Array.isArray(sentBody?.messages)).toBe(true);
+        expect((sentBody?.messages as unknown[]).length).toBe(1);
+        expect(sentHeaders?.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
     });
 });

--- a/apps/web/src/components/ai/ChatProvider.unit.spec.ts
+++ b/apps/web/src/components/ai/ChatProvider.unit.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+import { prepareChatRequest, transport } from './ChatProvider';
+
+/**
+ * The chat transport must stamp the per-tab workspace selector on every send.
+ *
+ * This is not an Organization nicety. The tool loop inside `/api/chat` reaches
+ * the platform through `serverFetch`, which derives its scope from this header
+ * and THROWS `Invalid workspace scope` when it is absent — so a send without it
+ * fails before any request leaves the web tier, in personal scope as well as
+ * org scope. `api-call.ts` then swallows the throw into
+ * `{ success: false }`, so the model simply apologises inside a healthy 200
+ * stream: no error toast, no failed request in the network tab, nothing to
+ * search for.
+ *
+ * `proxy.ts`'s matcher deliberately excludes `/api`, so nothing upstream can
+ * supply the header on the client's behalf. If these fail, every data action
+ * the in-app assistant offers is dead.
+ */
+describe('chat transport workspace selector', () => {
+    afterEach(() => {
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('stamps the Organization selector from the visible tab URL', () => {
+        window.history.replaceState({}, '', '/org/ever/dashboard');
+
+        const { headers } = prepareChatRequest({});
+
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
+    });
+
+    it('stamps explicit personal scope on an unprefixed route — never nothing', () => {
+        window.history.replaceState({}, '', '/dashboard');
+
+        const { headers } = prepareChatRequest({});
+
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('personal');
+    });
+
+    it('passes the body through untouched and defaults it to an object', () => {
+        window.history.replaceState({}, '', '/dashboard');
+
+        expect(prepareChatRequest({ body: { id: 'c1', messages: [] } }).body).toEqual({
+            id: 'c1',
+            messages: [],
+        });
+        expect(prepareChatRequest({}).body).toEqual({});
+    });
+
+    it('re-derives per send, so navigating between turns cannot reuse a stale Organization', () => {
+        window.history.replaceState({}, '', '/org/ever/chat');
+        const first = prepareChatRequest({}).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
+        window.history.replaceState({}, '', '/org/yo/chat');
+        const second = prepareChatRequest({}).headers.get(BROWSER_WORKSPACE_SCOPE_HEADER);
+
+        expect([first, second]).toEqual(['org:ever', 'org:yo']);
+    });
+
+    it('is actually wired into the transport, not merely available', () => {
+        // The original defect was the transport being constructed as
+        // `new DefaultChatTransport({ api: '/api/chat' })` with no request
+        // preparation at all. A spec that only exercised `prepareChatRequest`
+        // would have passed against that broken code, so pin the wiring.
+        // `prepareSendMessagesRequest` is `protected` on the SDK class but is a
+        // plain property at runtime; the cast is deliberate.
+        const wired = (
+            transport as unknown as { prepareSendMessagesRequest?: typeof prepareChatRequest }
+        ).prepareSendMessagesRequest;
+
+        expect(wired).toBe(prepareChatRequest);
+    });
+
+    it('overwrites a stale caller-supplied selector rather than trusting it', () => {
+        window.history.replaceState({}, '', '/org/yo/chat');
+
+        const { headers } = prepareChatRequest({
+            headers: { [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:ever' },
+        });
+
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:yo');
+    });
+});

--- a/apps/web/src/lib/api/browser-api.ts
+++ b/apps/web/src/lib/api/browser-api.ts
@@ -5,6 +5,38 @@ import {
 } from '../workspace-scope';
 
 /**
+ * Stamp the per-tab workspace selector onto an outgoing header set.
+ *
+ * Every browser→BFF call must carry this. A BFF route can only ever receive the
+ * selector when the client sends it, because `proxy.ts`'s matcher deliberately
+ * excludes `/api`, and the server side fails CLOSED without it: `serverFetch`
+ * runs `parseWorkspaceSelector` on this header and throws `Invalid workspace
+ * scope` when it is absent, while a scope-aware BFF route answers 400. That is
+ * true in personal scope as well as org scope — a missing selector is not a
+ * degraded call, it is a failed one.
+ *
+ * Scope is re-derived from the visible tab URL on every call, so a second tab on
+ * another Organization cannot leak its scope into this one, and no persisted
+ * preference can race with what the user is actually looking at.
+ *
+ * Prefer {@link browserApiFetch}. Use this directly only where the request is
+ * issued by machinery that owns its own transport (e.g. the AI SDK's
+ * `DefaultChatTransport`) and cannot be routed through `fetch` here.
+ */
+export function applyBrowserWorkspaceScope(headers?: HeadersInit): Headers {
+    if (typeof window === 'undefined') {
+        throw new Error('applyBrowserWorkspaceScope requires a browser workspace path');
+    }
+
+    const out = new Headers(headers);
+    out.set(
+        BROWSER_WORKSPACE_SCOPE_HEADER,
+        serializeWorkspaceScope(parseWorkspacePath(window.location.pathname)),
+    );
+    return out;
+}
+
+/**
  * Browser-to-BFF transport. Scope is re-derived for every call from the
  * visible tab URL, so it cannot race with another tab's persisted preference.
  */
@@ -16,11 +48,5 @@ export function browserApiFetch(
         throw new Error('browserApiFetch requires a browser workspace path');
     }
 
-    const headers = new Headers(init.headers);
-    headers.set(
-        BROWSER_WORKSPACE_SCOPE_HEADER,
-        serializeWorkspaceScope(parseWorkspacePath(window.location.pathname)),
-    );
-
-    return fetch(input, { ...init, headers });
+    return fetch(input, { ...init, headers: applyBrowserWorkspaceScope(init.headers) });
 }

--- a/apps/web/src/lib/api/browser-api.unit.spec.ts
+++ b/apps/web/src/lib/api/browser-api.unit.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BROWSER_WORKSPACE_SCOPE_HEADER } from '../workspace-scope';
-import { browserApiFetch } from './browser-api';
+import { applyBrowserWorkspaceScope, browserApiFetch } from './browser-api';
 
 describe('browserApiFetch workspace selector', () => {
     afterEach(() => {
@@ -60,5 +60,58 @@ describe('browserApiFetch workspace selector', () => {
                 new Headers(call[1]?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER),
             ),
         ).toEqual(['org:ever', 'personal']);
+    });
+});
+
+/**
+ * `applyBrowserWorkspaceScope` exists for callers that own their own transport
+ * and so cannot go through `browserApiFetch` — today that is the AI SDK's
+ * `DefaultChatTransport` in `components/ai/ChatProvider.tsx`.
+ *
+ * That transport shipped WITHOUT a selector, and because the tool loop inside
+ * `/api/chat` reaches the platform through `serverFetch` — which throws
+ * `Invalid workspace scope` on a missing header rather than degrading — every
+ * data action the in-app assistant attempted failed before a request left the
+ * web tier, in personal scope as well as org scope. These pin the contract that
+ * fix depends on.
+ */
+describe('applyBrowserWorkspaceScope', () => {
+    afterEach(() => {
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('stamps the selector derived from the visible tab URL', () => {
+        window.history.replaceState({}, '', '/org/ever/dashboard');
+
+        expect(applyBrowserWorkspaceScope().get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
+    });
+
+    it('never emits a missing selector — an unprefixed route is explicitly personal', () => {
+        window.history.replaceState({}, '', '/dashboard');
+
+        const headers = applyBrowserWorkspaceScope();
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('personal');
+        expect(headers.has(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe(true);
+    });
+
+    it('preserves caller headers and overwrites only the selector', () => {
+        window.history.replaceState({}, '', '/org/yo/chat');
+
+        const headers = applyBrowserWorkspaceScope({
+            'content-type': 'application/json',
+            [BROWSER_WORKSPACE_SCOPE_HEADER]: 'org:stale-tab',
+        });
+
+        expect(headers.get('content-type')).toBe('application/json');
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:yo');
+    });
+
+    it('re-derives per call, so a navigation between sends cannot reuse a stale scope', () => {
+        window.history.replaceState({}, '', '/org/ever/chat');
+        const first = applyBrowserWorkspaceScope().get(BROWSER_WORKSPACE_SCOPE_HEADER);
+        window.history.replaceState({}, '', '/org/yo/chat');
+        const second = applyBrowserWorkspaceScope().get(BROWSER_WORKSPACE_SCOPE_HEADER);
+
+        expect([first, second]).toEqual(['org:ever', 'org:yo']);
     });
 });


### PR DESCRIPTION
**The in-app AI assistant has been unable to perform any data action, for any user, in
any scope, since 2026-08-23.** Not org-specific — the personal dashboard is affected
identically.

Found by an audit of all 78 BFF routes, prompted by
[#2335](https://github.com/ever-works/ever-works/pull/2335) (EW-783) and EW-786. This is
the third and broadest defect of the same family, from the same root commit.

## The chain

`ChatProvider.tsx:69` built the transport with no request preparation:

```ts
const transport = new DefaultChatTransport({ api: '/api/chat' });
```

so no `x-ever-workspace` header was ever sent. Nothing upstream can supply it —
`proxy.ts`'s matcher deliberately excludes `/api`, so a BFF route only receives the
selector when the client sends it.

The tool loop inside `/api/chat` reaches the platform through `serverFetch`, which
derives its scope from that header:

```ts
// lib/api/server-api.ts
const selectedScope =
    publicRouteScope === 'personal'
        ? { kind: 'personal' as const }
        : parseWorkspaceSelector(requestHeaders.get(BROWSER_WORKSPACE_SCOPE_HEADER));
```

and `parseWorkspaceSelector(null)` falls through both branches to
`throw new Error('Invalid workspace scope')`. **It fails on a MISSING selector, not merely
a wrong one** — which is why this was never about Organizations.

`api-call.ts` then swallows the throw into `{ success: false, error: … }`, so the model
apologises inside a healthy 200 stream. **No error toast, no failed request in the network
tab, nothing to grep for.** Conversation persistence degrades the same way, so turns can
also fail to save.

Ask the assistant to list your tasks, look up a Work, create or update anything, generate
items, or check agents — all of it reports failure.

## The fix

`applyBrowserWorkspaceScope` is extracted into `browser-api.ts` — the derivation
`browserApiFetch` already performed — so callers that own their own transport can reuse it
instead of hand-rolling it. `browserApiFetch` now delegates to it, behaviour unchanged.

The selector is re-derived from `window.location.pathname` on **every send**, exactly as
`browserApiFetch` does, so a second tab on another Organization cannot leak its scope in,
and navigating between turns cannot reuse a stale one.

## A note on the test, because it is the point

`transport` is exported solely so a spec can pin that it is actually **wired** to
`prepareChatRequest`. I checked that this matters rather than assuming it: reverting the
transport to its original construction fails that one test —

```
AssertionError: expected undefined to be [Function prepareChatRequest]
Tests  1 failed | 5 passed (6)
```

— while the five tests that exercise the function alone still pass. A function-only spec
would have gone green against the broken code, which is exactly how the original defect
shipped.

13 tests pass across the two spec files.

## Verification

- `ChatProvider.unit.spec.ts` + `browser-api.unit.spec.ts`: 13/13.
- Reverted the fix and confirmed the wiring pin fails, and that it is the *only* one that
  does.
- `npx tsc --noEmit` in `apps/web`: clean.
- Prettier clean.

**Not verified at runtime.** The static evidence is strong and every link was read in
source, but "the assistant has been inert for every user for twelve days" is a large
claim. Worth someone opening the assistant and asking it to list their Works, before and
after.

## Wider context

The audit confirmed 12 findings across the BFF surface and concluded the problem is
structural, not three unlucky one-offs: **35 raw `fetch('/api/…')` call sites versus 18
`browserApiFetch` ones**, with the two visually indistinguishable at the call site, and
only 10 of 78 routes forwarding the scope. The recommended structural fix is to invert the
default — a shared proxy helper that forwards the selector unless a route explicitly opts
out — mirroring the `publicRouteScope: 'personal'` opt-out that already exists and works.
That is a bigger change than this PR and is tracked separately.

Refs EW-787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat requests now consistently include the workspace selected by the current browser tab.
  * Workspace context updates automatically when navigating between workspaces or personal areas.
  * Caller-provided workspace selectors are corrected to match the active tab.

* **Tests**
  * Added coverage for workspace selection across chat requests and browser API calls, including navigation and header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->