### PR TITLE
docs(api): correct an over-corrected security comment on ensureMember

### DIFF
--- a/apps/api/src/works/org-memory.controller.ts
+++ b/apps/api/src/works/org-memory.controller.ts
@@ -356,16 +356,28 @@ export class OrgMemoryController {
             };
         }
 
-        // NOT defence-in-depth, and NOT a formality. This comment used to say
-        // the check was "normally a formality" because "the scope was seeded
-        // from the user's own validated last-active Org" — that seeding was
-        // retired by 8f28edca0. `organizationId` now comes from the caller's
-        // own `x-scope-slug` header (or path param), so ANY authenticated user
-        // can name ANY Organization here. This `ensureMember` call is the
-        // load-bearing authorization check standing between them and another
-        // Organization's Memory, and it must not be weakened or reordered
-        // after the aggregation. Throws NotFound (not Forbidden) on a
-        // cross-tenant mismatch, matching the existence-leak contract.
+        // Two DIFFERENT gates, and conflating them gets one of them wrong.
+        //
+        // `ScopeOwnershipGuard` (registered APP_GUARD in `api.module.ts`) already
+        // rejects a cross-TENANT slug: it compares `request.user.tenantId`
+        // against the resolved scope and throws 403. A caller cannot reach
+        // another tenant's Memory by naming its slug.
+        //
+        // That guard checks tenantId ONLY. Within a single tenant the scope is
+        // still built from a caller-supplied `x-scope-slug` (or `/api/<slug>/…`),
+        // so any member of this tenant can name any Organization inside it. What
+        // stops them reading an Org they do not belong to is THIS call, and only
+        // this call — a different rule from the ownership guard, not a restatement
+        // of it. It must not be weakened or reordered after the aggregation.
+        //
+        // (This comment previously said the check was "normally a formality"
+        // because the scope was "seeded from the user's own validated last-active
+        // Org" — 8f28edca0 retired that seeding. A later revision over-corrected
+        // the other way, claiming any authenticated user can name ANY
+        // Organization; the tenant guard above is why that is not so.)
+        //
+        // Throws NotFound (not Forbidden) on a mismatch, matching the
+        // existence-leak contract.
         await this.membership.ensureMember(organizationId, auth.userId);
 
         return this.kb.aggregateOrgMemory(organizationId, {


### PR DESCRIPTION
Comment-only. No behaviour change. One file, one comment block.

## The comment has now been wrong twice, in opposite directions

**Originally** it called the `membership.ensureMember` check *"normally a formality"* because *"the scope was seeded from the user's own validated last-active Org."* `8f28edca0` retired that seeding, so it went stale.

**#2341 (mine)** replaced it with: `organizationId` comes from the caller's own header, *"so ANY authenticated user can name ANY Organization here"*, making `ensureMember` *"the load-bearing authorization check."*

That over-corrects. `ScopeOwnershipGuard` is registered as an `APP_GUARD` in `api.module.ts` and rejects a cross-**tenant** slug outright — it compares `request.user.tenantId` against the resolved scope and throws 403. A caller cannot reach another tenant's Memory by naming its slug. I asserted otherwise without reading the guard.

**#2337 caught it** and said so in its own version — but its framing went the other way, calling `ensureMember` *"the second, route-local statement of the same rule."* That undersells it: the ownership guard checks `tenantId` **only**. Within a tenant the scope is still caller-supplied, so any member of that tenant can name any Organization inside it, and `ensureMember` is the only thing stopping them reading one they don't belong to. A **different** rule, not a restatement.

## Why it needs a PR of its own

I resolved this correctly while fixing #2337's merge conflict (`04579e741`), combining both corrections. That branch was **rebased** before merging and my resolution commit was replaced, so develop kept the over-corrected wording.

## What it says now

Both gates, and what each actually covers — plus a short record of both wrong versions, so the next reader doesn't have to re-derive the tenant/Organization boundary from scratch.

Verified: `pnpm format:check` clean on the file. Comment-only, so no test or type impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authorization behavior for memory retrieval, including tenant scope, organization membership, caller-provided scope resolution, and not-found handling.
  * No user-facing runtime behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->