### PR TITLE
feat(api): trusted reviewer bots become Task feedback (EW-791)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -301,6 +301,15 @@ POSTHOG_HOST=https://us.i.posthog.com
 PLUGIN_GITHUB_CLIENT_ID=
 PLUGIN_GITHUB_CLIENT_SECRET=
 # Redirect URL or callback: [WEB_DOMAIN]/api/oauth/github/callback/plugins
+#
+# Trusted review bots (self-build fleet, R16). Reviews, inline findings and
+# summary comments from these GitHub logins become Task rejection feedback
+# (with severity) for the next resumed run. Comma separated, case-insensitive.
+# Default: coderabbitai[bot],copilot-pull-request-reviewer[bot],copilot,chatgpt-codex-connector[bot],greptile-apps[bot]
+# `none` disables every bot. The platform's own `<GITHUB_APP_SLUG>[bot]`
+# identity is ALWAYS excluded, even if listed here. `github-actions[bot]` is
+# deliberately not a default: any workflow in a repository can post as it.
+# GITHUB_TRUSTED_REVIEW_BOTS=
 
 # Tavily Plugin
 PLUGIN_TAVILY_API_KEY=

--- a/apps/api/src/config/constants.spec.ts
+++ b/apps/api/src/config/constants.spec.ts
@@ -3,6 +3,7 @@ import {
     AuthProvider,
     BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
     config,
+    DEFAULT_TRUSTED_REVIEW_BOTS,
 } from './constants';
 
 describe('config/constants', () => {
@@ -31,7 +32,8 @@ describe('config/constants', () => {
                 key === 'HTTP_DEBUG' ||
                 key === 'MAILER_PROVIDER' ||
                 key === 'WORK_STALE_TIMEOUT_HOURS' ||
-                key === 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS'
+                key === 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS' ||
+                key === 'GITHUB_TRUSTED_REVIEW_BOTS'
             ) {
                 delete process.env[key];
             }
@@ -685,6 +687,71 @@ describe('config/constants', () => {
             process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS =
                 'inngest,trigger,inngest,trigger';
             expect(config.tenantJobRuntime.getAllowedProviders()).toEqual(['inngest', 'trigger']);
+        });
+    });
+
+    describe('config.githubReviewBots (trusted review bots, R16)', () => {
+        it('trusts the four verified reviewer bots by default — and NOT github-actions', () => {
+            // Logins read off this repository's PR history with `gh api`.
+            // Copilot is two identities (review author vs inline author).
+            expect([...DEFAULT_TRUSTED_REVIEW_BOTS]).toEqual([
+                'coderabbitai[bot]',
+                'copilot-pull-request-reviewer[bot]',
+                'copilot',
+                'chatgpt-codex-connector[bot]',
+                'greptile-apps[bot]',
+            ]);
+            expect(config.githubReviewBots.trustedLogins()).toEqual([
+                ...DEFAULT_TRUSTED_REVIEW_BOTS,
+            ]);
+            expect(config.githubReviewBots.trustedLogins()).not.toContain('github-actions[bot]');
+        });
+
+        it('falls back to the defaults on a blank value', () => {
+            process.env.GITHUB_TRUSTED_REVIEW_BOTS = '   \t ';
+            expect(config.githubReviewBots.trustedLogins()).toEqual([
+                ...DEFAULT_TRUSTED_REVIEW_BOTS,
+            ]);
+        });
+
+        it('parses an operator list: trimmed, @-stripped, lower-cased, de-duplicated, order kept', () => {
+            process.env.GITHUB_TRUSTED_REVIEW_BOTS =
+                ' @Greptile-Apps[bot], coderabbitai[bot] ,GREPTILE-APPS[bot],, my-reviewer[bot]';
+            expect(config.githubReviewBots.trustedLogins()).toEqual([
+                'greptile-apps[bot]',
+                'coderabbitai[bot]',
+                'my-reviewer[bot]',
+            ]);
+        });
+
+        it('`none` is the explicit opt-out; a list of only separators is not', () => {
+            process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'NONE';
+            expect(config.githubReviewBots.trustedLogins()).toEqual([]);
+            process.env.GITHUB_TRUSTED_REVIEW_BOTS = ' , ,';
+            expect(config.githubReviewBots.trustedLogins()).toEqual([
+                ...DEFAULT_TRUSTED_REVIEW_BOTS,
+            ]);
+        });
+
+        it('derives the self identity from GITHUB_APP_SLUG (default ever-works[bot])', () => {
+            expect(config.githubReviewBots.selfLogins()).toEqual(['ever-works[bot]']);
+            process.env.GITHUB_APP_SLUG = 'Acme-Reviewer';
+            expect(config.githubReviewBots.selfLogins()).toEqual(['acme-reviewer[bot]']);
+        });
+
+        it('names the same self identity when GITHUB_APP_SLUG is pasted with an @ or a [bot] suffix', () => {
+            // A doubled `[bot][bot]` would leave the real login outside the
+            // self set — and an allow-list entry could then let it in.
+            process.env.GITHUB_APP_SLUG = 'ever-works[bot]';
+            expect(config.githubReviewBots.selfLogins()).toEqual(['ever-works[bot]']);
+            process.env.GITHUB_APP_SLUG = ' @Ever-Works[BOT] ';
+            expect(config.githubReviewBots.selfLogins()).toEqual(['ever-works[bot]']);
+        });
+
+        it('never ships the self identity inside the default trusted list', () => {
+            for (const self of config.githubReviewBots.selfLogins()) {
+                expect(config.githubReviewBots.trustedLogins()).not.toContain(self);
+            }
         });
     });
 

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -22,6 +22,32 @@ export const BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS = [
     'node',
 ] as const;
 
+/**
+ * Trusted review bots (self-build fleet, finding R16) — the GitHub logins
+ * whose pull-request reviews, inline findings and summary comments the
+ * webhook bridge records as Task rejection feedback (the loop the house
+ * rules mandate: poll the bot reviewers, fix P2+, repeat until clean).
+ *
+ * Every login was read off this repository's own PR history with
+ * `gh api`, not guessed. Copilot is two identities: its reviews are
+ * authored by `copilot-pull-request-reviewer[bot]` while the inline
+ * comments inside them carry the login `Copilot` (same user id), so both
+ * are listed. `github-actions[bot]` is deliberately ABSENT: it never
+ * reviews, and any workflow in the repository can post under it, which
+ * would make the allow-list only as trusted as the least-reviewed
+ * workflow file.
+ *
+ * All lower-case: GitHub logins are case-insensitive and the bridge
+ * compares canonical forms.
+ */
+export const DEFAULT_TRUSTED_REVIEW_BOTS = [
+    'coderabbitai[bot]',
+    'copilot-pull-request-reviewer[bot]',
+    'copilot',
+    'chatgpt-codex-connector[bot]',
+    'greptile-apps[bot]',
+] as const;
+
 export enum AuthProvider {
     LOCAL = 'local',
     GITHUB = 'github',
@@ -189,6 +215,60 @@ export const config = {
         callbackUrl: () => {
             const webUrl = config.webAppUrl();
             return process.env.GITHUB_APP_CALLBACK_URL || `${webUrl}/api/github-app/callback`;
+        },
+    },
+
+    /**
+     * Trusted review bots (self-build fleet, finding R16).
+     *
+     * `trustedLogins()` — `GITHUB_TRUSTED_REVIEW_BOTS`, comma separated.
+     * Unset / blank → {@link DEFAULT_TRUSTED_REVIEW_BOTS}. The literal
+     * `none` → an empty list (operator opt-out: every bot is dropped
+     * again, the pre-R16 posture). Otherwise the entries are trimmed,
+     * `@`-stripped, lower-cased and de-duplicated in operator order; there
+     * is no "known ids" filter because an operator may trust a reviewer
+     * bot this codebase has never met. A list that parses to nothing
+     * (`,,`) is treated as blank rather than as an opt-out — `none` is the
+     * only way to say "nobody", so a typo cannot silently mute every
+     * reviewer.
+     *
+     * `selfLogins()` — the platform's OWN reviewer identity, derived from
+     * `GITHUB_APP_SLUG` (GitHub renders an App's actions as
+     * `<slug>[bot]`). The bridge checks this set BEFORE the trusted one,
+     * so listing the app's own login under `GITHUB_TRUSTED_REVIEW_BOTS`
+     * changes nothing: the loop can never read its own output as
+     * reviewer feedback. That ordering is the security property; keep it.
+     * A slug pasted as `@ever-works` or `ever-works[bot]` is canonicalised
+     * first — a doubled `[bot][bot]` would leave the REAL login outside
+     * this set, and an allow-list entry could then let it in.
+     */
+    githubReviewBots: {
+        trustedLogins: (): string[] => {
+            const raw = (process.env.GITHUB_TRUSTED_REVIEW_BOTS ?? '').trim();
+            if (raw === '') {
+                return [...DEFAULT_TRUSTED_REVIEW_BOTS];
+            }
+            if (raw.toLowerCase() === 'none') {
+                return [];
+            }
+            const parsed = raw
+                .split(',')
+                .map((value) => value.trim().replace(/^@/, '').toLowerCase())
+                .filter((value) => value.length > 0);
+            const deduped = Array.from(new Set(parsed));
+            if (deduped.length === 0) {
+                return [...DEFAULT_TRUSTED_REVIEW_BOTS];
+            }
+            return deduped;
+        },
+        selfLogins: (): string[] => {
+            const slug = config.githubApp
+                .slug()
+                .trim()
+                .replace(/^@/, '')
+                .replace(/\[bot\]$/i, '')
+                .toLowerCase();
+            return [`${slug}[bot]`];
         },
     },
     facebook: {

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -7,6 +7,13 @@ jest.mock('@ever-works/agent/plugins', () => ({
     PluginSettingsService: class {},
     UserPluginRepository: class {},
 }));
+// The bridge injects two tasks-domain services by class. Mocking the
+// subpath keeps this unit suite from loading TasksDomainModule's entire
+// import graph (facades → agent-plugins → …) just to obtain two tokens.
+jest.mock('@ever-works/agent/tasks-domain', () => ({
+    TaskGitLinkService: class {},
+    TaskReviewRejectionService: class {},
+}));
 
 import {
     GITHUB_PUSH_COMMITS_MAX,
@@ -829,6 +836,507 @@ describe('GitHubPrReviewBridgeService', () => {
             await expect(
                 service.handleEvent(BINDING, 'pull_request_review', reviewBody()),
             ).resolves.toEqual({ ingested: null });
+        });
+    });
+
+    /**
+     * Trusted review bots (self-build fleet, finding R16).
+     *
+     * The bridge used to drop EVERY bot-authored review and comment. That
+     * kept the loop from echoing itself — and also kept CodeRabbit,
+     * Copilot, Codex and Greptile verdicts from ever becoming Task
+     * feedback, so a human relayed each finding by hand. Now an
+     * allow-listed reviewer bot's `changes_requested` review, inline
+     * findings and summary comments are recorded exactly as a human's
+     * would be, while the platform's own identity and unknown bots are
+     * still dropped at the door. Bodies below are the literal shapes the
+     * bots post on this repository (captured with `gh api`).
+     */
+    describe('trusted review bots (R16)', () => {
+        const ORIGINAL_TRUSTED = process.env.GITHUB_TRUSTED_REVIEW_BOTS;
+        const ORIGINAL_SLUG = process.env.GITHUB_APP_SLUG;
+
+        beforeEach(() => {
+            delete process.env.GITHUB_TRUSTED_REVIEW_BOTS;
+            delete process.env.GITHUB_APP_SLUG;
+        });
+
+        afterAll(() => {
+            if (ORIGINAL_TRUSTED === undefined) delete process.env.GITHUB_TRUSTED_REVIEW_BOTS;
+            else process.env.GITHUB_TRUSTED_REVIEW_BOTS = ORIGINAL_TRUSTED;
+            if (ORIGINAL_SLUG === undefined) delete process.env.GITHUB_APP_SLUG;
+            else process.env.GITHUB_APP_SLUG = ORIGINAL_SLUG;
+        });
+
+        /** A CodeRabbit inline finding, as posted on ever-works/ever-works#2344. */
+        const CODERABBIT_MAJOR_FINDING = [
+            '_🗄️ Data Integrity & Integration_ | _🟠 Major_ | _🏗️ Heavy lift_',
+            '',
+            '<details>',
+            '<summary>🔎 Supported by static analysis</summary>',
+            '',
+            '🤖 get_repo_knowledge executed:',
+            '',
+            'Length of output: 33708',
+            '',
+            '</details>',
+            '',
+            'The migration drops the column without a guard, so a partially applied database cannot converge.',
+        ].join('\n');
+
+        function botReview(login: string, over: Record<string, unknown> = {}) {
+            return {
+                action: 'submitted',
+                repository: { full_name: 'octo/site' },
+                pull_request: { number: 9, html_url: 'https://github.com/octo/site/pull/9' },
+                review: {
+                    id: 1,
+                    state: 'changes_requested',
+                    body: '**Actionable comments posted: 2**\n\n<details>\n<summary>🧹 Nitpick comments (1)</summary>\n\nx\n\n</details>',
+                    user: { login, type: 'Bot' },
+                },
+                ...over,
+            };
+        }
+
+        function botReviewComment(login: string, body: string, over: Record<string, unknown> = {}) {
+            return {
+                action: 'created',
+                repository: { full_name: 'octo/site' },
+                pull_request: {
+                    number: 9,
+                    title: 'Add severity',
+                    html_url: 'https://github.com/octo/site/pull/9',
+                },
+                comment: {
+                    id: 501,
+                    body,
+                    html_url: 'https://github.com/octo/site/pull/9#discussion_r501',
+                    path: 'apps/api/src/migrations/1788100000000-AddSeverity.ts',
+                    line: 144,
+                    original_line: 60,
+                    pull_request_review_id: 1,
+                    user: { login, type: 'Bot' },
+                },
+                ...over,
+            };
+        }
+
+        function botIssueComment(login: string, body: string, over: Record<string, unknown> = {}) {
+            return {
+                action: 'created',
+                repository: { full_name: 'octo/site' },
+                issue: {
+                    number: 9,
+                    title: 'Add severity',
+                    html_url: 'https://github.com/octo/site/pull/9',
+                    pull_request: { url: 'https://example.com/api/pulls/9' },
+                },
+                comment: {
+                    id: 601,
+                    body,
+                    html_url: 'https://github.com/octo/site/pull/9#issuecomment-601',
+                    user: { login, type: 'Bot' },
+                },
+                ...over,
+            };
+        }
+
+        describe('pull_request_review', () => {
+            it('⭐ records a changes_requested review from an allow-listed bot as rejection feedback', async () => {
+                const { service, rejections } = createService();
+                const result = await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('coderabbitai[bot]'),
+                );
+                expect(result).toEqual({ ingested: null });
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        userId: BINDING.userId,
+                        owner: 'octo',
+                        repo: 'site',
+                        prNumber: 9,
+                        reviewerLabel: 'coderabbitai[bot]',
+                        reviewerKind: 'bot',
+                        feedback: '**Actionable comments posted: 2**',
+                    }),
+                );
+            });
+
+            it('still drops a bot that is not on the list', async () => {
+                for (const login of ['github-actions[bot]', 'dependabot[bot]']) {
+                    const { service, rejections } = createService();
+                    await service.handleEvent(BINDING, 'pull_request_review', botReview(login));
+                    expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                }
+            });
+
+            it('⭐ still drops the platform identity — even when an operator lists it as trusted', async () => {
+                // THE security property of this slice: the loop must never
+                // read its own output as reviewer feedback, and the
+                // allow-list cannot be used to make it.
+                process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'ever-works[bot],coderabbitai[bot]';
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('ever-works[bot]'),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                // The same list still works for everyone else on it.
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('coderabbitai[bot]'),
+                );
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledTimes(1);
+            });
+
+            it('derives the self identity from GITHUB_APP_SLUG', async () => {
+                process.env.GITHUB_APP_SLUG = 'acme';
+                process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'acme[bot]';
+                const { service, rejections } = createService();
+                await service.handleEvent(BINDING, 'pull_request_review', botReview('acme[bot]'));
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            });
+
+            it('leaves a human review exactly as before, tagged human with no severity', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('octocat', {
+                        review: {
+                            id: 1,
+                            state: 'changes_requested',
+                            body: 'the migration has no down()',
+                            user: { login: 'octocat', type: 'User' },
+                        },
+                    }),
+                );
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        feedback: 'the migration has no down()',
+                        reviewerLabel: 'octocat',
+                        reviewerKind: 'human',
+                        severity: null,
+                    }),
+                );
+            });
+
+            it('ignores a trusted bot that merely COMMENTED — its findings arrive as inline comments', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('coderabbitai[bot]', {
+                        review: {
+                            id: 1,
+                            state: 'commented',
+                            body: '**Actionable comments posted: 2**',
+                            user: { login: 'coderabbitai[bot]', type: 'Bot' },
+                        },
+                    }),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            });
+
+            it('GITHUB_TRUSTED_REVIEW_BOTS=none restores the drop-every-bot posture', async () => {
+                process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'none';
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    botReview('coderabbitai[bot]'),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('platform identity (adversarial)', () => {
+            it('⭐ still drops the platform identity on BOTH comment paths — even when listed as trusted', async () => {
+                process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'ever-works[bot],coderabbitai[bot]';
+                const { service, rejections, eventIngestService, prReviewService } =
+                    createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment('ever-works[bot]', CODERABBIT_MAJOR_FINDING),
+                );
+                await service.handleEvent(
+                    BINDING,
+                    'issue_comment',
+                    botIssueComment('Ever-Works[bot]', '@ever-works please rebase.'),
+                );
+                await flush();
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+                expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
+            });
+
+            it('a slug misconfigured as `ever-works[bot]` or `@ever-works` still names the platform identity', async () => {
+                for (const slug of ['ever-works[bot]', '@Ever-Works', ' ever-works ']) {
+                    process.env.GITHUB_APP_SLUG = slug;
+                    process.env.GITHUB_TRUSTED_REVIEW_BOTS = 'ever-works[bot]';
+                    const { service, rejections } = createService();
+                    await service.handleEvent(
+                        BINDING,
+                        'pull_request_review',
+                        botReview('ever-works[bot]'),
+                    );
+                    expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                }
+            });
+
+            it('drops look-alikes of the platform identity that nobody listed', async () => {
+                for (const login of [
+                    'ever-works-bot[bot]',
+                    'everworks[bot]',
+                    'ever-works-ai[bot]',
+                ]) {
+                    const { service, rejections, eventIngestService } = createService();
+                    await service.handleEvent(BINDING, 'pull_request_review', botReview(login));
+                    await service.handleEvent(
+                        BINDING,
+                        'issue_comment',
+                        botIssueComment(login, '@ever-works please rebase.'),
+                    );
+                    expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                    expect(eventIngestService.ingest).not.toHaveBeenCalled();
+                }
+            });
+
+            it('still drops an @ever-works mention from an unlisted bot — neither feedback nor a review', async () => {
+                const { service, rejections, eventIngestService, prReviewService } =
+                    createService();
+                await service.handleEvent(
+                    BINDING,
+                    'issue_comment',
+                    botIssueComment('dependabot[bot]', '@ever-works is this migration safe?'),
+                );
+                await flush();
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+                expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
+            });
+
+            it('records an allow-listed bot finding that carries no severity marker — unstated, never dropped', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment(
+                        'coderabbitai[bot]',
+                        'The migration drops the column without a guard.',
+                    ),
+                );
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({ reviewerKind: 'bot', severity: null }),
+                );
+            });
+        });
+
+        describe('pull_request_review_comment (inline findings)', () => {
+            it('⭐ records a CodeRabbit Major finding with severity, location, and no static-analysis dump', async () => {
+                const { service, rejections, eventIngestService } = createService();
+                const result = await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment('coderabbitai[bot]', CODERABBIT_MAJOR_FINDING),
+                );
+                expect(result).toEqual({ ingested: null });
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledTimes(1);
+                const [input] = rejections.recordPullRequestRejection.mock.calls[0];
+                expect(input).toMatchObject({
+                    userId: BINDING.userId,
+                    owner: 'octo',
+                    repo: 'site',
+                    prNumber: 9,
+                    reviewerLabel: 'coderabbitai[bot]',
+                    reviewerKind: 'bot',
+                    severity: 'major',
+                    prUrl: 'https://github.com/octo/site/pull/9#discussion_r501',
+                });
+                expect(input.feedback).toMatch(
+                    /^apps\/api\/src\/migrations\/1788100000000-AddSeverity\.ts:144 — /,
+                );
+                expect(input.feedback).toContain('cannot converge');
+                expect(input.feedback).not.toContain('Length of output');
+                expect(input.feedback).not.toContain('<details>');
+            });
+
+            it('maps Codex P1 → critical and Greptile P2 → major', async () => {
+                const codex = createService();
+                await codex.service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment(
+                        'chatgpt-codex-connector[bot]',
+                        '**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Cast metadata before using JSON operator**\n\nThe JSON operator is applied to a text column.',
+                    ),
+                );
+                expect(codex.rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        severity: 'critical',
+                        reviewerLabel: 'chatgpt-codex-connector[bot]',
+                        feedback: expect.stringContaining(
+                            'Cast metadata before using JSON operator',
+                        ),
+                    }),
+                );
+
+                const greptile = createService();
+                await greptile.service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment(
+                        'greptile-apps[bot]',
+                        '<a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `import type` statement appears after the export block.',
+                    ),
+                );
+                expect(greptile.rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        severity: 'major',
+                        reviewerLabel: 'greptile-apps[bot]',
+                        feedback: expect.stringContaining('The `import type` statement'),
+                    }),
+                );
+            });
+
+            it('records a Copilot inline comment (login `Copilot`, no marker) with severity null', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment(
+                        'Copilot',
+                        'The retry loop never backs off, so a flaky provider is hammered.',
+                    ),
+                );
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        reviewerLabel: 'Copilot',
+                        reviewerKind: 'bot',
+                        severity: null,
+                    }),
+                );
+            });
+
+            it('never reviews its reviewers — a bot comment stays out of the mention loop even when it says @ever-works', async () => {
+                const { service, rejections, prReviewService, eventIngestService } =
+                    createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment('coderabbitai[bot]', '@ever-works please rebase.'),
+                );
+                await flush();
+                expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledTimes(1);
+            });
+
+            it('drops an edited bot comment — only `created` carries a new finding', async () => {
+                const { service, rejections, eventIngestService } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment('coderabbitai[bot]', CODERABBIT_MAJOR_FINDING, {
+                        action: 'edited',
+                    }),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+            });
+
+            it('still drops an inline comment from an unlisted bot', async () => {
+                const { service, rejections, eventIngestService } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review_comment',
+                    botReviewComment('github-actions[bot]', CODERABBIT_MAJOR_FINDING),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                expect(eventIngestService.ingest).not.toHaveBeenCalled();
+            });
+
+            it('a recorder failure on the bot path still answers the webhook', async () => {
+                const { service, rejections } = createService();
+                rejections.recordPullRequestRejection.mockRejectedValue(new Error('db down'));
+                await expect(
+                    service.handleEvent(
+                        BINDING,
+                        'pull_request_review_comment',
+                        botReviewComment('coderabbitai[bot]', CODERABBIT_MAJOR_FINDING),
+                    ),
+                ).resolves.toEqual({ ingested: null });
+            });
+        });
+
+        describe('issue_comment (summaries)', () => {
+            it('records the CodeRabbit summary comment on a pull request', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'issue_comment',
+                    botIssueComment(
+                        'coderabbitai[bot]',
+                        '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\n## Summary by CodeRabbit\n\n- Adds severity to rejections.\n\n<!-- end of auto-generated comment: summarize by coderabbit.ai -->',
+                    ),
+                );
+                expect(rejections.recordPullRequestRejection).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        prNumber: 9,
+                        reviewerLabel: 'coderabbitai[bot]',
+                        reviewerKind: 'bot',
+                        severity: null,
+                        feedback: '## Summary by CodeRabbit\n\n- Adds severity to rejections.',
+                        prUrl: 'https://github.com/octo/site/pull/9#issuecomment-601',
+                    }),
+                );
+            });
+
+            it('drops rate-limit and status chatter — there is nothing in it to fix', async () => {
+                for (const body of [
+                    '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n>\n> **Next included review available in 34 minutes.**',
+                    '<!-- greptile-status -->\nToo many files changed for review.',
+                    'You have reached your Codex usage limits for code reviews.',
+                ]) {
+                    const { service, rejections } = createService();
+                    await service.handleEvent(
+                        BINDING,
+                        'issue_comment',
+                        botIssueComment('coderabbitai[bot]', body),
+                    );
+                    expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+                }
+            });
+
+            it('drops a bot comment on a plain issue — only PR threads carry review feedback', async () => {
+                const { service, rejections } = createService();
+                const body = botIssueComment(
+                    'coderabbitai[bot]',
+                    '## Summary by CodeRabbit\n\n- x',
+                );
+                (body.issue as any).pull_request = undefined;
+                await service.handleEvent(BINDING, 'issue_comment', body);
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            });
+
+            it('drops a comment that is nothing but markup once stripped', async () => {
+                const { service, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'issue_comment',
+                    botIssueComment(
+                        'coderabbitai[bot]',
+                        '<!-- walkthrough_start -->\n<details>\n<summary>x</summary>\ny\n</details>\n<!-- walkthrough_end -->',
+                    ),
+                );
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            });
         });
     });
 

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -11,6 +11,15 @@ import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/p
 import { TaskGitLinkService, TaskReviewRejectionService } from '@ever-works/agent/tasks-domain';
 import type { TaskGitLink } from '@ever-works/agent/tasks-domain';
 import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
