### PR TITLE
test(e2e): create the org-chart agent in its Organization's scope

### DIFF
--- a/apps/web/e2e/flow-org-members-rbac-multistep.spec.ts
+++ b/apps/web/e2e/flow-org-members-rbac-multistep.spec.ts
@@ -756,10 +756,22 @@ test.describe('Org RBAC — end-to-end org-admin journey', () => {
 
         // 1. Create a team and staff it: an agent LEAD + the human owner as a MEMBER.
         const team = await createTeam(request, ctx, { name: `Ops ${stamp()}` });
-        const agent = await createAgentViaAPI(request, ctx.token, {
-            scope: 'tenant',
-            name: `OpsBot ${stamp()}`,
-        });
+        // Created IN org A's scope (X-Scope-Slug), exactly like the org-A Work in
+        // step 2 — so the row is stamped `organizationId = ctx.orgId`. A bare-Bearer
+        // create is the PERSONAL contract and lands `organizationId: null`, and the
+        // org-chart deliberately also lists the tenant's org-LESS agents, so a null
+        // stamp would surface this agent in EVERY org of the tenant (OrgChartService
+        // `tenantAgents`). Note `scope: 'tenant'` is the agent's TARGET (no mission/
+        // idea/work FK) — orthogonal to the Organization that owns the row.
+        const agent = await createAgentViaAPI(
+            request,
+            ctx.token,
+            {
+                scope: 'tenant',
+                name: `OpsBot ${stamp()}`,
+            },
+            ctx.orgSlug,
+        );
         expect(
             (
                 await request.post(`${orgBase(ctx.orgId)}/teams/${team.id}/members`, {


### PR DESCRIPTION
Shard 16's last failure — and **I had mis-filed it as a product question.** It is a stale
test, and this is the setup-only fix.

## What it actually was

The spec created its agent with a bare Bearer. Since `8f28edca0` that is the **personal**
contract, so the row is stamped `organizationId: null` — and `OrgChartService` deliberately
lists the tenant's org-*less* agents alongside each org's own. A null-stamped agent
therefore surfaces in **every** org of the tenant, which is exactly what the assertion
caught.

The regression commit confirms it. Before `8f28edca0` the guard seeded an unprefixed
request as `{ tenantId, organizationId: lastScopeOrganizationId ?? null }`, and `buildOwner`
creates org A immediately beforehand — so the agent used to inherit org A and the test
passed. **What changed is the seeding, not the chart.**

Fix: pass `ctx.orgSlug` as `createAgentViaAPI`'s existing 4th argument. One token.

**No assertion changed anywhere in the diff** — I checked explicitly, because bending an
assertion is how a test gets made green against a product that quietly moved.

One thing worth the comment I added, because it is easy to misread: the agent's
`scope: 'tenant'` is its **target** (no mission/idea/work FK) and is orthogonal to which
Organization owns the row. Those two senses of "scope" sitting next to each other is
probably why this was written bare-Bearer in the first place.

## I was wrong to escalate this one

I filed three of shard 13/14/16's failures as EW-785 product rulings. This one was not —
it was the same stale-scope bug as the other thirty, and I handed you a decision that was
really just work. The check that caught my error was asking a concrete counterfactual —
*would this pass if it acted in a properly scoped organization?* — rather than reasoning
from the code as I had.

The other two survive that test and remain genuinely yours, but both are **smaller than I
represented**:

- **The DTO one (shard 13) is close to a rubber stamp.** `e49936d83` already answered it
  deliberately, with a unit spec that is green today and has since been extended. Say yes
  and the two column-absence assertions become value assertions.
- **The task-delegation one (shard 14) is a real question**, and it has a sharp piece of
  evidence: the green sibling `flow-task-assignees-deep.spec.ts:369` asserts the *exact
  opposite* contract from an identical setup. Two specs cannot both be right about one
  endpoint. The green one encodes the post-`dc0639e33` behaviour; the failing one predates
  it by a month and is the surviving witness that the delegation envelope narrowed.

## Not verified

e2e needs service containers and production builds, so this is proven from the guard's
pre-image at `8f28edca0^` plus the in-test control at `:793` that passes today — not by a
run. Shard 16 should go 225/225 on the next stage push.

Refs EW-785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Corrected the organization-admin workflow coverage so newly created agents are assigned to the intended organization.
  - Improved validation of organization charts by preventing agents created during testing from appearing across unrelated organizations.
  - Ensures multi-step role-based access scenarios accurately reflect organization-specific membership and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->