### PR TITLE
fix(web): scope the chat attachment ingest into Memory

### DIFF
--- a/apps/web/src/app/api/chat/route.attachment-scope.unit.spec.ts
+++ b/apps/web/src/app/api/chat/route.attachment-scope.unit.spec.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/constants', () => ({ API_URL: 'http://api.example' }));
+vi.mock('@/lib/auth/cookies', () => ({ getAuthAccessCookie: vi.fn(async () => 'fake-jwt') }));
+vi.mock('@/lib/ai/persistence', () => ({ saveConversationMessages: vi.fn(async () => undefined) }));
+
+// `after()` normally defers until the response is flushed. Run the callback
+// immediately so the ingest call is observable — that scheduling is exactly why
+// the bug existed (Next's `headers()` is gone by then, so the call hand-built
+// its headers and forwarded no scope).
+vi.mock('next/server', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('next/server')>()),
+    after: (fn: () => Promise<void> | void) => {
+        void fn();
+    },
+}));
+
+// The agent runtime is irrelevant here and enormous; short-circuit it.
+vi.mock('@/lib/ai/agent', () => ({
+    runAgent: vi.fn(async () => ({
+        consumeStream: () => undefined,
+        toUIMessageStreamResponse: () => new Response('ok', { status: 200 }),
+    })),
+}));
+
+import { POST } from './route';
+
+/**
+ * The chat route's Memory ingest was the last unscoped call in the chat path.
+ * #2342 fixed the client transport so `/api/chat` receives the selector, and
+ * `serverFetch` picks it up from `headers()` for the tool loop — but this call
+ * is a direct `fetch` with hand-built headers inside `after()`, so it forwarded
+ * nothing.
+ *
+ * `OrgMemoryController.ingestFromAttachments` requires an active Organization
+ * and answers 422 without one, and the call sits inside an empty `catch`. Every
+ * file a member attached inside an Org was therefore silently dropped from that
+ * Org's Memory while the chat turn looked completely healthy.
+ *
+ * These drive the REAL route so they fail if the route stops calling
+ * `applyBffWorkspaceScope` — testing the helper alone would pass either way.
+ */
+describe('POST /api/chat — attachment ingest workspace scope', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        process.env.WEB_URL = 'http://web.example';
+        fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        delete process.env.WEB_URL;
+    });
+
+    function chatRequest(selector?: string) {
+        const headers = new Headers({ 'content-type': 'application/json' });
+        if (selector) headers.set('x-ever-workspace', selector);
+        return new Request('http://web.example/api/chat', {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+                messages: [{ id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+                providerOverride: 'openai',
+                // sha256 shape — `chatBodySchema` constrains attachmentIds to the
+                // id the uploads spine issues, so a UUID here is a 400.
+                attachmentIds: ['a'.repeat(64)],
+            }),
+        });
+    }
+
+    /** The ingest call, or undefined if the route never made it. */
+    function ingestCall() {
+        return fetchMock.mock.calls.find((c) =>
+            String(c[0]).includes('/memory/uploads/from-attachments'),
+        );
+    }
+
+    it('forwards the Organization selector on the ingest call', async () => {
+        await POST(chatRequest('org:ever'));
+
+        const call = ingestCall();
+        expect(call, 'route never issued the ingest call').toBeDefined();
+        const headers = new Headers((call?.[1] as RequestInit).headers);
+        expect(headers.get('x-scope-slug')).toBe('ever');
+        expect(headers.get('Authorization')).toBe('Bearer fake-jwt');
+        expect(headers.get('x-ever-workspace')).toBeNull();
+    });
+
+    it('forwards the personal sentinel rather than nothing', async () => {
+        await POST(chatRequest('personal'));
+
+        const headers = new Headers((ingestCall()?.[1] as RequestInit).headers);
+        expect(headers.get('x-scope-slug')).toBe('@personal');
+    });
+
+    /**
+     * The best-effort half: ingest is an enhancement of the turn, never part of
+     * it. A caller with no selector must lose the ingest, not the message.
+     */
+    it('skips the ingest without failing the turn when no selector is present', async () => {
+        const response = await POST(chatRequest());
+
+        expect(response.status).toBe(200);
+        expect(ingestCall()).toBeUndefined();
+    });
+});

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import { runAgent } from '@/lib/ai/agent';
 import { API_URL } from '@/lib/constants';
 import { getAuthAccessCookie } from '@/lib/auth/cookies';
 import { saveConversationMessages, type MessageUsage } from '@/lib/ai/persistence';
