### PR TITLE
refactor(web): migrate the Memory review + settings routes onto bffProxy

### DIFF
--- a/apps/web/src/app/api/memory/consolidation/settings/route.ts
+++ b/apps/web/src/app/api/memory/consolidation/settings/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
-import { getAuthAccessCookie } from '@/lib/auth/cookies';
-import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
+import { bffProxy } from '@/lib/api/bff-proxy';
 
 /**
  * Proxy for the scheduled Memory Consolidation settings.
@@ -30,25 +29,15 @@ import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
  * a hard 400.
  */
 
-async function forward(request: NextRequest, method: 'GET' | 'PUT', body?: string) {
-    const token = await getAuthAccessCookie();
-    if (!token) return new Response('Unauthorized', { status: 401 });
-
-    const base: Record<string, string> = {
-        Accept: 'application/json',
-        Authorization: `Bearer ${token}`,
-    };
-    if (body !== undefined) base['Content-Type'] = 'application/json';
-
-    // Fail closed. A missing or stale selector is answered here rather
-    // than forwarded unscoped, which would silently read and write the
-    // caller's personal scope while they are looking at an Organization.
-    let headers: Headers;
-    try {
-        headers = applyBffWorkspaceScope(request, base);
-    } catch {
-        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
-    }
+/**
+ * Auth and scope are settled by {@link bffProxy} before this runs, and it
+ * fails closed on a missing or stale selector — which is the point: an
+ * unscoped forward would silently read and write the caller's PERSONAL
+ * scope while they are looking at an Organization.
+ */
+async function forward(headers: Headers, method: 'GET' | 'PUT', body?: string) {
+    headers.set('Accept', 'application/json');
+    if (body !== undefined) headers.set('Content-Type', 'application/json');
 
     const upstream = await fetch(`${API_URL}/memory/consolidation/settings`, {
         method,
@@ -72,13 +61,22 @@ async function forward(request: NextRequest, method: 'GET' | 'PUT', body?: strin
     return NextResponse.json(json ?? {}, { status: 200 });
 }
 
-export async function GET(request: NextRequest) {
-    return forward(request, 'GET');
-}
+// The plain-text `Unauthorized` is preserved deliberately: the wrapper's
+// default is JSON, and changing this route's wire format as a side effect of
+// adopting it would be exactly the kind of silent drift bffProxy exists to
+// stop.
+const unauthorizedText = () => new Response('Unauthorized', { status: 401 });
 
-export async function PUT(request: NextRequest) {
-    // Read and re-serialize rather than streaming: this is a small JSON
-    // body, and buffering keeps the upstream Content-Length honest.
-    const raw = await request.text().catch(() => '{}');
-    return forward(request, 'PUT', raw || '{}');
-}
+export const GET = bffProxy(async ({ headers }) => forward(headers, 'GET'), {
+    onUnauthorized: unauthorizedText,
+});
+
+export const PUT = bffProxy(
+    async ({ request, headers }) => {
+        // Read and re-serialize rather than streaming: this is a small JSON
+        // body, and buffering keeps the upstream Content-Length honest.
+        const raw = await request.text().catch(() => '{}');
+        return forward(headers, 'PUT', raw || '{}');
+    },
+    { onUnauthorized: unauthorizedText },
+);

--- a/apps/web/src/app/api/memory/review/[docId]/accept/route.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/accept/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
-import { getAuthAccessCookie } from '@/lib/auth/cookies';
-import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
+import { bffProxy } from '@/lib/api/bff-proxy';
 
 type RouteContext = { params: Promise<{ docId: string }> };
 
@@ -18,45 +17,38 @@ type RouteContext = { params: Promise<{ docId: string }> };
  * Organization off the request scope and refuses with 422 when there is
  * none, so every Accept click from an Organization tab failed — the
  * write path has no empty-payload fallback the way the queue read does.
- * Translating the browser's `x-ever-workspace` selector into
- * `x-scope-slug` here is what makes the button work at all, and it must
- * land in the same change as the panel's `browserApiFetch` transport:
- * scoped route + raw `fetch()` caller is a guaranteed 400.
+ *
+ * {@link bffProxy} now performs that conversion. The unauthenticated
+ * response is overridden to keep this route's PLAIN-TEXT `Unauthorized`
+ * rather than the wrapper's JSON default — same bytes as before.
  */
-export async function POST(request: NextRequest, { params }: RouteContext) {
-    const { docId } = await params;
-    const token = await getAuthAccessCookie();
-    if (!token) {
-        return new Response('Unauthorized', { status: 401 });
-    }
+export const POST = bffProxy<RouteContext>(
+    async ({ headers }, { params }) => {
+        const { docId } = await params;
+        headers.set('Accept', 'application/json');
 
-    let headers: Headers;
-    try {
-        headers = applyBffWorkspaceScope(request, {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
-        });
-    } catch {
-        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
-    }
-
-    const upstream = await fetch(`${API_URL}/memory/review/${encodeURIComponent(docId)}/accept`, {
-        method: 'POST',
-        headers,
-        cache: 'no-store',
-    });
-
-    if (!upstream.ok) {
-        const text = await upstream.text().catch(() => '');
-        return new Response(text, {
-            status: upstream.status,
-            headers: {
-                'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
-                'Cache-Control': 'no-store',
+        const upstream = await fetch(
+            `${API_URL}/memory/review/${encodeURIComponent(docId)}/accept`,
+            {
+                method: 'POST',
+                headers,
+                cache: 'no-store',
             },
-        });
-    }
+        );
 
-    const body = await upstream.json().catch(() => null);
-    return NextResponse.json(body ?? {}, { status: 200 });
-}
+        if (!upstream.ok) {
+            const text = await upstream.text().catch(() => '');
+            return new Response(text, {
+                status: upstream.status,
+                headers: {
+                    'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+                    'Cache-Control': 'no-store',
+                },
+            });
+        }
+
+        const body = await upstream.json().catch(() => null);
+        return NextResponse.json(body ?? {}, { status: 200 });
+    },
+    { onUnauthorized: () => new Response('Unauthorized', { status: 401 }) },
+);

--- a/apps/web/src/app/api/memory/review/[docId]/reject/route.ts
+++ b/apps/web/src/app/api/memory/review/[docId]/reject/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
-import { getAuthAccessCookie } from '@/lib/auth/cookies';
-import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
+import { bffProxy } from '@/lib/api/bff-proxy';
 
 type RouteContext = { params: Promise<{ docId: string }> };
 
@@ -19,41 +18,38 @@ type RouteContext = { params: Promise<{ docId: string }> };
  * Organization on the request scope. Both verbs are fixed together
  * because the panel disables neither independently: a user who can see a
  * row can click either button.
+ *
+ * {@link bffProxy} now performs that conversion. The unauthenticated
+ * response is overridden to keep this route's PLAIN-TEXT `Unauthorized`
+ * rather than the wrapper's JSON default — same bytes as before.
  */
-export async function POST(request: NextRequest, { params }: RouteContext) {
-    const { docId } = await params;
-    const token = await getAuthAccessCookie();
-    if (!token) {
-        return new Response('Unauthorized', { status: 401 });
-    }
+export const POST = bffProxy<RouteContext>(
+    async ({ headers }, { params }) => {
+        const { docId } = await params;
+        headers.set('Accept', 'application/json');
 
-    let headers: Headers;
-    try {
-        headers = applyBffWorkspaceScope(request, {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
-        });
-    } catch {
-        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
-    }
-
-    const upstream = await fetch(`${API_URL}/memory/review/${encodeURIComponent(docId)}/reject`, {
-        method: 'POST',
-        headers,
-        cache: 'no-store',
-    });
-
-    if (!upstream.ok) {
-        const text = await upstream.text().catch(() => '');
-        return new Response(text, {
-            status: upstream.status,
-            headers: {
-                'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
-                'Cache-Control': 'no-store',
+        const upstream = await fetch(
+            `${API_URL}/memory/review/${encodeURIComponent(docId)}/reject`,
+            {
+                method: 'POST',
+                headers,
+                cache: 'no-store',
             },
-        });
-    }
+        );
 
-    const body = await upstream.json().catch(() => null);
-    return NextResponse.json(body ?? {}, { status: 200 });
-}
+        if (!upstream.ok) {
+            const text = await upstream.text().catch(() => '');
+            return new Response(text, {
+                status: upstream.status,
+                headers: {
+                    'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+                    'Cache-Control': 'no-store',
+                },
+            });
+        }
+
+        const body = await upstream.json().catch(() => null);
+        return NextResponse.json(body ?? {}, { status: 200 });
+    },
+    { onUnauthorized: () => new Response('Unauthorized', { status: 401 }) },
+);

--- a/apps/web/src/app/api/memory/review/route.ts
+++ b/apps/web/src/app/api/memory/review/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { API_URL } from '@/lib/constants';
-import { getAuthAccessCookie } from '@/lib/auth/cookies';
-import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
+import { bffProxy } from '@/lib/api/bff-proxy';
 
 /**
  * Proxy for `GET /api/memory/review` — the Memory review queue.
@@ -18,42 +17,35 @@ import { applyBffWorkspaceScope } from '@/lib/api/bff-scope';
  * empty payload rather than an error — and `MemoryReviewPanel` hides
  * itself on an empty queue, so a backlog of proposed documents was
  * indistinguishable from a clean queue on every `/org/<slug>/memory`
- * visit. Scoping this GET without also scoping the panel's transport
- * would swap that silence for a hard 400, so the two ship together.
+ * visit.
+ *
+ * That conversion now happens in {@link bffProxy}. The unauthenticated
+ * response is overridden to keep this route's PLAIN-TEXT `Unauthorized`
+ * rather than the wrapper's JSON default — same bytes as before.
  */
-export async function GET(request: NextRequest) {
-    const token = await getAuthAccessCookie();
-    if (!token) {
-        return new Response('Unauthorized', { status: 401 });
-    }
+export const GET = bffProxy(
+    async ({ request, headers }) => {
+        headers.set('Accept', 'application/json');
 
-    let headers: Headers;
-    try {
-        headers = applyBffWorkspaceScope(request, {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
+        const upstream = await fetch(`${API_URL}/memory/review${request.nextUrl.search}`, {
+            method: 'GET',
+            headers,
+            cache: 'no-store',
         });
-    } catch {
-        return NextResponse.json({ error: 'Invalid workspace scope' }, { status: 400 });
-    }
 
-    const upstream = await fetch(`${API_URL}/memory/review${request.nextUrl.search}`, {
-        method: 'GET',
-        headers,
-        cache: 'no-store',
-    });
+        if (!upstream.ok) {
+            const text = await upstream.text().catch(() => '');
+            return new Response(text, {
+                status: upstream.status,
+                headers: {
+                    'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+                    'Cache-Control': 'no-store',
+                },
+            });
+        }
 
-    if (!upstream.ok) {
-        const text = await upstream.text().catch(() => '');
-        return new Response(text, {
-            status: upstream.status,
-            headers: {
-                'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
-                'Cache-Control': 'no-store',
-            },
-        });
-    }
-
-    const body = await upstream.json().catch(() => null);
-    return NextResponse.json(body ?? { items: [], total: 0 }, { status: 200 });
-}
+        const body = await upstream.json().catch(() => null);
+        return NextResponse.json(body ?? { items: [], total: 0 }, { status: 200 });
+    },
+    { onUnauthorized: () => new Response('Unauthorized', { status: 401 }) },
+);

--- a/apps/web/src/lib/api/bff-proxy.ts
+++ b/apps/web/src/lib/api/bff-proxy.ts
@@ -81,11 +81,20 @@ export interface BffProxyOptions {
     readonly reason?: string;
     /**
      * Response for a request with no auth cookie. Defaults to
-     * `401 { error: 'Unauthorized' }`. Some routes deliberately soften this (the
-     * org-templates catalogue answers `[]` so its modal skips a step rather than
-     * erroring), which is why it is overridable.
+     * `401 { error: 'Unauthorized' }`.
+     *
+     * Routes differ here and the difference is on the wire, so it is
+     * overridable: the org-templates catalogue answers `[]`/200 so its modal
+     * skips a step rather than erroring, and the Memory routes answer a
+     * PLAIN-TEXT `Unauthorized` rather than JSON.
+     *
+     * Typed as `Response`, not `NextResponse`, so a plain `new Response(...)`
+     * can be preserved verbatim. Narrowing it would force those routes to
+     * change their wire format merely to adopt the wrapper — a silent
+     * behaviour change smuggled in by a refactor, which is exactly what this
+     * wrapper exists to prevent.
      */
-    readonly onUnauthorized?: () => NextResponse;
+    readonly onUnauthorized?: () => Response;
 }
 
 const unauthorized = () => NextResponse.json({ error: 'Unauthorized' }, { status: 401 });


### PR DESCRIPTION
Second migratable batch, following [#2348](https://github.com/ever-works/ever-works/pull/2348):
the Memory review queue, its accept and reject verbs, and consolidation settings.
Behaviour-preserving.

## One thing nearly went wrong

All four answer an unauthenticated request with a **plain-text**
`new Response('Unauthorized', { status: 401 })`. `bffProxy`'s default is
`NextResponse.json({ error: 'Unauthorized' })`.

Migrating them naively would have changed the wire format of a 401 as a side effect of a
refactor — **precisely the silent drift this wrapper exists to prevent.** I only caught it
because I grepped the auth shape of each route before touching any of them, rather than
assuming they matched the nine already migrated.

Each now passes `onUnauthorized` to preserve its exact bytes. That required widening
`BffProxyOptions.onUnauthorized` from `() => NextResponse` to `() => Response`. Narrowing
it would have forced these routes to change their wire format merely to adopt the wrapper,
which is the wrong direction for a helper whose whole point is making posture explicit
rather than accidental.

`consolidation/settings` also had a shared `forward(request, method, body)` doing its own
auth and scope; it now takes the ready `Headers` and both verbs wrap it.

## Verification

- **101 tests across 16 files pass. No spec was edited** (`git diff --name-only | grep -c spec` = 0)
  and **no `expect(...)` was altered** anywhere in the diff. A spec needing a change would
  have meant behaviour changed.
- `tsc --noEmit` clean; prettier clean.
- **`turbo build --filter=ever-works-web` exits 0.** This one matters: two of these are
  *dynamic* routes using `bffProxy<RouteContext>`, and Next's route-type validation is the
  check `tsc` cannot do — it is what failed on exactly this pattern in #2348 and it is not
  something I am willing to leave to CI twice.

## What remains hand-rolled

Ten routes. Five plus the shared `memory/files/proxy.ts` attach the bearer only
`if (token)`, forwarding cookieless requests upstream anonymously so the API's own 401 comes
back — `bffProxy` has no pass-through auth mode, and adding one is a design decision I have
deliberately not taken unilaterally. The download route is blocked on the EW-788 carrier
decision.

Refs EW-789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
