### PR TITLE
test(e2e): align two July specs with the 2026-08-23 scope hardening

### DIFF
--- a/apps/web/e2e/flow-mission-ideas-isolation-deep.spec.ts
+++ b/apps/web/e2e/flow-mission-ideas-isolation-deep.spec.ts
@@ -499,7 +499,7 @@ test.describe('Mission ↔ Ideas — deep cross-user / cross-mission isolation &
         expect((await survived.json()).status).toBe('pending');
     });
 
-    test('org-context is INERT on /api/me/missions: the x-organization-id header neither changes the DTO nor adds a tenant/org column, and the row lists under the plain owner GET', async ({
+    test('org-context is INERT on /api/me/missions: the x-organization-id header stamps no Organization (organizationId stays null, tenantId is the session tenant either way), and the row lists under the plain owner GET', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -516,15 +516,19 @@ test.describe('Mission ↔ Ideas — deep cross-user / cross-mission isolation &
         expect(org.tenantId).toMatch(UUID_RE);
 
         // …then create a Mission WITH the org header set. /api/me/missions is
-        // strictly user-scoped: the header is inert, the DTO carries no
-        // tenantId/organizationId, and the row is the user's regardless of org.
+        // strictly user-scoped: the header is not the scope carrier, so the row
+        // gets no Organization. Every row does carry a tenantId now — the
+        // SESSION's tenant, seeded per request by SessionScopeGuard — so the
+        // inertness proof is: same tenant as a plain create, no org stamped.
+        const plain = await createMission(request, headers, { title: `Plain ${stamp('pl')}` });
         const orgScoped = await createMission(
             request,
             { ...headers, 'x-organization-id': org.id },
             { title: `OrgHeader ${stamp('oh')}` },
         );
-        expect(orgScoped.raw).not.toHaveProperty('tenantId');
-        expect(orgScoped.raw).not.toHaveProperty('organizationId');
+        expect(orgScoped.raw.tenantId).toMatch(UUID_RE);
+        expect(orgScoped.raw.tenantId).toBe(plain.raw.tenantId);
+        expect(orgScoped.raw.organizationId ?? null).toBeNull();
         expect(orgScoped.raw).not.toHaveProperty('orgId');
 
         // It lists under the PLAIN owner GET (no org header) — proving the list

--- a/apps/web/e2e/flow-notifications-event-preferences-digest-chain.spec.ts
+++ b/apps/web/e2e/flow-notifications-event-preferences-digest-chain.spec.ts
@@ -584,7 +584,7 @@ test.describe('Real-event notification chain — Task assignment -> inbox -> lif
         expect((await listNotifications(request, token)).length).toBe(1);
     });
 
-    test('cross-user delivery — assigning user B lands the row in B inbox with actor=A; the actor A inbox stays empty for that task', async ({
+    test('cross-user isolation — a personal-scope Task refuses a stranger as assignee (400, one shared no-oracle message), so nothing is delivered to either inbox', async ({
         request,
     }) => {
         const alice = await registerUserViaAPI(request);
@@ -593,29 +593,32 @@ test.describe('Real-event notification chain — Task assignment -> inbox -> lif
         const task = await createTaskViaAPI(request, alice.access_token, {
             title: 'Delegate to Bob',
         });
-        await assignUser(request, alice.access_token, task.id, bob.user.id);
 
-        // Bob receives it; the actor stamp is Alice.
-        const bobRows = await waitFor(
-            request,
-            bob.access_token,
-            (r) => r.some((n) => (n.metadata as { taskId?: string } | null)?.taskId === task.id),
-            'Bob receives the assignment',
+        // Since the Task-scope hardening a user actor is reachable only as the
+        // Task owner (personal scope) or through an Organization roster row
+        // (org scope). Bob is neither. Every mismatch shares one message so a
+        // known user id is not a scope oracle. The delivery half of this
+        // journey (assignee inside an Organization) has no API fixture: the
+        // org-invite token is email-only by design and never returned.
+        const refused = await request.post(`${API_BASE}/api/tasks/${task.id}/assignees`, {
+            headers: authedHeaders(alice.access_token),
+            data: { assigneeType: 'user', assigneeId: bob.user.id },
+        });
+        const refusedBody = await refused.text();
+        expect(refused.status(), `addAssignee body=${refusedBody}`).toBe(400);
+        expect(JSON.parse(refusedBody).message).toBe(
+            'Task actor is not reachable in this Task scope.',
         );
-        const bobNotif = bobRows.find(
-            (n) => (n.metadata as { taskId?: string } | null)?.taskId === task.id,
-        )!;
-        expect(bobNotif.userId).toBe(bob.user.id);
-        expect((bobNotif.metadata as { actorUserId?: string }).actorUserId).toBe(alice.user.id);
-        expect(bobNotif.message).toContain(alice.user.id.slice(0, 8));
-        expect(await unreadCount(request, bob.access_token)).toBe(1);
 
-        // Alice (the actor / creator, not a watcher) gets nothing for this task.
-        const aliceRows = await listNotifications(request, alice.access_token);
-        expect(
-            aliceRows.some((n) => (n.metadata as { taskId?: string } | null)?.taskId === task.id),
-        ).toBe(false);
-        expect(await unreadCount(request, alice.access_token)).toBe(0);
+        // The refusal happened before any event: neither inbox has a row for
+        // this Task and both unread counts stay at zero.
+        for (const who of [bob, alice]) {
+            const rows = await listNotifications(request, who.access_token);
+            expect(
+                rows.some((n) => (n.metadata as { taskId?: string } | null)?.taskId === task.id),
+            ).toBe(false);
+            expect(await unreadCount(request, who.access_token)).toBe(0);
+        }
     });
 
     test('cross-user isolation — user B cannot read or dismiss user A notification (404 each), and unread counts stay per-user', async ({

--- a/apps/web/e2e/flow-org-members-rbac-multistep.spec.ts
+++ b/apps/web/e2e/flow-org-members-rbac-multistep.spec.ts
@@ -756,10 +756,19 @@ test.describe('Org RBAC — end-to-end org-admin journey', () => {
 
         // 1. Create a team and staff it: an agent LEAD + the human owner as a MEMBER.
         const team = await createTeam(request, ctx, { name: `Ops ${stamp()}` });
-        const agent = await createAgentViaAPI(request, ctx.token, {
-            scope: 'tenant',
-            name: `OpsBot ${stamp()}`,
-        });
+        // Created IN org A. An agent created with no workspace selector is
+        // tenant-wide (organizationId NULL), and the org-chart deliberately
+        // projects tenant-wide agents into every org of the tenant (spec §5) —
+        // which is exactly what the disjointness check below must not see.
+        const agent = await createAgentViaAPI(
+            request,
+            ctx.token,
+            {
+                scope: 'tenant',
+                name: `OpsBot ${stamp()}`,
+            },
+            ctx.orgSlug,
+        );
         expect(
             (
                 await request.post(`${orgBase(ctx.orgId)}/teams/${team.id}/members`, {


### PR DESCRIPTION
## Why

Stage E2E (run 33903566975) has 4 red shards after the 2026-09-04 cascade. None is a product regression — three are July specs asserting pre-scope behaviour, and one is infra:

| Shard | Spec | Real cause | Fix |
|---|---|---|---|
| 13 | `flow-mission-ideas-isolation-deep.spec.ts:502` | Asserts the Mission row has **no** `tenantId`; every row carries the session tenant since `8f28edca0` (2026-08-23). | **this PR** |
| 14 | `flow-notifications-event-preferences-digest-chain.spec.ts:587` | Assigns a stranger to a personal-scope Task; `tasks.service.ts:389` now refuses with `Task actor is not reachable in this Task scope.` | **this PR** |
| 16 | `flow-org-members-rbac-multistep.spec.ts:751` | LEAD agent created with no selector → tenant-wide; `org-chart.service.ts:52` projects tenant-wide agents into **every** org of the tenant (spec §5). | #2351 (already on develop) |
| 23 | — | `Install pnpm` step failed (`ENOTEMPTY` cleanup). Never ran a test. | infra |

All three specs have been red since 2026-08-23, masked by the BFF Referer bug that #2335 fixed — which is why they only surfaced now.

## What changed

- **mission**: the header-inert proof becomes *same tenant as a plain create, no organization stamped* (`organizationId` null), instead of *no tenant column*.
- **notifications**: assert the 400 + shared no-oracle message, and that neither inbox receives anything. This is a real contract test of the hardening.

## Coverage gap to note (not fixed here)

The *delivery* half of the shard-14 journey — assignee inside an Organization — has no e2e path: `POST organizations/:id/invitations` never returns the token (email-only by design) and there is no direct org member-add endpoint. If that path matters, it needs a test-only fixture (mail sink or seeded roster), which is a product decision.

## Verification

- `tsc` (apps/web, covers `e2e/`): exit 0 · ESLint on the files: clean · Prettier: clean
- Playwright runs only on push to `stage`; these land there via the held cascade #2355.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mission isolation so missions consistently remain associated with the active session and are listed only through the appropriate user-scoped views.
  * Prevented personal tasks from assigning users outside the task’s scope. Invalid assignments are rejected, and no inbox notifications or unread counts are generated.

* **Tests**
  * Updated coverage to verify tenant isolation, scoped mission visibility, cross-user task protection, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->