+import { config } from '../../config/constants';
+import {
+    classifyReviewer,
+    formatInlineFinding,
+    isReviewBotNoise,
+    parseReviewBotSeverity,
+    stripReviewBotMarkup,
+    type ReviewBotPolicy,
+} from './github-review-bots';
 
 export const GITHUB_PLUGIN_ID = 'github';
 
@@ -177,6 +186,17 @@ export interface GitHubWebhookBody {
         body?: string;
         html_url?: string;
         user?: { login?: string; type?: string };
+        /**
+         * Trusted review bots (R16) — `pull_request_review_comment` only.
+         * The diff anchor of an inline finding: `line` on the current
+         * diff, `original_line` when the line has since moved. Recorded
+         * as `path:line` in front of the finding so the resumed run can
+         * open the file the reviewer bot meant.
+         */
+        path?: string;
+        line?: number | null;
+        original_line?: number | null;
+        pull_request_review_id?: number;
     };
     /**
      * Orchestration M9 - `pull_request_review` deliveries. A human
@@ -300,8 +320,17 @@ function taskFields(link: TaskGitLink | null): Record<string, unknown> {
  *    not awaited: webhooks need a fast 200, and the review is
  *    best-effort (failures are logged, never thrown).
  *
- * Bot-authored comments (including our own review replies) are never
- * ingested — the loop must not echo its own output.
+ * ## Reviewer bots (self-build fleet, finding R16)
+ *
+ * The platform's OWN replies (`<GITHUB_APP_SLUG>[bot]`) and any bot that
+ * is not on the trusted allow-list are never ingested — the loop must not
+ * echo its own output, and an unknown automation must not steer a Task.
+ * Reviews, inline findings and summary comments from the TRUSTED reviewer
+ * bots (`config.githubReviewBots`; CodeRabbit, Copilot, Codex and Greptile
+ * by default) become Task rejection feedback carrying the bot's own
+ * severity, so the next resumed run fixes P2+ first. They are recorded,
+ * never reviewed: a bot comment does not enter the mention loop even when
+ * it happens to say `@ever-works`.
  *
  * ## Git activity (audit item j)
  *
@@ -518,6 +547,21 @@ export class GitHubPrReviewBridgeService {
             return { ingested: null };
         }
 
+        // Trusted review bots (R16) - an inline finding or a summary
+        // comment from an allow-listed reviewer bot is rejection feedback
+        // for the Task, on the same footing as a human's. It is handled
+        // here, BEFORE normalize(), for the same reason a review is: the
+        // loop must never review its reviewers, so the comment cannot
+        // become a `github.mention` no matter what it says.
+        if (
+            (eventName === 'issue_comment' || eventName === 'pull_request_review_comment') &&
+            body.action === 'created' &&
+            classifyReviewer(body.comment?.user, this.reviewBotPolicy()) === 'trusted-bot'
+        ) {
+            await this.recordBotCommentFeedback(binding, eventName, body);
+            return { ingested: null };
+        }
+
         // Git activity ingestion (audit item j) - pushes, the commits
         // inside them and merged pull requests. They take the SAME path
         // every other kind takes (envelope -> dedupe-insert -> spine
@@ -558,10 +602,16 @@ export class GitHubPrReviewBridgeService {
      * durable rejection feedback for the Task the PR belongs to.
      *
      * Best-effort throughout: a webhook must answer 200 fast, and every
-     * miss here (not a rejection, a bot reviewer, an empty body, a PR
+     * miss here (not a rejection, a dropped reviewer, an empty body, a PR
      * that maps to no Work/Task) is an ORDINARY outcome, not an error.
-     * Bot reviewers are excluded for the same reason bot comments are:
-     * the loop must never treat its own output as human feedback.
+     *
+     * Trusted review bots (R16): the platform's own identity and any bot
+     * NOT on the allow-list are dropped — the loop must never treat its
+     * own output as reviewer feedback. An allow-listed reviewer bot in
+     * "request changes" mode is a rejection exactly like a human's, with
+     * the bot's own severity marker carried along; its `COMMENTED`
+     * summaries are not (their findings arrive as inline comments and are
+     * recorded by {@link recordBotCommentFeedback}).
      */
     private async recordReviewRejection(
         binding: GitHubEventsBinding,
@@ -569,8 +619,11 @@ export class GitHubPrReviewBridgeService {
     ): Promise<void> {
         const review = body.review;
         if (!review || review.state?.toLowerCase() !== 'changes_requested') return;
-        if (review.user?.type === 'Bot') return;
-        const feedback = (review.body ?? '').trim();
+        const who = classifyReviewer(review.user, this.reviewBotPolicy());
+        if (who === 'self' || who === 'untrusted-bot') return;
+        const raw = review.body ?? '';
+        if (who === 'trusted-bot' && isReviewBotNoise(raw)) return;
+        const feedback = (who === 'trusted-bot' ? stripReviewBotMarkup(raw) : raw).trim();
         if (feedback.length === 0) return;
 
         const fullName = body.repository?.full_name ?? '';
@@ -587,6 +640,8 @@ export class GitHubPrReviewBridgeService {
                 feedback: feedback.slice(0, GITHUB_EVENT_TEXT_MAX_CHARS),
                 reviewerLabel: review.user?.login ?? null,
                 prUrl: body.pull_request?.html_url ?? review.html_url ?? null,
+                reviewerKind: who === 'trusted-bot' ? 'bot' : 'human',
+                severity: who === 'trusted-bot' ? parseReviewBotSeverity(raw) : null,
             });
         } catch (error) {
             this.logger.warn(
@@ -595,6 +650,84 @@ export class GitHubPrReviewBridgeService {
                 }`,
             );
         }
+    }
+
+    /**
+     * Trusted review bots (R16) — persist one inline finding
+     * (`pull_request_review_comment`) or summary comment (`issue_comment`)
+     * from an allow-listed reviewer bot as rejection feedback for the
+     * Task the PR belongs to. The caller has already classified the
+     * author as `trusted-bot` and checked `action === 'created'`.
+     *
+     * Status chatter (rate limits, "too many files", usage caps) is
+     * dropped: it carries nothing to fix. Presentation markup — HTML
+     * comments, collapsed static-analysis dumps, badges — is stripped
+     * BEFORE the text cap so the finding itself survives the budget, and
+     * an inline finding is prefixed with its `path:line` anchor. Same
+     * best-effort posture as {@link recordReviewRejection}.
+     */
+    private async recordBotCommentFeedback(
+        binding: GitHubEventsBinding,
+        eventName: string,
+        body: GitHubWebhookBody,
+    ): Promise<void> {
+        const comment = body.comment;
+        if (!comment || typeof comment.id !== 'number') return;
+        const raw = comment.body ?? '';
+        if (isReviewBotNoise(raw)) return;
+        // issue_comment fires for plain issues too — only PR threads carry
+        // review feedback.
+        const prNumber =
+            eventName === 'issue_comment'
+                ? body.issue?.pull_request
+                    ? body.issue?.number
+                    : undefined
+                : body.pull_request?.number;
+        if (typeof prNumber !== 'number') return;
+
+        const fullName = body.repository?.full_name ?? '';
+        const [owner, repo] = fullName.split('/');
+        if (!owner || !repo) return;
+
+        const stripped = stripReviewBotMarkup(raw);
+        const feedback =
+            eventName === 'pull_request_review_comment'
+                ? formatInlineFinding(comment, stripped)
+                : stripped;
+        if (feedback.length === 0) return;
+
+        try {
+            await this.rejections.recordPullRequestRejection({
+                userId: binding.userId,
+                owner,
+                repo,
+                prNumber,
+                feedback: feedback.slice(0, GITHUB_EVENT_TEXT_MAX_CHARS),
+                reviewerLabel: comment.user?.login ?? null,
+                prUrl:
+                    comment.html_url ?? body.pull_request?.html_url ?? body.issue?.html_url ?? null,
+                reviewerKind: 'bot',
+                severity: parseReviewBotSeverity(raw),
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Reviewer-bot feedback record failed for ${fullName}#${prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * The allow-list and the self identity, resolved per delivery so an
+     * operator's env change (and a spec's) takes effect without a restart.
+     * Both sets hold canonical (lower-case) logins.
+     */
+    private reviewBotPolicy(): ReviewBotPolicy {
+        return {
+            trusted: new Set(config.githubReviewBots.trustedLogins()),
+            self: new Set(config.githubReviewBots.selfLogins()),
+        };
     }
 
     /**
@@ -861,7 +994,10 @@ export class GitHubPrReviewBridgeService {
                 return null;
             }
             // Never ingest bot-authored comments (incl. our own review
-            // replies) — the loop must not echo its own output.
+            // replies) — the loop must not echo its own output. Trusted
+            // reviewer bots (R16) were intercepted in handleEvent() and
+            // recorded as feedback; whatever bot reaches this line is
+            // either the platform itself or one nobody vouched for.
             if (comment.user?.type === 'Bot') {
                 return null;
             }

--- a/apps/api/src/ingest/github/github-review-bots.spec.ts
+++ b/apps/api/src/ingest/github/github-review-bots.spec.ts
@@ -1,0 +1,249 @@
+import {
+    classifyReviewer,
+    formatInlineFinding,
+    isReviewBotNoise,
+    normalizeReviewerLogin,
+    parseReviewBotSeverity,
+    stripReviewBotMarkup,
+} from './github-review-bots';
+
+/**
+ * Trusted review bots (self-build fleet, finding R16) — the pure policy.
+ *
+ * Every fixture below is the literal shape captured from this
+ * repository's own PR history with `gh api` (CodeRabbit on #2344, Codex
+ * on #1219, Greptile on #1709, Copilot on #261), not a guess at what the
+ * bots might post.
+ */
+describe('github-review-bots', () => {
+    const POLICY = {
+        trusted: new Set(['coderabbitai[bot]', 'copilot']),
+        self: new Set(['ever-works[bot]']),
+    };
+
+    describe('classifyReviewer', () => {
+        it('treats a non-bot account as human, whatever its login', () => {
+            expect(classifyReviewer({ login: 'octocat', type: 'User' }, POLICY)).toBe('human');
+            expect(classifyReviewer({ login: 'coderabbitai[bot]', type: 'User' }, POLICY)).toBe(
+                'human',
+            );
+            expect(classifyReviewer(undefined, POLICY)).toBe('human');
+        });
+
+        it('recognises an allow-listed bot case-insensitively', () => {
+            expect(classifyReviewer({ login: 'coderabbitai[bot]', type: 'Bot' }, POLICY)).toBe(
+                'trusted-bot',
+            );
+            expect(classifyReviewer({ login: 'Copilot', type: 'Bot' }, POLICY)).toBe('trusted-bot');
+            expect(classifyReviewer({ login: 'copilot', type: 'Bot' }, POLICY)).toBe('trusted-bot');
+        });
+
+        it('drops a bot that is not on the list', () => {
+            expect(classifyReviewer({ login: 'github-actions[bot]', type: 'Bot' }, POLICY)).toBe(
+                'untrusted-bot',
+            );
+            expect(classifyReviewer({ login: 'dependabot[bot]', type: 'Bot' }, POLICY)).toBe(
+                'untrusted-bot',
+            );
+            expect(classifyReviewer({ type: 'Bot' }, POLICY)).toBe('untrusted-bot');
+        });
+
+        it('⭐ self wins over trusted — listing the platform identity changes nothing', () => {
+            // THE security property. The loop must never treat its own
+            // output as reviewer feedback, no matter what the operator
+            // types into the allow-list.
+            const policy = {
+                trusted: new Set(['ever-works[bot]', 'coderabbitai[bot]']),
+                self: new Set(['ever-works[bot]']),
+            };
+            expect(classifyReviewer({ login: 'ever-works[bot]', type: 'Bot' }, policy)).toBe(
+                'self',
+            );
+            expect(classifyReviewer({ login: 'Ever-Works[bot]', type: 'Bot' }, policy)).toBe(
+                'self',
+            );
+        });
+    });
+
+    describe('normalizeReviewerLogin', () => {
+        it('lower-cases, trims and strips a pasted @', () => {
+            expect(normalizeReviewerLogin('  @CodeRabbitAI[bot] ')).toBe('coderabbitai[bot]');
+            expect(normalizeReviewerLogin(undefined)).toBe('');
+        });
+    });
+
+    describe('parseReviewBotSeverity', () => {
+        it('reads the CodeRabbit severity cell on the first line', () => {
+            expect(
+                parseReviewBotSeverity(
+                    '_🗄️ Data Integrity & Integration_ | _🟠 Major_ | _🏗️ Heavy lift_\n\n<details>…</details>',
+                ),
+            ).toBe('major');
+            expect(
+                parseReviewBotSeverity(
+                    '_📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_',
+                ),
+            ).toBe('minor');
+            expect(parseReviewBotSeverity('_🔒 Security_ | _🔴 Critical_ | _🏗️ Heavy lift_')).toBe(
+                'critical',
+            );
+        });
+
+        it('maps the Codex P-badge: P1 → critical, P2 → major, P3 → minor', () => {
+            expect(
+                parseReviewBotSeverity(
+                    '**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Cast metadata before using JSON operator**\n\nOn the Postgres schema…',
+                ),
+            ).toBe('critical');
+            expect(
+                parseReviewBotSeverity(
+                    '**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Title**',
+                ),
+            ).toBe('major');
+            expect(parseReviewBotSeverity('![P3 Badge](https://img.shields.io/badge/P3)')).toBe(
+                'minor',
+            );
+        });
+
+        it('maps the Greptile badge image', () => {
+            expect(
+                parseReviewBotSeverity(
+                    '<a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `import type` statement appears after the export block.',
+                ),
+            ).toBe('major');
+            expect(parseReviewBotSeverity('<img alt="P1" src="x.svg">')).toBe('critical');
+        });
+
+        it('returns null for Copilot prose and for a human-shaped body', () => {
+            expect(
+                parseReviewBotSeverity(
+                    'The retry loop never backs off, so a flaky provider is hammered.',
+                ),
+            ).toBeNull();
+            expect(parseReviewBotSeverity('')).toBeNull();
+            expect(parseReviewBotSeverity(undefined)).toBeNull();
+        });
+
+        it('only looks at the head of the body — a marker buried in a log is not a verdict', () => {
+            const buried = `${'x'.repeat(700)}\n_🟠 Major_`;
+            expect(parseReviewBotSeverity(buried)).toBeNull();
+        });
+    });
+
+    describe('isReviewBotNoise', () => {
+        it('flags the CodeRabbit rate-limit notice (both markers)', () => {
+            expect(
+                isReviewBotNoise(
+                    '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n>\n> **Next included review available in 34 minutes.**',
+                ),
+            ).toBe(true);
+            expect(isReviewBotNoise('> ## Review limit reached')).toBe(true);
+        });
+
+        it('flags Greptile status chatter and the Codex usage cap', () => {
+            expect(
+                isReviewBotNoise('<!-- greptile-status -->\nToo many files changed for review.'),
+            ).toBe(true);
+            expect(isReviewBotNoise('Too many files changed for review')).toBe(true);
+            expect(
+                isReviewBotNoise('You have reached your Codex usage limits for code reviews.'),
+            ).toBe(true);
+        });
+
+        it('flags a CodeRabbit review that has nothing actionable and nothing else', () => {
+            expect(
+                isReviewBotNoise(
+                    '**Actionable comments posted: 0**\n\n<details>\n<summary>🧹 Nitpick comments (1)</summary>\n\nblah\n\n</details>',
+                ),
+            ).toBe(true);
+        });
+
+        it('keeps real findings and summaries', () => {
+            expect(isReviewBotNoise('**Actionable comments posted: 3**')).toBe(false);
+            expect(
+                isReviewBotNoise(
+                    '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\n## Summary by CodeRabbit\n\n- Adds severity to rejections.',
+                ),
+            ).toBe(false);
+            expect(isReviewBotNoise('<h3>Greptile Summary</h3>\n\nThis PR adds…')).toBe(false);
+            expect(isReviewBotNoise('')).toBe(false);
+        });
+    });
+
+    describe('stripReviewBotMarkup', () => {
+        it('drops HTML comments and nested <details> blocks, keeping the finding', () => {
+            const body = [
+                '_🗄️ Data Integrity & Integration_ | _🟠 Major_ | _🏗️ Heavy lift_',
+                '',
+                '<details>',
+                '<summary>🔎 Supported by static analysis</summary>',
+                '',
+                '🤖 get_repo_knowledge executed:',
+                '',
+                '<details>',
+                '<summary>inner</summary>',
+                'Length of output: 33708',
+                '</details>',
+                '',
+                '</details>',
+                '',
+                '<!-- fingerprinting:phantom:triton:puma -->',
+                '',
+                'The migration drops the column without a guard.',
+            ].join('\n');
+            const stripped = stripReviewBotMarkup(body);
+            expect(stripped).toBe(
+                '_🗄️ Data Integrity & Integration_ | _🟠 Major_ | _🏗️ Heavy lift_\n\nThe migration drops the column without a guard.',
+            );
+            expect(stripped).not.toContain('Length of output');
+            expect(stripped).not.toContain('fingerprinting');
+        });
+
+        it('unwraps the Codex badge and the Greptile anchor', () => {
+            expect(
+                stripReviewBotMarkup(
+                    '**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Cast metadata**\n\nBody.',
+                ),
+            ).toBe('**  Cast metadata**\n\nBody.');
+            expect(
+                stripReviewBotMarkup(
+                    '<a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The import is mid-file.',
+                ),
+            ).toBe('The import is mid-file.');
+        });
+
+        it('leaves generics in code samples alone — only presentation tags are stripped', () => {
+            expect(stripReviewBotMarkup('Return `Promise<void>` here, not `Array<string>`.')).toBe(
+                'Return `Promise<void>` here, not `Array<string>`.',
+            );
+        });
+
+        it('tolerates an empty or missing body', () => {
+            expect(stripReviewBotMarkup('')).toBe('');
+            expect(stripReviewBotMarkup(undefined)).toBe('');
+        });
+    });
+
+    describe('formatInlineFinding', () => {
+        it('prefixes path:line so the resumed run can open the file', () => {
+            expect(
+                formatInlineFinding(
+                    { path: 'apps/web/eslint.config.mjs', line: 144, original_line: 60 },
+                    'Use the scoped rule.',
+                ),
+            ).toBe('apps/web/eslint.config.mjs:144 — Use the scoped rule.');
+        });
+
+        it('falls back to original_line, then to the bare path', () => {
+            expect(
+                formatInlineFinding({ path: 'src/a.ts', line: null, original_line: 53 }, 'x'),
+            ).toBe('src/a.ts:53 — x');
+            expect(formatInlineFinding({ path: 'src/a.ts' }, 'x')).toBe('src/a.ts — x');
+        });
+
+        it('returns the text alone with no path, and nothing for an empty finding', () => {
+            expect(formatInlineFinding({}, 'x')).toBe('x');
+            expect(formatInlineFinding({ path: 'src/a.ts', line: 1 }, '   ')).toBe('');
+        });
+    });
+});

--- a/apps/api/src/ingest/github/github-review-bots.ts
+++ b/apps/api/src/ingest/github/github-review-bots.ts
@@ -1,0 +1,208 @@
+/**
+ * Trusted review bots (self-build fleet, finding R16) — the pure half of
+ * the GitHub bridge's reviewer policy. No Nest, no I/O: everything here is
+ * a function of a webhook body and the operator's allow-list, so the
+ * bridge spec can pin each rule with the literal bodies the bots post.
+ *
+ * ## Why a class of reviewer rather than a boolean
+ *
+ * The bridge used to drop EVERY `user.type === 'Bot'` review and comment
+ * on one principle: the loop must never treat its own output as human
+ * feedback. That principle is right, and it filtered out the wrong
+ * thing along with it — CodeRabbit, Copilot, Codex and Greptile verdicts
+ * never became Task feedback, so a human had to relay every finding by
+ * hand. The four classes below keep the security property (`self` wins
+ * over everything, including an operator who lists the platform's own
+ * login as trusted) while letting an allow-listed reviewer bot speak.
+ *
+ * ## Severity
+ *
+ * The house rule is "fix P2+ before declaring a PR clean". The bots each
+ * mark severity differently, all on the FIRST line of a finding, so the
+ * parser reads the head of the body only and maps every scale onto one:
+ *
+ *   * CodeRabbit  `_🗄️ Data Integrity & Integration_ | _🟠 Major_ | _🏗️ Heavy lift_`
+ *                 (`_🔴 Critical_` / `_🟡 Minor_` are the other two);
+ *   * Codex       `**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Title**`;
+ *   * Greptile    `<a href="#"><img alt="P2" src="…/badges/p2.svg?v=9" align="top"></a> text`;
+ *   * Copilot     plain prose, no marker → `null` ("severity unknown").
+ *
+ * `P1` (and `P0`) map to `critical`, `P2` to `major`, `P3` to `minor`, so
+ * "P2+" is exactly `critical | major` on every bot.
+ */
+
+export type ReviewBotSeverity = 'critical' | 'major' | 'minor';
+
+/**
+ * Who submitted a review or comment, as far as the bridge cares:
+ *
+ *   * `human`         — not a bot account; today's behaviour, unchanged.
+ *   * `self`          — the platform's own GitHub App identity. Dropped
+ *                       unconditionally: the loop must not echo itself.
+ *   * `trusted-bot`   — an allow-listed reviewer bot. Recorded as
+ *                       rejection feedback, never reviewed.
+ *   * `untrusted-bot` — any other bot (`dependabot[bot]`,
+ *                       `github-actions[bot]`, …). Dropped.
+ */
+export type ReviewerClass = 'human' | 'trusted-bot' | 'self' | 'untrusted-bot';
+
+export interface ReviewerIdentity {
+    login?: string;
+    type?: string;
+}
+
+/** Lower-cased login sets the bridge resolves once per delivery. */
+export interface ReviewBotPolicy {
+    readonly trusted: ReadonlySet<string>;
+    readonly self: ReadonlySet<string>;
+}
+
+/**
+ * Canonical form of a GitHub login for allow-list comparison: GitHub
+ * logins are case-insensitive, and an operator pasting `@coderabbitai`
+ * from a PR thread should not be punished for the `@`.
+ */
+export function normalizeReviewerLogin(login: string | null | undefined): string {
+    return (login ?? '').trim().replace(/^@/, '').toLowerCase();
+}
+
+/**
+ * Classify a review / comment author. `self` is checked BEFORE `trusted`
+ * on purpose: that ordering is the security property. Adding the app's
+ * own `<slug>[bot]` login to `GITHUB_TRUSTED_REVIEW_BOTS` changes nothing.
+ */
+export function classifyReviewer(
+    user: ReviewerIdentity | null | undefined,
+    policy: ReviewBotPolicy,
+): ReviewerClass {
+    if (!user || (user.type ?? '').toLowerCase() !== 'bot') return 'human';
+    const login = normalizeReviewerLogin(user.login);
+    // A bot with no login cannot be on any list, so it cannot be trusted.
+    if (login.length === 0) return 'untrusted-bot';
+    if (policy.self.has(login)) return 'self';
+    if (policy.trusted.has(login)) return 'trusted-bot';
+    return 'untrusted-bot';
+}
+
+/** Severity markers sit on the first line; this is more than enough of it. */
+const SEVERITY_SCAN_CHARS = 600;
+
+/** CodeRabbit: `_🟠 Major_` — an italic cell, optionally led by an emoji. */
+const CODERABBIT_SEVERITY = /_\s*(?:\S+\s+)?(critical|major|minor)\s*_/i;
+
+/** Codex: a shields.io badge image named `P<n> Badge`. */
+const CODEX_SEVERITY = /!\[P([0-3]) Badge\]/i;
+
+/** Greptile: an `<img alt="P<n>">` badge. */
+const GREPTILE_SEVERITY = /<img\b[^>]*\balt="P([0-3])"/i;
+
+function priorityToSeverity(priority: string): ReviewBotSeverity | null {
+    switch (priority) {
+        case '0':
+        case '1':
+            return 'critical';
+        case '2':
+            return 'major';
+        case '3':
+            return 'minor';
+        default:
+            return null;
+    }
+}
+
+/**
+ * The severity a reviewer bot tagged a finding with, or `null` when the
+ * body carries no recognisable marker. Never guesses from prose.
+ */
+export function parseReviewBotSeverity(body: string | null | undefined): ReviewBotSeverity | null {
+    const head = (body ?? '').slice(0, SEVERITY_SCAN_CHARS);
+    const coderabbit = CODERABBIT_SEVERITY.exec(head);
+    if (coderabbit) return coderabbit[1].toLowerCase() as ReviewBotSeverity;
+    const codex = CODEX_SEVERITY.exec(head);
+    if (codex) return priorityToSeverity(codex[1]);
+    const greptile = GREPTILE_SEVERITY.exec(head);
+    if (greptile) return priorityToSeverity(greptile[1]);
+    return null;
+}
+
+/**
+ * Status chatter the bots post that carries no finding: rate-limit
+ * notices, "too many files" refusals, usage-cap messages. Recording these
+ * would seed a resumed run with an instruction to do nothing.
+ */
+const NOISE_MARKERS: readonly RegExp[] = [
+    /rate limited by coderabbit\.ai/i,
+    /^\s*>?\s*#{1,6}\s*Review limit reached/im,
+    /<!--\s*greptile-status\s*-->/i,
+    /Too many files changed for review/i,
+    /reached your Codex usage limits/i,
+];
+
+/** `**Actionable comments posted: 0**` with nothing else left to say. */
+const NOTHING_ACTIONABLE = /^\**\s*Actionable comments posted:\s*0\s*\**$/i;
+
+export function isReviewBotNoise(body: string | null | undefined): boolean {
+    const text = body ?? '';
+    if (NOISE_MARKERS.some((marker) => marker.test(text))) return true;
+    return NOTHING_ACTIONABLE.test(stripReviewBotMarkup(text));
+}
+
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+
+/**
+ * One `<details>` block that contains no nested `<details>`. Applied until
+ * nothing changes so nested blocks (CodeRabbit nests its static-analysis
+ * logs two deep) unwind from the inside out.
+ */
+const INNERMOST_DETAILS = /<details\b[^>]*>(?:(?!<details\b)[\s\S])*?<\/details>/gi;
+
+/** `![P1 Badge](https://…)` — pure decoration once the severity is parsed. */
+const MARKDOWN_IMAGE = /!\[[^\]]*\]\([^)]*\)/g;
+
+/**
+ * Presentation tags the bots wrap findings in. Deliberately a fixed list
+ * rather than "any tag": `Promise<void>` in a code sample must survive.
+ */
+const HTML_TAG =
+    /<\/?(?:a|img|sub|sup|br|hr|p|div|span|h[1-6]|b|i|strong|em|blockquote|summary|table|thead|tbody|tr|td|th|kbd|picture|source)\b[^>]*>/gi;
+
+/**
+ * Reduce a bot body to the words a Task can act on. CodeRabbit's inline
+ * findings carry up to ~33 KB of collapsed static-analysis output; the
+ * 4000-character feedback cap would otherwise be spent entirely on that
+ * and never reach the finding itself.
+ */
+export function stripReviewBotMarkup(body: string | null | undefined): string {
+    let text = (body ?? '').replace(HTML_COMMENT, '');
+    let previous: string;
+    do {
+        previous = text;
+        text = text.replace(INNERMOST_DETAILS, '');
+    } while (text !== previous);
+    text = text.replace(MARKDOWN_IMAGE, '').replace(HTML_TAG, '');
+    return text
+        .split('\n')
+        .map((line) => line.trimEnd())
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+/**
+ * Label an inline (diff-anchored) finding with where it points, so the
+ * resumed run can open the file instead of guessing which of its changes
+ * the reviewer meant. `line` is the position on the CURRENT diff;
+ * `original_line` is the fallback GitHub keeps when the line moved.
+ */
+export function formatInlineFinding(
+    comment: { path?: string; line?: number | null; original_line?: number | null },
+    text: string,
+): string {
+    const body = text.trim();
+    if (body.length === 0) return '';
+    const path = (comment.path ?? '').trim();
+    if (path.length === 0) return body;
+    const line = comment.line ?? comment.original_line;
+    const location = typeof line === 'number' ? `${path}:${line}` : path;
+    return `${location} — ${body}`;
+}

--- a/apps/api/src/migrations/1788100000000-AddTaskReviewRejectionSeverity.ts
+++ b/apps/api/src/migrations/1788100000000-AddTaskReviewRejectionSeverity.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Trusted review bots (self-build fleet, finding R16) —
+ * `task_review_rejections.severity` + `.reviewerKind`.
+ *
+ * The GitHub bridge now records reviews, inline findings and summary
+ * comments from allow-listed reviewer bots (CodeRabbit, Copilot, Codex,
+ * Greptile) as rejection feedback, next to the human rejections it always
+ * recorded. Two things a resumed run needs to know about such a row that
+ * the schema could not say:
+ *
+ *   * `reviewerKind` — `human` | `bot`. The seeded prompt labels an
+ *     automated finding as such, so the model weighs it as a reviewer
+ *     bot's opinion rather than the owner's instruction.
+ *   * `severity` — `critical` | `major` | `minor`, parsed from the bot's
+ *     own marker (CodeRabbit's `_🟠 Major_`, Codex/Greptile `P1..P3`).
+ *     The house rule is "fix P2+ before the PR is clean"; without this
+ *     column a nit and a data-loss bug would replay as equals.
+ *
+ * Both nullable: every existing row and every non-bot writer reads NULL,
+ * which is the honest history ("a human, severity not stated"). No index —
+ * rows are read by Task through the existing pending-lookup index.
+ * Forward-only with a guard so a partially applied database converges;
+ * portable `TableColumn` DDL because the e2e stack and CI run
+ * better-sqlite3 while production runs Postgres.
+ */
+export class AddTaskReviewRejectionSeverity1788100000000 implements MigrationInterface {
+    name = 'AddTaskReviewRejectionSeverity1788100000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const rejections = await queryRunner.getTable('task_review_rejections');
+        if (!rejections) return;
+        if (!rejections.findColumnByName('severity')) {
+            await queryRunner.addColumn(
+                'task_review_rejections',
+                new TableColumn({
+                    name: 'severity',
+                    type: 'varchar',
+                    length: '16',
+                    isNullable: true,
+                }),
+            );
+        }
+        if (!rejections.findColumnByName('reviewerKind')) {
+            await queryRunner.addColumn(
+                'task_review_rejections',
+                new TableColumn({
+                    name: 'reviewerKind',
+                    type: 'varchar',
+                    length: '8',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const rejections = await queryRunner.getTable('task_review_rejections');
+        if (!rejections) return;
+        if (rejections.findColumnByName('reviewerKind')) {
+            await queryRunner.dropColumn('task_review_rejections', 'reviewerKind');
+        }
+        if (rejections.findColumnByName('severity')) {
+            await queryRunner.dropColumn('task_review_rejections', 'severity');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddTaskReviewRejectionSeverity.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddTaskReviewRejectionSeverity.spec.ts
@@ -1,0 +1,108 @@
+import { DataSource, Table } from 'typeorm';
+import { AddTaskReviewRejectionSeverity1788100000000 } from '../1788100000000-AddTaskReviewRejectionSeverity';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ * What matters: existing rejections survive reading NULL for both new
+ * columns (a human rejection with no stated severity), re-running is a
+ * no-op, and `down()` reverses it.
+ */
+describe('AddTaskReviewRejectionSeverity1788100000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddTaskReviewRejectionSeverity1788100000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'task_review_rejections',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'taskId', type: 'uuid' },
+                    { name: 'source', type: 'varchar', length: '16' },
+                    { name: 'reviewerLabel', type: 'varchar', length: '200', isNullable: true },
+                    { name: 'feedback', type: 'text' },
+                    { name: 'prNumber', type: 'int', isNullable: true },
+                    { name: 'consumedByRunId', type: 'uuid', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO task_review_rejections (id, "taskId", source, "reviewerLabel", feedback, "prNumber") VALUES (?, ?, ?, ?, ?, ?)`,
+            ['rej-1', 'task-1', 'pull-request', 'octocat', 'the migration has no down()', 9],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    it('adds nullable severity + reviewerKind and leaves existing rejections unclassified', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        const table = await runner.getTable('task_review_rejections');
+        await runner.release();
+        expect(table?.findColumnByName('severity')).toMatchObject({ isNullable: true });
+        expect(table?.findColumnByName('reviewerKind')).toMatchObject({ isNullable: true });
+        expect(
+            await dataSource.query(
+                `SELECT id, severity, "reviewerKind" FROM task_review_rejections WHERE id = ?`,
+                ['rej-1'],
+            ),
+        ).toEqual([{ id: 'rej-1', severity: null, reviewerKind: null }]);
+    });
+
+    it('accepts a bot finding with its severity once applied', async () => {
+        await runUp();
+        await dataSource.query(
+            `INSERT INTO task_review_rejections (id, "taskId", source, "reviewerLabel", feedback, "prNumber", severity, "reviewerKind") VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            ['rej-2', 'task-1', 'pull-request', 'coderabbitai[bot]', 'x', 9, 'major', 'bot'],
+        );
+        expect(
+            await dataSource.query(
+                `SELECT severity, "reviewerKind" FROM task_review_rejections WHERE id = ?`,
+                ['rej-2'],
+            ),
+        ).toEqual([{ severity: 'major', reviewerKind: 'bot' }]);
+    });
+
+    it('is idempotent on re-run and reversible', async () => {
+        await runUp();
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        expect(
+            (await runner.getTable('task_review_rejections'))?.findColumnByName('severity'),
+        ).toBeDefined();
+        await migration.down(runner);
+        const afterDown = await runner.getTable('task_review_rejections');
+        expect(afterDown?.findColumnByName('severity')).toBeUndefined();
+        expect(afterDown?.findColumnByName('reviewerKind')).toBeUndefined();
+        await migration.down(runner);
+        expect(
+            (await runner.getTable('task_review_rejections'))?.findColumnByName('reviewerKind'),
+        ).toBeUndefined();
+        await runner.release();
+    });
+
+    it('is a no-op when the table does not exist yet (ordering safety)', async () => {
+        const runner = dataSource.createQueryRunner();
+        await runner.dropTable('task_review_rejections');
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+        await runner.release();
+    });
+});

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -51,7 +51,9 @@ Security: every delivery — events and slash commands alike — is verified wit
 
 Point a repository webhook at `POST /api/ingest/github/events` and Agents review your pull requests.
 
-On `pull_request` opened/synchronize — and on `@ever-works` mentions in PR comments — the reviewer matches the repository to a Work (across all three repo roles), builds a byte-capped diff, adds Knowledge-Base context and memory recall, makes one structured AI call, and posts the review. The review is keyed on the head SHA, so each pushed revision is reviewed exactly once and bot comments are never re-ingested.
+On `pull_request` opened/synchronize — and on `@ever-works` mentions in PR comments — the reviewer matches the repository to a Work (across all three repo roles), builds a byte-capped diff, adds Knowledge-Base context and memory recall, makes one structured AI call, and posts the review. The review is keyed on the head SHA, so each pushed revision is reviewed exactly once.
+
+The platform's own replies and unknown bots are never ingested — the loop must not echo its own output. Reviews, inline findings and summary comments from **trusted reviewer bots** (CodeRabbit, Copilot, Codex and Greptile by default; `GITHUB_TRUSTED_REVIEW_BOTS` to change the list, `none` to disable) become Task rejection feedback with a severity (`critical | major | minor`, mapped from CodeRabbit's Major/Minor/Critical and Codex/Greptile P1–P3) so the next resumed run fixes P2+ first. A `changes_requested` review from a trusted bot is recorded exactly as a human's would be; a bot comment is recorded, never reviewed. The platform's own `<GITHUB_APP_SLUG>[bot]` identity stays excluded even if it is listed. A trusted-bot finding with no recognisable marker is stored with no severity and the resumed run is told to treat it as major — an unrecognised marker is never read as a nit.
 
 Deliveries are verified with the configured webhook secret (HMAC SHA-256 over the raw body, constant-time compare) and the endpoint fails closed the same way. A missing `x-github-event` header is rejected outright.
 

--- a/packages/agent/src/agents/__tests__/run-steering-rejection-feedback.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-steering-rejection-feedback.spec.ts
@@ -207,4 +207,54 @@ describe('composeRejectionFeedbackMessage', () => {
             'Please rebase on develop & re-run CI.',
         );
     });
+
+    it('labels an automated finding with its reviewer kind and severity (R16)', () => {
+        const message = composeRejectionFeedbackMessage([
+            {
+                source: 'pull-request',
+                feedback: 'apps/api/x.ts:144 — drop without a guard',
+                reviewerLabel: 'coderabbitai[bot]',
+                prNumber: 9,
+                reviewerKind: 'bot',
+                severity: 'major',
+            },
+            {
+                source: 'pull-request',
+                feedback: 'plain prose',
+                reviewerLabel: 'Copilot',
+                prNumber: 9,
+                reviewerKind: 'bot',
+                severity: null,
+            },
+        ]);
+        expect(message).toContain(
+            'Rejection from coderabbitai[bot] (pull request #9, automated review, severity: major):',
+        );
+        expect(message).toContain('Rejection from Copilot (pull request #9, automated review):');
+        expect(message).toContain('critical or major');
+        // Conservative default: a bot finding with no marker is not a nit.
+        expect(message).toContain('no stated severity (treat it as major)');
+        expect(message).toContain('  apps/api/x.ts:144 — drop without a guard');
+    });
+
+    it('renders a human rejection byte-identically to before R16', () => {
+        const before = composeRejectionFeedbackMessage([
+            { source: 'pull-request', feedback: 'no tests', reviewerLabel: 'octocat', prNumber: 7 },
+        ]);
+        const after = composeRejectionFeedbackMessage([
+            {
+                source: 'pull-request',
+                feedback: 'no tests',
+                reviewerLabel: 'octocat',
+                prNumber: 7,
+                reviewerKind: 'human',
+                severity: null,
+            },
+        ]);
+        expect(after).toBe(before);
+        expect(after).toBe(
+            'Your previous work on this task was REJECTED by a reviewer. Address the feedback below before doing anything else, then finish.\n\nRejection from octocat (pull request #7):\n  no tests',
+        );
+        expect(after).not.toContain('automated');
+    });
 });

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -74,12 +74,28 @@ export function composeRejectionFeedbackMessage(
         feedback: string;
         reviewerLabel?: string | null;
         prNumber?: number | null;
+        /**
+         * Trusted review bots (R16) — `human` | `bot`. A bot finding is
+         * labelled "automated review" so the model weighs it as a
+         * reviewer bot's opinion rather than the owner's instruction.
+         */
+        reviewerKind?: string | null;
+        /** R16 — `critical` | `major` | `minor` when the bot stated one. */
+        severity?: string | null;
     }>,
 ): string {
     const lines: string[] = [
         'Your previous work on this task was REJECTED by a reviewer. Address the feedback below before doing anything else, then finish.',
         '',
     ];
+    // Only when at least one row is bot-authored, so a human-only message
+    // stays byte-identical to what the model has already learned to read.
+    if (rejections.some((rejection) => rejection.reviewerKind === 'bot')) {
+        lines.push(
+            'Some of it comes from automated reviewers. Fix every finding marked critical or major, and every one with no stated severity (treat it as major); a minor one may be left as-is only if you say why.',
+            '',
+        );
+    }
     for (const rejection of rejections) {
         const who = rejection.reviewerLabel
             ? neutralizeRejectionText(String(rejection.reviewerLabel))
@@ -90,7 +106,13 @@ export function composeRejectionFeedbackMessage(
                 : rejection.source === 'gate'
                   ? 'quality gate'
                   : 'task review';
-        lines.push(`Rejection from ${who} (${where}):`);
+        const qualifiers: string[] = [];
+        if (rejection.reviewerKind === 'bot') qualifiers.push('automated review');
+        if (rejection.severity) {
+            qualifiers.push(`severity: ${neutralizeRejectionText(String(rejection.severity))}`);
+        }
+        const context = qualifiers.length > 0 ? `${where}, ${qualifiers.join(', ')}` : where;
+        lines.push(`Rejection from ${who} (${context}):`);
         for (const feedbackLine of neutralizeRejectionText(rejection.feedback).split('\n')) {
             lines.push(`  ${feedbackLine}`);
         }

--- a/packages/agent/src/database/repositories/task-review-rejection.repository.ts
+++ b/packages/agent/src/database/repositories/task-review-rejection.repository.ts
@@ -4,6 +4,8 @@ import { IsNull, Repository } from 'typeorm';
 import {
     TASK_REVIEW_REJECTION_MAX_FEEDBACK_CHARS,
     TaskReviewRejection,
+    type TaskReviewRejectionReviewerKind,
+    type TaskReviewRejectionSeverity,
     type TaskReviewRejectionSource,
 } from '../../entities/task-review-rejection.entity';
 
@@ -18,6 +20,10 @@ export interface RecordTaskReviewRejectionInput {
     prNumber?: number | null;
     prUrl?: string | null;
     organizationId?: string | null;
+    /** R16 — set by the GitHub bridge for reviewer-bot findings. */
+    severity?: TaskReviewRejectionSeverity | null;
+    /** R16 — `human` | `bot`; absent = not stated (legacy / gate). */
+    reviewerKind?: TaskReviewRejectionReviewerKind | null;
 }
 
 /**
@@ -59,6 +65,8 @@ export class TaskReviewRejectionRepository {
             reviewerLabel: input.reviewerLabel ?? null,
             prNumber: input.prNumber ?? null,
             prUrl: input.prUrl ?? null,
+            severity: input.severity ?? null,
+            reviewerKind: input.reviewerKind ?? null,
             ...(input.organizationId !== undefined ? { organizationId: input.organizationId } : {}),
         });
         return this.repository.save(row);

--- a/packages/agent/src/entities/task-review-rejection.entity.ts
+++ b/packages/agent/src/entities/task-review-rejection.entity.ts
@@ -6,9 +6,10 @@ import { PortableDateColumn } from './_types';
  *
  * - `task-review`  — a platform reviewer moved a `task_reviewers` row to
  *                    `requested-changes` and typed feedback.
- * - `pull-request` — a human rejected the agent's PR on the git provider
- *                    (`changes_requested` review, or a `@ever-works` reply
- *                    asking for changes).
+ * - `pull-request` — a human OR an allow-listed reviewer bot rejected the
+ *                    agent's PR on the git provider (`changes_requested`
+ *                    review, an inline finding, or a summary comment).
+ *                    `reviewerKind` tells the two apart.
  * - `gate`         — a quality gate exhausted its attempts; the machine
  *                    feedback is recorded so a later resume replays it.
  */
@@ -19,6 +20,30 @@ export const TASK_REVIEW_REJECTION_SOURCES: readonly TaskReviewRejectionSource[]
     'pull-request',
     'gate',
 ];
+
+/**
+ * Trusted review bots (self-build fleet, finding R16) — the severity a
+ * reviewer bot tagged a finding with, folded onto one scale: CodeRabbit's
+ * `Critical | Major | Minor`, and Codex / Greptile `P1 | P2 | P3`. The
+ * house rule "fix P2+ before the PR is clean" is exactly
+ * `critical | major`. NULL = not stated (every human rejection, and a bot
+ * body with no recognisable marker). Readers MUST treat NULL on a bot row
+ * as `major`: an unrecognised marker is not evidence of a nit, and the
+ * seeded prompt says so.
+ */
+export type TaskReviewRejectionSeverity = 'critical' | 'major' | 'minor';
+
+export const TASK_REVIEW_REJECTION_SEVERITIES: readonly TaskReviewRejectionSeverity[] = [
+    'critical',
+    'major',
+    'minor',
+];
+
+/**
+ * Who rejected: a person, or an allow-listed reviewer bot. NULL on rows
+ * written before the column existed, which were all human or gate.
+ */
+export type TaskReviewRejectionReviewerKind = 'human' | 'bot';
 
 /** Hard cap on stored feedback. Applied by the writer before persisting. */
 export const TASK_REVIEW_REJECTION_MAX_FEEDBACK_CHARS = 8000;
@@ -94,6 +119,21 @@ export class TaskReviewRejection {
 
     @Column({ type: 'varchar', length: 500, nullable: true })
     prUrl?: string | null;
+
+    /**
+     * Severity the reviewer bot attached to this finding (R16). NULL for
+     * human rejections and for bot bodies with no marker — the seeded
+     * prompt then states no severity rather than inventing one.
+     */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    severity?: TaskReviewRejectionSeverity | null;
+
+    /**
+     * `human` | `bot` (R16). Lets the resumed run read an automated
+     * finding as a reviewer bot's opinion, not the owner's instruction.
+     */
+    @Column({ type: 'varchar', length: 8, nullable: true })
+    reviewerKind?: TaskReviewRejectionReviewerKind | null;
 
     /**
      * The resumed run this rejection was seeded into. NULL = still

--- a/packages/agent/src/tasks-domain/__tests__/task-review-rejection.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-review-rejection.service.spec.ts
@@ -168,6 +168,30 @@ describe('TaskReviewRejectionService (M9)', () => {
             ).resolves.toBeNull();
             expect(works.findByUser).not.toHaveBeenCalled();
         });
+
+        it('persists the reviewer kind and severity of a trusted-bot finding (R16)', async () => {
+            await makeSvc().recordPullRequestRejection({
+                ...input,
+                reviewerLabel: 'coderabbitai[bot]',
+                reviewerKind: 'bot',
+                severity: 'major',
+            });
+            expect(rejections.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    source: 'pull-request',
+                    reviewerLabel: 'coderabbitai[bot]',
+                    reviewerKind: 'bot',
+                    severity: 'major',
+                }),
+            );
+        });
+
+        it('stores NULL kind and severity when the caller states none', async () => {
+            await makeSvc().recordPullRequestRejection(input);
+            expect(rejections.record).toHaveBeenCalledWith(
+                expect.objectContaining({ reviewerKind: null, severity: null }),
+            );
+        });
     });
 
     describe('recordGateRejection', () => {

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -60,3 +60,10 @@ export {
     TaskReviewRejectionRepository,
     type RecordTaskReviewRejectionInput,
 } from '../database/repositories/task-review-rejection.repository';
+// Trusted review bots (R16) — the classification a bridge attaches to a
+// reviewer-bot finding, exported so api-side writers speak the same union.
+export {
+    TASK_REVIEW_REJECTION_SEVERITIES,
+    type TaskReviewRejectionReviewerKind,
+    type TaskReviewRejectionSeverity,
+} from '../entities/task-review-rejection.entity';

--- a/packages/agent/src/tasks-domain/task-review-rejection.service.ts
+++ b/packages/agent/src/tasks-domain/task-review-rejection.service.ts
@@ -4,7 +4,11 @@ import { TaskReviewRejectionRepository } from '../database/repositories/task-rev
 import { TaskReviewerRepository } from '../database/repositories/task-side.repositories';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { matchWorkByRepo } from '../works/work-repo-match';
-import type { TaskReviewRejection } from '../entities/task-review-rejection.entity';
+import type {
+    TaskReviewRejection,
+    TaskReviewRejectionReviewerKind,
+    TaskReviewRejectionSeverity,
+} from '../entities/task-review-rejection.entity';
 
 /**
  * Orchestration M9 — the write half of the rejection loop.
@@ -95,13 +99,18 @@ export class TaskReviewRejectionService {
     }
 
     /**
-     * A human rejected the agent's PULL REQUEST on the git provider.
+     * A human — or a trusted reviewer bot (R16) — rejected the agent's
+     * PULL REQUEST on the git provider.
      *
      * Best-effort by contract and returns `null` on every miss: the caller
      * is a webhook handler that must answer 200 quickly, and "we could not
      * map this PR to a Task" is an ordinary outcome (the PR may belong to
      * a repo that is not a Work, or to a Task that was deleted). It is
      * never an error the delivery should fail on.
+     *
+     * `reviewerKind` and `severity` are the bridge's classification of the
+     * author and of the bot's own marker; they are stored verbatim so the
+     * resumed run can tell a CodeRabbit "Major" from a nit.
      */
     async recordPullRequestRejection(input: {
         userId: string;
@@ -111,6 +120,8 @@ export class TaskReviewRejectionService {
         feedback: string;
         reviewerLabel?: string | null;
         prUrl?: string | null;
+        reviewerKind?: TaskReviewRejectionReviewerKind | null;
+        severity?: TaskReviewRejectionSeverity | null;
     }): Promise<TaskReviewRejection | null> {
         const trimmed = (input.feedback ?? '').trim();
         if (trimmed.length === 0) return null;
@@ -128,6 +139,8 @@ export class TaskReviewRejectionService {
                 reviewerLabel: input.reviewerLabel ?? null,
                 prNumber: input.prNumber,
                 prUrl: input.prUrl ?? null,
+                reviewerKind: input.reviewerKind ?? null,
+                severity: input.severity ?? null,
                 organizationId: task.organizationId ?? null,
             });
             if (row) {


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AB** (self-build program note finding R16, epic EW-762). Refs **EW-791**.

`recordReviewRejection` returned early whenever the reviewing GitHub user was a Bot, so CodeRabbit / Copilot / Codex / Greptile verdicts never became Task feedback, and bot-authored issue comments were dropped on the same principle. The review loop the house rules mandate (poll the bots, fix P2+, repeat until clean) was being filtered out at the door. On 2026-09-04 every CodeRabbit finding across seven PRs had to be relayed by hand, and one of them was a real defect.

### What changes

- **`apps/api/src/ingest/github/github-review-bots.ts`** (new): `classifyReviewer(user, { trusted, self })` → `human | self | trusted-bot | untrusted-bot`. The platform's own reviewer identity is checked **before** the trusted list, so the loop can never treat its own output as feedback even if an operator puts the app slug on the allow-list. That distinction is the security property; it has tests.
- **`config.githubReviewBots`**: `GITHUB_TRUSTED_REVIEW_BOTS` (default `coderabbitai[bot]`, `copilot-pull-request-reviewer[bot]`, `copilot`, `chatgpt-codex-connector[bot]`, `greptile-apps[bot]`); `selfLogins()` canonicalises `GITHUB_APP_SLUG` (`slug`, `slug[bot]`, case-insensitive).
- **PR review bridge**: reviews, inline review comments and issue comments from trusted bots are recorded as rejection rows with `reviewerKind` and a `severity` mapped from the bot's own tags (critical / major / minor / nit). Untrusted bots are still dropped.
- **Entity + migration** `1788100000000-AddTaskReviewRejectionSeverity`: `severity` and `reviewer_kind` on `task_review_rejections`, with its migration spec.
- **Run steering**: a rejection with no severity is treated as major, so a missing tag can never downgrade a finding.
- Docs: `docs/features/integrations.md`, `apps/api/.env.example`.

### Verified locally

- `apps/api` jest: the two bridge/bot suites, `constants.spec.ts`, and the whole `src/migrations` tree including `migrations-directory-contract.spec.ts` — **37 suites, 330 tests, all passing**.
- `packages/agent` jest: `run-steering-rejection-feedback.spec.ts`, `task-review-rejection.service.spec.ts` — **2 suites, 26 tests, all passing**.
- `prettier --check` on every touched file: clean.
- `tsc --noEmit` in `apps/api` and `packages/agent`: no errors in any touched file (the only local errors are pre-existing unbuilt-workspace-package resolutions unrelated to this change).

### Not verified locally

- e2e never runs locally (stage-only gate).
- No `next build`: no web route or page is touched.
- Full `apps/api` / `packages/agent` jest runs are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
