### PR TITLE
feat(web): bffProxy — forward the workspace scope by default

### DIFF
--- a/apps/web/src/app/api/org-templates/route.ts
+++ b/apps/web/src/app/api/org-templates/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
-import { getAuthAccessCookie } from '@/lib/auth/cookies';
-import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
+import { bffProxy } from '@/lib/api/bff-proxy';
 
 /**
  * Teams & Prebuilt Companies (spec §6) — web BFF proxy for
@@ -10,36 +9,29 @@ import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
  * The `CreateOrganizationModal` fetches this client-side when it opens;
  * ANY failure returns `[]` so the modal simply skips its template step
  * (guaranteed no-regression fallback, same posture as agent templates).
+ *
+ * Auth and workspace scope come from {@link bffProxy}, which forwards the
+ * browser's per-tab selector by default. The unauthenticated response is
+ * softened to `[]` here to preserve that fallback.
  */
-export async function GET(request: NextRequest) {
-    const token = await getAuthAccessCookie();
-    if (!token) {
-        return NextResponse.json([], { status: 200 });
-    }
-
-    let headers: Headers;
-    try {
-        headers = applyBffWorkspaceScope(request, {
-            Authorization: `Bearer ${token}`,
-        });
-    } catch {
-        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
-    }
-
-    try {
-        const upstream = await fetch(`${API_URL}/org-templates`, {
-            method: 'GET',
-            headers,
-            cache: 'no-store',
-            signal: AbortSignal.timeout(10_000),
-        });
-        if (!upstream.ok) {
+export const GET = bffProxy(
+    async ({ headers }) => {
+        try {
+            const upstream = await fetch(`${API_URL}/org-templates`, {
+                method: 'GET',
+                headers,
+                cache: 'no-store',
+                signal: AbortSignal.timeout(10_000),
+            });
+            if (!upstream.ok) {
+                return NextResponse.json([], { status: 200 });
+            }
+            const body = await upstream.json();
+            return NextResponse.json(Array.isArray(body) ? body : [], { status: 200 });
+        } catch (error) {
+            console.error('Failed to proxy /api/org-templates:', error);
             return NextResponse.json([], { status: 200 });
         }
-        const body = await upstream.json();
-        return NextResponse.json(Array.isArray(body) ? body : [], { status: 200 });
-    } catch (error) {
-        console.error('Failed to proxy /api/org-templates:', error);
-        return NextResponse.json([], { status: 200 });
-    }
-}
+    },
+    { onUnauthorized: () => NextResponse.json([], { status: 200 }) },
+);

--- a/apps/web/src/lib/api/bff-proxy.ts
+++ b/apps/web/src/lib/api/bff-proxy.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+import { applyBffWorkspaceScope } from './bff-scope';
+
+/**
+ * Wrap a BFF route so it carries the workspace scope BY DEFAULT.
+ *
+ * ## Why this exists
+ *
+ * `apps/web/src/app/api/**` is a BFF: the browser calls it, it calls the
+ * platform. Since `8f28edca0` an Organization scope reaches the API only from an
+ * explicit `X-Scope-Slug` header or an `/api/<slug>/…` path, so the route has to
+ * convert the browser's per-tab `x-ever-workspace` selector.
+ *
+ * Today that conversion is **opt-in**: a route forwards nothing unless its author
+ * remembers `applyBffWorkspaceScope`. 10 of 78 route files do. That default
+ * produced four production defects in a single day (EW-783, EW-786, EW-787,
+ * EW-788), and it produced them silently — the API answers a missing Organization
+ * scope with an empty payload and HTTP 200, so the symptom is "my data vanished",
+ * never a stack trace.
+ *
+ * Wrapping a route inverts that: the scope is forwarded unless the route says
+ * otherwise, and saying otherwise is a visible argument someone has to defend in
+ * review. That mirrors `serverFetch`'s `publicRouteScope: 'personal'` opt-out,
+ * which already exists and has not caused this class of bug.
+ *
+ * ## What it does
+ *
+ * 1. Reads the encrypted auth cookie and refuses without it. The cookie is
+ *    decrypted here and NEVER shipped to the browser.
+ * 2. Converts the browser selector into the API scope header, failing closed with
+ *    400 when the selector is missing or malformed.
+ * 3. Hands the handler a ready `Headers` and the token.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * It does not perform the upstream fetch or shape the response. Routes differ too
+ * much — some pass the upstream status through, some soften a failure to an empty
+ * list on purpose — and hiding that behind a helper would make those choices
+ * invisible. This wrapper owns auth and scope only.
+ *
+ * @example
+ * export const GET = bffProxy(async ({ headers }) => {
+ *     const upstream = await fetch(`${API_URL}/org-templates`, { headers });
+ *     return NextResponse.json(await upstream.json());
+ * });
+ *
+ * @example A route that is genuinely scope-free must say so:
+ * export const GET = bffProxy(handler, {
+ *     scope: 'none', // reason required — see BffProxyOptions.reason
+ *     reason: 'Global plugin catalogue; the handler ignores the Organization.',
+ * });
+ */
+export interface ScopedBffRequest {
+    /** The original request, for callers that need the URL or body. */
+    readonly request: NextRequest;
+    /** Auth + scope headers, ready to forward upstream. */
+    readonly headers: Headers;
+    /** The decrypted bearer token, for routes that build their own headers. */
+    readonly token: string;
+}
+
+export interface BffProxyOptions {
+    /**
+     * `'workspace'` (default) converts the browser's per-tab selector and fails
+     * closed without it.
+     *
+     * `'none'` forwards no scope header at all. Use it ONLY when the upstream
+     * handler genuinely ignores the Organization — a global catalogue, a health
+     * check. If you are reaching for it because a caller does not send the
+     * selector, fix the caller instead: this opt-out makes the request run in the
+     * personal scope, which for an Organization-aware handler means silently
+     * wrong data, not an error.
+     */
+    readonly scope?: 'workspace' | 'none';
+    /**
+     * Required with `scope: 'none'`. Written into the code, not just the commit
+     * message, so the next reader can tell a considered exemption from an
+     * oversight — the distinction that made the four defects above so hard to see.
+     */
+    readonly reason?: string;
+    /**
+     * Response for a request with no auth cookie. Defaults to
+     * `401 { error: 'Unauthorized' }`. Some routes deliberately soften this (the
+     * org-templates catalogue answers `[]` so its modal skips a step rather than
+     * erroring), which is why it is overridable.
+     */
+    readonly onUnauthorized?: () => NextResponse;
+}
+
+const unauthorized = () => NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+export function bffProxy<Ctx = unknown>(
+    handler: (scoped: ScopedBffRequest, context: Ctx) => Promise<Response> | Response,
+    options: BffProxyOptions = {},
+): (request: NextRequest, context: Ctx) => Promise<Response> {
+    const { scope = 'workspace', reason, onUnauthorized = unauthorized } = options;
+
+    if (scope === 'none' && !reason?.trim()) {
+        // Thrown at module load, so a missing justification fails the build
+        // rather than shipping an unexplained exemption.
+        throw new Error(
+            'bffProxy({ scope: "none" }) requires a `reason` explaining why this route needs no workspace scope.',
+        );
+    }
+
+    return async (request: NextRequest, context: Ctx): Promise<Response> => {
+        const token = await getAuthAccessCookie();
+        if (!token) return onUnauthorized();
+
+        const base: HeadersInit = { Authorization: `Bearer ${token}` };
+        if (scope === 'none') {
+            return handler({ request, headers: new Headers(base), token }, context);
+        }
+
+        let headers: Headers;
+        try {
+            headers = applyBffWorkspaceScope(request, base);
+        } catch {
+            return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
+        }
+
+        return handler({ request, headers, token }, context);
+    };
+}

--- a/apps/web/src/lib/api/bff-proxy.unit.spec.ts
+++ b/apps/web/src/lib/api/bff-proxy.unit.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { API_SCOPE_HEADER, BROWSER_WORKSPACE_SCOPE_HEADER } from '../workspace-scope';
+
+const getAuthAccessCookie = vi.fn<() => Promise<string | undefined>>();
+vi.mock('@/lib/auth/cookies', () => ({
+    getAuthAccessCookie: () => getAuthAccessCookie(),
+}));
+
+const { bffProxy } = await import('./bff-proxy');
+type ScopedBffRequest = import('./bff-proxy').ScopedBffRequest;
+
+const PUBLIC_ORIGIN = 'https://app.example';
+
+/** Typed so `handler.mock.calls[0]` keeps its argument types. */
+const makeHandler = () =>
+    vi.fn<(scoped: ScopedBffRequest, context: unknown) => Promise<Response>>(async () =>
+        NextResponse.json({ ok: true }),
+    );
+
+/**
+ * Built the way a real Next server sees a request: the request URL is the
+ * SERVER's own address, which is never the browser's. See bff-scope.unit.spec.ts
+ * — an earlier guard compared the two and rejected every real call.
+ */
+function req(selector?: string): NextRequest {
+    const headers = new Headers();
+    if (selector !== undefined) headers.set(BROWSER_WORKSPACE_SCOPE_HEADER, selector);
+    return new NextRequest(new Request('http://0.0.0.0:3000/api/thing', { headers }));
+}
+
+describe('bffProxy', () => {
+    const previous = process.env.NEXT_PUBLIC_WEB_URL;
+
+    beforeEach(() => {
+        process.env.NEXT_PUBLIC_WEB_URL = PUBLIC_ORIGIN;
+        getAuthAccessCookie.mockResolvedValue('fake-jwt');
+    });
+
+    afterEach(() => {
+        if (previous === undefined) delete process.env.NEXT_PUBLIC_WEB_URL;
+        else process.env.NEXT_PUBLIC_WEB_URL = previous;
+        vi.clearAllMocks();
+    });
+
+    it('forwards the workspace scope without the route asking — the whole point', async () => {
+        const handler = makeHandler();
+        const route = bffProxy(handler);
+
+        await route(req('org:ever'), undefined);
+
+        const { headers } = handler.mock.calls[0][0];
+        expect(headers.get(API_SCOPE_HEADER)).toBe('ever');
+        expect(headers.get('authorization')).toBe('Bearer fake-jwt');
+        // The browser-facing selector must never reach the platform.
+        expect(headers.get(BROWSER_WORKSPACE_SCOPE_HEADER)).toBeNull();
+    });
+
+    it('fails closed with 400 when the selector is missing, and never runs the handler', async () => {
+        const handler = makeHandler();
+
+        const res = await bffProxy(handler)(req(), undefined);
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'Invalid workspace scope' });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('fails closed on a malformed selector too', async () => {
+        const handler = makeHandler();
+
+        const res = await bffProxy(handler)(req('org:Not A Slug'), undefined);
+
+        expect(res.status).toBe(400);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unauthenticated request before touching the scope', async () => {
+        getAuthAccessCookie.mockResolvedValue(undefined);
+        const handler = makeHandler();
+
+        // No selector either — auth must be decided first, so this is 401 not 400.
+        const res = await bffProxy(handler)(req(), undefined);
+
+        expect(res.status).toBe(401);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('lets a route soften the unauthenticated response without losing the scope default', async () => {
+        getAuthAccessCookie.mockResolvedValue(undefined);
+        const handler = makeHandler();
+
+        const res = await bffProxy(handler, {
+            onUnauthorized: () => NextResponse.json([], { status: 200 }),
+        })(req('org:ever'), undefined);
+
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual([]);
+    });
+
+    it('passes the route context (params) straight through', async () => {
+        const handler = makeHandler();
+        const context = { params: Promise.resolve({ id: 'work-1' }) };
+
+        await bffProxy<typeof context>(handler)(req('personal'), context);
+
+        expect(handler.mock.calls[0][1]).toBe(context);
+        expect(handler.mock.calls[0][0].headers.get(API_SCOPE_HEADER)).toBe('@personal');
+    });
+
+    describe('the opt-out', () => {
+        it('forwards no scope header when a route declares scope: none', async () => {
+            const handler = makeHandler();
+
+            await bffProxy(handler, {
+                scope: 'none',
+                reason: 'Global catalogue; the handler ignores the Organization.',
+            })(req(), undefined);
+
+            const { headers } = handler.mock.calls[0][0];
+            expect(headers.get(API_SCOPE_HEADER)).toBeNull();
+            expect(headers.get('authorization')).toBe('Bearer fake-jwt');
+        });
+
+        it('refuses to build an unexplained opt-out, at module load', () => {
+            // A silent exemption is indistinguishable from an oversight, which is
+            // exactly how the defects this wrapper exists to prevent survived
+            // review. Make it impossible to add one without saying why.
+            expect(() => bffProxy(async () => NextResponse.json({}), { scope: 'none' })).toThrow(
+                /requires a `reason`/,
+            );
+            expect(() =>
+                bffProxy(async () => NextResponse.json({}), { scope: 'none', reason: '   ' }),
+            ).toThrow(/requires a `reason`/);
+        });
+    });
+});


### PR DESCRIPTION
The audit's **highest-leverage recommendation**, built as a reviewable primitive rather
than a 78-route sweep. Third and last of the preventions, after the
[lint rule](https://github.com/ever-works/ever-works/pull/2344).

## The problem this addresses

Four production defects in one day — EW-783, EW-786, EW-787, EW-788 — were one mistake
repeated. A BFF route forwards no workspace scope unless its author remembers
`applyBffWorkspaceScope`, and **10 of 78 route files do**.

That default is wrong in a way that hides itself: the API answers a missing Organization
scope with an **empty payload and HTTP 200**, so the symptom is "my data vanished", never
a stack trace. The routes that got it right are the ones written *for* the scope feature;
everything written beside it inherited the wrong default.

## What `bffProxy` does

It owns **auth and scope only**:

```ts
export const GET = bffProxy(async ({ headers }) => {
    const upstream = await fetch(`${API_URL}/org-templates`, { headers });
    return NextResponse.json(await upstream.json());
});
```

1. Reads the encrypted auth cookie, refuses without it (overridable — see below).
2. Converts the browser's per-tab selector into the API scope header.
3. **Fails closed with 400** when the selector is missing or malformed.

Not forwarding the scope becomes an explicit argument — and **that argument requires a
written reason, enforced at module load**:

```ts
export const GET = bffProxy(handler, {
    scope: 'none',
    reason: 'Global plugin catalogue; the handler ignores the Organization.',
});
```

Omit the reason and the build fails. That is the deliberate part: **a silent exemption is
indistinguishable from an oversight**, and that ambiguity is exactly how these defects
passed review. Making someone write the justification into the code is the difference
between a decision and an accident.

## What it deliberately does not do

It does not own the upstream fetch or the response shape. Routes differ genuinely — some
pass the upstream status through, some soften a failure to `[]` on purpose, one returns
`[]` even for an unauthenticated caller so a modal can skip a step. Hiding those choices
behind a helper would make them invisible, which is the same failure mode in a new place.

## The worked example

`org-templates` is migrated, and it was chosen precisely because it is *not* the simple
case: its unauthenticated path is deliberately softened to `[]`. If the wrapper could only
handle the easy shape, that would show up here. Behaviour is unchanged.

## Honest scope

**This does not by itself invert the default.** The default flips only for routes that
adopt the wrapper, and migrating the remaining 77 is a sweep that deserves its own
deliberate pass — not a rider on the commit that introduces the primitive. What this PR
buys you is the tool, a proof it handles a real route, and a decision to make.

If you would rather not adopt this pattern, say so and I will close it — the
[lint rule](https://github.com/ever-works/ever-works/pull/2344) covers the client half
independently and does not depend on this.

## Verification

- 8 unit tests, covering: scope forwarded without the route asking, the browser selector
  stripped before it reaches the platform, 400 with the handler never invoked on a missing
  or malformed selector, 401 decided before scope, the softened-unauthorized override, route
  params passed through, `scope: 'none'` forwarding nothing, and the missing-reason throw.
- The fixture builds requests the way a real Next server does — a **server** URL that
  differs from the browser origin — so nothing can pass by virtue of the request's own URL.
  That is the shape that made EW-783 invisible to its own unit spec.
- `npx tsc --noEmit`: clean. Prettier: clean. ESLint: clean on both files.

Background: Workspace `knowledge/design/EVER_WORKS_BFF_WORKSPACE_SCOPE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
