### PR TITLE
fix(web): carry the workspace selector across the Memory surface

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1238,6 +1238,7 @@
                     "dry-run": "Report only",
                     "propose": "Propose merges"
                 },
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again.",
                 "subtitle": "Periodically merge near-duplicate Memory documents. Proposals go to the review queue — nothing is ever accepted or deleted automatically.",
                 "title": "Scheduled consolidation"
             }

--- a/apps/web/src/app/api/memory/consolidation/settings/route.ts
+++ b/apps/web/src/app/api/memory/consolidation/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Proxy for the scheduled Memory Consolidation settings.
@@ -11,15 +12,43 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * The write matters more than it looks: the scheduler only selects
  * organizations whose settings column is non-null, and nothing used to
  * write that column, so the scheduled pass could never run for anyone.
+ *
+ * EW-786 — both handlers are genuinely Organization-scoped:
+ * `OrgMemoryController.getConsolidationSettings` /
+ * `putConsolidationSettings` take the Organization from
+ * `ScopeContextService.getOrganizationId()`, which the API populates only
+ * from an `/api/<slug>/…` path or the `X-Scope-Slug` header. Translating
+ * the browser's per-tab `x-ever-workspace` selector into that header is
+ * therefore the whole feature on an Organization: without it `GET`
+ * answered with the personal-scope defaults instead of the stored
+ * settings, and `PUT` answered 422 "No active Organization", which the
+ * panel showed as a toggle that flipped and quietly flipped back.
+ *
+ * The selector only arrives if the caller sends it, so this change and
+ * the `browserApiFetch` switch in `MemoryConsolidationSettings` are one
+ * change: scoping the route alone would turn those silent failures into
+ * a hard 400.
  */
 