+import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
 
 export const maxDuration = 60;
 
@@ -152,22 +153,44 @@ export async function POST(request: Request) {
     // best-effort — a failure here must never cost the user their message,
     // so nothing about the chat response depends on the outcome.
     if (attachmentIds && attachmentIds.length > 0) {
-        after(async () => {
-            try {
-                await fetch(`${API_URL}/memory/uploads/from-attachments`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        Authorization: `Bearer ${token}`,
-                    },
-                    body: JSON.stringify({ attachmentIds }),
-                    cache: 'no-store',
-                });
-            } catch {
-                // Deliberately silent: Memory ingest is an enhancement of
-                // the chat turn, not part of it.
-            }
-        });
+        // Scope has to be resolved HERE, not inside `after()`. The callback
+        // runs after the response, where Next's `headers()` is no longer
+        // available — which is why this call hand-built its headers and so
+        // forwarded no selector at all. `OrgMemoryController.ingestFromAttachments`
+        // requires an active Organization and answers 422 without one, so
+        // every attachment a member added inside an Org was silently dropped:
+        // the catch below swallowed it and the chat turn looked fine.
+        //
+        // Still strictly best-effort. A caller with no selector (or a stale
+        // one) must not cost the user their message, so a failure to build
+        // scoped headers skips the ingest rather than throwing — same
+        // contract the empty catch already gave this call.
+        let ingestHeaders: Headers | null = null;
+        try {
+            ingestHeaders = applyBffWorkspaceScope(request, {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            });
+        } catch {
+            ingestHeaders = null;
+        }
+
+        if (ingestHeaders) {
+            const headersForIngest = ingestHeaders;
+            after(async () => {
+                try {
+                    await fetch(`${API_URL}/memory/uploads/from-attachments`, {
+                        method: 'POST',
+                        headers: headersForIngest,
+                        body: JSON.stringify({ attachmentIds }),
+                        cache: 'no-store',
+                    });
+                } catch {
+                    // Deliberately silent: Memory ingest is an enhancement of
+                    // the chat turn, not part of it.
+                }
+            });
+        }
     }
 
     if (!providerOverride) {


### PR DESCRIPTION
The last unscoped call in the chat path, and the third of the three chat failures the BFF audit found.

## What was broken

#2342 fixed the client transport, so `/api/chat` now receives the selector and `serverFetch` picks it up from `headers()` for the tool loop. But the Memory ingest is a **direct `fetch` with hand-built headers**, so it forwarded nothing.

`OrgMemoryController.ingestFromAttachments` requires an active Organization and answers **422** without one — and the call sits inside an empty `catch`. Every file a member attached inside an Org was silently dropped from that Org's Memory while the chat turn looked completely healthy.

## Why it wasn't just "add the helper"

Scope has to be resolved **before** the `after()` callback. That callback runs after the response is flushed, where Next's `headers()` is no longer available — which is precisely why this call hand-built its headers to begin with. Calling `applyBffWorkspaceScope` inside `after()` would not have worked.

It also stays **strictly best-effort**: ingest is an enhancement of the turn, never part of it, so a caller with no selector skips the ingest rather than throwing. That preserves the contract the empty `catch` already provided — a missing selector costs the ingest, never the user's message.

## On the tests

My first version asserted `applyBffWorkspaceScope` in isolation. It passed — and would have passed **with or without this fix**, because it tested the helper rather than the route's use of it. Coverage in appearance only, and exactly the "verify the caller exists" trap.

Rewritten to drive the real `POST`, mocking the agent runtime and running `after()` eagerly so the ingest call is observable. **Mutation-tested: reverting the route fails all 3.**

Two things the route taught the fixture along the way: `attachmentIds` is constrained to the sha256 shape the uploads spine issues (a UUID is a 400), and the agent result needs `consumeStream`.

## Verified

- 3/3 pass; all 3 fail with the route reverted
- `prettier --check` clean
- `eslint src/app/api/chat` clean against the 42-error pre-existing `apps/web` baseline

## Audit status after this

Group A of the audit is complete. Remaining: **Group B** (3 navigation-reached routes, needs an API-shape decision — a browser navigation cannot carry a header) and **Group C** (3 upload write-stamping routes, which must land with their mirror read path or every existing attachment link 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)