-async function forward(method: 'GET' | 'PUT', body?: string) {
+async function forward(request: NextRequest, method: 'GET' | 'PUT', body?: string) {
     const token = await getAuthAccessCookie();
     if (!token) return new Response('Unauthorized', { status: 401 });
 
-    const headers = new Headers({ Accept: 'application/json' });
-    headers.set('Authorization', `Bearer ${token}`);
-    if (body !== undefined) headers.set('Content-Type', 'application/json');
+    const base: Record<string, string> = {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+    };
+    if (body !== undefined) base['Content-Type'] = 'application/json';
+
+    // Fail closed. A missing or stale selector is answered here rather
+    // than forwarded unscoped, which would silently read and write the
+    // caller's personal scope while they are looking at an Organization.
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, base);
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
 
     const upstream = await fetch(`${API_URL}/memory/consolidation/settings`, {
         method,
@@ -43,13 +72,13 @@ async function forward(method: 'GET' | 'PUT', body?: string) {
     return NextResponse.json(json ?? {}, { status: 200 });
 }
 
-export async function GET(_request: NextRequest) {
-    return forward('GET');
+export async function GET(request: NextRequest) {
+    return forward(request, 'GET');
 }
 
 export async function PUT(request: NextRequest) {
     // Read and re-serialize rather than streaming: this is a small JSON
     // body, and buffering keeps the upstream Content-Length honest.
     const raw = await request.text().catch(() => '{}');
-    return forward('PUT', raw || '{}');
+    return forward(request, 'PUT', raw || '{}');
 }

--- a/apps/web/src/app/api/memory/consolidation/settings/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/consolidation/settings/route.unit.spec.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+const { getAuthAccessCookieMock } = vi.hoisted(() => ({
+    getAuthAccessCookieMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({ headers: vi.fn(), cookies: vi.fn() }));
+vi.mock('@/lib/auth/cookies', () => ({ getAuthAccessCookie: getAuthAccessCookieMock }));
+
+import { GET, PUT } from './route';
+
+const URL_UNDER_TEST = 'https://app.example/api/memory/consolidation/settings';
+
+const STORED = {
+    enabled: true,
+    cadence: 'weekly',
+    mode: 'propose',
+    notify: true,
+    lastRunAt: null,
+};
+
+function build(method: 'GET' | 'PUT', selector?: string, body?: string): NextRequest {
+    const headers = new Headers();
+    if (selector !== undefined) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest(URL_UNDER_TEST, { method, headers, body });
+}
+
+/**
+ * `OrgMemoryController` resolves the Organization from
+ * `ScopeContextService.getOrganizationId()`, which the platform fills only
+ * from an `/api/<slug>/…` path or the `X-Scope-Slug` header. This proxy is
+ * the only thing that can produce that header for the Memory schedule
+ * panel, so the two halves are pinned together: the selector the browser
+ * sends becomes the API scope, and no selector means no upstream call.
+ *
+ * Before EW-786 neither handler looked at the selector, so on
+ * `/org/<slug>/memory` the GET returned the personal-scope defaults rather
+ * than the stored settings and the PUT was refused 422 by the API — the
+ * schedule could not be turned on for any Organization.
+ */
+describe('/api/memory/consolidation/settings workspace scope', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAuthAccessCookieMock.mockResolvedValue('access-token');
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(JSON.stringify(STORED), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' },
+                    }),
+            ),
+        );
+    });
+
+    it('GET forwards the browser selector to the platform as the API scope header', async () => {
+        const response = await GET(build('GET', 'org:ever'));
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ enabled: true, mode: 'propose' });
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(String(url)).toMatch(/\/memory\/consolidation\/settings$/);
+        const forwarded = new Headers(init?.headers);
+        expect(forwarded.get(API_SCOPE_HEADER)).toBe('ever');
+        // The browser-facing selector is an internal transport detail and
+        // must not leak to the platform.
+        expect(forwarded.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+    });
+
+    it('PUT forwards the selector alongside the patch body', async () => {
+        const response = await PUT(build('PUT', 'org:ever', JSON.stringify({ enabled: true })));
+
+        expect(response.status).toBe(200);
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        const forwarded = new Headers(init?.headers);
+        expect(forwarded.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(init?.body).toBe(JSON.stringify({ enabled: true }));
+        // Scoping rebuilt the header set; the auth and content headers the
+        // platform needs have to survive that.
+        expect(forwarded.get('authorization')).toBe('Bearer access-token');
+        expect(forwarded.get('content-type')).toBe('application/json');
+    });
+
+    it('translates an unprefixed tab into the explicit personal sentinel', async () => {
+        await GET(build('GET', 'personal'));
+
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect(new Headers(init?.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+    });
+
+    it('GET fails closed without a selector: 400 and no upstream call', async () => {
+        const response = await GET(build('GET'));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('PUT fails closed without a selector, so nothing is written to the wrong scope', async () => {
+        const response = await PUT(build('PUT', undefined, JSON.stringify({ enabled: true })));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('PUT rejects a malformed selector rather than falling back to personal', async () => {
+        const response = await PUT(build('PUT', 'org:Not A Slug', '{}'));
+
+        expect(response.status).toBe(400);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('answers 401 before any scope work when the auth cookie is absent', async () => {
+        getAuthAccessCookieMock.mockResolvedValue(null);
+
+        const response = await GET(build('GET', 'org:ever'));
+
+        expect(response.status).toBe(401);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/memory/files/[id]/download/route.ts
+++ b/apps/web/src/app/api/memory/files/[id]/download/route.ts
@@ -1,8 +1,59 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../../proxy';
 
-/** Proxy — `GET /api/memory/files/:id/download` (binary passthrough). */
+/**
+ * Proxy — `GET /api/memory/files/:id/download` (binary passthrough).
+ *
+ * ─── KNOWN GAP (EW-786) — org-scoped Memory originals do not download ───
+ *
+ * This is the one route in the family that is org-aware and STILL
+ * unscoped, and it is left that way on purpose.
+ *
+ * `MemoryFilesController.download` reads
+ * `ScopeContextService.getOrganizationId()` and passes it into
+ * `resolveBytes`. For `source=kb-upload` rows with no `workId` — i.e.
+ * exactly the org-scoped Memory originals added through the Originals
+ * panel — `WorkKnowledgeUploadRepository.findForMemoryFiles` only
+ * matches when an `organizationId` is supplied, and `resolveBytes` then
+ * re-checks membership before reading bytes. With no scope header the
+ * row is invisible and the API answers `404 { status: 'error', message:
+ * 'File not found' }`.
+ *
+ * So why not scope it? Because this URL is reached by BROWSER DOCUMENT
+ * REQUESTS, which cannot carry a custom header:
+ *
+ *   1. the Download anchor in `MemoryFilesPanel.tsx` (`<a href=…>`);
+ *   2. the same anchor inside the `MemoryFilePreview` overlay;
+ *   3. the KB binary viewers (`KbPdfViewer`, `KbImageViewer`,
+ *      `KbVideoViewer`, `KbAudioViewer`, …) which are handed this URL by
+ *      `MemoryFilePreview` and put it on their own `<img src>` /
+ *      `<video src>` / object element.
+ *
+ * `browserApiFetch` cannot reach any of those, and
+ * `applyBffWorkspaceScope` THROWS without a selector — so scoping here
+ * would turn a 404 on org originals into a 400 on every download,
+ * including the personal chat uploads that work today. That is strictly
+ * worse.
+ *
+ * What still works unscoped: `source=upload` rows (owner-gated by
+ * `userId` through `UploadsService.readFile`) and `source=kb-upload`
+ * rows that belong to a Work (re-checked against Work view access by
+ * `userId`). What is broken: downloading or previewing an org-scoped
+ * Memory original — and note that scoping the sibling `GET
+ * /api/memory/files` list is what makes those rows VISIBLE in the Files
+ * table in the first place, so the failure is now reachable where before
+ * the rows simply never appeared.
+ *
+ * Carrying the scope some other way (a query parameter, an `/org/<slug>/`
+ * path segment, a scope cookie) is a contract change to the API's
+ * `X-Scope-Slug`-or-path rule from `8f28edca0` and a security decision
+ * about a browser-tamperable channel on a bytes-serving endpoint. That
+ * belongs to a human, not to this fix — do not invent one here.
+ */
 export async function GET(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
     const { id } = await ctx.params;
-    return proxyMemoryFiles(request, `/memory/files/${encodeURIComponent(id)}/download`);
+    return proxyMemoryFiles(request, `/memory/files/${encodeURIComponent(id)}/download`, {
+        method: 'GET',
+        scoped: false,
+    });
 }

--- a/apps/web/src/app/api/memory/files/folders/[id]/route.ts
+++ b/apps/web/src/app/api/memory/files/folders/[id]/route.ts
@@ -1,13 +1,22 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../../proxy';
 
-/** Proxy — `PATCH` / `DELETE /api/memory/files/folders/:id`. */
+/**
+ * Proxy — `PATCH` / `DELETE /api/memory/files/folders/:id`.
+ *
+ * NOT scoped (EW-786): both `MemoryFilesController.updateFolder` (rename
+ * / move / git-sync target) and `.deleteFolder` operate purely on
+ * `MemoryFoldersService` with `auth.userId`. The Organization only
+ * enters the picture when the folder's CONTENTS are read, which is the
+ * separately scoped `folders/:id/sync` route.
+ */
 
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
     const { id } = await ctx.params;
     return proxyMemoryFiles(request, `/memory/files/folders/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         body: request.body,
+        scoped: false,
     });
 }
 
@@ -15,5 +24,6 @@ export async function DELETE(request: NextRequest, ctx: { params: Promise<{ id: 
     const { id } = await ctx.params;
     return proxyMemoryFiles(request, `/memory/files/folders/${encodeURIComponent(id)}`, {
         method: 'DELETE',
+        scoped: false,
     });
 }

--- a/apps/web/src/app/api/memory/files/folders/[id]/sync/route.ts
+++ b/apps/web/src/app/api/memory/files/folders/[id]/sync/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../../../proxy';
 
-/** Proxy — `POST /api/memory/files/folders/:id/sync` (manual "Sync now"). */
+/**
+ * Proxy — `POST /api/memory/files/folders/:id/sync` (manual "Sync now").
+ *
+ * Scoped (EW-786): `MemoryFilesController.syncFolder` takes the
+ * Organization from the request scope context and threads it through the
+ * sync walk's byte reader (`readFileBytes` → `resolveBytes`), so an
+ * unscoped sync silently skipped — or failed to read — every org-scoped
+ * Memory original in the folder while reporting success for the rest.
+ */
 export async function POST(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
     const { id } = await ctx.params;
     return proxyMemoryFiles(request, `/memory/files/folders/${encodeURIComponent(id)}/sync`, {
         method: 'POST',
         body: null,
+        scoped: true,
     });
 }

--- a/apps/web/src/app/api/memory/files/folders/route.ts
+++ b/apps/web/src/app/api/memory/files/folders/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../proxy';
 
-/** Proxy — `POST /api/memory/files/folders` (create folder). */
+/**
+ * Proxy — `POST /api/memory/files/folders` (create folder).
+ *
+ * NOT scoped (EW-786): `MemoryFilesController.createFolder` delegates to
+ * `MemoryFoldersService.createFolder(auth.userId, …)`. Folders are
+ * per-user, not per-Organization — see `tree/route.ts`.
+ */
 export async function POST(request: NextRequest) {
     return proxyMemoryFiles(request, '/memory/files/folders', {
         method: 'POST',
         body: request.body,
+        scoped: false,
     });
 }

--- a/apps/web/src/app/api/memory/files/move/route.ts
+++ b/apps/web/src/app/api/memory/files/move/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../proxy';
 
-/** Proxy — `PATCH /api/memory/files/move` (batch file → folder move). */
+/**
+ * Proxy — `PATCH /api/memory/files/move` (batch file → folder move).
+ *
+ * Scoped (EW-786): `MemoryFilesController.moveFiles` resolves the
+ * Organization from the request scope context and hands it to
+ * `MemoryFilesService.moveFiles`, whose visibility query is what decides
+ * whether an org Memory original is movable at all. Unscoped, moving one
+ * of those rows matched nothing and reported a no-op success.
+ */
 export async function PATCH(request: NextRequest) {
     return proxyMemoryFiles(request, '/memory/files/move', {
         method: 'PATCH',
         body: request.body,
+        scoped: true,
     });
 }

--- a/apps/web/src/app/api/memory/files/proxy.ts
+++ b/apps/web/src/app/api/memory/files/proxy.ts
@@ -1,6 +1,7 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Shared same-origin proxy for the /api/memory/files BFF routes.
@@ -11,22 +12,62 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * for NestJS's FileInterceptor. Responses are relayed as-is — including
  * binary downloads — rather than re-parsed, so Content-Type /
  * Content-Disposition from the API reach the browser intact.
+ *
+ * **Workspace scope (EW-786).** `scoped` is REQUIRED, and deliberately
+ * has no default: the routes fanning through this one function do not
+ * agree on whether the Organization matters, so every call site has to
+ * make that call explicitly rather than inherit a silent default.
+ *
+ * `scoped: true` converts the browser's per-tab `x-ever-workspace`
+ * selector into the API's `X-Scope-Slug` contract and overwrites any
+ * client-supplied value; a missing or stale selector is a 400 here
+ * instead of a personal-scoped answer. A `scoped: true` route can
+ * therefore only be reached through `browserApiFetch`.
+ *
+ * The current table, checked against `MemoryFilesController`:
+ *
+ * | route                              | handler       | org-aware | scoped |
+ * | ---------------------------------- | ------------- | --------- | ------ |
+ * | `GET  /files`                       | `list`        | yes       | yes    |
+ * | `PATCH /files/move`                 | `moveFiles`   | yes       | yes    |
+ * | `POST /files/folders/:id/sync`      | `syncFolder`  | yes       | yes    |
+ * | `GET  /files/tree`                  | `getTree`     | no        | no     |
+ * | `POST /files/upload`                | `upload`      | no        | no     |
+ * | `POST /files/folders`               | `createFolder`| no        | no     |
+ * | `PATCH|DELETE /files/folders/:id`   | `update|delete` | no      | no     |
+ * | `GET  /files/:id/download`          | `download`    | yes       | NO — see that route |
+ *
+ * The four `no`-org handlers key off `auth.userId` (and, for folders,
+ * `MemoryFoldersService` ownership) and never touch
+ * `ScopeContextService`, so scoping them would buy nothing and would
+ * newly 400 a request that works today. Download is the exception that
+ * needs its own paragraph — it is org-aware but unreachable by
+ * `browserApiFetch`; the reasoning lives in `[id]/download/route.ts`.
  */
 export async function proxyMemoryFiles(
     request: NextRequest,
     upstreamPath: string,
-    init: { method: string; body?: BodyInit | null } = { method: 'GET' },
+    init: { method: string; body?: BodyInit | null; scoped: boolean },
 ): Promise<Response> {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
-    headers.set('Accept', request.headers.get('accept') ?? 'application/json');
+    const baseHeaders = new Headers();
+    baseHeaders.set('Accept', request.headers.get('accept') ?? 'application/json');
     const contentType = request.headers.get('content-type');
     if (contentType && init.body !== undefined) {
-        headers.set('Content-Type', contentType);
+        baseHeaders.set('Content-Type', contentType);
     }
     if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+        baseHeaders.set('Authorization', `Bearer ${token}`);
+    }
+
+    let headers = baseHeaders;
+    if (init.scoped) {
+        try {
+            headers = applyBffWorkspaceScope(request, baseHeaders);
+        } catch {
+            return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+        }
     }
 
     const upstream = await fetch(`${API_URL}${upstreamPath}${request.nextUrl.search}`, {

--- a/apps/web/src/app/api/memory/files/route.ts
+++ b/apps/web/src/app/api/memory/files/route.ts
@@ -1,7 +1,19 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from './proxy';
 
-/** Proxy — `GET /api/memory/files` (unified list). */
+/**
+ * Proxy — `GET /api/memory/files` (unified list).
+ *
+ * Scoped (EW-786): `MemoryFilesController.list` reads
+ * `ScopeContextService.getOrganizationId()` and passes it to
+ * `MemoryFilesService.list`, which is what pulls the active
+ * Organization's Memory originals into the unified listing alongside the
+ * caller's own chat uploads. Unscoped, the API answered 200 with the
+ * personal subset only — the Files area looked complete and quietly was
+ * not. Reach this route through `browserApiFetch` (see
+ * `components/memory/MemoryFilesPanel.tsx`); without the per-tab
+ * selector it is a 400.
+ */
 export async function GET(request: NextRequest) {
-    return proxyMemoryFiles(request, '/memory/files');
+    return proxyMemoryFiles(request, '/memory/files', { method: 'GET', scoped: true });
 }

--- a/apps/web/src/app/api/memory/files/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/files/route.unit.spec.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET as listFiles } from './route';
+import { GET as getTree } from './tree/route';
+import { POST as uploadFile } from './upload/route';
+import { PATCH as moveFiles } from './move/route';
+import { POST as createFolder } from './folders/route';
+import { PATCH as updateFolder, DELETE as deleteFolder } from './folders/[id]/route';
+import { POST as syncFolder } from './folders/[id]/sync/route';
+import { GET as downloadFile } from './[id]/download/route';
+
+/**
+ * Build a request for the shared `/api/memory/files` proxy.
+ *
+ * `x-scope-slug` is pre-set on EVERY request so each case also proves the
+ * BFF never relays a browser-chosen Organization: a scoped route must
+ * overwrite it, an unscoped route must drop it.
+ */
+function request(
+    path: string,
+    { method = 'GET', selector, body }: { method?: string; selector?: string; body?: string } = {},
+): NextRequest {
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-org' });
+    if (body !== undefined) headers.set('content-type', 'application/json');
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest(`http://web.example${path}`, {
+        method,
+        headers,
+        ...(body !== undefined ? { body } : {}),
+    });
+}
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function forwarded(fetchMock: ReturnType<typeof vi.fn>, call = 0): Headers {
+    const [, init] = fetchMock.mock.calls[call] as [string, RequestInit];
+    return new Headers(init.headers);
+}
+
+/**
+ * EW-786 — the `/api/memory/files` half of the BFF scope contract.
+ *
+ * Since `8f28edca0` an Organization reaches the API only through
+ * `X-Scope-Slug`; the whole Files area forwarded nothing, so it ran in
+ * personal scope and the org's Memory originals were invisible at HTTP 200.
+ *
+ * These routes all fan through one `proxyMemoryFiles`, but they do NOT all
+ * want scoping, so the spec pins the routing table itself — which handlers
+ * are org-aware (`MemoryFilesController` reading `ScopeContextService`) and
+ * which are per-user — as much as it pins the mechanics. Scoping a route
+ * whose handler ignores the org would only buy a new 400.
+ */
+describe('/api/memory/files workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ ok: true }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    describe('scoped — the handler reads ScopeContextService', () => {
+        it('GET /files forwards the per-tab selector as the API scope header', async () => {
+            const response = await listFiles(
+                request('/api/memory/files?folderId=fold-1', { selector: 'org:ever' }),
+            );
+
+            expect(response.status).toBe(200);
+            const [url] = fetchMock.mock.calls[0] as [string];
+            expect(url).toBe('http://api.example/memory/files?folderId=fold-1');
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('ever');
+            // The browser-side selector is an internal transport detail and
+            // must not leak upstream, and the client's own `x-scope-slug`
+            // guess must not survive.
+            expect(forwarded(fetchMock).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+            expect(forwarded(fetchMock).get('Authorization')).toBe('Bearer fake-jwt');
+        });
+
+        it('GET /files maps the personal selector to the personal sentinel', async () => {
+            await listFiles(request('/api/memory/files', { selector: 'personal' }));
+
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('@personal');
+        });
+
+        it('PATCH /files/move forwards the selector and still streams the body', async () => {
+            const req = request('/api/memory/files/move', {
+                method: 'PATCH',
+                selector: 'org:ever',
+                body: JSON.stringify({ files: [{ source: 'upload', id: 'up-1' }], folderId: null }),
+            });
+
+            const response = await moveFiles(req);
+
+            expect(response.status).toBe(200);
+            const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('http://api.example/memory/files/move');
+            expect(init.body).not.toBeUndefined();
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('ever');
+            expect(forwarded(fetchMock).get('Content-Type')).toBe('application/json');
+        });
+
+        it('POST /files/folders/:id/sync forwards the selector', async () => {
+            await syncFolder(
+                request('/api/memory/files/folders/fold-1/sync', {
+                    method: 'POST',
+                    selector: 'org:ever',
+                }),
+                params('fold-1'),
+            );
+
+            const [url] = fetchMock.mock.calls[0] as [string];
+            expect(url).toBe('http://api.example/memory/files/folders/fold-1/sync');
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('ever');
+        });
+
+        it.each([
+            ['GET /files', () => listFiles(request('/api/memory/files'))],
+            [
+                'PATCH /files/move',
+                () => moveFiles(request('/api/memory/files/move', { method: 'PATCH', body: '{}' })),
+            ],
+            [
+                'POST /files/folders/:id/sync',
+                () =>
+                    syncFolder(
+                        request('/api/memory/files/folders/fold-1/sync', { method: 'POST' }),
+                        params('fold-1'),
+                    ),
+            ],
+        ])('%s fails closed before upstream without a selector', async (_label, call) => {
+            const response = await call();
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('GET /files fails closed on a malformed selector', async () => {
+            const response = await listFiles(
+                request('/api/memory/files', { selector: 'org:Not A Slug' }),
+            );
+
+            expect(response.status).toBe(400);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+
+    /**
+     * These four handlers key off `auth.userId` alone — `getTree`,
+     * `upload`, `createFolder`, `updateFolder`/`deleteFolder` never touch
+     * `ScopeContextService`. `memory_folders` is one per-user tree shared
+     * by every workspace, and an upload lands in the caller's own
+     * `user_uploads` spine. Scoping them would forward a header nobody
+     * reads and would newly 400 requests that are correct today, so the
+     * spec pins them as unscoped-on-purpose rather than as an oversight.
+     */
+    describe('unscoped — the handler is per-user', () => {
+        it.each([
+            ['GET /files/tree', () => getTree(request('/api/memory/files/tree'))],
+            [
+                'POST /files/upload',
+                () => uploadFile(request('/api/memory/files/upload', { method: 'POST' })),
+            ],
+            [
+                'POST /files/folders',
+                () => createFolder(request('/api/memory/files/folders', { method: 'POST' })),
+            ],
+            [
+                'PATCH /files/folders/:id',
+                () =>
+                    updateFolder(
+                        request('/api/memory/files/folders/fold-1', { method: 'PATCH' }),
+                        params('fold-1'),
+                    ),
+            ],
+            [
+                'DELETE /files/folders/:id',
+                () =>
+                    deleteFolder(
+                        request('/api/memory/files/folders/fold-1', { method: 'DELETE' }),
+                        params('fold-1'),
+                    ),
+            ],
+        ])('%s reaches upstream without a selector and sends no scope', async (_label, call) => {
+            const response = await call();
+
+            expect(response.status).toBe(200);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            // Not merely "absent": the incoming request DID carry an
+            // `x-scope-slug`, and the proxy must not relay a browser's.
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBeNull();
+            expect(forwarded(fetchMock).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        });
+    });
+
+    /**
+     * KNOWN GAP, pinned so a later change is a deliberate one.
+     *
+     * `MemoryFilesController.download` IS org-aware, but the URL is reached
+     * by browser document requests — the `<a href>` in `MemoryFilesPanel`,
+     * the same anchor in `MemoryFilePreview`, and the KB binary viewers'
+     * `<img>`/`<video>` sources — none of which can carry a custom header.
+     * Scoping it would 400 every download instead of 404-ing the org-scoped
+     * originals only, so it stays unscoped until a human picks a carrier.
+     */
+    describe('unscoped — download cannot carry a header', () => {
+        it('GET /files/:id/download serves without a selector and sends no scope', async () => {
+            const response = await downloadFile(
+                request('/api/memory/files/kb-9/download?source=kb-upload'),
+                params('kb-9'),
+            );
+
+            expect(response.status).toBe(200);
+            const [url] = fetchMock.mock.calls[0] as [string];
+            expect(url).toBe('http://api.example/memory/files/kb-9/download?source=kb-upload');
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBeNull();
+        });
+
+        it('GET /files/:id/download ignores a selector rather than acting on it', async () => {
+            await downloadFile(
+                request('/api/memory/files/kb-9/download?source=kb-upload', {
+                    selector: 'org:ever',
+                }),
+                params('kb-9'),
+            );
+
+            // A selector reaches this route only from the preview's text
+            // fetch, never from the anchor or the binary viewers. Honouring
+            // it here would make downloads succeed or 404 depending on which
+            // control the user clicked.
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBeNull();
+        });
+    });
+});

--- a/apps/web/src/app/api/memory/files/tree/route.ts
+++ b/apps/web/src/app/api/memory/files/tree/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../proxy';
 
-/** Proxy — `GET /api/memory/files/tree` (folder tree + counts). */
+/**
+ * Proxy — `GET /api/memory/files/tree` (folder tree + counts).
+ *
+ * NOT scoped (EW-786), deliberately. `MemoryFilesController.getTree`
+ * calls `MemoryFoldersService.getTree(auth.userId)` and never touches
+ * `ScopeContextService`: `memory_folders` is a per-user tree, the same
+ * one in every workspace. Scoping this would forward a header the
+ * handler ignores and would newly 400 a request that is correct today.
+ */
 export async function GET(request: NextRequest) {
-    return proxyMemoryFiles(request, '/memory/files/tree');
+    return proxyMemoryFiles(request, '/memory/files/tree', { method: 'GET', scoped: false });
 }

--- a/apps/web/src/app/api/memory/files/upload/route.ts
+++ b/apps/web/src/app/api/memory/files/upload/route.ts
@@ -1,10 +1,20 @@
 import { NextRequest } from 'next/server';
 import { proxyMemoryFiles } from '../proxy';
 
-/** Proxy — `POST /api/memory/files/upload` (multipart, streamed upstream). */
+/**
+ * Proxy — `POST /api/memory/files/upload` (multipart, streamed upstream).
+ *
+ * NOT scoped (EW-786), deliberately. `MemoryFilesController.upload`
+ * validates the folder against `auth.userId`, stores through
+ * `UploadsService.saveFile(auth.userId, …)` and files the row by sha256
+ * — no `ScopeContextService` anywhere on the path. The bytes land in the
+ * caller's own `user_uploads` spine regardless of workspace, so there is
+ * no Organization for a scope header to select.
+ */
 export async function POST(request: NextRequest) {
     return proxyMemoryFiles(request, '/memory/files/upload', {
         method: 'POST',
         body: request.body,
+        scoped: false,
     });
 }

--- a/apps/web/src/app/api/memory/health/route.ts
+++ b/apps/web/src/app/api/memory/health/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Memory health (memory upgrades M10) — read-only same-origin proxy for
@@ -11,18 +12,46 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * `Authorization: Bearer`, API base URL stays server-side). The query
  * string (`?windowDays=&staleAfterDays=`) is forwarded verbatim.
  *
- * The active Organization is resolved by the API from the request scope
- * context, never a param — so there is nothing org-specific to forward.
- * An org-less session gets the empty payload (all counts 0, every rate
- * `null`), which the panel renders as "not measurable yet".
+ * The active Organization is never a param — the API resolves it from the
+ * request scope context. That context does NOT arrive on its own, though:
+ * this hop is what puts an Organization in it (see EW-786 below). A
+ * genuinely org-less session still gets the empty payload (all counts 0,
+ * every rate `null`), which the panel renders as "not measurable yet".
+ *
+ * EW-786 — why that scope context needs help from this hop. It only ever
+ * carries an Organization when the request arrived with `x-scope-slug`
+ * (or on an `/api/<slug>/…` path): `ScopeResolverMiddleware` runs an
+ * unprefixed call under `EMPTY_SCOPE`, and `SessionScopeGuard` then seeds
+ * bare personal scope — it deliberately refuses to read the user's stored
+ * last-Organization preference, because that is a navigation default and
+ * not request authorization. This proxy forwarded no scope header at all,
+ * so `OrgMemoryController.getMemoryHealth` took its
+ * `organizationId === null` branch on EVERY request from the web app and
+ * answered `emptyHealth()` — `MemoryHealthService.getOrgHealth` was
+ * unreachable, for personal and Organization sessions alike. The panel
+ * has no way to tell that payload apart from a genuinely quiet
+ * Organization, so it rendered a measurable-looking wall of zeroes over
+ * real retrieval history: precisely the "a number nobody should act on"
+ * failure its own `null` handling exists to prevent.
+ *
+ * Translating the browser's per-tab selector here is what makes the org
+ * branch reachable. `KbMemoryHealthPanel` moves to `browserApiFetch` in
+ * the same change, so the 400 below is a contract violation by some
+ * future caller, never something a reader of the panel can reach.
  */
 export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
-    headers.set('Accept', 'application/json');
+    const baseHeaders: Record<string, string> = { Accept: 'application/json' };
     if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+        baseHeaders.Authorization = `Bearer ${token}`;
+    }
+
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, baseHeaders);
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
     }
 
     const search = request.nextUrl.search;

--- a/apps/web/src/app/api/memory/health/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/health/route.unit.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET } from './route';
+
+function request(selector?: string) {
+    // A spoofed API scope header rides along on purpose: the browser may
+    // select a workspace, never name the Organization the API resolves.
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-yo' });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/health?windowDays=7', { headers });
+}
+
+/**
+ * EW-786. `OrgMemoryController.getMemoryHealth` reads the Organization off
+ * the request scope and returns `emptyHealth()` — all counts 0, every rate
+ * `null` — when there is none. That scope only ever holds an Organization
+ * when `x-scope-slug` arrives (`SessionScopeGuard` refuses to read the
+ * user's stored last-Organization preference), so an unscoped proxy hop
+ * made `MemoryHealthService.getOrgHealth` unreachable from the web app for
+ * every session. It did not fail: it reported a confident, measurable zero
+ * over real retrieval history, which is the one thing `KbMemoryHealthPanel`
+ * is written not to show.
+ */
+describe('GET /api/memory/health workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ windowDays: 7, recallHitRate: null }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await GET(request('org:ever'));
+
+        expect(response.status).toBe(200);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        // The metric window survives the hop; only the scope headers change.
+        expect(String(url)).toBe('http://api.example/memory/health?windowDays=7');
+        const headers = new Headers(init.headers);
+        expect(headers.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+    });
+
+    it('forwards a genuinely personal workspace as the personal sentinel', async () => {
+        await GET(request('personal'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await GET(request());
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/memory/review/[docId]/accept/route.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/accept/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 type RouteContext = { params: Promise<{ docId: string }> };
 
@@ -11,18 +12,37 @@ type RouteContext = { params: Promise<{ docId: string }> };
  * for context injection, so the upstream re-fetches it scoped to the
  * caller's Organization before writing and answers 404 — not 403 — when
  * it belongs to someone else. Nothing about that decision happens here;
- * this only forwards the caller's bearer.
+ * this only forwards the caller's bearer and the caller's scope.
+ *
+ * EW-786: the scope half was missing. `acceptMemoryDocument` reads the
+ * Organization off the request scope and refuses with 422 when there is
+ * none, so every Accept click from an Organization tab failed — the
+ * write path has no empty-payload fallback the way the queue read does.
+ * Translating the browser's `x-ever-workspace` selector into
+ * `x-scope-slug` here is what makes the button work at all, and it must
+ * land in the same change as the panel's `browserApiFetch` transport:
+ * scoped route + raw `fetch()` caller is a guaranteed 400.
  */
-export async function POST(_request: NextRequest, { params }: RouteContext) {
+export async function POST(request: NextRequest, { params }: RouteContext) {
     const { docId } = await params;
     const token = await getAuthAccessCookie();
     if (!token) {
         return new Response('Unauthorized', { status: 401 });
     }
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(`${API_URL}/memory/review/${encodeURIComponent(docId)}/accept`, {
         method: 'POST',
-        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        headers,
         cache: 'no-store',
     });
 

--- a/apps/web/src/app/api/memory/review/[docId]/accept/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/accept/route.unit.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { POST } from './route';
+
+const params = Promise.resolve({ docId: 'doc-1' });
+
+function request(selector?: string) {
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-yo' });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/review/doc-1/accept', {
+        method: 'POST',
+        headers,
+    });
+}
+
+/**
+ * EW-786. Unlike the queue read, `acceptMemoryDocument` has no empty-payload
+ * fallback: with no Organization on the request scope it throws 422. So an
+ * unscoped proxy hop made every Accept click fail for an Organization member,
+ * and only the browser's per-tab selector can supply that scope.
+ */
+describe('POST /api/memory/review/[docId]/accept workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ id: 'doc-1', reviewState: 'accepted' }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await POST(request('org:ever'), { params });
+
+        expect(response.status).toBe(200);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(String(url)).toBe('http://api.example/memory/review/doc-1/accept');
+        const headers = new Headers(init.headers);
+        expect(headers.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await POST(request(), { params });
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/memory/review/[docId]/reject/route.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/reject/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 type RouteContext = { params: Promise<{ docId: string }> };
 
@@ -10,18 +11,35 @@ type RouteContext = { params: Promise<{ docId: string }> };
  * Rejecting ARCHIVES the document — it is not a delete, and the upstream
  * refuses ids outside the caller's Organization with a 404 rather than a
  * 403 so the endpoint cannot be used to probe which ids exist elsewhere.
- * None of that is decided here; this only forwards the caller's bearer.
+ * None of that is decided here; this only forwards the caller's bearer
+ * and the caller's scope.
+ *
+ * EW-786: the scope half was missing, exactly as on the accept twin, and
+ * with the same consequence — `rejectMemoryDocument` answers 422 with no
+ * Organization on the request scope. Both verbs are fixed together
+ * because the panel disables neither independently: a user who can see a
+ * row can click either button.
  */
-export async function POST(_request: NextRequest, { params }: RouteContext) {
+export async function POST(request: NextRequest, { params }: RouteContext) {
     const { docId } = await params;
     const token = await getAuthAccessCookie();
     if (!token) {
         return new Response('Unauthorized', { status: 401 });
     }
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(`${API_URL}/memory/review/${encodeURIComponent(docId)}/reject`, {
         method: 'POST',
-        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        headers,
         cache: 'no-store',
     });
 

--- a/apps/web/src/app/api/memory/review/[docId]/reject/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/reject/route.unit.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { POST } from './route';
+
+const params = Promise.resolve({ docId: 'doc-1' });
+
+function request(selector?: string) {
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-yo' });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/review/doc-1/reject', {
+        method: 'POST',
+        headers,
+    });
+}
+
+/**
+ * EW-786, the accept twin. `rejectMemoryDocument` refuses with 422 when the
+ * request scope names no Organization, so this verb needs the same
+ * translation — and needs it in the same change, because the panel offers
+ * both buttons on every row it shows.
+ */
+describe('POST /api/memory/review/[docId]/reject workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ id: 'doc-1', status: 'archived' }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await POST(request('org:ever'), { params });
+
+        expect(response.status).toBe(200);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(String(url)).toBe('http://api.example/memory/review/doc-1/reject');
+        const headers = new Headers(init.headers);
+        expect(headers.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await POST(request(), { params });
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/memory/review/route.ts
+++ b/apps/web/src/app/api/memory/review/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Proxy for `GET /api/memory/review` — the Memory review queue.
@@ -9,6 +10,16 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  * Memory Consolidation produces and deliberately does not auto-accept.
  * The Organization is resolved server-side from the request scope, so
  * there is no org id for a client to tamper with.
+ *
+ * EW-786: "the request scope" reaches the API only from `x-scope-slug`
+ * (or an `/api/<slug>/…` path), so this hop is where the browser's
+ * per-tab `x-ever-workspace` selector has to become that header. Until it
+ * did, `listMemoryReviewQueue` found no Organization and returned its
+ * empty payload rather than an error — and `MemoryReviewPanel` hides
+ * itself on an empty queue, so a backlog of proposed documents was
+ * indistinguishable from a clean queue on every `/org/<slug>/memory`
+ * visit. Scoping this GET without also scoping the panel's transport
+ * would swap that silence for a hard 400, so the two ship together.
  */
 export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
@@ -16,9 +27,19 @@ export async function GET(request: NextRequest) {
         return new Response('Unauthorized', { status: 401 });
     }
 
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        });
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+    }
+
     const upstream = await fetch(`${API_URL}/memory/review${request.nextUrl.search}`, {
         method: 'GET',
-        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        headers,
         cache: 'no-store',
     });
 

--- a/apps/web/src/app/api/memory/review/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/review/route.unit.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET } from './route';
+
+function request(selector?: string) {
+    // A spoofed API scope header is present on purpose: the browser must
+    // never be able to name the Organization directly, only select one.
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-yo' });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/review?limit=50', { headers });
+}
+
+/**
+ * EW-786. `OrgMemoryController.listMemoryReviewQueue` reads the Organization
+ * off the request scope and returns `{ items: [], total: 0 }` when there is
+ * none — so an unscoped proxy hop did not fail loudly, it reported an empty
+ * queue, and `MemoryReviewPanel` renders nothing on an empty queue. A backlog
+ * of proposed documents was therefore invisible rather than broken.
+ */
+describe('GET /api/memory/review workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ items: [], total: 0 }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('overwrites spoofing and forwards the explicit per-tab Organization selector', async () => {
+        const response = await GET(request('org:ever'));
+
+        expect(response.status).toBe(200);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        // The pagination query survives the hop; only the scope headers change.
+        expect(String(url)).toBe('http://api.example/memory/review?limit=50');
+        const headers = new Headers(init.headers);
+        expect(headers.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+    });
+
+    it('forwards a genuinely personal workspace as the personal sentinel', async () => {
+        await GET(request('personal'));
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(new Headers(init.headers).get(API_SCOPE_HEADER)).toBe('@personal');
+    });
+
+    it('fails closed before upstream when the browser selector is absent', async () => {
+        const response = await GET(request());
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/app/api/memory/uploads/route.ts
+++ b/apps/web/src/app/api/memory/uploads/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 /**
  * Proxy for global-Memory originals — `GET`/`POST /api/memory/uploads`.
@@ -12,15 +13,38 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  *
  * The POST body is streamed upstream rather than parsed here so the
  * multipart boundary survives intact for NestJS's `FileInterceptor`.
+ *
+ * **Workspace scope (EW-786).** "Resolved server-side from the request
+ * scope" is precisely what stopped working: since `8f28edca0` the API
+ * only sees an Organization through `X-Scope-Slug` (or an `/api/<slug>/`
+ * path), and this proxy forwarded neither. Both handlers on
+ * `OrgMemoryController` read `ScopeContextService.getOrganizationId()`,
+ * and both fail SOFTLY without one — `listMemoryUploads` returns
+ * `{ items: [], total: 0 }` with a 200, `createMemoryUpload` throws 422
+ * — so the Originals panel showed an empty list and blamed the user's
+ * org setup for uploads it had scoped away itself.
+ *
+ * `applyBffWorkspaceScope` converts the browser's per-tab
+ * `x-ever-workspace` selector into `X-Scope-Slug` and overwrites any
+ * client-supplied value; a missing or stale selector is a 400 here
+ * rather than a silently personal-scoped answer. Callers must therefore
+ * use `browserApiFetch` — see `components/memory/MemoryUploadsPanel.tsx`.
  */
 
 export async function GET(request: NextRequest) {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
-    headers.set('Accept', 'application/json');
+    const baseHeaders = new Headers();
+    baseHeaders.set('Accept', 'application/json');
     if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+        baseHeaders.set('Authorization', `Bearer ${token}`);
+    }
+
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, baseHeaders);
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
     }
 
     const upstream = await fetch(`${API_URL}/memory/uploads${request.nextUrl.search}`, {
@@ -45,13 +69,20 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
     const token = await getAuthAccessCookie();
 
-    const headers = new Headers();
+    const baseHeaders = new Headers();
     const contentType = request.headers.get('content-type');
     if (contentType) {
-        headers.set('Content-Type', contentType);
+        baseHeaders.set('Content-Type', contentType);
     }
     if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+        baseHeaders.set('Authorization', `Bearer ${token}`);
+    }
+
+    let headers: Headers;
+    try {
+        headers = applyBffWorkspaceScope(request, baseHeaders);
+    } catch {
+        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
     }
 
     const upstream = await fetch(`${API_URL}/memory/uploads`, {

--- a/apps/web/src/app/api/memory/uploads/route.unit.spec.ts
+++ b/apps/web/src/app/api/memory/uploads/route.unit.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: vi.fn(async () => 'fake-jwt'),
+}));
+
+vi.mock('@/lib/constants', () => ({
+    API_URL: 'http://api.example',
+}));
+
+import { GET, POST } from './route';
+
+function listRequest(selector?: string): NextRequest {
+    // Pre-set so the spec proves the BFF overwrites the API contract header
+    // rather than letting a browser choose the Organization it reads.
+    const headers = new Headers({ [API_SCOPE_HEADER]: 'attacker-supplied-org' });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/uploads?limit=50', { headers });
+}
+
+function uploadRequest(selector?: string): NextRequest {
+    const headers = new Headers({
+        'content-type': 'multipart/form-data; boundary=----spec',
+        [API_SCOPE_HEADER]: 'attacker-supplied-org',
+    });
+    if (selector) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest('http://web.example/api/memory/uploads', {
+        method: 'POST',
+        headers,
+        body: '------spec\r\n\r\n------spec--\r\n',
+    });
+}
+
+function forwarded(fetchMock: ReturnType<typeof vi.fn>): Headers {
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    return new Headers(init.headers);
+}
+
+/**
+ * EW-786 — the global-Memory Originals half of the BFF scope contract.
+ *
+ * Both handlers on `OrgMemoryController` resolve the Organization from
+ * `ScopeContextService`, and both fail SOFTLY without one:
+ * `listMemoryUploads` returns `{ items: [], total: 0 }` at HTTP 200 and
+ * `createMemoryUpload` throws 422 ("no active Organization"). Since
+ * `8f28edca0` this proxy forwarded no scope at all, so the panel showed an
+ * empty Originals list for a populated org and blamed the user's org setup
+ * for every upload it had itself scoped away.
+ *
+ * These pin both halves: the per-tab `x-ever-workspace` selector becomes
+ * `X-Scope-Slug`, and its absence is a 400 BEFORE the upstream call — never
+ * a personal-scoped empty list or a misleading 422.
+ */
+describe('/api/memory/uploads workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ items: [{ id: 'up-1' }], total: 1 }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    describe('GET — list originals', () => {
+        it('forwards the per-tab selector as the API scope header', async () => {
+            const response = await GET(listRequest('org:ever'));
+
+            expect(response.status).toBe(200);
+            expect(await response.json()).toMatchObject({ total: 1 });
+
+            const [url] = fetchMock.mock.calls[0] as [string];
+            expect(url).toBe('http://api.example/memory/uploads?limit=50');
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('ever');
+            expect(forwarded(fetchMock).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+            expect(forwarded(fetchMock).get('Authorization')).toBe('Bearer fake-jwt');
+        });
+
+        it('maps the personal selector to the personal sentinel', async () => {
+            await GET(listRequest('personal'));
+
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('@personal');
+        });
+
+        it('fails closed before upstream when the selector is absent', async () => {
+            const response = await GET(listRequest());
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('fails closed on a malformed selector', async () => {
+            const response = await GET(listRequest('org:Not A Slug'));
+
+            expect(response.status).toBe(400);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('POST — upload an original', () => {
+        it('forwards the selector and keeps the multipart content type intact', async () => {
+            const response = await POST(uploadRequest('org:ever'));
+
+            expect(response.status).toBe(200);
+            const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('http://api.example/memory/uploads');
+            // The body is streamed, not re-parsed — the boundary has to
+            // survive for NestJS's FileInterceptor.
+            expect(init.body).not.toBeUndefined();
+            expect(forwarded(fetchMock).get(API_SCOPE_HEADER)).toBe('ever');
+            expect(forwarded(fetchMock).get('Content-Type')).toBe(
+                'multipart/form-data; boundary=----spec',
+            );
+        });
+
+        it('fails closed before writing anything when the selector is absent', async () => {
+            const response = await POST(uploadRequest());
+
+            expect(response.status).toBe(400);
+            expect(await response.json()).toEqual({ error: 'Invalid workspace scope' });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/web/src/components/kb/workbench/KbMemoryHealthPanel.tsx
+++ b/apps/web/src/components/kb/workbench/KbMemoryHealthPanel.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Activity, HelpCircle, Inbox, Milestone, Search } from 'lucide-react';
 import type { KbMemoryHealth } from '@ever-works/contracts';
 import { cn } from '@/lib/utils/cn';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 /**
  * Memory health panel (memory upgrades M10).
@@ -21,8 +22,19 @@ import { cn } from '@/lib/utils/cn';
  * is how a health panel starts lying to its reader.
  *
  * Org-scoped: the API resolves the Organization from the request scope
- * context, so there is nothing to pass — a session with no active org
+ * context, so there is no org id to pass — a session with no active org
  * gets the empty payload and the panel says so.
+ *
+ * EW-786 — but the scope context has to be told which workspace this tab
+ * is looking at. `browserApiFetch` (not a bare `fetch`) is what stamps
+ * the per-tab `x-ever-workspace` selector the BFF route turns into the
+ * API's `x-scope-slug`. Without it the request reached the API unscoped,
+ * `getMemoryHealth` fell to its org-less branch, and this panel rendered
+ * a fully populated wall of zeroes for an Organization with real
+ * retrieval history — a lie the `null` handling above cannot catch,
+ * because `emptyHealth()` reports measurable zeroes rather than `null`.
+ * The route now answers 400 without that selector, so the two halves are
+ * a matched pair: a raw `fetch` here would surface as the error state.
  */
 
 export interface KbMemoryHealthPanelProps {
@@ -55,7 +67,7 @@ export function KbMemoryHealthPanel({
         if (initialHealth) return;
         let cancelled = false;
         const query = windowDays ? `?windowDays=${windowDays}` : '';
-        fetch(`/api/memory/health${query}`, { cache: 'no-store' })
+        browserApiFetch(`/api/memory/health${query}`, { cache: 'no-store' })
             .then(async (res) => {
                 if (!res.ok) throw new Error(`HTTP ${res.status}`);
                 return (await res.json()) as KbMemoryHealth;

--- a/apps/web/src/components/kb/workbench/KbMemoryHealthPanel.unit.spec.tsx
+++ b/apps/web/src/components/kb/workbench/KbMemoryHealthPanel.unit.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import type { KbMemoryHealth } from '@ever-works/contracts';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 
 vi.mock('next-intl', () => ({
     useTranslations: () => (key: string, values?: Record<string, unknown>) =>
@@ -116,5 +117,72 @@ describe('KbMemoryHealthPanel', () => {
         render(<KbMemoryHealthPanel initialHealth={health({ windowDays: 7 })} />);
 
         expect(screen.getByTestId('kb-memory-health-window').textContent).toContain('7');
+    });
+});
+
+/**
+ * EW-786 — the client half of the health-panel fix.
+ *
+ * `GET /api/memory/health` now translates the per-tab `x-ever-workspace`
+ * selector into the API's `x-scope-slug` and answers 400 without it, so this
+ * panel has to reach it through `browserApiFetch`. A raw `fetch()` sent no
+ * selector at all: the API resolved no Organization, returned `emptyHealth()`
+ * — measurable zeroes, not `null`s — and the panel rendered "0% recall, 0
+ * backlog" over an Organization with real retrieval history. That is the one
+ * failure the tests above exist to prevent, arriving by a route they cannot
+ * see — every one of them injects `initialHealth` and so never touches the
+ * transport. It is pinned here instead: the selector must be derived from the
+ * visible URL on the request the panel actually makes.
+ */
+describe('KbMemoryHealthPanel workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    function selectorOf(index: number): string | null {
+        const init = fetchMock.mock.calls[index][1] as RequestInit | undefined;
+        return new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER);
+    }
+
+    beforeEach(() => {
+        fetchMock = vi.fn(
+            async () =>
+                new Response(JSON.stringify(health()), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/works/w1/kb/review', 'org:ever'],
+        ['/works/w1/kb/review', 'personal'],
+    ])(
+        'loads health from %s with the selector derived from the visible URL',
+        async (pathname, selector) => {
+            window.history.replaceState({}, '', pathname);
+
+            render(<KbMemoryHealthPanel />);
+
+            await waitFor(() => expect(screen.getByTestId('kb-memory-health')).toBeTruthy());
+            expect(String(fetchMock.mock.calls[0][0])).toBe('/api/memory/health');
+            expect(selectorOf(0)).toBe(selector);
+        },
+    );
+
+    it('keeps the window query and still scopes the request', async () => {
+        window.history.replaceState({}, '', '/org/ever/works/w1/kb/review');
+
+        render(<KbMemoryHealthPanel windowDays={7} />);
+
+        await waitFor(() => expect(screen.getByTestId('kb-memory-health')).toBeTruthy());
+        expect(String(fetchMock.mock.calls[0][0])).toBe('/api/memory/health?windowDays=7');
+        expect(selectorOf(0)).toBe('org:ever');
     });
 });

--- a/apps/web/src/components/memory/MemoryConsolidationSettings.tsx
+++ b/apps/web/src/components/memory/MemoryConsolidationSettings.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { CalendarClock, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 /**
  * Scheduled Memory Consolidation — the settings that turn it on.
@@ -20,6 +21,12 @@ import { cn } from '@/lib/utils/cn';
  *              which appear in the review queue and are withheld from
  *              agent context until a human accepts them
  * Neither ever auto-accepts, and neither deletes anything.
+ *
+ * EW-786 — every call goes through `browserApiFetch`, which stamps the
+ * visible tab's `x-ever-workspace` selector; the BFF route translates it
+ * into the API's `X-Scope-Slug`. These settings live on the Organization,
+ * so with a plain `fetch()` the read returned the personal-scope defaults
+ * and the write was rejected 422 by the API — see the route's own note.
  */
 
 interface Settings {
@@ -37,12 +44,13 @@ export function MemoryConsolidationSettings() {
     const t = useTranslations('dashboard.memoryPage.schedule');
     const [settings, setSettings] = useState<Settings | null>(null);
     const [saving, setSaving] = useState(false);
+    const [saveFailed, setSaveFailed] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
         void (async () => {
             try {
-                const res = await fetch('/api/memory/consolidation/settings', {
+                const res = await browserApiFetch('/api/memory/consolidation/settings', {
                     headers: { Accept: 'application/json' },
                     cache: 'no-store',
                 });
@@ -61,6 +69,7 @@ export function MemoryConsolidationSettings() {
 
     const save = useCallback(async (patch: Partial<Settings>) => {
         setSaving(true);
+        setSaveFailed(false);
         // Optimistic so the control responds immediately — but a settings
         // form must never keep a value it failed to store. Both the error
         // and the non-ok paths roll back to what was actually saved,
@@ -72,19 +81,25 @@ export function MemoryConsolidationSettings() {
             return prev ? { ...prev, ...patch } : prev;
         });
         try {
-            const res = await fetch('/api/memory/consolidation/settings', {
+            const res = await browserApiFetch('/api/memory/consolidation/settings', {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(patch),
             });
             if (!res.ok) {
+                // Rolling back is necessary but not sufficient. On its own
+                // the control just flicks back to its old value, which is
+                // indistinguishable from a mis-click — so the user retries
+                // the same failing write instead of learning it failed.
                 setSettings(previous);
+                setSaveFailed(true);
                 return;
             }
             const body = (await res.json()) as Settings;
             setSettings(body);
         } catch {
             setSettings(previous);
+            setSaveFailed(true);
         } finally {
             setSaving(false);
         }
@@ -112,6 +127,16 @@ export function MemoryConsolidationSettings() {
                 {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" strokeWidth={1.5} />}
             </div>
             <p className="text-sm text-text-muted dark:text-text-muted-dark">{t('subtitle')}</p>
+
+            {saveFailed && (
+                <p
+                    role="alert"
+                    data-testid="memory-schedule-error"
+                    className="rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-sm text-red-600 dark:text-red-400"
+                >
+                    {t('saveFailed')}
+                </p>
+            )}
 
             <div className="flex flex-wrap items-center gap-3">
                 <label className="flex items-center gap-2 text-sm text-text dark:text-text-dark">

--- a/apps/web/src/components/memory/MemoryConsolidationSettings.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryConsolidationSettings.unit.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 
 vi.mock('next-intl', () => ({
     useTranslations: () => (key: string) => key,
@@ -16,6 +17,13 @@ import { MemoryConsolidationSettings } from './MemoryConsolidationSettings';
  * but stored nothing leaves the user believing consolidation is on when
  * it is not — the same class of silent wrongness the underlying feature
  * had before it was configurable at all.
+ *
+ * Two distinct faults are pinned below. The scope one (EW-786): these
+ * settings are per-Organization, and the BFF route can only derive the
+ * Organization from the `x-ever-workspace` selector `browserApiFetch`
+ * stamps — a plain `fetch()` read the personal defaults and wrote
+ * nothing. And the reporting one: the panel already rolled a failed
+ * write back, but said nothing, so the toggle simply flicked back.
  */
 
 const SETTINGS = {
@@ -36,9 +44,18 @@ function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
     });
 }
 
+function selectorsFrom(fetchMock: { mock: { calls: unknown[][] } }): (string | null)[] {
+    return fetchMock.mock.calls.map((call) =>
+        new Headers((call[1] as RequestInit | undefined)?.headers).get(
+            BROWSER_WORKSPACE_SCOPE_HEADER,
+        ),
+    );
+}
+
 describe('MemoryConsolidationSettings', () => {
     afterEach(() => {
         vi.restoreAllMocks();
+        window.history.replaceState({}, '', '/');
     });
 
     beforeEach(() => {
@@ -119,5 +136,98 @@ describe('MemoryConsolidationSettings', () => {
             const current = screen.getByTestId('memory-schedule-enabled') as HTMLInputElement;
             expect(current.checked).toBe(false);
         });
+    });
+
+    it('stamps the visible tab Organization on the read and the write alike', async () => {
+        // The settings row is keyed by Organization on the platform side.
+        // A read without the selector answers with the personal-scope
+        // defaults, which would render as "off, weekly, dry-run" over the
+        // top of a schedule that is actually running.
+        const fetchMock = mockFetch((url, init) =>
+            init?.method === 'PUT'
+                ? { ok: true, json: () => ({ ...SETTINGS, enabled: true }) }
+                : { ok: true, json: () => SETTINGS },
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        window.history.replaceState({}, '', '/org/ever/memory');
+
+        render(<MemoryConsolidationSettings />);
+        fireEvent.click(await screen.findByTestId('memory-schedule-enabled'));
+
+        await waitFor(() => {
+            expect(fetchMock.mock.calls.length).toBe(2);
+        });
+        expect(selectorsFrom(fetchMock)).toEqual(['org:ever', 'org:ever']);
+    });
+
+    it('sends the explicit personal selector from an unprefixed route', async () => {
+        // Not the same as sending nothing: the route fails closed on an
+        // absent selector, so "personal" has to be said out loud.
+        const fetchMock = mockFetch(() => ({ ok: true, json: () => SETTINGS }));
+        vi.stubGlobal('fetch', fetchMock);
+        window.history.replaceState({}, '', '/memory');
+
+        render(<MemoryConsolidationSettings />);
+        await screen.findByTestId('memory-schedule-enabled');
+
+        expect(selectorsFrom(fetchMock)).toEqual(['personal']);
+    });
+
+    it('says the save failed rather than only reverting the control', async () => {
+        // A rollback on its own is indistinguishable from a mis-click, so
+        // the user retries the same failing write. This is the shape the
+        // scope bug wore in production: every PUT came back 422 and the
+        // toggle just refused to stay on, with nothing on screen.
+        const fetchMock = mockFetch((url, init) =>
+            init?.method === 'PUT'
+                ? { ok: false, json: () => ({}) }
+                : { ok: true, json: () => SETTINGS },
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(<MemoryConsolidationSettings />);
+        const toggle = (await screen.findByTestId('memory-schedule-enabled')) as HTMLInputElement;
+        expect(screen.queryByTestId('memory-schedule-error')).toBeNull();
+
+        fireEvent.click(toggle);
+
+        const alert = await screen.findByTestId('memory-schedule-error');
+        expect(alert).toHaveAttribute('role', 'alert');
+        expect((screen.getByTestId('memory-schedule-enabled') as HTMLInputElement).checked).toBe(
+            false,
+        );
+    });
+
+    it('reports a thrown save the same way, and clears the notice on the next attempt', async () => {
+        let failNext = true;
+        const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+            if (init?.method !== 'PUT') {
+                return Promise.resolve({ ok: true, json: () => Promise.resolve(SETTINGS) });
+            }
+            if (failNext) return Promise.reject(new Error('offline'));
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ ...SETTINGS, enabled: true }),
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(<MemoryConsolidationSettings />);
+        const toggle = (await screen.findByTestId('memory-schedule-enabled')) as HTMLInputElement;
+
+        fireEvent.click(toggle);
+        await screen.findByTestId('memory-schedule-error');
+
+        failNext = false;
+        fireEvent.click(screen.getByTestId('memory-schedule-enabled'));
+
+        // A stale error banner over a control that now saved fine is the
+        // mirror image of the original defect.
+        await waitFor(() => {
+            expect(screen.queryByTestId('memory-schedule-error')).toBeNull();
+        });
+        expect((screen.getByTestId('memory-schedule-enabled') as HTMLInputElement).checked).toBe(
+            true,
+        );
     });
 });

--- a/apps/web/src/components/memory/MemoryFilePreview.tsx
+++ b/apps/web/src/components/memory/MemoryFilePreview.tsx
@@ -27,6 +27,17 @@ import type { MemoryFileRow } from '@/lib/api/memory-files-types';
  * Unlike the KB (which stores a rendered body to show instead), Files
  * has only bytes, so this component fetches small text payloads itself
  * and renders them; anything else falls back to a download card.
+ *
+ * **Transport (EW-786).** The text preview below stays on a raw
+ * `fetch()` — the exception to the rest of Memory, which moved to
+ * `browserApiFetch`. `url` is the download route, and that route is
+ * deliberately left UNSCOPED because the binary viewers put the very
+ * same `url` on an `<img>`/`<video>`/object element and the overlay's
+ * own Download control is an `<a href>`; neither can carry a header, and
+ * a scoped route 400s without one. Sending the selector from here alone
+ * would imply a contract the route does not honour. The consequence is
+ * that previewing an org-scoped Memory original 404s — see
+ * `app/api/memory/files/[id]/download/route.ts` for the full analysis.
  */
 
 /** Text payloads above this are not fetched for inline display. */

--- a/apps/web/src/components/memory/MemoryFilesPanel.tsx
+++ b/apps/web/src/components/memory/MemoryFilesPanel.tsx
@@ -17,6 +17,7 @@ import {
     Upload,
     X,
 } from 'lucide-react';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { cn } from '@/lib/utils/cn';
 import { UploadDropZone } from '@/components/kb/workbench/UploadDropZone';
 import { MemoryFilePreview } from './MemoryFilePreview';
@@ -39,6 +40,20 @@ import type {
  * agent-owner badge on agent-private folders, and a Global/Agents scope
  * toggle. Additive beside the existing memory panels; talks to the
  * same-origin BFF proxies under `/api/memory/files`.
+ *
+ * **Transport (EW-786).** Every request here goes through
+ * `browserApiFetch`, never a raw `fetch()`. Three of those proxies —
+ * the unified list, `move`, and `folders/:id/sync` — now mint the API's
+ * `X-Scope-Slug` from the per-tab `x-ever-workspace` selector and answer
+ * 400 without it; a raw `fetch()` left them in personal scope, where the
+ * API returns a 200 with the org's Memory originals silently missing.
+ * The tree / upload / folder-CRUD proxies are per-user and deliberately
+ * unscoped (see their route files), but they share the panel's transport
+ * so a later scoping change cannot half-land: the `refresh()` pair fires
+ * tree and list together, and only one of the two is scope-sensitive.
+ *
+ * The one thing `browserApiFetch` cannot reach is the Download anchor —
+ * see the comment on it below, and on `[id]/download/route.ts`.
  */
 
 type ScopeFilter = 'all' | 'global' | 'agents';
@@ -94,8 +109,10 @@ export function MemoryFilesPanel() {
             }
             const query = params.toString();
             const [treeRes, listRes] = await Promise.all([
-                fetch('/api/memory/files/tree', { cache: 'no-store' }),
-                fetch(`/api/memory/files${query ? `?${query}` : ''}`, { cache: 'no-store' }),
+                browserApiFetch('/api/memory/files/tree', { cache: 'no-store' }),
+                browserApiFetch(`/api/memory/files${query ? `?${query}` : ''}`, {
+                    cache: 'no-store',
+                }),
             ]);
             if (treeRes.ok) {
                 const body = (await treeRes.json()) as MemoryFolderTreeResponse;
@@ -177,7 +194,7 @@ export function MemoryFilesPanel() {
         setIsSubmittingFolder(true);
         setError(null);
         try {
-            const res = await fetch('/api/memory/files/folders', {
+            const res = await browserApiFetch('/api/memory/files/folders', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -209,7 +226,7 @@ export function MemoryFilesPanel() {
                     const form = new FormData();
                     form.append('file', file);
                     if (currentFolderId) form.append('folderId', currentFolderId);
-                    const res = await fetch('/api/memory/files/upload', {
+                    const res = await browserApiFetch('/api/memory/files/upload', {
                         method: 'POST',
                         body: form,
                     });
@@ -229,7 +246,7 @@ export function MemoryFilesPanel() {
         async (row: MemoryFileRow, folderId: string | null) => {
             setError(null);
             try {
-                const res = await fetch('/api/memory/files/move', {
+                const res = await browserApiFetch('/api/memory/files/move', {
                     method: 'PATCH',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -253,14 +270,14 @@ export function MemoryFilesPanel() {
         async (folder: MemoryFolderNode) => {
             setError(null);
             try {
-                const res = await fetch(
+                const res = await browserApiFetch(
                     `/api/memory/files/folders/${encodeURIComponent(folder.id)}`,
                     { method: 'DELETE' },
                 );
                 if (res.status === 422) {
                     const confirmed = window.confirm(t('deleteRecursiveConfirm'));
                     if (!confirmed) return;
-                    const forced = await fetch(
+                    const forced = await browserApiFetch(
                         `/api/memory/files/folders/${encodeURIComponent(folder.id)}?recursive=true`,
                         { method: 'DELETE' },
                     );
@@ -290,7 +307,7 @@ export function MemoryFilesPanel() {
             setError(null);
             setNotice(null);
             try {
-                const res = await fetch(
+                const res = await browserApiFetch(
                     `/api/memory/files/folders/${encodeURIComponent(folder.id)}/sync`,
                     { method: 'POST' },
                 );
@@ -322,7 +339,7 @@ export function MemoryFilesPanel() {
         async (folder: MemoryFolderNode, syncRepo: MemoryFolderSyncRepo | null) => {
             setError(null);
             try {
-                const res = await fetch(
+                const res = await browserApiFetch(
                     `/api/memory/files/folders/${encodeURIComponent(folder.id)}`,
                     {
                         method: 'PATCH',
@@ -763,6 +780,20 @@ export function MemoryFilesPanel() {
                                                         </option>
                                                     ))}
                                                 </select>
+                                                {/*
+                                                 * EW-786 known gap: a document
+                                                 * navigation carries no custom
+                                                 * header, so this anchor cannot
+                                                 * use `browserApiFetch` and the
+                                                 * download route stays unscoped.
+                                                 * Org-scoped Memory originals —
+                                                 * now VISIBLE in this table
+                                                 * because the list above is
+                                                 * scoped — 404 here. Do not
+                                                 * smuggle the scope into the
+                                                 * href; see
+                                                 * `app/api/memory/files/[id]/download/route.ts`.
+                                                 */}
                                                 <a
                                                     href={`/api/memory/files/${encodeURIComponent(row.id)}/download?source=${row.source}`}
                                                     data-testid={`memory-files-download-${row.id}`}

--- a/apps/web/src/components/memory/MemoryFilesPanel.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryFilesPanel.unit.spec.tsx
@@ -1,6 +1,7 @@
 import React, { type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 
 vi.mock('next-intl', () => ({
     useTranslations: () => (key: string) => key,
@@ -197,5 +198,117 @@ describe('MemoryFilesPanel', () => {
         fireEvent.submit(form);
 
         await waitFor(() => expect(calls).toContain('PATCH /api/memory/files/folders/fold-1'));
+    });
+});
+
+/**
+ * EW-786 — the client half of the Files BFF scope contract.
+ *
+ * `GET /api/memory/files`, `PATCH /api/memory/files/move` and
+ * `POST /api/memory/files/folders/:id/sync` now mint the API's
+ * `X-Scope-Slug` from the per-tab `x-ever-workspace` selector and answer
+ * 400 without it, so every call this panel makes has to go through
+ * `browserApiFetch`. With a raw `fetch()` the list came back at HTTP 200
+ * with the Organization's Memory originals silently missing — the Files
+ * area looked complete and was not.
+ *
+ * The sibling tree / upload / folder-CRUD proxies are per-user and stay
+ * unscoped, but they share this transport on purpose: `refresh()` fires
+ * tree and list as one `Promise.all`, and splitting the transport across
+ * that pair is how a half-landed change hides.
+ */
+describe('MemoryFilesPanel BFF transport', () => {
+    /** Records the workspace selector each request carried. */
+    function installScopedFetch(folders: MemoryFolderNode[] = [folder]) {
+        const seen: Array<{ url: string; selector: string | null }> = [];
+        const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            seen.push({
+                url,
+                selector: new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER),
+            });
+            if (url.startsWith('/api/memory/files/tree')) {
+                return new Response(JSON.stringify({ folders }), { status: 200 });
+            }
+            if (url.startsWith('/api/memory/files?') || url === '/api/memory/files') {
+                return new Response(JSON.stringify({ files: [file] }), { status: 200 });
+            }
+            return new Response(JSON.stringify({ results: [] }), { status: 200 });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        return seen;
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/memory', 'org:ever'],
+        ['/memory', 'personal'],
+    ])('stamps the %s selector on the initial tree + list pair', async (pathname, selector) => {
+        window.history.replaceState({}, '', pathname);
+        const seen = installScopedFetch();
+
+        render(<MemoryFilesPanel />);
+
+        await waitFor(() => expect(screen.getByTestId('memory-files-folder-fold-1')).toBeVisible());
+        const listed = seen.filter((r) => r.url.startsWith('/api/memory/files'));
+        expect(listed.length).toBeGreaterThanOrEqual(2);
+        // Every call, not just the scoped ones — the pair must not split.
+        expect(listed.every((r) => r.selector === selector)).toBe(true);
+    });
+
+    it('stamps the selector on the move request', async () => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+        const seen = installScopedFetch();
+        render(<MemoryFilesPanel />);
+        await waitFor(() => expect(screen.getByTestId('memory-files-folder-fold-1')).toBeVisible());
+
+        fireEvent.change(screen.getByTestId('memory-files-move-up-1'), {
+            target: { value: 'fold-1' },
+        });
+
+        await waitFor(() =>
+            expect(seen.some((r) => r.url === '/api/memory/files/move')).toBe(true),
+        );
+        expect(seen.find((r) => r.url === '/api/memory/files/move')?.selector).toBe('org:ever');
+    });
+
+    it('stamps the selector on the folder sync request', async () => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+        // "Sync now" only renders once a git target is configured.
+        const seen = installScopedFetch([
+            { ...folder, syncRepo: { owner: 'acme', repo: 'docs', branch: 'main' } },
+        ]);
+        render(<MemoryFilesPanel />);
+        await waitFor(() => expect(screen.getByTestId('memory-files-folder-fold-1')).toBeVisible());
+
+        fireEvent.click(screen.getByTestId('memory-files-sync-fold-1'));
+
+        const syncUrl = '/api/memory/files/folders/fold-1/sync';
+        await waitFor(() => expect(seen.some((r) => r.url === syncUrl)).toBe(true));
+        expect(seen.find((r) => r.url === syncUrl)?.selector).toBe('org:ever');
+    });
+
+    /**
+     * KNOWN GAP (EW-786), pinned deliberately. A document navigation
+     * carries no custom header, so the Download control stays a plain
+     * `<a href>` and `app/api/memory/files/[id]/download/route.ts` stays
+     * unscoped. Org-scoped Memory originals — which the now-scoped list
+     * above is what makes visible here — 404 on download. If this
+     * assertion ever fails because someone put the scope in the href,
+     * that is the design decision this fix deliberately did not make.
+     */
+    it('leaves the download control a bare anchor with no scope carrier', async () => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+        installScopedFetch();
+        render(<MemoryFilesPanel />);
+
+        const anchor = await screen.findByTestId('memory-files-download-up-1');
+        expect(anchor.tagName).toBe('A');
+        expect(anchor).toHaveAttribute('href', '/api/memory/files/up-1/download?source=upload');
     });
 });

--- a/apps/web/src/components/memory/MemoryReviewPanel.tsx
+++ b/apps/web/src/components/memory/MemoryReviewPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Check, Loader2, ShieldQuestion, X } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
+import { browserApiFetch } from '@/lib/api/browser-api';
 
 /**
  * The Memory review queue.
@@ -20,6 +21,12 @@ import { cn } from '@/lib/utils/cn';
  * this — so the row leaves the queue and stops being eligible for any
  * context, while the text itself stays readable. Nothing on this page is
  * irreversible.
+ *
+ * Every call here goes through `browserApiFetch`, never a raw `fetch()`.
+ * The BFF routes behind `/api/memory/review` derive the Organization
+ * solely from the per-tab `x-ever-workspace` selector that helper stamps
+ * from the visible URL (EW-786); a plain `fetch()` sends no selector, and
+ * the queue then read as permanently empty while both verbs would refuse.
  */
 
 type ReviewAction = 'accept' | 'reject';
@@ -51,7 +58,7 @@ export function MemoryReviewPanel() {
     const load = useCallback(async () => {
         setLoading(true);
         try {
-            const res = await fetch('/api/memory/review?limit=50', {
+            const res = await browserApiFetch('/api/memory/review?limit=50', {
                 headers: { Accept: 'application/json' },
                 cache: 'no-store',
             });
@@ -88,7 +95,9 @@ export function MemoryReviewPanel() {
             return next;
         });
         try {
-            const res = await fetch(`/api/memory/review/${docId}/${action}`, { method: 'POST' });
+            const res = await browserApiFetch(`/api/memory/review/${docId}/${action}`, {
+                method: 'POST',
+            });
             if (res.ok) {
                 // Drop it locally rather than refetching: the row is
                 // gone from the queue by definition once acted on, and

--- a/apps/web/src/components/memory/MemoryReviewPanel.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryReviewPanel.unit.spec.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { MemoryReviewPanel } from './MemoryReviewPanel';
+
+/**
+ * EW-786 — the client half of the review-queue fix.
+ *
+ * The three BFF routes behind `/api/memory/review` now translate the per-tab
+ * `x-ever-workspace` selector into the API's `x-scope-slug` and answer 400
+ * without it, so this panel must reach them through `browserApiFetch`. A raw
+ * `fetch()` here sent no selector: the queue read as empty for every
+ * Organization (and so the panel hid itself), and both write verbs would now
+ * refuse outright. The two halves only work together, which is what these
+ * assertions pin.
+ */
+describe('MemoryReviewPanel workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    function selectorOf(index: number): string | null {
+        const init = fetchMock.mock.calls[index][1] as RequestInit | undefined;
+        return new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER);
+    }
+
+    beforeEach(() => {
+        fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.startsWith('/api/memory/review?')) {
+                return new Response(
+                    JSON.stringify({
+                        items: [
+                            {
+                                id: 'doc-1',
+                                title: 'Merged onboarding notes',
+                                path: 'memory/onboarding.md',
+                            },
+                        ],
+                        total: 1,
+                    }),
+                    { status: 200, headers: { 'content-type': 'application/json' } },
+                );
+            }
+            return new Response(JSON.stringify({ id: 'doc-1' }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/memory', 'org:ever'],
+        ['/memory', 'personal'],
+    ])(
+        'loads the queue from %s with the selector derived from the visible URL',
+        async (pathname, selector) => {
+            window.history.replaceState({}, '', pathname);
+
+            render(<MemoryReviewPanel />);
+
+            await waitFor(() => expect(screen.getByTestId('memory-review-row')).toBeTruthy());
+            expect(String(fetchMock.mock.calls[0][0])).toBe('/api/memory/review?limit=50');
+            expect(selectorOf(0)).toBe(selector);
+        },
+    );
+
+    it.each([
+        ['memory-review-accept', 'accept'],
+        ['memory-review-reject', 'reject'],
+    ])('sends %s with the same selector the queue was read under', async (testId, verb) => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+
+        render(<MemoryReviewPanel />);
+        await waitFor(() => expect(screen.getByTestId('memory-review-row')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId(testId));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        expect(String(fetchMock.mock.calls[1][0])).toBe(`/api/memory/review/doc-1/${verb}`);
+        expect(selectorOf(1)).toBe('org:ever');
+        // The row leaves the queue, which is the whole point of the verb
+        // working — an unscoped write left it in place with an error.
+        await waitFor(() => expect(screen.queryByTestId('memory-review-row')).toBeNull());
+    });
+});

--- a/apps/web/src/components/memory/MemoryShell.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryShell.unit.spec.tsx
@@ -7,8 +7,9 @@
 // must still render when the meetings fetch failed or returned nothing.
 
 import React, { type ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
 
 vi.mock('next-intl', () => ({
     useTranslations: () => (key: string) => key,
@@ -121,5 +122,80 @@ describe('MemoryShell — Meetings block', () => {
         render(<MemoryShell initial={initial} meetings={meetingsData({ meetings: [] })} />);
         expect(screen.getByTestId('memory-shell')).not.toBeNull();
         expect(screen.getByTestId('meetings-empty')).not.toBeNull();
+    });
+});
+
+/**
+ * EW-786 — the client half of the Memory BFF scope contract.
+ *
+ * `/api/memory` and `/api/memory/consolidate` now mint `X-Scope-Slug` from
+ * the per-tab `x-ever-workspace` selector and answer 400 without it, so both
+ * of this shell's calls have to go through `browserApiFetch`. With a raw
+ * `fetch()` the search/filter refetch and the consolidation pass both ran in
+ * personal scope, where the API returns an empty feed / a zeroed report with
+ * HTTP 200 — silently wrong rather than visibly broken.
+ */
+describe('MemoryShell BFF transport', () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(
+                        JSON.stringify({
+                            documents: [],
+                            counts: { documents: 0, indexed: 0 },
+                            facets: { types: [], works: [], statuses: [], sources: [] },
+                            scanned: 0,
+                            promoted: 0,
+                            synthesized: 0,
+                            superseded: 0,
+                            dryRun: true,
+                            notes: [],
+                            details: {
+                                promotedIds: [],
+                                supersededPairs: [],
+                                synthesizedIds: [],
+                            },
+                        }),
+                        { status: 200, headers: { 'content-type': 'application/json' } },
+                    ),
+            ),
+        );
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/memory', 'org:ever'],
+        ['/memory', 'personal'],
+    ])('refetches the feed from %s with the workspace selector', async (pathname, selector) => {
+        window.history.replaceState({}, '', pathname);
+        render(<MemoryShell initial={initial} />);
+
+        fireEvent.change(screen.getByTestId('memory-search'), { target: { value: 'cortex' } });
+
+        // The refetch is debounced by 300ms; waitFor's 1s budget covers it.
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(String(url)).toContain('/api/memory?');
+        expect(new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe(selector);
+    });
+
+    it('posts the consolidation dry-run with the workspace selector', async () => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+        render(<MemoryShell initial={initial} />);
+
+        fireEvent.click(screen.getByTestId('memory-consolidate-button'));
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe('/api/memory/consolidate');
+        expect(init?.method).toBe('POST');
+        expect(new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBe('org:ever');
     });
 });

--- a/apps/web/src/components/memory/MemoryUploadsPanel.tsx
+++ b/apps/web/src/components/memory/MemoryUploadsPanel.tsx
@@ -3,6 +3,7 @@
 import { DragEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertCircle, CheckCircle2, FileText, Loader2, Upload } from 'lucide-react';
+import { browserApiFetch } from '@/lib/api/browser-api';
 import { cn } from '@/lib/utils/cn';
 
 /**
@@ -17,6 +18,16 @@ import { cn } from '@/lib/utils/cn';
  * Deliberately mirrors the per-Work workbench Originals panel rather than
  * inventing a second visual language for the same concept — Memory is the
  * org-wide counterpart of a Work's KB, not a different kind of thing.
+ *
+ * **Transport (EW-786).** Both calls go through `browserApiFetch`, never
+ * a raw `fetch()`. This panel is the most org-dependent surface in
+ * Memory — its whole subject is "the active Organization's originals" —
+ * and the BFF can only tell the API which Organization that is by
+ * turning the per-tab `x-ever-workspace` selector into `X-Scope-Slug`.
+ * With a raw `fetch()` the list came back `{ items: [], total: 0 }` at
+ * HTTP 200 (indistinguishable from a genuinely empty org) and every
+ * upload took the 422 branch below, so the panel rendered `noOrg` at a
+ * user who was looking straight at their Organization.
  */
 
 interface MemoryUpload {
@@ -55,7 +66,7 @@ export function MemoryUploadsPanel() {
 
     const refresh = useCallback(async () => {
         try {
-            const res = await fetch('/api/memory/uploads?limit=50', {
+            const res = await browserApiFetch('/api/memory/uploads?limit=50', {
                 headers: { Accept: 'application/json' },
                 cache: 'no-store',
             });
@@ -88,7 +99,7 @@ export function MemoryUploadsPanel() {
                     // uploader rarely knows or cares which bucket it lands in.
                     form.append('autoClassify', 'true');
                     try {
-                        const res = await fetch('/api/memory/uploads', {
+                        const res = await browserApiFetch('/api/memory/uploads', {
                             method: 'POST',
                             body: form,
                         });

--- a/apps/web/src/components/memory/MemoryUploadsPanel.unit.spec.tsx
+++ b/apps/web/src/components/memory/MemoryUploadsPanel.unit.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BROWSER_WORKSPACE_SCOPE_HEADER } from '@/lib/workspace-scope';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { MemoryUploadsPanel } from './MemoryUploadsPanel';
+
+/** Records the workspace selector each request carried. */
+function installScopedFetch(listStatus = 200) {
+    const seen: Array<{ url: string; method: string; selector: string | null }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        seen.push({
+            url,
+            method: init?.method ?? 'GET',
+            selector: new Headers(init?.headers).get(BROWSER_WORKSPACE_SCOPE_HEADER),
+        });
+        if (url.startsWith('/api/memory/uploads?')) {
+            return new Response(
+                JSON.stringify({
+                    items: [
+                        {
+                            id: 'up-1',
+                            originalFilename: 'handbook.pdf',
+                            mimeType: 'application/pdf',
+                            fileSize: 4096,
+                            extractionStatus: 'succeeded',
+                            createdAt: '2026-08-01T00:00:00.000Z',
+                        },
+                    ],
+                    total: 1,
+                }),
+                { status: listStatus },
+            );
+        }
+        return new Response(JSON.stringify({}), { status: 201 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return seen;
+}
+
+/**
+ * EW-786 — the client half of the global-Memory Originals scope contract.
+ *
+ * This panel's whole subject is "the active Organization's originals", and
+ * the BFF can only tell the API which Organization that is by turning the
+ * per-tab `x-ever-workspace` selector into `X-Scope-Slug`. Both
+ * `/api/memory/uploads` handlers now 400 without that selector, so both
+ * calls have to go through `browserApiFetch`.
+ *
+ * The pre-fix failure was invisible rather than loud: `listMemoryUploads`
+ * answered `{ items: [], total: 0 }` at HTTP 200 (an empty panel that looked
+ * like an empty org) and `createMemoryUpload` threw 422, which this panel
+ * renders as `noOrg` — telling a user staring at their Organization that
+ * they had none.
+ */
+describe('MemoryUploadsPanel BFF transport', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it.each([
+        ['/org/ever/memory', 'org:ever'],
+        ['/memory', 'personal'],
+    ])('lists originals from %s with the workspace selector', async (pathname, selector) => {
+        window.history.replaceState({}, '', pathname);
+        const seen = installScopedFetch();
+
+        render(<MemoryUploadsPanel />);
+
+        await waitFor(() => expect(screen.getByTestId('memory-upload-row')).toBeVisible());
+        const list = seen.find((r) => r.url.startsWith('/api/memory/uploads?'));
+        expect(list?.selector).toBe(selector);
+    });
+
+    it('uploads with the workspace selector so the API can resolve the org', async () => {
+        window.history.replaceState({}, '', '/org/ever/memory');
+        const seen = installScopedFetch();
+        render(<MemoryUploadsPanel />);
+        await waitFor(() => expect(screen.getByTestId('memory-upload-row')).toBeVisible());
+
+        fireEvent.change(screen.getByTestId('memory-upload-input'), {
+            target: { files: [new File(['x'], 'notes.md', { type: 'text/markdown' })] },
+        });
+
+        await waitFor(() =>
+            expect(seen.some((r) => r.method === 'POST' && r.url === '/api/memory/uploads')).toBe(
+                true,
+            ),
+        );
+        expect(seen.find((r) => r.method === 'POST')?.selector).toBe('org:ever');
+    });
+});


### PR DESCRIPTION
Fixes EW-786. Unblocked by [#2335](https://github.com/ever-works/ever-works/pull/2335)
merging, since `applyBffWorkspaceScope` had to work before anything could call it.

## Read this first — one trade-off is yours to accept or reject

`GET /api/memory/files/:id/download` **stays unscoped**, deliberately. It is reached by an
`<a href>` and by `<img>`/`<video>` sources — document navigations that cannot carry a
custom header — so scoping it would 400 every download, including the personal ones that
work today. Choosing a carrier (path segment? signed query param?) is a contract decision
with real consequences, tracked as EW-788, and not something to invent in this PR.

**The consequence you should weigh:** scoping the sibling *list* route is what makes
org-owned originals appear in the Files table at all. So a 404 that was previously
unreachable becomes reachable for that subset. Today those rows are invisible; after this,
they are visible but their Download link fails.

I think that is still net better — the feed, review queue, settings, uploads panel and
files list all start working for Organizations — but it is a user-visible regression on one
control and it is your call, not mine. **If you disagree, drop the files/uploads cluster
and merge the rest**; the clusters are independent.

## What was wrong

**Zero of the 16 route files under `app/api/memory` forwarded the selector, and every
client used raw `fetch()`.** The whole feature ran in the personal scope. On
`/org/<slug>/memory` a viewer got a correctly scoped SSR render and then, on first
interaction:

- an empty document feed;
- a review queue that returns empty — and `MemoryReviewPanel` hides itself when empty, so
  an org admin saw no queue, no empty state and no error, making Memory Consolidation
  silently inert;
- settings rendering the wrong schedule, with changes appearing to save then reverting;
- an empty Originals panel, and uploading answering "Select an Organization before
  uploading" to a user standing in one;
- a files list omitting org rows while the folder chips counted them — the page
  contradicting itself in a way that reads as data corruption.

All of it HTTP 200. That is the shape that hid this: the API answers a missing scope with
an empty payload, not an error.

## How it was fixed

**Every cluster moves its route and all its callers in the same commit.** Not tidiness:
`applyBffWorkspaceScope` throws without a selector and the route answers 400, so scoping a
route whose client still used raw `fetch()` would convert "silently empty" into a hard
error — a regression, not a fix. The audit pass re-grepped every route path across
`apps/web/src` rather than trusting the reports, because a route can have more than one
caller.

**Routes were scoped only where the handler actually reads the org.** In
`memory-files.controller.ts` that is `list`, `syncFolder`, `moveFiles`, `unlinkFile` and
`download`. `getTree`, `upload`, `createFolder`, `updateFolder` and `deleteFolder` contain
no scope reference at all and were left alone rather than given a new 400 failure mode for
no benefit.

**A second, independent defect** turned up in the settings panel: a failed `PUT` was
swallowed, so the toggle flipped optimistically and then silently reverted with no error.
Fixed, and kept clearly separate from the scope change.

**Stale prose removed.** Several route docblocks asserted *"the active Organization is
resolved by the API from the request scope context, so there is nothing org-specific to
forward here."* That sentence is the belief that produced the bug. The same false claim in
`org-memory.controller.ts`'s class docblock is corrected too.

## Verification

- **98 tests pass** across 16 files.
- **The tests are real, proven globally rather than sampled.** All 25 modified
  implementation files were reverted to `HEAD` and the suite re-run: **59 failed**. Every
  scope assertion in the 11 new spec files and 5 extended ones goes red without the fix.
  The 39 that still passed are pre-existing tests plus the deliberately-*unscoped*
  assertions, which are correct in both states on purpose.
- `npx tsc --noEmit` in `apps/web`: clean. Prettier: clean.
- **No carrier was invented.** The download `href` is byte-identical to `HEAD` and a spec
  pins it.

## Something I checked because it would have been invisible

The new specs omit `Referer`, so they exercise only the fast path of
`applyBffWorkspaceScope` — but a real browser always sends one, and the helper then
requires the Referer's path to agree with the selector. `parseWorkspacePath` expects
`/org/<slug>` at position zero, so a locale-prefixed URL like `/en/org/ever/memory` would
have parsed as *personal* and 400'd the whole surface in production while every test
passed.

It does not: `i18n/routing.ts` sets `localePrefix: 'never'`, so the locale lives in the
`NEXT_LOCALE` cookie and never appears in the browser URL, and `proxy.ts` redirects legacy
`/en/…` URLs before the workspace parse. Worth knowing if anyone ever reconsiders that
setting — it would break far more than Memory.

## Not verified

Nothing was run in a browser. Disk limits on this machine forbid a `next build`, so
end-to-end confirmation that `/org/<slug>/memory` now returns org data is inference from
source, not observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
