### PR TITLE
feat(fleet): eligibility-aware routing + queued-job SLA (EW-775)

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
@@ -177,6 +177,54 @@ describe('FleetAgentTaskPlannerService', () => {
         expect(taskWorkspace.describeFleetWorkspace).not.toHaveBeenCalled();
     });
 
+    describe('requirements — the tags the job will need, known BEFORE the plan (slice S)', () => {
+        beforeEach(() => {
+            delete process.env.FLEET_NODE_REQUIRED_CAPABILITIES;
+        });
+
+        it('is the operator config tags alone in command mode, and reads no Task or workspace', async () => {
+            process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace,git';
+
+            await expect(build().requirements(payload)).resolves.toEqual({
+                requiredCapabilities: ['workspace', 'git'],
+            });
+            expect(tasks.findById).not.toHaveBeenCalled();
+            expect(taskWorkspace.describeFleetWorkspace).not.toHaveBeenCalled();
+        });
+
+        it('adds the provider tag in model-cli mode, de-duplicated against the config tags', async () => {
+            process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+            process.env.FLEET_NODE_AGENT_EXECUTION_PROVIDER = 'codex';
+            process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace,codex';
+
+            await expect(build().requirements(payload)).resolves.toEqual({
+                requiredCapabilities: ['workspace', 'codex'],
+            });
+        });
+
+        it('honours the tenant provider overlay, so the router counts the machines that have THAT CLI', async () => {
+            process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+            process.env.FLEET_NODE_AGENT_EXECUTION_PROVIDER = 'claude-code';
+            pluginSettings.getResolvedSettings.mockResolvedValue({
+                agentExecutionProvider: { value: 'codex', source: 'user' },
+            });
+
+            await expect(build().requirements(payload)).resolves.toEqual({
+                requiredCapabilities: ['codex'],
+            });
+        });
+
+        it('falls back to the instance env when the settings lookup fails', async () => {
+            process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+            process.env.FLEET_NODE_AGENT_EXECUTION_PROVIDER = 'claude-code';
+            pluginSettings.getResolvedSettings.mockRejectedValue(new Error('settings down'));
+
+            await expect(build().requirements(payload)).resolves.toEqual({
+                requiredCapabilities: ['claude-code'],
+            });
+        });
+    });
+
     it('builds a full model-cli plan from the instance env', async () => {
         process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
         process.env.FLEET_NODE_AGENT_EXECUTION_MODEL = 'claude-opus-5';

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-reconciler.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { FleetJobCompletedEvent, FleetJobLeasedEvent } from '@ever-works/agent/events';
+import { isQueueExpiredError } from '@ever-works/contracts';
 import type { FleetAgentTaskResult, FleetJobView } from '@ever-works/contracts';
 import {
     FleetAgentTaskReconcilerService,
@@ -384,6 +385,106 @@ describe('FleetAgentTaskReconcilerService', () => {
         expect(runs.markFailed).not.toHaveBeenCalled();
         expect(runs.markCompleted).not.toHaveBeenCalled();
         expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
+    });
+
+    describe('queue SLA — a job no node ever took (self-build slice S)', () => {
+        const PINNED = '22222222-2222-4222-8222-222222222222';
+        const expiredError = `queued-max-age-exceeded: no eligible runner took the job within 24h (pinned to node ${PINNED}) [requires claude-code]`;
+        const expiredJob = (): FleetJobView =>
+            job({
+                status: 'failed',
+                nodeId: null,
+                targetNodeId: PINNED,
+                requiredCapabilities: ['claude-code'],
+                queuedAt: '2026-09-01T00:00:00.000Z',
+                completedAt: '2026-09-02T00:00:00.000Z',
+            });
+
+        it('fails the run with the stable token and files exactly ONE "never started" Inbox notice', async () => {
+            await build().onCompleted(
+                new FleetJobCompletedEvent(
+                    expiredJob(),
+                    USER,
+                    'queue-expired',
+                    null,
+                    null,
+                    expiredError,
+                ),
+            );
+
+            // The machine token lands in `failureReason`, switchable later.
+            expect(runs.markFailed).toHaveBeenCalledWith(RUN, expiredError);
+            expect(isQueueExpiredError(runs.markFailed.mock.calls[0][1])).toBe(true);
+            expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
+
+            expect(inbox!.notice).toHaveBeenCalledTimes(1);
+            const [userId, notice] = inbox!.notice.mock.calls[0];
+            expect(userId).toBe(USER);
+            expect(notice.title).toMatch(/^Fleet run never started: /);
+            // The owner reads a sentence with the facts they need to fix it.
+            expect(notice.body).toContain('within 24h');
+            expect(notice.body).toContain(`pinned to node ${PINNED}`);
+            expect(notice.body).toContain('claude-code');
+            expect(notice.body).toContain('Wake the runner');
+            expect(notice).toMatchObject({ taskId: TASK, agentRunId: RUN, workId: 'work-1' });
+
+            // Nothing ran, so nothing to push or finalize.
+            expect(taskWorkspace.finalizeRemotePush).not.toHaveBeenCalled();
+            expect(runs.markCompleted).not.toHaveBeenCalled();
+            expect(dispatchGate.drainForWork).toHaveBeenCalledWith('work-1');
+        });
+
+        it('says "never started" in the Task chat rather than "failed"', async () => {
+            await build().onCompleted(
+                new FleetJobCompletedEvent(
+                    expiredJob(),
+                    USER,
+                    'queue-expired',
+                    null,
+                    null,
+                    expiredError,
+                ),
+            );
+
+            expect(taskChat.post).toHaveBeenCalledTimes(1);
+            expect(JSON.stringify(taskChat.post.mock.calls[0])).toContain(
+                'Fleet run never started',
+            );
+        });
+
+        it('keeps the stable token even when the event carries no error text', async () => {
+            await build().onCompleted(
+                new FleetJobCompletedEvent(expiredJob(), USER, 'queue-expired'),
+            );
+
+            expect(isQueueExpiredError(runs.markFailed.mock.calls[0][1])).toBe(true);
+            expect(inbox!.notice).toHaveBeenCalledTimes(1);
+        });
+
+        it('only mirrors the board when the run was already cancelled', async () => {
+            runs.findById.mockResolvedValue({
+                id: RUN,
+                userId: USER,
+                agentId: AGENT,
+                workId: 'work-1',
+                status: 'cancelled',
+            });
+
+            await build().onCompleted(
+                new FleetJobCompletedEvent(
+                    expiredJob(),
+                    USER,
+                    'queue-expired',
+                    null,
+                    null,
+                    expiredError,
+                ),
+            );
+
+            expect(runs.markFailed).not.toHaveBeenCalled();
+            expect(inbox!.notice).not.toHaveBeenCalled();
+            expect(runDenorm.recordTerminal).toHaveBeenCalledWith(TASK, RUN, 'failed');
+        });
     });
 
     // Cancellation reaches a node as a REFUSED HEARTBEAT, and

--- a/apps/api/src/fleet/__tests__/fleet-run-routing.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-run-routing.spec.ts
@@ -2,7 +2,7 @@ import type {
     AgentTaskExecuteDispatcher,
     AgentTaskExecuteDispatchPayload,
 } from '@ever-works/agent/tasks-domain';
-import type { FleetExecutionPreferenceService } from '@ever-works/agent/fleet';
+import type { FleetExecutionPreferenceService, FleetJobService } from '@ever-works/agent/fleet';
 import { NodeDispatcherFactory, NodeJobRuntimePlugin } from '@ever-works/job-runtime-node-plugin';
 import { QUEUED_REASON_WAITING_FOR_RUNNER } from '@ever-works/contracts';
 import type { FleetRunnerAvailability } from '@ever-works/contracts';
@@ -26,7 +26,12 @@ import type { FleetRunnerStatusService } from '../fleet-runner-status.service';
  *   - a tenant that was never on the fleet stays silent, because nothing
  *     was taken away from it;
  *   - a notification outage cannot turn a successful fallback into a
- *     failed dispatch.
+ *     failed dispatch;
+ *   - (self-build slice S / EW-775) the availability question is asked
+ *     about the runners that could take THIS job — the Agent's pinned
+ *     node and the tags the job will require — so a pin to an offline PC
+ *     with five idle siblings is a fallback (or a visible wait), never a
+ *     silent forever-queue.
  */
 
 const WORK_ID = '44444444-4444-4444-8444-444444444444';
@@ -55,6 +60,8 @@ describe('fleet run routing (local-runner preference matrix)', () => {
     let runners: { availability: jest.Mock };
     let notifications: { notifyFleetRunnerFallback: jest.Mock };
     let scopeResolver: { resolve: jest.Mock };
+    let jobs: { resolveAgentTaskTarget: jest.Mock };
+    let planner: { plan: jest.Mock; requirements?: jest.Mock } | undefined;
 
     const buildDispatcher = (): AgentTaskExecuteDispatcher => {
         const factory = new NodeDispatcherFactory({ store });
@@ -65,10 +72,12 @@ describe('fleet run routing (local-runner preference matrix)', () => {
             undefined,
             preferences as unknown as FleetExecutionPreferenceService,
             runners as unknown as FleetRunnerStatusService,
+            jobs as unknown as FleetJobService,
         );
         return createFleetAwareAgentTaskExecuteDispatcher(delegate, router, {
             scopeResolver,
             notifications,
+            ...(planner ? { planner } : {}),
         });
     };
 
@@ -88,7 +97,10 @@ describe('fleet run routing (local-runner preference matrix)', () => {
         process.env.EVER_WORKS_JOB_RUNTIME = 'node';
         delete process.env.FLEET_NODE_RUNTIME_ENABLED;
         delete process.env.FLEET_NODE_AGENT_TASK_COMMAND;
+        delete process.env.FLEET_NODE_REQUIRED_CAPABILITIES;
 
+        jobs = { resolveAgentTaskTarget: jest.fn(async () => null) };
+        planner = undefined;
         store = {
             enqueue: jest.fn(async () => ({ id: 'fleet-job-1' })),
             findById: jest.fn(async () => null),
@@ -264,6 +276,180 @@ describe('fleet run routing (local-runner preference matrix)', () => {
             await buildDispatcher().enqueue(payload());
 
             expect(preferences.resolveForUser).toHaveBeenCalledWith('user-1', {});
+        });
+    });
+
+    describe('eligibility — the job is judged against the runners that could take it (slice S)', () => {
+        const NODE_B = '22222222-2222-4222-8222-222222222222';
+        const pinnedOffline = (): FleetRunnerAvailability => ({
+            total: 1,
+            online: 0,
+            free: 0,
+            fleetTotal: 6,
+            pinnedNodeId: NODE_B,
+        });
+
+        it('asks the affinity question BEFORE the job exists and counts against the pinned node', async () => {
+            jobs.resolveAgentTaskTarget.mockResolvedValue(NODE_B);
+
+            await buildDispatcher().enqueue(payload());
+
+            // The SAME question the enqueue path asks, so the two agree.
+            expect(jobs.resolveAgentTaskTarget).toHaveBeenCalledWith('user-1', 'agent-1');
+            expect(runners.availability).toHaveBeenCalledWith('user-1', {
+                targetNodeId: NODE_B,
+                requiredCapabilities: [],
+            });
+        });
+
+        it('REGRESSION (R5): an Agent pinned to an offline PC with five idle siblings falls back to the cloud, naming the pinned runner', async () => {
+            // Before: the router judged the WHOLE fleet — five idle siblings
+            // made `free > 0`, the decision was `fleet`, the enqueue pinned
+            // the row to the offline node, and the job sat queued forever
+            // with `queuedReason` null and no notice.
+            jobs.resolveAgentTaskTarget.mockResolvedValue(NODE_B);
+            preferences.resolveForUser.mockResolvedValue('local-fallback');
+            runners.availability.mockResolvedValue(pinnedOffline());
+
+            const result = await buildDispatcher().enqueue(payload());
+
+            expect(result).toEqual({ runId: 'trigger-run-1' });
+            expect(store.enqueue).not.toHaveBeenCalled();
+            expect(notifications.notifyFleetRunnerFallback).toHaveBeenCalledWith({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'pinned-runner-offline',
+                // Precise: ONE eligible runner (the pinned one), of six.
+                runnerCount: 1,
+                fleetRunnerCount: 6,
+                pinnedNodeId: NODE_B,
+            });
+        });
+
+        it('REGRESSION (R5): the same pin under local-wait WAITS with the reason on the row', async () => {
+            jobs.resolveAgentTaskTarget.mockResolvedValue(NODE_B);
+            preferences.resolveForUser.mockResolvedValue('local-wait');
+            runners.availability.mockResolvedValue(pinnedOffline());
+
+            const result = await buildDispatcher().enqueue(payload());
+
+            // Still the fleet — the fleet queue IS the wait — but VISIBLY,
+            // and the queue SLA bounds it from here.
+            expect(result).toEqual({ runId: 'fleet-job-1' });
+            expect(store.enqueue.mock.calls[0][0].queuedReason).toBe(
+                QUEUED_REASON_WAITING_FOR_RUNNER,
+            );
+            expect(notifications.notifyFleetRunnerFallback).not.toHaveBeenCalled();
+        });
+
+        it('reports no-eligible-runners with the precise counts when nothing advertises the required tags', async () => {
+            runners.availability.mockResolvedValue({
+                total: 0,
+                online: 0,
+                free: 0,
+                fleetTotal: 3,
+                pinnedNodeId: null,
+            });
+
+            await buildDispatcher().enqueue(payload());
+
+            expect(delegate.enqueue).toHaveBeenCalledTimes(1);
+            expect(notifications.notifyFleetRunnerFallback).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reason: 'no-eligible-runners',
+                    runnerCount: 0,
+                    fleetRunnerCount: 3,
+                }),
+            );
+            expect(notifications.notifyFleetRunnerFallback.mock.calls[0][0]).not.toHaveProperty(
+                'pinnedNodeId',
+            );
+        });
+
+        it('feeds the planner-resolved tags to the availability check, and the config tags without a planner', async () => {
+            process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace';
+            planner = {
+                plan: jest.fn(async () => null),
+                requirements: jest.fn(async () => ({
+                    requiredCapabilities: ['workspace', 'claude-code'],
+                })),
+            };
+
+            await buildDispatcher().enqueue(payload());
+
+            expect(planner.requirements).toHaveBeenCalledWith(
+                expect.objectContaining({ taskId: 'task-1', userId: 'user-1' }),
+            );
+            expect(runners.availability).toHaveBeenCalledWith('user-1', {
+                targetNodeId: null,
+                requiredCapabilities: ['workspace', 'claude-code'],
+            });
+            // The plan is still built AFTER the decision, only for a fleet run.
+            expect(planner.plan).toHaveBeenCalledTimes(1);
+
+            runners.availability.mockClear();
+            planner = undefined;
+            await buildDispatcher().enqueue(payload());
+            expect(runners.availability).toHaveBeenCalledWith('user-1', {
+                targetNodeId: null,
+                requiredCapabilities: ['workspace'],
+            });
+        });
+
+        it('never plans, and never asks the affinity question, for a tenant not on the fleet', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'trigger';
+            planner = {
+                plan: jest.fn(async () => null),
+                requirements: jest.fn(async () => ({ requiredCapabilities: [] })),
+            };
+
+            await buildDispatcher().enqueue(payload());
+
+            // The requirements lookup is settings-only and cheap, but a
+            // tenant not on the fleet must still never plan anything.
+            expect(planner.plan).not.toHaveBeenCalled();
+            expect(jobs.resolveAgentTaskTarget).not.toHaveBeenCalled();
+            expect(delegate.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('degrades to the config tags when the requirements lookup throws, and still dispatches', async () => {
+            process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace';
+            planner = {
+                plan: jest.fn(async () => null),
+                requirements: jest.fn(async () => {
+                    throw new Error('settings down');
+                }),
+            };
+
+            const result = await buildDispatcher().enqueue(payload());
+
+            expect(result).toEqual({ runId: 'fleet-job-1' });
+            expect(runners.availability).toHaveBeenCalledWith('user-1', {
+                targetNodeId: null,
+                requiredCapabilities: ['workspace'],
+            });
+        });
+
+        it('judges an affinity lookup that throws as unpinned, and still dispatches', async () => {
+            jobs.resolveAgentTaskTarget.mockRejectedValue(new Error('affinity table down'));
+
+            const result = await buildDispatcher().enqueue(payload());
+
+            expect(result).toEqual({ runId: 'fleet-job-1' });
+            expect(runners.availability).toHaveBeenCalledWith(
+                'user-1',
+                expect.objectContaining({ targetNodeId: null }),
+            );
+        });
+
+        it('stamps the SAME tag set on the row that the decision was counted against', async () => {
+            process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace';
+
+            await buildDispatcher().enqueue(payload());
+
+            const counted = runners.availability.mock.calls[0][1].requiredCapabilities;
+            expect(store.enqueue.mock.calls[0][0].requiredCapabilities).toEqual(counted);
+            expect(counted).toEqual(['workspace']);
         });
     });
 });

--- a/apps/api/src/fleet/__tests__/fleet-runner-status.service.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-runner-status.service.spec.ts
@@ -30,7 +30,11 @@ const node = (overrides: Partial<FleetNodeView> = {}): FleetNodeView => ({
  *   2. a job-runtime hiccup degrades (nodes still render, `busy` reads
  *      false, `loadUnavailable` says so) instead of taking down the read
  *      — and, crucially, `availability` reports ZERO free runners in that
- *      state rather than claiming capacity it could not verify.
+ *      state rather than claiming capacity it could not verify;
+ *   3. (self-build slice S) with an eligibility filter, `availability`
+ *      counts only the nodes that could take THE job — the pinned node,
+ *      the nodes advertising the required tags — and says how big the
+ *      whole fleet was, so a pin to a closed laptop reads 1/0/0 of 6.
  */
 describe('FleetRunnerStatusService', () => {
     let fleet: { listEnrolledForUser: jest.Mock };
@@ -183,6 +187,172 @@ describe('FleetRunnerStatusService', () => {
                 total: 0,
                 online: 0,
                 free: 0,
+            });
+        });
+    });
+
+    describe('availability — eligibility (self-build slice S)', () => {
+        const sixNodes = () => [
+            node({ id: 'a', status: 'online' }),
+            node({ id: 'b', status: 'offline' }),
+            node({ id: 'c', status: 'online' }),
+            node({ id: 'd', status: 'online' }),
+            node({ id: 'e', status: 'online' }),
+            node({ id: 'f', status: 'online' }),
+        ];
+
+        it('keeps the fleet-wide three-field shape when no eligibility is given', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+
+            // Exactly three keys: the legacy callers (and the pure rule's
+            // legacy shapes) see byte-for-byte what they always saw.
+            await expect(build().availability('user-1')).resolves.toEqual({
+                total: 6,
+                online: 5,
+                free: 5,
+            });
+        });
+
+        it('REGRESSION (R5): a pin to an offline node with five idle siblings is 1/0/0 of 6, not 6/5/5', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+
+            await expect(build().availability('user-1', { targetNodeId: 'b' })).resolves.toEqual({
+                total: 1,
+                online: 0,
+                free: 0,
+                fleetTotal: 6,
+                pinnedNodeId: 'b',
+            });
+        });
+
+        it('a pinned node that is online and idle is placeable', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+
+            await expect(build().availability('user-1', { targetNodeId: 'a' })).resolves.toEqual({
+                total: 1,
+                online: 1,
+                free: 1,
+                fleetTotal: 6,
+                pinnedNodeId: 'a',
+            });
+        });
+
+        it('a pinned node that is online but busy is eligible, not free', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+            jobs.loadByNodeForUser.mockResolvedValue({
+                a: { activeJobCount: 1, currentJobKind: 'agent-task', currentJobId: 'j' },
+            });
+
+            await expect(
+                build().availability('user-1', { targetNodeId: 'a' }),
+            ).resolves.toMatchObject({ total: 1, online: 1, free: 0 });
+        });
+
+        it.each(['paused', 'disabled'] as const)(
+            'a pinned node that is %s is not online (the lease would refuse it)',
+            async (status) => {
+                fleet.listEnrolledForUser.mockResolvedValue([node({ id: 'a', status })]);
+
+                await expect(
+                    build().availability('user-1', { targetNodeId: 'a' }),
+                ).resolves.toMatchObject({ total: 1, online: 0, free: 0 });
+            },
+        );
+
+        it('a pinned node that is no longer enrolled is no eligible runner at all', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+
+            await expect(
+                build().availability('user-1', { targetNodeId: 'ghost' }),
+            ).resolves.toEqual({
+                total: 0,
+                online: 0,
+                free: 0,
+                fleetTotal: 6,
+                pinnedNodeId: 'ghost',
+            });
+        });
+
+        it('excludes nodes that do not advertise EVERY required tag', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue([
+                node({ id: 'claude', capabilities: ['terminal', 'claude-code'] }),
+                node({ id: 'codex', capabilities: ['terminal', 'codex'] }),
+                node({ id: 'bare', capabilities: [] }),
+            ]);
+
+            await expect(
+                build().availability('user-1', { requiredCapabilities: ['claude-code'] }),
+            ).resolves.toEqual({
+                total: 1,
+                online: 1,
+                free: 1,
+                fleetTotal: 3,
+                pinnedNodeId: null,
+            });
+            await expect(
+                build().availability('user-1', {
+                    requiredCapabilities: ['terminal', 'claude-code'],
+                }),
+            ).resolves.toMatchObject({ total: 1 });
+            await expect(
+                build().availability('user-1', { requiredCapabilities: ['gpu'] }),
+            ).resolves.toMatchObject({ total: 0, fleetTotal: 3 });
+        });
+
+        it('applies both filters: the pinned node must also advertise the tags', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue([
+                node({ id: 'a', capabilities: ['terminal'] }),
+                node({ id: 'b', capabilities: ['terminal', 'claude-code'] }),
+            ]);
+
+            await expect(
+                build().availability('user-1', {
+                    targetNodeId: 'a',
+                    requiredCapabilities: ['claude-code'],
+                }),
+            ).resolves.toEqual({
+                total: 0,
+                online: 0,
+                free: 0,
+                fleetTotal: 2,
+                pinnedNodeId: 'a',
+            });
+        });
+
+        it('treats an empty filter as "every enrolled node", with the fleet fields attached', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+
+            await expect(build().availability('user-1', {})).resolves.toEqual({
+                total: 6,
+                online: 5,
+                free: 5,
+                fleetTotal: 6,
+                pinnedNodeId: null,
+            });
+        });
+
+        it('still reports ZERO free for the eligible set when the job load could not be read', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue(sixNodes());
+            jobs.loadByNodeForUser.mockRejectedValue(new Error('fleet_jobs unreachable'));
+
+            await expect(build().availability('user-1', { targetNodeId: 'a' })).resolves.toEqual({
+                total: 1,
+                online: 1,
+                free: 0,
+                fleetTotal: 6,
+                pinnedNodeId: 'a',
+            });
+        });
+
+        it('keeps the pin on the "fleet unavailable" answer when the registry read throws', async () => {
+            fleet.listEnrolledForUser.mockRejectedValue(new Error('db down'));
+
+            await expect(build().availability('user-1', { targetNodeId: 'b' })).resolves.toEqual({
+                total: 0,
+                online: 0,
+                free: 0,
+                fleetTotal: 0,
+                pinnedNodeId: 'b',
             });
         });
     });

--- a/apps/api/src/fleet/fleet-agent-task-capabilities.ts
+++ b/apps/api/src/fleet/fleet-agent-task-capabilities.ts
@@ -1,0 +1,29 @@
+import { config } from '@ever-works/agent/config';
+
+/**
+ * The capability tags an `agent-task` job requires (self-build slice S).
+ *
+ * ONE definition, used at both ends of the dispatch path:
+ *
+ *   - the router, BEFORE the routing decision, to count only the nodes
+ *     that could actually lease the job (eligibility-aware availability);
+ *   - `enqueueAgentTask`, to stamp `requiredCapabilities` on the row the
+ *     lease CAS filters on.
+ *
+ * Extracted so the two cannot disagree — a router that counted nodes
+ * against one tag set while the row demanded another would re-create the
+ * exact "placed, but nothing can take it" hole this slice closes.
+ *
+ * The operator's `FLEET_NODE_REQUIRED_CAPABILITIES` always applies. In
+ * `model-cli` mode the resolved provider is added: the tag is backed by a
+ * resolved executable on the node, which is what keeps a Claude job off a
+ * machine that only has Codex (and vice versa). `null` is the legacy
+ * `command` mode, where only the operator tags apply.
+ */
+export function agentTaskRequiredCapabilities(provider: string | null | undefined): string[] {
+    const tags = config.fleetNode.getRequiredCapabilities();
+    if (!provider) {
+        return tags;
+    }
+    return Array.from(new Set([...tags, provider]));
+}

--- a/apps/api/src/fleet/fleet-agent-task-planner.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-planner.service.ts
@@ -37,7 +37,12 @@ import {
     type FleetTaskWorkspaceSpec,
     type TaskAcceptanceCheck,
 } from '@ever-works/contracts';
-import type { FleetAgentTaskPlan, FleetAgentTaskPlanner } from './fleet-agent-task.dispatcher';
+import { agentTaskRequiredCapabilities } from './fleet-agent-task-capabilities';
+import type {
+    FleetAgentTaskPlan,
+    FleetAgentTaskPlanner,
+    FleetAgentTaskRequirements,
+} from './fleet-agent-task.dispatcher';
 
 /** Plugin id whose per-tenant settings overlay the instance defaults. */
 export const FLEET_NODE_RUNTIME_PLUGIN_ID = 'job-runtime-node';
@@ -233,6 +238,25 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
         const skip = read('agentExecutionSkipPermissions');
         if (typeof skip === 'boolean') settings.skipPermissions = skip;
         return settings;
+    }
+
+    /**
+     * Self-build slice S — the capability tags the job WILL be stamped
+     * with, from settings alone (no Task / workspace reads), so the
+     * router can count only the nodes that could lease it. Mirrors what
+     * {@link plan} + `enqueueAgentTask` produce through the ONE shared
+     * `agentTaskRequiredCapabilities`: the provider tag in `model-cli`
+     * mode, the operator's config tags otherwise.
+     */
+    async requirements(
+        payload: AgentTaskExecuteDispatchPayload,
+    ): Promise<FleetAgentTaskRequirements> {
+        const settings = await this.resolveSettings(payload.userId);
+        return {
+            requiredCapabilities: agentTaskRequiredCapabilities(
+                settings.mode === 'model-cli' ? settings.provider : null,
+            ),
+        };
     }
 
     async plan(payload: AgentTaskExecuteDispatchPayload): Promise<FleetAgentTaskPlan | null> {

--- a/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
@@ -17,6 +17,7 @@ import {
 import { redactSecrets } from '@ever-works/agent/utils';
 import {
     FLEET_AGENT_TASK_QUESTION_MAX_TEXT_CHARS,
+    FLEET_JOB_QUEUE_EXPIRED_REASON,
     INBOX_MAX_BODY_CHARS,
     normalizeFleetAgentTaskQuestion,
     normalizeFleetTaskWorkspaceMounts,
@@ -259,12 +260,20 @@ export class FleetAgentTaskReconcilerService {
 
         const succeeded = event.succeeded && result?.status === 'succeeded';
         if (!succeeded) {
+            // Self-build slice S — the queue SLA settled a job NO node ever
+            // took. Same failure path (the run must settle either way; the
+            // stable `queued-max-age-exceeded` prefix lands in
+            // `failureReason`), but the notice says "never started" rather
+            // than "failed": the owner's fix is a runner, not the code.
+            const queueExpired = event.source === 'queue-expired';
             const reason = truncate(
                 result?.failureReason ||
                     event.error ||
                     (event.source === 'lease-exhausted'
                         ? 'The fleet node stopped reporting; lease budget exhausted'
-                        : 'Fleet job failed without a reason'),
+                        : queueExpired
+                          ? `${FLEET_JOB_QUEUE_EXPIRED_REASON}: no eligible fleet runner took the job within its max queued age`
+                          : 'Fleet job failed without a reason'),
                 MAX_SUMMARY_CHARS,
             );
             await this.runs.markFailed(ctx.runId, reason);
@@ -300,12 +309,22 @@ export class FleetAgentTaskReconcilerService {
                     );
                 }
             }
-            await this.postChat(task, event.userId, agentId, composeFailureMessage(reason, result));
+            await this.postChat(
+                task,
+                event.userId,
+                agentId,
+                composeFailureMessage(reason, result, queueExpired),
+            );
+            // Exactly ONE Inbox notice per settled job: this is the single
+            // producer, and the emitting CAS fires the event once.
             await this.bestEffort('inbox notice', async () => {
                 if (!this.inbox) return;
+                const taskLabel = task?.title ? truncate(task.title, 120) : ctx.taskId;
                 await this.inbox.notice(event.userId, {
-                    title: `Fleet run failed: ${task?.title ? truncate(task.title, 120) : ctx.taskId}`,
-                    body: reason,
+                    title: queueExpired
+                        ? `Fleet run never started: ${taskLabel}`
+                        : `Fleet run failed: ${taskLabel}`,
+                    body: queueExpired ? composeQueueExpiryBody(event.job) : reason,
                     agentId,
                     agentRunId: ctx.runId,
                     taskId: ctx.taskId,
@@ -1035,8 +1054,55 @@ function composeQuestionMessage(
     return lines.join('\n');
 }
 
-function composeFailureMessage(reason: string, result: FleetAgentTaskResult | null): string {
-    const lines = ['**Fleet run failed** (executed on one of your own machines).', '', reason];
+/**
+ * The human body of the "never started" notice (self-build slice S): how
+ * long it waited, what narrowed the eligible set to nothing, and the
+ * three fixes. The stable machine token stays on the run row; the owner
+ * reads a sentence.
+ */
+function composeQueueExpiryBody(job: FleetJobView): string {
+    const waited = describeQueuedAge(job);
+    const lines = [
+        `No eligible runner on your machines took this run${waited ? ` within ${waited}` : ''}.`,
+    ];
+    if (job.targetNodeId) {
+        lines.push(`It was pinned to node ${truncate(job.targetNodeId, MAX_QUOTED_CHARS)}.`);
+    }
+    if (job.requiredCapabilities.length > 0) {
+        lines.push(
+            `It required: ${job.requiredCapabilities
+                .map((tag) => truncate(tag, MAX_QUOTED_CHARS))
+                .join(', ')}.`,
+        );
+    }
+    lines.push(
+        'Wake the runner, bind the Agent to another machine, or set the Work to "Local runner (fall back to cloud)".',
+    );
+    return truncate(lines.join(' '), INBOX_MAX_BODY_CHARS);
+}
+
+/** "24h" / "90m" from the job's own timestamps; empty when either is missing. */
+function describeQueuedAge(job: FleetJobView): string {
+    if (!job.queuedAt || !job.completedAt) return '';
+    const ms = new Date(job.completedAt).getTime() - new Date(job.queuedAt).getTime();
+    if (!Number.isFinite(ms) || ms <= 0) return '';
+    const minutes = Math.round(ms / 60_000);
+    if (minutes >= 120) return `${Math.round(minutes / 60)}h`;
+    return `${Math.max(minutes, 1)}m`;
+}
+
+function composeFailureMessage(
+    reason: string,
+    result: FleetAgentTaskResult | null,
+    neverStarted = false,
+): string {
+    const lines = [
+        neverStarted
+            ? '**Fleet run never started** (no eligible runner among your own machines took it).'
+            : '**Fleet run failed** (executed on one of your own machines).',
+        '',
+        reason,
+    ];
     const failing = result?.checks?.filter((check) => check.status !== 'green') ?? [];
     if (failing.length > 0) {
         lines.push('', 'Failing checks:');

--- a/apps/api/src/fleet/fleet-agent-task.dispatcher.ts
+++ b/apps/api/src/fleet/fleet-agent-task.dispatcher.ts
@@ -42,6 +42,22 @@ export interface FleetAgentTaskPlan {
  */
 export interface FleetAgentTaskPlanner {
     plan(payload: AgentTaskExecuteDispatchPayload): Promise<FleetAgentTaskPlan | null>;
+    /**
+     * Self-build slice S — what the job WILL require, known before the
+     * plan is built: the capability tags, resolved from the tenant's
+     * execution settings alone (no Task / workspace reads, so a cloud
+     * run still never pays for planning). Fed to the router so
+     * availability is counted over the nodes that could lease the job.
+     * Optional and best-effort: absent or throwing, the router falls
+     * back to the operator's config tags (what a legacy `command` job is
+     * stamped with) and the queue SLA bounds a wrong "placed".
+     */
+    requirements?(payload: AgentTaskExecuteDispatchPayload): Promise<FleetAgentTaskRequirements>;
+}
+
+/** What {@link FleetAgentTaskPlanner.requirements} resolves. */
+export interface FleetAgentTaskRequirements {
+    requiredCapabilities: string[];
 }
 
 const logger = new Logger('FleetAwareAgentTaskExecuteDispatcher');
@@ -125,7 +141,12 @@ export function createFleetAwareAgentTaskExecuteDispatcher(
             let decision: FleetRunRoutingDecision = { target: 'cloud', mode: 'cloud' };
             try {
                 const scope = await resolveScope(deps.scopeResolver, payload.taskId);
-                decision = await router.routeAgentTask(payload, scope);
+                const requirements = await resolveRequirements(deps.planner, payload);
+                decision = await router.routeAgentTask(
+                    payload,
+                    scope,
+                    requirements ? { requiredCapabilities: requirements.requiredCapabilities } : {},
+                );
             } catch (err) {
                 logger.warn(
                     `Fleet routing check failed for task ${payload.taskId} — using the platform dispatcher: ${
@@ -151,16 +172,26 @@ export function createFleetAwareAgentTaskExecuteDispatcher(
             // here too, with no reason, and must stay silent.
             if (decision.fallbackReason && deps.notifications) {
                 try {
-                    await deps.notifications.notifyFleetRunnerFallback({
-                        userId: payload.userId,
-                        taskId: payload.taskId,
-                        reason: decision.fallbackReason,
-                        // The real count from the availability snapshot,
-                        // not a stand-in derived from the reason: an
-                        // owner with four busy runners must not read
-                        // "1" in a stored notification.
-                        runnerCount: decision.runnerCount ?? 0,
-                    });
+                    const notice: Parameters<NotificationService['notifyFleetRunnerFallback']>[0] =
+                        {
+                            userId: payload.userId,
+                            taskId: payload.taskId,
+                            reason: decision.fallbackReason,
+                            // The real count from the availability snapshot,
+                            // not a stand-in derived from the reason: an
+                            // owner with four busy runners must not read
+                            // "1" in a stored notification. Since slice S
+                            // this is the ELIGIBLE count; the whole fleet
+                            // and the pinned node ride alongside it.
+                            runnerCount: decision.runnerCount ?? 0,
+                        };
+                    if (typeof decision.fleetRunnerCount === 'number') {
+                        notice.fleetRunnerCount = decision.fleetRunnerCount;
+                    }
+                    if (decision.pinnedNodeId) {
+                        notice.pinnedNodeId = decision.pinnedNodeId;
+                    }
+                    await deps.notifications.notifyFleetRunnerFallback(notice);
                 } catch (err) {
                     // Best-effort by contract: the run is what matters,
                     // and a notification outage must never turn a
@@ -175,6 +206,30 @@ export function createFleetAwareAgentTaskExecuteDispatcher(
             return delegate.enqueue(payload);
         },
     };
+}
+
+/**
+ * Best-effort requirements lookup (self-build slice S). A planner that
+ * throws here, or has no `requirements`, degrades to "the router counts
+ * against the operator's config tags" — never to a failed dispatch. The
+ * plan itself (built later, only for a fleet-bound run) keeps its loud
+ * failure semantics; this is the cheap settings-only preview of it.
+ */
+async function resolveRequirements(
+    planner: FleetAgentTaskPlanner | undefined,
+    payload: AgentTaskExecuteDispatchPayload,
+): Promise<FleetAgentTaskRequirements | null> {
+    if (!planner || typeof planner.requirements !== 'function') return null;
+    try {
+        return await planner.requirements(payload);
+    } catch (err) {
+        logger.debug(
+            `Fleet requirements lookup failed for task ${payload.taskId} — counting availability against the config tags: ${
+                err instanceof Error ? err.message : String(err)
+            }`,
+        );
+        return null;
+    }
 }
 
 /**

--- a/apps/api/src/fleet/fleet-run-router.service.ts
+++ b/apps/api/src/fleet/fleet-run-router.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { config } from '@ever-works/agent/config';
 import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
-import { FleetExecutionPreferenceService } from '@ever-works/agent/fleet';
+import { FleetExecutionPreferenceService, FleetJobService } from '@ever-works/agent/fleet';
 import type { AgentTaskExecuteDispatchPayload } from '@ever-works/agent/tasks-domain';
 import { decideFleetRouting, DEFAULT_FLEET_EXECUTION_MODE } from '@ever-works/contracts';
 import type {
@@ -16,6 +16,7 @@ import type {
     NodeDispatcherFactory,
     NodeJobRuntimePlugin,
 } from '@ever-works/job-runtime-node-plugin';
+import { agentTaskRequiredCapabilities } from './fleet-agent-task-capabilities';
 import type { FleetAgentTaskPlan } from './fleet-agent-task.dispatcher';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
 import {
@@ -73,6 +74,17 @@ export function renderAgentTaskCommand(
 }
 
 /**
+ * What the dispatcher already knows about the job before the routing
+ * decision (self-build slice S). Today: the capability tags the planner
+ * resolved from the tenant's execution settings, so the router counts
+ * only the nodes that could lease the job. Absent = the operator's
+ * config tags alone, exactly what a legacy `command` job is stamped with.
+ */
+export interface FleetRunRoutingHints {
+    requiredCapabilities?: readonly string[];
+}
+
+/**
  * AUDIT A46/A24 — the missing PRODUCER for the fleet job queue.
  *
  * `FleetJobService.enqueue` is the server half of the `job-runtime-node`
@@ -126,6 +138,11 @@ export class FleetRunRouterService {
         private readonly preferences?: FleetExecutionPreferenceService,
         @Optional()
         private readonly runners?: FleetRunnerStatusService,
+        // Self-build slice S — the affinity question, asked BEFORE the job
+        // exists (see `FleetJobService.resolveAgentTaskTarget`). Same
+        // positional-arity rule; absent = every job is judged unpinned.
+        @Optional()
+        private readonly jobs?: FleetJobService,
     ) {}
 
     /**
@@ -191,14 +208,31 @@ export class FleetRunRouterService {
      *      is `resolveForUser` + `availability` fed into the pure
      *      {@link decideFleetRouting}.
      *
+     * "A runner" means a runner that could take THIS job (self-build
+     * slice S / EW-775). `FleetJobService.enqueue` pins an `agent-task`
+     * to the node its Agent is bound to and stamps the tags the lease
+     * scan filters on, so availability is asked the same two questions
+     * here, first: the affinity (through the same
+     * `resolveAgentTaskTarget` the enqueue path uses, so the two cannot
+     * disagree) and the required tags (`hints`, resolved by the planner
+     * from settings only — the plan itself is still built AFTER the
+     * decision so a cloud run never pays for it). Before this, a job
+     * pinned to a closed laptop was "placed" because five idle siblings
+     * made `free > 0`, and then sat queued forever with no reason and no
+     * notice.
+     *
      * Never throws: any failure below step 1 degrades to plain `fleet`,
      * which is byte-for-byte what this path did before preferences
      * existed. Deciding WHERE to run is infrastructure, and an
-     * infrastructure hiccup must not cost the user a run.
+     * infrastructure hiccup must not cost the user a run. An affinity
+     * lookup that fails is judged as UNPINNED and logged — the enqueue
+     * path re-asks and would fail loudly if the store is really down,
+     * and the queue SLA bounds a wrong "placed" either way.
      */
     async routeAgentTask(
         payload: AgentTaskExecuteDispatchPayload,
         scope: FleetExecutionScopeQuery = {},
+        hints: FleetRunRoutingHints = {},
     ): Promise<FleetRunRoutingDecision> {
         if (!(await this.shouldDispatchToFleet(payload.tenantId))) {
             // Not a fallback: this tenant was never routed to the fleet,
@@ -210,8 +244,23 @@ export class FleetRunRouterService {
         }
         try {
             const mode = await this.preferences.resolveForUser(payload.userId, scope);
-            const availability = await this.runners.availability(payload.userId);
-            return decideFleetRouting(mode, availability);
+            const targetNodeId = await this.resolveAffinity(payload);
+            const requiredCapabilities = hints.requiredCapabilities
+                ? [...hints.requiredCapabilities]
+                : agentTaskRequiredCapabilities(null);
+            const availability = await this.runners.availability(payload.userId, {
+                targetNodeId,
+                requiredCapabilities,
+            });
+            const decision = decideFleetRouting(mode, availability);
+            this.logger.debug(
+                `Fleet routing for task ${payload.taskId}: ${decision.target} (mode ${mode}, eligible ${
+                    availability.free
+                }/${availability.online}/${availability.total} of ${availability.fleetTotal ?? availability.total}${
+                    targetNodeId ? `, pinned to ${targetNodeId}` : ''
+                }${requiredCapabilities.length > 0 ? `, requires ${requiredCapabilities.join(',')}` : ''})`,
+            );
+            return decision;
         } catch (err) {
             this.logger.warn(
                 `Fleet execution-preference routing failed for task ${payload.taskId} — dispatching to the fleet: ${
@@ -219,6 +268,27 @@ export class FleetRunRouterService {
                 }`,
             );
             return { target: 'fleet', mode: DEFAULT_FLEET_EXECUTION_MODE };
+        }
+    }
+
+    /**
+     * The node this run's Agent is pinned to, or null. Best-effort by
+     * contract (see {@link routeAgentTask}): a lookup that throws is
+     * "unpinned" for the count, and the reason is logged.
+     */
+    private async resolveAffinity(
+        payload: AgentTaskExecuteDispatchPayload,
+    ): Promise<string | null> {
+        if (!this.jobs) return null;
+        try {
+            return await this.jobs.resolveAgentTaskTarget(payload.userId, payload.agentId);
+        } catch (err) {
+            this.logger.warn(
+                `Fleet affinity lookup failed for task ${payload.taskId} — judging availability fleet-wide: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return null;
         }
     }
 
@@ -275,12 +345,12 @@ export class FleetRunRouterService {
         // A model-CLI job may only be leased by a node that advertises the
         // CLI it needs: the tag is backed by a resolved executable on the
         // node, so requiring it here is what keeps a Claude job off a
-        // machine that only has Codex (and vice versa).
-        const requiredCapabilities = plan
-            ? Array.from(
-                  new Set([...config.fleetNode.getRequiredCapabilities(), plan.execution.provider]),
-              )
-            : config.fleetNode.getRequiredCapabilities();
+        // machine that only has Codex (and vice versa). ONE definition,
+        // shared with the routing decision above, so the row can never
+        // demand a tag the router did not count against.
+        const requiredCapabilities = agentTaskRequiredCapabilities(
+            plan ? plan.execution.provider : null,
+        );
 
         const leaseTtlSec = config.fleetNode.getLeaseTtlSeconds();
         const enqueueOptions: {

--- a/apps/api/src/fleet/fleet-runner-status.service.ts
+++ b/apps/api/src/fleet/fleet-runner-status.service.ts
@@ -3,6 +3,7 @@ import { FleetJobService, FleetService } from '@ever-works/agent/fleet';
 import {
     FLEET_NODE_NON_LEASABLE_STATUSES,
     FLEET_RUNNER_STATUS_REFRESH_SEC,
+    nodeSatisfiesCapabilities,
 } from '@ever-works/contracts';
 import type {
     FleetNodeLoadView,
@@ -11,6 +12,21 @@ import type {
     FleetRunnerNodeView,
     FleetRunnerStatusView,
 } from '@ever-works/contracts';
+
+/**
+ * What narrows "the fleet" down to "the runners that could take THIS
+ * job" (self-build slice S). Both halves mirror the lease scan exactly:
+ * `FleetJobService.lease` skips a candidate whose `targetNodeId` is
+ * another node, and one whose required tags the node does not advertise.
+ * Counting a node here that the lease would skip is the bug this exists
+ * to remove.
+ */
+export interface FleetRunnerEligibility {
+    /** Node the job is pinned to by an Agent affinity; null/absent = unbound. */
+    targetNodeId?: string | null;
+    /** Capability tags the job will require; a node must advertise every one. */
+    requiredCapabilities?: readonly string[];
+}
 
 /**
  * Runner status — ONE composer behind both the sidebar pill and the run
@@ -46,25 +62,7 @@ export class FleetRunnerStatusService {
 
     /** The full pill payload for one owner. */
     async snapshot(userId: string): Promise<FleetRunnerStatusView> {
-        // `listEnrolledForUser`, not `listForUser`: the latter merges
-        // live nodes from the user's own Kubernetes clusters, which
-        // costs a cluster round-trip on a path polled every 30s and
-        // would count machines that can never lease a fleet job.
-        const nodes = await this.fleet.listEnrolledForUser(userId);
-
-        let load: Record<string, FleetNodeLoadView> = {};
-        let loadUnavailable = false;
-        try {
-            load = await this.jobs.loadByNodeForUser(userId);
-        } catch (err) {
-            loadUnavailable = true;
-            this.logger.debug(
-                `Runner status degraded to registry-only for user ${userId}: ${
-                    err instanceof Error ? err.message : String(err)
-                }`,
-            );
-        }
-
+        const { nodes, load, loadUnavailable } = await this.collect(userId);
         const rows = nodes.map((node) => toRunnerView(node, load[node.id] ?? null));
         const online = rows.filter((row) => row.status === 'online');
 
@@ -117,32 +115,103 @@ export class FleetRunnerStatusService {
      * queue instead of taking the cloud path the mode exists to
      * guarantee. So the same snapshot answers the two questions
      * differently, on purpose.
+     *
+     * **Eligibility (self-build slice S / EW-775).** With `eligibility`
+     * the three counts are over the nodes that could actually take THE
+     * JOB BEING ROUTED — unbound or pinned to `targetNodeId`, every
+     * required tag advertised — and the result also carries `fleetTotal`
+     * (every enrolled runner) and `pinnedNodeId`, so the fallback reason
+     * can say "the runner this Agent is pinned to is offline" rather
+     * than "1 of 6 offline". Before this, the router judged the WHOLE
+     * fleet while `FleetJobService.enqueue` pinned the job to ONE node:
+     * five idle siblings made `free > 0`, the job was "placed", and it
+     * sat queued forever with no reason and no notice. Without
+     * `eligibility` the result is the fleet-wide three-field shape it
+     * always was.
      */
-    async availability(userId: string): Promise<FleetRunnerAvailability> {
+    async availability(
+        userId: string,
+        eligibility?: FleetRunnerEligibility,
+    ): Promise<FleetRunnerAvailability> {
         try {
-            const status = await this.snapshot(userId);
-            const free = status.loadUnavailable
+            const { nodes, load, loadUnavailable } = await this.collect(userId);
+            const eligible = eligibility
+                ? nodes.filter((node) => isEligible(node, eligibility))
+                : nodes;
+            const online = eligible.filter((node) => node.status === 'online');
+            const free = loadUnavailable
                 ? []
-                : status.nodes.filter(
+                : online.filter(
                       (node) =>
-                          node.status === 'online' &&
                           !FLEET_NODE_NON_LEASABLE_STATUSES.includes(node.status) &&
-                          !node.busy,
+                          (load[node.id]?.activeJobCount ?? 0) <= 0,
                   );
-            return {
-                total: status.total,
-                online: status.online,
+            const result: FleetRunnerAvailability = {
+                total: eligible.length,
+                online: online.length,
                 free: free.length,
             };
+            if (eligibility) {
+                result.fleetTotal = nodes.length;
+                result.pinnedNodeId = eligibility.targetNodeId ?? null;
+            }
+            return result;
         } catch (err) {
             this.logger.warn(
                 `Runner availability lookup failed for user ${userId} — treating the fleet as unavailable: ${
                     err instanceof Error ? err.message : String(err)
                 }`,
             );
-            return { total: 0, online: 0, free: 0 };
+            const result: FleetRunnerAvailability = { total: 0, online: 0, free: 0 };
+            if (eligibility) {
+                result.fleetTotal = 0;
+                result.pinnedNodeId = eligibility.targetNodeId ?? null;
+            }
+            return result;
         }
     }
+
+    /**
+     * The one read both public methods are built on: the owner's
+     * enrolled registry rows plus the live load table, the latter
+     * degrading to "unknown" rather than taking the read down.
+     */
+    private async collect(userId: string): Promise<{
+        nodes: FleetNodeView[];
+        load: Record<string, FleetNodeLoadView>;
+        loadUnavailable: boolean;
+    }> {
+        // `listEnrolledForUser`, not `listForUser`: the latter merges
+        // live nodes from the user's own Kubernetes clusters, which
+        // costs a cluster round-trip on a path polled every 30s and
+        // would count machines that can never lease a fleet job.
+        const nodes = await this.fleet.listEnrolledForUser(userId);
+
+        let load: Record<string, FleetNodeLoadView> = {};
+        let loadUnavailable = false;
+        try {
+            load = await this.jobs.loadByNodeForUser(userId);
+        } catch (err) {
+            loadUnavailable = true;
+            this.logger.debug(
+                `Runner status degraded to registry-only for user ${userId}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
+        return { nodes, load, loadUnavailable };
+    }
+}
+
+/** The lease scan's two skip conditions, as a predicate over the registry row. */
+function isEligible(node: FleetNodeView, eligibility: FleetRunnerEligibility): boolean {
+    if (eligibility.targetNodeId && node.id !== eligibility.targetNodeId) {
+        return false;
+    }
+    return nodeSatisfiesCapabilities(
+        node.capabilities ?? [],
+        eligibility.requiredCapabilities ?? [],
+    );
 }
 
 function toRunnerView(node: FleetNodeView, load: FleetNodeLoadView | null): FleetRunnerNodeView {

--- a/apps/api/src/fleet/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/fleet.controller.spec.ts
@@ -37,7 +37,7 @@ describe('FleetController', () => {
         enroll: jest.Mock;
         heartbeat: jest.Mock;
     };
-    let jobs: { loadByNodeForUser: jest.Mock };
+    let jobs: { loadByNodeForUser: jest.Mock; promoteWaitingForNode: jest.Mock };
     let controller: FleetController;
 
     // Appended constructor deps (runner status + execution preferences).
@@ -64,7 +64,10 @@ describe('FleetController', () => {
             enroll: jest.fn(async () => null),
             heartbeat: jest.fn(async () => null),
         };
-        jobs = { loadByNodeForUser: jest.fn(async () => ({})) };
+        jobs = {
+            loadByNodeForUser: jest.fn(async () => ({})),
+            promoteWaitingForNode: jest.fn(async () => 0),
+        };
         controller = new FleetController(
             service as never,
             jobs as never,
@@ -183,6 +186,41 @@ describe('FleetController', () => {
                 secret: 'x'.repeat(43),
             } as FleetHeartbeatDto);
             expect(result).toEqual({ ok: true, node: nodeView });
+        });
+
+        it('promotes waiting jobs after a beat that leaves the node online, and never otherwise (slice S)', async () => {
+            const beat = { nodeId: nodeView.id, secret: 'x'.repeat(43) } as FleetHeartbeatDto;
+
+            service.heartbeat.mockResolvedValue({ node: nodeView });
+            await controller.heartbeat(beat);
+            expect(jobs.promoteWaitingForNode).toHaveBeenCalledWith(nodeView.id);
+
+            // A drained node keeps beating (observability) but will not
+            // lease, so nothing may be promoted on its account.
+            for (const status of ['paused', 'disabled', 'offline'] as const) {
+                jobs.promoteWaitingForNode.mockClear();
+                service.heartbeat.mockResolvedValue({ node: { ...nodeView, status } });
+                await controller.heartbeat(beat);
+                expect(jobs.promoteWaitingForNode).not.toHaveBeenCalled();
+            }
+
+            // A rejected credential promotes nothing either.
+            jobs.promoteWaitingForNode.mockClear();
+            service.heartbeat.mockResolvedValue(null);
+            await expect(controller.heartbeat(beat)).rejects.toBeInstanceOf(UnauthorizedException);
+            expect(jobs.promoteWaitingForNode).not.toHaveBeenCalled();
+        });
+
+        it('a promotion failure never fails the beat', async () => {
+            service.heartbeat.mockResolvedValue({ node: nodeView });
+            jobs.promoteWaitingForNode.mockRejectedValue(new Error('db down'));
+
+            await expect(
+                controller.heartbeat({
+                    nodeId: nodeView.id,
+                    secret: 'x'.repeat(43),
+                } as FleetHeartbeatDto),
+            ).resolves.toEqual({ ok: true, node: nodeView });
         });
 
         it('enroll and heartbeat are @Public (token/secret ARE the auth)', () => {

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -6,6 +6,7 @@ import {
     Get,
     HttpCode,
     HttpStatus,
+    Logger,
     Param,
     ParseUUIDPipe,
     Patch,
@@ -103,6 +104,8 @@ const NODE_HISTORY_LIMIT = 25;
 @Controller('api/fleet')
 @UseGuards(FleetEnabledGuard)
 export class FleetController {
+    private readonly logger = new Logger(FleetController.name);
+
     constructor(
         private readonly service: FleetService,
         private readonly jobs: FleetJobService,
@@ -410,6 +413,25 @@ export class FleetController {
         });
         if (!result) {
             throw new UnauthorizedException('Invalid node credential');
+        }
+        // Self-build slice S — an eligible runner is back: clear
+        // `waiting-for-runner` on the owner's queued jobs this node can
+        // take, so the Fleet UI stops saying "waiting" the moment it is
+        // no longer true (the node's own lease poll claims them next).
+        // Only for a beat that left the node ONLINE — a paused/disabled
+        // node keeps beating but will not lease — and never able to fail
+        // or refuse the beat: the service re-reads the node row itself
+        // and swallows its own errors; this guard is the belt.
+        if (result.node.status === 'online') {
+            try {
+                await this.jobs.promoteWaitingForNode(result.node.id);
+            } catch (err) {
+                this.logger.debug(
+                    `waiting-job promotion skipped for node ${result.node.id}: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
         }
         return { ok: true, node: result.node };
     }

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -37,7 +37,11 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  * `FleetRunnerStatusService` is the ONE composer behind both the
  * always-visible runner pill and the router's availability check, so
  * "3 of 4 runners online" and "there is a free runner, send the work
- * locally" can never disagree. The Task → (Work, Goal) lookup the
+ * locally" can never disagree. The router narrows that check to the
+ * runners that could take THE job (Agent affinity + required tags,
+ * self-build slice S), asking `FleetJobService` — exported by
+ * `AgentFleetModule` — the same affinity question the enqueue path
+ * asks. The Task → (Work, Goal) lookup the
  * execution preference is resolved against lives in
  * `fleet-task-scope.resolver.ts` but is PROVIDED by the api-side
  * `TasksModule`, which is the module that has `TaskRepository` — the

--- a/apps/api/src/migrations/1788200000000-AddFleetJobQueuedAt.ts
+++ b/apps/api/src/migrations/1788200000000-AddFleetJobQueuedAt.ts
@@ -1,0 +1,71 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+const INDEX_NAME = 'idx_fleet_jobs_queued_at';
+
+/**
+ * Self-build slice S (EW-775) — `fleet_jobs.queuedAt`, the queue SLA clock.
+ *
+ * Nothing used to bound how long a `queued` job could wait: the reclaim
+ * sweep only scans ACTIVE statuses, so a job pinned to a node that never
+ * came back (or requiring a tag no node advertises) sat `queued` forever
+ * with its AgentRun waiting on a verdict that was never coming.
+ * `queuedAt` records when the row last ENTERED `queued` (enqueue,
+ * reclaim, drain release) and `FleetJobService.expireQueued` fails rows
+ * older than their kind's max age.
+ *
+ * Backfill: rows that are `queued` at upgrade time get `createdAt` — a
+ * row that has already waited past the bound is exactly the stuck row
+ * the SLA exists to settle. Terminal and active rows keep NULL; they
+ * never re-enter the scan unless reclaim re-stamps them. NULLABLE on
+ * purpose: a row written by an older replica during a mixed rollout has
+ * an UNKNOWN age, and the sweep never destructively fails an unknown age.
+ *
+ * Index on (`status`, `queuedAt`) mirrors `idx_fleet_jobs_lease_expiry`:
+ * the sweep is `status = 'queued' AND queuedAt < cutoff`, per kind.
+ *
+ * Forward-only with per-step guards so a partially applied database
+ * converges; portable `TableColumn` / `TableIndex` DDL because the e2e
+ * stack and CI run better-sqlite3 while production runs Postgres.
+ */
+export class AddFleetJobQueuedAt1788200000000 implements MigrationInterface {
+    name = 'AddFleetJobQueuedAt1788200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const jobs = await queryRunner.getTable('fleet_jobs');
+        if (!jobs) return;
+
+        if (!jobs.findColumnByName('queuedAt')) {
+            await queryRunner.addColumn(
+                'fleet_jobs',
+                new TableColumn({ name: 'queuedAt', type: 'timestamp', isNullable: true }),
+            );
+        }
+
+        // Idempotent by its own WHERE clause: a re-run finds nothing NULL.
+        await queryRunner.query(
+            `UPDATE "fleet_jobs" SET "queuedAt" = "createdAt" WHERE "queuedAt" IS NULL AND "status" = 'queued'`,
+        );
+
+        // Re-read: the sqlite driver rebuilds the table on addColumn, so
+        // the metadata captured above is stale for the index check.
+        const refreshed = await queryRunner.getTable('fleet_jobs');
+        if (refreshed && !refreshed.indices.some((index) => index.name === INDEX_NAME)) {
+            await queryRunner.createIndex(
+                'fleet_jobs',
+                new TableIndex({ name: INDEX_NAME, columnNames: ['status', 'queuedAt'] }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const jobs = await queryRunner.getTable('fleet_jobs');
+        if (!jobs) return;
+        if (jobs.indices.some((index) => index.name === INDEX_NAME)) {
+            await queryRunner.dropIndex('fleet_jobs', INDEX_NAME);
+        }
+        const refreshed = await queryRunner.getTable('fleet_jobs');
+        if (refreshed?.findColumnByName('queuedAt')) {
+            await queryRunner.dropColumn('fleet_jobs', 'queuedAt');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddFleetJobQueuedAt.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddFleetJobQueuedAt.spec.ts
@@ -1,0 +1,114 @@
+import { DataSource, Table } from 'typeorm';
+import { AddFleetJobQueuedAt1788200000000 } from '../1788200000000-AddFleetJobQueuedAt';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling fleet migration
+ * specs. What matters (self-build slice S):
+ *
+ *   - the column is nullable — an unknown age must be representable,
+ *     because the sweep never destructively fails one;
+ *   - rows that are `queued` at upgrade time are backfilled from
+ *     `createdAt` (the stuck rows the SLA exists to settle), every other
+ *     status keeps NULL;
+ *   - the (status, queuedAt) index exists for the sweep;
+ *   - re-running is a no-op and `down()` reverses all of it.
+ */
+describe('AddFleetJobQueuedAt1788200000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddFleetJobQueuedAt1788200000000();
+
+    const QUEUED_CREATED = '2026-09-01 10:00:00';
+    const RUNNING_CREATED = '2026-09-01 11:00:00';
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'fleet_jobs',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'status', type: 'varchar', length: '16' },
+                    { name: 'createdAt', type: 'datetime' },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO fleet_jobs (id, "userId", status, "createdAt") VALUES (?, ?, ?, ?)`,
+            ['job-queued', 'user-1', 'queued', QUEUED_CREATED],
+        );
+        await runner.query(
+            `INSERT INTO fleet_jobs (id, "userId", status, "createdAt") VALUES (?, ?, ?, ?)`,
+            ['job-running', 'user-1', 'running', RUNNING_CREATED],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function rows(): Promise<Array<{ id: string; queuedAt: string | null }>> {
+        return dataSource.query(`SELECT id, "queuedAt" FROM fleet_jobs ORDER BY id`);
+    }
+
+    it('adds a nullable queuedAt and backfills ONLY the rows that are queued', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        const jobs = await runner.getTable('fleet_jobs');
+        await runner.release();
+
+        expect(jobs?.findColumnByName('queuedAt')).toMatchObject({ isNullable: true });
+        expect(await rows()).toEqual([
+            // A queued row's clock starts where the row did.
+            { id: 'job-queued', queuedAt: QUEUED_CREATED },
+            // An active row is not in the queue; it gets a fresh stamp only
+            // when reclaim returns it there.
+            { id: 'job-running', queuedAt: null },
+        ]);
+    });
+
+    it('creates the (status, queuedAt) index the sweep scans on', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        const jobs = await runner.getTable('fleet_jobs');
+        await runner.release();
+
+        const index = jobs?.indices.find((entry) => entry.name === 'idx_fleet_jobs_queued_at');
+        expect(index?.columnNames).toEqual(['status', 'queuedAt']);
+    });
+
+    it('is idempotent and down() drops the index and the column without touching rows', async () => {
+        await runUp();
+        await expect(runUp()).resolves.not.toThrow();
+        // The backfill did not re-stamp the already-stamped row.
+        expect((await rows())[0]).toEqual({ id: 'job-queued', queuedAt: QUEUED_CREATED });
+
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        const jobs = await runner.getTable('fleet_jobs');
+        await runner.release();
+
+        expect(jobs?.findColumnByName('queuedAt')).toBeUndefined();
+        expect(jobs?.indices.some((entry) => entry.name === 'idx_fleet_jobs_queued_at')).toBe(
+            false,
+        );
+        expect(await dataSource.query(`SELECT id, status FROM fleet_jobs ORDER BY id`)).toEqual([
+            { id: 'job-queued', status: 'queued' },
+            { id: 'job-running', status: 'running' },
+        ]);
+    });
+});

--- a/apps/web/e2e/flow-fleet-runner-pill.spec.ts
+++ b/apps/web/e2e/flow-fleet-runner-pill.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { loginViaUI } from './helpers/auth';
+
+/**
+ * Runner-status pill (self-build slice S, EW-775) — the always-visible
+ * "N of M runners online" indicator in the dashboard sidebar, walked end
+ * to end against a REAL enrolled node.
+ *
+ * `api-public-contract.spec.ts` pins the data endpoint's authz
+ * (`GET /api/fleet/runner-status` is 401 anonymous). What was never
+ * covered is the rendering: the pill is hidden until the account has a
+ * runner, appears the moment one enrolls, reflects the node in its
+ * popover, and follows a drain. That is the surface a user reads to
+ * decide whether a fleet run will actually start — and the one that
+ * would quietly disagree with routing if the two composers drifted.
+ *
+ * Every test logs in as a FRESH account in a fresh browser context
+ * rather than reusing the seeded `storageState`, so the seeded user's
+ * registry is never polluted and "no runner enrolled" is a true
+ * statement, not an assumption about test ordering.
+ *
+ * Node enrollment is driven through the public protocol
+ * (`POST /api/fleet/nodes/enrollment-token` → `POST /api/fleet/enroll`),
+ * exactly as `flow-fleet-enrollment-contract.spec.ts` does; no daemon is
+ * needed because enroll itself flips the node `online`.
+ */
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function enrollNode(
+    request: APIRequestContext,
+    token: string,
+    capabilities: string[] = ['terminal', 'workspace'],
+): Promise<{ nodeId: string; secret: string; name: string }> {
+    const name = `Pill node ${uniq()}`;
+    const minted = await request.post(`${API_BASE}/api/fleet/nodes/enrollment-token`, {
+        headers: authedHeaders(token),
+        data: { name, kind: 'desktop-node' },
+    });
+    expect(minted.status(), `mint body=${await minted.text().catch(() => '')}`).toBe(201);
+    const { token: enrollmentToken } = await minted.json();
+
+    const enrolled = await request.post(`${API_BASE}/api/fleet/enroll`, {
+        data: {
+            token: enrollmentToken,
+            platform: 'linux/x64',
+            version: '1.0.0',
+            capabilities,
+        },
+    });
+    expect(enrolled.status(), `enroll body=${await enrolled.text().catch(() => '')}`).toBe(201);
+    const body = await enrolled.json();
+    return { nodeId: body.nodeId, secret: body.secret, name };
+}
+
+async function openDashboard(page: Page): Promise<void> {
+    await page.goto('/en/works', { waitUntil: 'networkidle' });
+}
+
+test.describe('runner-status pill', () => {
+    test('GET /api/fleet/runner-status: a fresh account has no runners and advertises the 30s cadence', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/fleet/runner-status`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status(), `body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({
+            total: 0,
+            online: 0,
+            busy: 0,
+            offline: 0,
+            drained: 0,
+            // The pill takes its polling cadence FROM the payload, so the
+            // caption cannot drift from the server's intent.
+            refreshIntervalSec: 30,
+            loadUnavailable: false,
+            nodes: [],
+        });
+    });
+
+    test('renders nothing until the account has an enrolled runner', async ({
+        browser,
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: u.email, password: u.password });
+            await openDashboard(page);
+
+            // The sidebar has mounted (the pill lives in its footer), and
+            // the status request has had a chance to resolve to `total: 0`.
+            await expect(page.locator('nav, aside').first()).toBeVisible();
+            await page.waitForTimeout(1_000);
+            await expect(page.getByTestId('runner-status')).toHaveCount(0);
+        } finally {
+            await context.close();
+        }
+    });
+
+    test('appears once a node enrolls, names it in the popover and links to Fleet settings', async ({
+        browser,
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const node = await enrollNode(request, u.access_token);
+
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: u.email, password: u.password });
+            await openDashboard(page);
+
+            const pill = page.getByTestId('runner-status-pill');
+            await expect(pill).toBeVisible({ timeout: 15_000 });
+            // Enroll flips the node online, so the count reads 1 of 1.
+            await expect(page.getByTestId('runner-status-count')).toHaveText(/1\D+1/);
+
+            await pill.click();
+            const popover = page.getByTestId('runner-status-popover');
+            await expect(popover).toBeVisible();
+            const row = page.getByTestId(`runner-status-node-${node.nodeId}`);
+            await expect(row).toBeVisible();
+            await expect(row).toContainText(node.name);
+
+            const manage = page.getByTestId('runner-status-manage');
+            await expect(manage).toBeVisible();
+            expect(await manage.getAttribute('href')).toContain('/settings/fleet');
+        } finally {
+            await context.close();
+        }
+    });
+
+    test('follows a drain: the count drops to 0 of 1 after a manual refresh', async ({
+        browser,
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const node = await enrollNode(request, u.access_token);
+
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: u.email, password: u.password });
+            await openDashboard(page);
+            await expect(page.getByTestId('runner-status-count')).toHaveText(/1\D+1/, {
+                timeout: 15_000,
+            });
+
+            // Drain through the owner route: disable AND requeue. The node
+            // stays enrolled (total 1) but is no longer online.
+            const drained = await request.post(`${API_BASE}/api/fleet/nodes/${node.nodeId}/drain`, {
+                headers: authedHeaders(u.access_token),
+                data: { drain: true },
+            });
+            expect(drained.status(), `drain body=${await drained.text().catch(() => '')}`).toBe(
+                200,
+            );
+
+            await page.getByTestId('runner-status-pill').click();
+            await expect(page.getByTestId('runner-status-popover')).toBeVisible();
+            await page.getByTestId('runner-status-refresh').click();
+            await expect(page.getByTestId('runner-status-count')).toHaveText(/0\D+1/, {
+                timeout: 15_000,
+            });
+        } finally {
+            await context.close();
+        }
+    });
+
+    test('a heartbeat with the wrong secret is 401 and leaves the pill untouched', async ({
+        browser,
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const node = await enrollNode(request, u.access_token);
+
+        const beat = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: { nodeId: node.nodeId, secret: 'b'.repeat(43) },
+        });
+        expect(beat.status()).toBe(401);
+
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: u.email, password: u.password });
+            await openDashboard(page);
+            await expect(page.getByTestId('runner-status-count')).toHaveText(/1\D+1/, {
+                timeout: 15_000,
+            });
+        } finally {
+            await context.close();
+        }
+    });
+
+    test('the pill and the API agree on the same machines', async ({ browser, request }) => {
+        // The pill and the run router read ONE composer. This pins the
+        // half a browser can see: what the pill renders is what the
+        // endpoint returns for the same account at the same moment.
+        const u = await registerUserViaAPI(request);
+        const first = await enrollNode(request, u.access_token);
+        const second = await enrollNode(request, u.access_token, ['terminal']);
+
+        const status = await request.get(`${API_BASE}/api/fleet/runner-status`, {
+            headers: authedHeaders(u.access_token),
+        });
+        const body = (await status.json()) as {
+            total: number;
+            online: number;
+            nodes: Array<{ id: string; status: string }>;
+        };
+        expect(body.total).toBe(2);
+        expect(body.online).toBe(2);
+        expect(body.nodes.map((row) => row.id).sort()).toEqual(
+            [first.nodeId, second.nodeId].sort(),
+        );
+
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const page = await context.newPage();
+        try {
+            await loginViaUI(page, { email: u.email, password: u.password });
+            await openDashboard(page);
+            await expect(page.getByTestId('runner-status-count')).toHaveText(/2\D+2/, {
+                timeout: 15_000,
+            });
+            await page.getByTestId('runner-status-pill').click();
+            for (const row of body.nodes) {
+                await expect(page.getByTestId(`runner-status-node-${row.id}`)).toBeVisible();
+            }
+        } finally {
+            await context.close();
+        }
+    });
+});

--- a/docs/internal/feat-fleet-notes.md
+++ b/docs/internal/feat-fleet-notes.md
@@ -131,6 +131,82 @@ becoming "offline" gets through, because that is news.
 Best-effort by contract — a notification outage cannot turn a successful
 fallback into a failed dispatch.
 
+### 5. Eligibility-aware routing + queue SLA (self-build slice S, EW-775)
+
+**The defect.** `decideFleetRouting` judged a FLEET-WIDE `{ total, online,
+free }` while `FleetJobService.enqueue` pinned an `agent-task` to ONE node (the
+Agent affinity) and stamped capability tags the lease scan filters on. An Agent
+pinned to a closed laptop with five idle siblings made `free > 0`, the decision
+was `fleet`, `local-fallback` never fired, and the row sat `queued` forever with
+`queuedReason` null and no notice. Nothing bounded a queued row's age either —
+reclaim only scans ACTIVE statuses.
+
+**Routing over the eligible set.** `FleetRunRouterService.routeAgentTask` now
+asks, BEFORE the job exists, the same two questions the enqueue path asks:
+
+- the affinity, through `FleetJobService.resolveAgentTaskTarget` (the same
+  method enqueue uses, so the two cannot disagree; a lookup that throws is
+  judged "unpinned" and logged);
+- the required tags, through the planner's new settings-only `requirements()`
+  (`agentTaskRequiredCapabilities(provider)` in
+  `fleet-agent-task-capabilities.ts` — ONE definition shared with
+  `enqueueAgentTask`, so the row can never demand a tag the router did not count
+  against). The plan itself is still built AFTER the decision.
+
+`FleetRunnerStatusService.availability(userId, { targetNodeId,
+requiredCapabilities })` counts only nodes the lease scan would accept and adds
+`fleetTotal` + `pinnedNodeId`. Without a filter the result is the legacy
+three-field shape. `decideFleetRouting` gains two reasons —
+`no-eligible-runners` (fleet non-empty, eligible set empty: pinned node
+unenrolled, or no node advertises the tags) and `pinned-runner-offline` — and
+echoes `fleetRunnerCount` / `pinnedNodeId` on a fallback decision only when the
+snapshot carried them. `FLEET_FALLBACK_REASONS` is the canonical list.
+
+**Precise `runnerCount`** (follow-up 4, closed): the notice's `runnerCount` is
+now the ELIGIBLE count, with `fleetRunnerCount` and `pinnedNodeId` alongside it
+in `metadata`; the copy explains both new reasons. Dedup key unchanged.
+
+**Queue SLA.** New `fleet_jobs.queuedAt` (when the row last ENTERED `queued`:
+enqueue, reclaim, drain release; NOT reset by promotion) and
+`FleetJobService.expireQueued(userId?)`: per kind, rows older than
+`config.fleetNode.getQueuedMaxAgeSeconds(kind)` are failed through a CAS pinned
+to `queued` + the observed `queuedAt` + not-cancelled (a claim / reclaim / cancel
+that lands first wins, no event), with `error` =
+`queued-max-age-exceeded: …` (`FLEET_JOB_QUEUE_EXPIRED_REASON`,
+`isQueueExpiredError`) and ONE `fleet.job.completed` (source `queue-expired`).
+The reconciler marks the run failed with that reason and files exactly one Inbox
+notice titled **Fleet run never started: <task>** (body: how long it waited, the
+pin, the tags, the three fixes). Rows with `queuedAt IS NULL` (written before the
+column existed) are never touched. Runs inline on every lease poll (owner-scoped,
+best-effort) and on the `fleet-job-lease-sweeper` cron (global — the only path
+that reaches an owner whose every runner is offline).
+
+| Env                                                  | Default                                              |
+| ---------------------------------------------------- | ---------------------------------------------------- |
+| `FLEET_NODE_QUEUE_MAX_AGE_SECONDS`                   | per kind: `agent-task` 86400 (24h), checks 7200 (2h) |
+| `FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK`        | overrides the above for that kind                    |
+| `FLEET_NODE_QUEUE_MAX_AGE_SECONDS_ACCEPTANCE_CHECKS` | idem                                                 |
+| `FLEET_NODE_QUEUE_MAX_AGE_SECONDS_BROWSER_CHECK`     | idem                                                 |
+
+Clamped to `[60s, 7d]` by `clampQueuedMaxAgeSec`; unset / nonsense is the kind
+default. **Deliberately not disableable** — this changes the documented
+`local-wait` guarantee from "waits forever" to "waits up to the bound, then the
+run FAILS (never falls back)". A tenant that wants longer raises the variable up
+to the 7-day ceiling. The AgentRun sweeper's queued-too-long ESCALATION (60 min)
+still fires first; the fleet SLA files the terminal NOTICE later — two Inbox
+artefacts over one stuck run, by design.
+
+**Promotion on heartbeat** (follow-up 3, closed): after a beat that leaves the
+node `online`, `FleetController.heartbeat` calls
+`FleetJobService.promoteWaitingForNode(nodeId)`, which re-reads the node row and
+clears `waiting-for-runner` on the owner's queued rows this node could lease
+(unbound or pinned to it, every tag advertised) — only when the node holds no
+claim (a busy runner cannot take it, so the token stays true). Never throws,
+never slows a rejected beat, leaves `queuedAt` alone.
+
+Non-`agent-task` kinds have no run correlation and no notice producer; a queue
+expiry on them settles the row (`error`, drawer failure entry) and nothing else.
+
 ---
 
 ## Data model
@@ -139,6 +215,8 @@ fallback into a failed dispatch.
 fleet_nodes                 + cliVersion varchar(64) NULL
                             + diskFreeBytes bigint NULL
 fleet_jobs                  + queuedReason varchar(64) NULL
+                            + queuedAt timestamp NULL        (slice S; idx_fleet_jobs_queued_at (status, queuedAt);
+                                                              backfilled from createdAt for rows queued at upgrade)
 
 fleet_execution_preferences   id uuid pk
                               userId uuid            → FK users ON DELETE CASCADE
@@ -162,7 +240,8 @@ behind by a deleted Work simply stops matching.
 
 Migration: `apps/api/src/migrations/1786920000000-FleetRunnerTelemetryAndRouting.ts`
 — forward-only, per-step guards, portable DDL (`Table`/`TableIndex`/
-`TableForeignKey`), full `down()`.
+`TableForeignKey`), full `down()`. Slice S adds
+`1788200000000-AddFleetJobQueuedAt.ts` (same shape, spec on better-sqlite3).
 
 ---
 
@@ -192,20 +271,26 @@ new optional self-description fields.
 
 ## Tests
 
-| Command                                                                                    | Covers                                                                               |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| `cd packages/contracts && npx vitest run src/__tests__/fleet-execution-preference.spec.ts` | 16 — narrowest-wins resolution, the full `decideFleetRouting` matrix, pill summary   |
-| `cd packages/agent && npx jest --testPathPattern='fleet-node-telemetry'`                   | 14 — heartbeat backward-compat (old payload), refuse-not-clamp, bigint normalization |
-| `cd packages/agent && npx jest --testPathPattern='fleet-execution-preference'`             | 14 — scope/id validation, owner scoping, degradation                                 |
-| `cd packages/agent && npx jest --testPathPattern='fleet-runner-fallback'`                  | 8 — notification producer, event key, dedup, sanitization                            |
-| `cd packages/agent && npx jest --testPathPattern='fleet'`                                  | 61 — plus the pre-existing suites and the module pin                                 |
-| `cd apps/api && npx jest --testPathPattern='fleet-run-routing'`                            | 15 — the routing matrix end-to-end through the dispatch seam                         |
-| `cd apps/api && npx jest --testPathPattern='fleet-runner-status'`                          | 6 — composition + degradation + availability                                         |
-| `cd apps/api && npx jest --testPathPattern='fleet-runner-routes'`                          | 18 — endpoint authz scoping + DTO validation                                         |
-| `cd apps/api && npx jest --testPathPattern='FleetRunnerTelemetryAndRouting'`               | 6 — migration up/down/idempotency on better-sqlite3                                  |
-| `cd apps/node && npx vitest run src/core/telemetry-probe.spec.ts`                          | 24 — probes, parsing, never-fail-the-beat                                            |
-| `cd apps/web && npx vitest run src/components/dashboard/runner-status.unit.spec.ts`        | 9 — row state, byte + relative-time formatting                                       |
-| `cd packages/plugins/job-runtime-node && npx vitest run`                                   | 21 — existing suite, still green                                                     |
+| Command                                                                                              | Covers                                                                               |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `cd packages/contracts && npx vitest run src/__tests__/fleet-execution-preference.spec.ts`           | 16 — narrowest-wins resolution, the full `decideFleetRouting` matrix, pill summary   |
+| `cd packages/agent && npx jest --testPathPattern='fleet-node-telemetry'`                             | 14 — heartbeat backward-compat (old payload), refuse-not-clamp, bigint normalization |
+| `cd packages/agent && npx jest --testPathPattern='fleet-execution-preference'`                       | 14 — scope/id validation, owner scoping, degradation                                 |
+| `cd packages/agent && npx jest --testPathPattern='fleet-runner-fallback'`                            | 8 — notification producer, event key, dedup, sanitization                            |
+| `cd packages/agent && npx jest --testPathPattern='fleet'`                                            | 61 — plus the pre-existing suites and the module pin                                 |
+| `cd apps/api && npx jest --testPathPattern='fleet-run-routing'`                                      | 15 — the routing matrix end-to-end through the dispatch seam                         |
+| `cd apps/api && npx jest --testPathPattern='fleet-runner-status'`                                    | 6 — composition + degradation + availability                                         |
+| `cd apps/api && npx jest --testPathPattern='fleet-runner-routes'`                                    | 18 — endpoint authz scoping + DTO validation                                         |
+| `cd apps/api && npx jest --testPathPattern='FleetRunnerTelemetryAndRouting'`                         | 6 — migration up/down/idempotency on better-sqlite3                                  |
+| `cd apps/node && npx vitest run src/core/telemetry-probe.spec.ts`                                    | 24 — probes, parsing, never-fail-the-beat                                            |
+| `cd apps/web && npx vitest run src/components/dashboard/runner-status.unit.spec.ts`                  | 9 — row state, byte + relative-time formatting                                       |
+| `cd packages/plugins/job-runtime-node && npx vitest run`                                             | 21 — existing suite, still green                                                     |
+| `cd packages/contracts && npx vitest run src/fleet src/__tests__/fleet-execution-preference.spec.ts` | slice S — eligibility-aware rule shapes, `clampQueuedMaxAgeSec`, barrel (99 symbols) |
+| `cd packages/agent && npx jest --testPathPattern='fleet-job.queue-expiry'`                           | slice S — queue SLA (CAS, once-only event, per-kind cutoffs), heartbeat promotion    |
+| `cd apps/api && npx jest --testPathPattern='fleet-run-routing\|fleet-runner-status'`                 | slice S — R5 pinned-to-offline routes to fallback / visible wait; eligible counts    |
+| `cd apps/api && npx jest --testPathPattern='fleet-agent-task-reconciler\|fleet.controller'`          | slice S — "never started" notice exactly once; promotion only on an online beat      |
+| `cd apps/api && npx jest --testPathPattern='AddFleetJobQueuedAt'`                                    | slice S — migration up/backfill/index/down on better-sqlite3                         |
+| `cd apps/web && npx playwright test e2e/flow-fleet-runner-pill.spec.ts`                              | slice S — the pill against a real enrolled node (written; validated on CI)           |
 
 `apps/web/e2e/api-public-contract.spec.ts` gains `/api/fleet/runner-status` and
 `/api/fleet/execution-preferences` to the unauthenticated-401 matrix. The pill
@@ -258,13 +343,11 @@ unrelated feature PR.
 2. **Surface `fleet_jobs.queuedReason` in the node detail drawer.** It is on the
    row and in `FleetJobView`; the drawer's history list does not render it yet, so
    "waiting for a free runner" is currently visible via the API but not the UI.
-3. **Promote a waiting fleet job when a runner comes online.** Not needed for
-   correctness — a `local-wait` job sits `queued` and the next lease poll takes
-   it — but a nudge would shorten the wait after a laptop wakes up.
-4. **`runnerCount` in the fallback notification is coarse** (0 vs 1). The reason
-   token carries the actionable information; a precise count would mean threading
-   the whole availability snapshot through the dispatcher for a number the copy
-   does not currently use.
-5. **e2e coverage for the pill itself.** The data endpoint's authz is pinned in
-   `api-public-contract.spec.ts`; a rendering spec would need a seeded enrolled
-   node, which is a heavier fixture than this branch warrants.
+3. ~~**Promote a waiting fleet job when a runner comes online.**~~ Done in slice S
+   (`FleetJobService.promoteWaitingForNode`, called from the heartbeat edge).
+4. ~~**`runnerCount` in the fallback notification is coarse**~~ Done in slice S:
+   `runnerCount` is the eligible count; `fleetRunnerCount` / `pinnedNodeId` ride
+   alongside it.
+5. ~~**e2e coverage for the pill itself.**~~ Written in slice S
+   (`apps/web/e2e/flow-fleet-runner-pill.spec.ts`, enrolls a real node through the
+   public protocol); runs on CI.

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -268,6 +268,49 @@ describe('agent/config', () => {
             );
         });
 
+        describe('getQueuedMaxAgeSeconds (queue SLA, self-build slice S)', () => {
+            const KINDS = ['agent-task', 'acceptance-checks', 'browser-check'] as const;
+
+            it('defaults per kind — a day for agent-task, two hours for the checks — never "forever"', () => {
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('agent-task')).toBe(24 * 3600);
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('acceptance-checks')).toBe(2 * 3600);
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('browser-check')).toBe(2 * 3600);
+            });
+
+            it('applies FLEET_NODE_QUEUE_MAX_AGE_SECONDS to every kind', () => {
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = '3600';
+                for (const kind of KINDS) {
+                    expect(config.fleetNode.getQueuedMaxAgeSeconds(kind)).toBe(3600);
+                }
+            });
+
+            it('lets the per-kind variable win over the all-kinds one', () => {
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = '3600';
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK = '7200';
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_ACCEPTANCE_CHECKS = '900';
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('agent-task')).toBe(7200);
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('acceptance-checks')).toBe(900);
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('browser-check')).toBe(3600);
+            });
+
+            it('clamps into [60s, 7d] rather than honouring an absurd value', () => {
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = '5';
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('agent-task')).toBe(60);
+                process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = '999999999';
+                expect(config.fleetNode.getQueuedMaxAgeSeconds('agent-task')).toBe(7 * 86400);
+            });
+
+            it.each(['0', '-5', 'soon', ''])(
+                "falls back to the kind default for nonsense value '%s' (fail closed)",
+                (raw) => {
+                    process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = raw;
+                    process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_BROWSER_CHECK = raw;
+                    expect(config.fleetNode.getQueuedMaxAgeSeconds('agent-task')).toBe(24 * 3600);
+                    expect(config.fleetNode.getQueuedMaxAgeSeconds('browser-check')).toBe(2 * 3600);
+                },
+            );
+        });
+
         describe('getRequiredCapabilities', () => {
             it('defaults to an empty list (any enrolled node is eligible)', () => {
                 expect(config.fleetNode.getRequiredCapabilities()).toEqual([]);

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -1,4 +1,5 @@
 import {
+    clampQueuedMaxAgeSec,
     DEFAULT_FLEET_AGENT_EXECUTION_MODE,
     DEFAULT_FLEET_AGENT_EXECUTION_PERMISSION_MODE,
     DEFAULT_FLEET_AGENT_EXECUTION_PROVIDER,
@@ -16,6 +17,7 @@ import {
     type FleetAgentExecutionMode,
     type FleetAgentExecutionPermissionMode,
     type FleetAgentExecutionProvider,
+    type FleetJobKind,
     FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS,
     FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
     FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
@@ -203,6 +205,31 @@ export const config = {
         getLeaseTtlSeconds(): number | undefined {
             const raw = parseInt(process.env.FLEET_NODE_LEASE_TTL_SECONDS || '', 10);
             return Number.isFinite(raw) && raw > 0 ? raw : undefined;
+        },
+        /**
+         * Queue SLA (self-build slice S / EW-775): the longest a `queued`
+         * job of `kind` may wait for an eligible runner before
+         * `FleetJobService.expireQueued` fails it.
+         *
+         * `FLEET_NODE_QUEUE_MAX_AGE_SECONDS` sets every kind; the per-kind
+         * `FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK` /
+         * `_ACCEPTANCE_CHECKS` / `_BROWSER_CHECK` overrides it. Always
+         * passed through `clampQueuedMaxAgeSec`: unset or nonsense is the
+         * kind's default, out-of-range is clamped, and there is no value
+         * that means "wait forever" — a deploy-manifest typo must fail
+         * closed to the documented bound, not to an unbounded queue.
+         */
+        getQueuedMaxAgeSeconds(kind: FleetJobKind): number {
+            const suffix = kind.toUpperCase().replace(/-/g, '_');
+            const perKind = parseInt(
+                process.env[`FLEET_NODE_QUEUE_MAX_AGE_SECONDS_${suffix}`] || '',
+                10,
+            );
+            if (Number.isFinite(perKind) && perKind > 0) {
+                return clampQueuedMaxAgeSec(kind, perKind);
+            }
+            const all = parseInt(process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS || '', 10);
+            return clampQueuedMaxAgeSec(kind, Number.isFinite(all) && all > 0 ? all : undefined);
         },
         /**
          * Capability tags a node must advertise to be eligible for this

--- a/packages/agent/src/entities/fleet-job.entity.ts
+++ b/packages/agent/src/entities/fleet-job.entity.ts
@@ -49,6 +49,7 @@ import type { FleetJobKind, FleetJobStatus } from '@ever-works/contracts';
 @Index('idx_fleet_jobs_node_status', ['nodeId', 'status'])
 @Index('idx_fleet_jobs_target_status', ['targetNodeId', 'status'])
 @Index('idx_fleet_jobs_lease_expiry', ['status', 'leaseExpiresAt'])
+@Index('idx_fleet_jobs_queued_at', ['status', 'queuedAt'])
 export class FleetJob {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -135,6 +136,21 @@ export class FleetJob {
      */
     @Column({ type: 'varchar', length: 64, nullable: true })
     queuedReason?: string | null;
+
+    /**
+     * When the row last ENTERED `queued` (self-build slice S / EW-775).
+     * Set at enqueue, reset by reclaim and by a drain releasing the
+     * claim, NOT reset by a heartbeat promotion (clearing
+     * `queuedReason` does not make the job younger). The queue SLA
+     * (`FleetJobService.expireQueued`) is measured from it. Nullable so
+     * a row written by an older replica during rollout has an UNKNOWN
+     * age, and an unknown age is never destructively failed.
+     *
+     * Migration: `1788200000000-AddFleetJobQueuedAt` (backfills
+     * `createdAt` onto rows that were `queued` at upgrade time).
+     */
+    @PortableDateColumn({ nullable: true })
+    queuedAt?: Date | null;
 
     /**
      * Operator cancel request on an ACTIVE job (agent execution v2 /

--- a/packages/agent/src/events/fleet-job.events.ts
+++ b/packages/agent/src/events/fleet-job.events.ts
@@ -38,7 +38,13 @@ export type FleetJobCompletionSource =
     /** The reclaim sweep exhausted the attempt budget without a verdict. */
     | 'lease-exhausted'
     /** An operator cancelled a job that no node had claimed yet. */
-    | 'cancelled';
+    | 'cancelled'
+    /**
+     * The queue SLA failed a job no eligible runner took within its
+     * kind's max queued age (self-build slice S). `error` carries the
+     * stable `queued-max-age-exceeded` prefix.
+     */
+    | 'queue-expired';
 
 /**
  * A job reached `done` or `failed`.

--- a/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
@@ -53,6 +53,7 @@ function makeJob(over: Partial<FleetJob> = {}): FleetJob {
         result: null,
         error: null,
         queuedReason: null,
+        queuedAt: new Date('2026-09-02T10:00:00Z'),
         cancelRequestedAt: null,
         startedAt: null,
         completedAt: null,
@@ -101,6 +102,8 @@ describe('FleetJobService — cancel + lifecycle events', () => {
                 return true;
             }),
             findExpiredLeases: jest.fn(async () => []),
+            // Queue SLA scan on the lease path (slice S): nothing stale here.
+            findQueuedOlderThan: jest.fn(async () => []),
             reclaim: jest.fn(async () => true),
             failExhausted: jest.fn(
                 async (_id: string, _observed: unknown, error: string, completedAt: Date) => {

--- a/packages/agent/src/fleet/__tests__/fleet-job.queue-expiry.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.queue-expiry.spec.ts
@@ -1,0 +1,680 @@
+import { createHash, randomBytes } from 'crypto';
+import { IsNull, LessThan } from 'typeorm';
+import {
+    FLEET_JOB_QUEUE_EXPIRED_REASON,
+    isQueueExpiredError,
+    QUEUED_REASON_WAITING_FOR_RUNNER,
+} from '@ever-works/contracts';
+import { FleetJobCompletedEvent, FleetJobLeasedEvent } from '../../events/fleet-job.events';
+import { FleetJob } from '../../entities/fleet-job.entity';
+import { FleetJobRepository } from '../fleet-job.repository';
+import { FleetJobService } from '../fleet-job.service';
+
+/**
+ * Self-build slice S (EW-775) — the two things `FleetJobService` learned
+ * so a queued job can never wait forever:
+ *
+ *   1. the QUEUE SLA (`expireQueued`): a `queued` row older than its
+ *      kind's max age is failed with the stable
+ *      `queued-max-age-exceeded` prefix and exactly ONE
+ *      `fleet.job.completed` (source `queue-expired`), through a CAS that
+ *      loses to any claim / cancel / reclaim that lands first;
+ *   2. HEARTBEAT PROMOTION (`promoteWaitingForNode`): when an eligible
+ *      runner beats online and idle, `waiting-for-runner` is cleared on
+ *      the rows it could lease — and on nothing else.
+ *
+ * Hand-rolled repository doubles over an in-memory table whose
+ * conditional writes honour the same WHERE semantics the real repository
+ * pins, because those conditions ARE the exactly-once guarantee.
+ */
+
+const NODE_A = '11111111-1111-4111-8111-111111111111';
+const NODE_B = '22222222-2222-4222-8222-222222222222';
+const OWNER = 'owner-1';
+const OTHER_OWNER = 'owner-2';
+const HOUR = 60 * 60 * 1000;
+
+const sha256Hex = (value: string): string =>
+    createHash('sha256').update(value, 'utf8').digest('hex');
+
+function makeNode(id: string, secret: string, over: Record<string, unknown> = {}) {
+    return {
+        id,
+        userId: OWNER,
+        status: 'online',
+        disabled: false,
+        enrollmentTokenHash: sha256Hex(secret),
+        capabilities: ['workspace', 'claude-code'],
+        ...over,
+    };
+}
+
+let seq = 0;
+function makeJob(over: Partial<FleetJob> = {}): FleetJob {
+    seq += 1;
+    const created = new Date(Date.now() - 25 * HOUR);
+    return {
+        id: `job-${seq}`,
+        userId: OWNER,
+        organizationId: null,
+        nodeId: null,
+        targetNodeId: null,
+        kind: 'agent-task',
+        status: 'queued',
+        payload: { taskId: 'task-1', runId: 'run-1', agentId: 'agent-1' },
+        requiredCapabilities: [],
+        leaseExpiresAt: null,
+        attempts: 0,
+        maxAttempts: 3,
+        idempotencyKey: null,
+        result: null,
+        error: null,
+        queuedReason: null,
+        queuedAt: created,
+        cancelRequestedAt: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: created,
+        updatedAt: created,
+        ...over,
+    } as FleetJob;
+}
+
+describe('FleetJobService — queue SLA + heartbeat promotion', () => {
+    const originalEnv = process.env;
+    const secretA = randomBytes(24).toString('base64url');
+    let table: FleetJob[];
+    let nodes: Array<ReturnType<typeof makeNode>>;
+    let jobs: Record<string, jest.Mock>;
+    let emitter: { emit: jest.Mock };
+    let service: FleetJobService;
+
+    const completions = (): FleetJobCompletedEvent[] =>
+        emitter.emit.mock.calls
+            .filter(([name]) => name === FleetJobCompletedEvent.EVENT_NAME)
+            .map(([, event]) => event as FleetJobCompletedEvent);
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        for (const key of Object.keys(process.env)) {
+            if (key.startsWith('FLEET_NODE_QUEUE_MAX_AGE_SECONDS')) delete process.env[key];
+        }
+        table = [];
+        nodes = [makeNode(NODE_A, secretA)];
+        jobs = {
+            findById: jest.fn(async (id: string) => table.find((j) => j.id === id) ?? null),
+            findQueuedForNode: jest.fn(async (userId: string, nodeId: string, limit: number) =>
+                table
+                    .filter(
+                        (j) =>
+                            j.userId === userId &&
+                            j.status === 'queued' &&
+                            (!j.targetNodeId || j.targetNodeId === nodeId),
+                    )
+                    .slice(0, limit),
+            ),
+            claim: jest.fn(async (id: string, patch: Partial<FleetJob>) => {
+                const row = table.find(
+                    (j) => j.id === id && j.status === 'queued' && !j.cancelRequestedAt,
+                );
+                if (!row) return false;
+                Object.assign(row, patch);
+                return true;
+            }),
+            findExpiredLeases: jest.fn(async () => []),
+            reclaim: jest.fn(async () => true),
+            failExhausted: jest.fn(async () => true),
+            findActiveForUser: jest.fn(async (userId: string) =>
+                table.filter(
+                    (j) =>
+                        j.userId === userId &&
+                        (j.status === 'leased' || j.status === 'running') &&
+                        Boolean(j.nodeId),
+                ),
+            ),
+            findQueuedOlderThan: jest.fn(
+                async (kind: string, cutoff: Date, limit: number, userId?: string) =>
+                    table
+                        .filter(
+                            (j) =>
+                                (!userId || j.userId === userId) &&
+                                j.kind === kind &&
+                                j.status === 'queued' &&
+                                Boolean(j.queuedAt) &&
+                                j.queuedAt!.getTime() < cutoff.getTime() &&
+                                !j.cancelRequestedAt,
+                        )
+                        .sort((a, b) => a.queuedAt!.getTime() - b.queuedAt!.getTime())
+                        .slice(0, limit),
+            ),
+            failQueuedExpired: jest.fn(
+                async (id: string, cutoff: Date, error: string, completedAt: Date) => {
+                    // The real CAS: still queued, clock still older than the
+                    // cutoff, not cancelled.
+                    const row = table.find(
+                        (j) =>
+                            j.id === id &&
+                            j.status === 'queued' &&
+                            Boolean(j.queuedAt) &&
+                            j.queuedAt!.getTime() < cutoff.getTime() &&
+                            !j.cancelRequestedAt,
+                    );
+                    if (!row) return false;
+                    Object.assign(row, {
+                        status: 'failed',
+                        error,
+                        completedAt,
+                        leaseExpiresAt: null,
+                        queuedReason: null,
+                    });
+                    return true;
+                },
+            ),
+            findWaitingForNode: jest.fn(async (userId: string, nodeId: string, limit: number) =>
+                table
+                    .filter(
+                        (j) =>
+                            j.userId === userId &&
+                            j.status === 'queued' &&
+                            j.queuedReason === QUEUED_REASON_WAITING_FOR_RUNNER &&
+                            (!j.targetNodeId || j.targetNodeId === nodeId),
+                    )
+                    .slice(0, limit),
+            ),
+            promoteWaiting: jest.fn(async (id: string) => {
+                const row = table.find(
+                    (j) =>
+                        j.id === id &&
+                        j.status === 'queued' &&
+                        j.queuedReason === QUEUED_REASON_WAITING_FOR_RUNNER,
+                );
+                if (!row) return false;
+                row.queuedReason = null;
+                return true;
+            }),
+        };
+        emitter = { emit: jest.fn() };
+        service = new FleetJobService(
+            jobs as never,
+            {
+                findById: jest.fn(async (id: string) => nodes.find((n) => n.id === id) ?? null),
+            } as never,
+            { findForOwnedAgent: jest.fn(async () => null) } as never,
+            emitter as never,
+        );
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    describe('expireQueued', () => {
+        it('fails a queued row older than its kind max age with the stable reason, exactly once', async () => {
+            const job = makeJob();
+            table.push(job);
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 1 });
+
+            expect(job.status).toBe('failed');
+            expect(job.error!.startsWith(`${FLEET_JOB_QUEUE_EXPIRED_REASON}: `)).toBe(true);
+            expect(isQueueExpiredError(job.error)).toBe(true);
+            expect(job.error).toContain('24h');
+            expect(job.queuedReason).toBeNull();
+            expect(job.completedAt).toBeInstanceOf(Date);
+            // `queuedAt` is evidence of how long it waited; it is not erased.
+            expect(job.queuedAt).toBeInstanceOf(Date);
+
+            const events = completions();
+            expect(events).toHaveLength(1);
+            expect(events[0].source).toBe('queue-expired');
+            expect(events[0].userId).toBe(OWNER);
+            expect(events[0].nodeId).toBeNull();
+            expect(events[0].error).toBe(job.error);
+            expect(events[0].job).toMatchObject({
+                id: job.id,
+                status: 'failed',
+                queuedReason: null,
+                leaseExpiresAt: null,
+            });
+            expect(events[0].job.queuedAt).toBe(job.queuedAt!.toISOString());
+            expect(events[0].succeeded).toBe(false);
+
+            // Settled rows are terminal: a second pass finds nothing.
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 0, expired: 0 });
+            expect(completions()).toHaveLength(1);
+        });
+
+        it('names the pinned node and the required tags in the reason', async () => {
+            const job = makeJob({
+                targetNodeId: NODE_B,
+                requiredCapabilities: ['workspace', 'codex'],
+            });
+            table.push(job);
+
+            await service.expireQueued();
+
+            expect(job.error).toContain(`pinned to node ${NODE_B}`);
+            expect(job.error).toContain('requires workspace, codex');
+        });
+
+        it('uses per-kind cutoffs: 3h is fresh for an agent-task and stale for a check', async () => {
+            const threeHoursAgo = new Date(Date.now() - 3 * HOUR);
+            const agentTask = makeJob({ queuedAt: threeHoursAgo });
+            const checks = makeJob({ kind: 'acceptance-checks', queuedAt: threeHoursAgo });
+            const browser = makeJob({ kind: 'browser-check', queuedAt: threeHoursAgo });
+            table.push(agentTask, checks, browser);
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 2, expired: 2 });
+
+            expect(agentTask.status).toBe('queued');
+            expect(checks.status).toBe('failed');
+            expect(browser.status).toBe('failed');
+            expect(checks.error).toContain('2h');
+        });
+
+        it('honours the per-kind env override, clamped to the floor (never disabled)', async () => {
+            process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK = '120';
+            const threeMinutes = makeJob({ queuedAt: new Date(Date.now() - 3 * 60_000) });
+            // 90s, not 60s: the cutoff is `now - floor` and the CAS is a
+            // strict `<`, so a row sitting EXACTLY on the floor expires only
+            // if a millisecond ticks between its creation and the scan — a
+            // clock race, not the clamp under test. 90s is still under the
+            // 120s override above and over the 60s floor below.
+            const ninetySeconds = makeJob({ queuedAt: new Date(Date.now() - 90_000) });
+            table.push(threeMinutes, ninetySeconds);
+
+            await service.expireQueued();
+            expect(threeMinutes.status).toBe('failed');
+            expect(threeMinutes.error).toContain('2m');
+            expect(ninetySeconds.status).toBe('queued');
+
+            // `10` clamps UP to the 60s floor: an operator cannot make the
+            // SLA fire instantly, and `0` / garbage falls back to the
+            // default rather than to "never".
+            process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK = '10';
+            const thirtySeconds = makeJob({ queuedAt: new Date(Date.now() - 30_000) });
+            table.push(thirtySeconds);
+            await service.expireQueued();
+            expect(thirtySeconds.status).toBe('queued');
+            expect(ninetySeconds.status).toBe('failed');
+
+            process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_AGENT_TASK = '0';
+            const twoHours = makeJob({ queuedAt: new Date(Date.now() - 2 * HOUR) });
+            table.push(twoHours);
+            await service.expireQueued();
+            expect(twoHours.status).toBe('queued');
+        });
+
+        it('applies the all-kinds env value beneath the per-kind one', async () => {
+            process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS = '3600';
+            process.env.FLEET_NODE_QUEUE_MAX_AGE_SECONDS_BROWSER_CHECK = '7200';
+            const agentTask = makeJob({ queuedAt: new Date(Date.now() - 1.5 * HOUR) });
+            const browser = makeJob({
+                kind: 'browser-check',
+                queuedAt: new Date(Date.now() - 1.5 * HOUR),
+            });
+            table.push(agentTask, browser);
+
+            await service.expireQueued();
+
+            expect(agentTask.status).toBe('failed');
+            expect(browser.status).toBe('queued');
+        });
+
+        it('leaves fresh rows, unknown-age rows and cancel-requested rows alone', async () => {
+            const fresh = makeJob({ queuedAt: new Date(Date.now() - HOUR) });
+            const unknownAge = makeJob({ queuedAt: null });
+            const cancelled = makeJob({ cancelRequestedAt: new Date() });
+            const leased = makeJob({ status: 'leased', nodeId: NODE_A });
+            table.push(fresh, unknownAge, cancelled, leased);
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 0, expired: 0 });
+
+            expect(table.map((j) => j.status)).toEqual(['queued', 'queued', 'queued', 'leased']);
+            expect(completions()).toHaveLength(0);
+        });
+
+        it('never destructively fails an unknown age even if the scan returns one', async () => {
+            // Belt on top of the query predicate: a driver that returned a
+            // NULL-clock row must still not have it failed.
+            const unknownAge = makeJob({ queuedAt: null });
+            table.push(unknownAge);
+            jobs.findQueuedOlderThan.mockResolvedValueOnce([unknownAge]);
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 0 });
+            expect(unknownAge.status).toBe('queued');
+            expect(jobs.failQueuedExpired).not.toHaveBeenCalled();
+        });
+
+        it('loses to a claim that lands between the scan and the write — no event', async () => {
+            const job = makeJob();
+            table.push(job);
+            // A node claims the row after the scan snapshot was taken.
+            jobs.findQueuedOlderThan.mockImplementationOnce(async () => {
+                const snapshot = { ...job } as FleetJob;
+                Object.assign(job, { status: 'leased', nodeId: NODE_A });
+                return [snapshot];
+            });
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 0 });
+
+            expect(job.status).toBe('leased');
+            expect(completions()).toHaveLength(0);
+        });
+
+        it('loses to a reclaim that re-stamped the clock between the scan and the write', async () => {
+            const job = makeJob();
+            table.push(job);
+            jobs.findQueuedOlderThan.mockImplementationOnce(async () => {
+                const snapshot = { ...job } as FleetJob;
+                // Reclaim returned the row to the pool with a fresh clock.
+                job.queuedAt = new Date();
+                return [snapshot];
+            });
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 0 });
+            expect(job.status).toBe('queued');
+            expect(completions()).toHaveLength(0);
+        });
+
+        it('settles a backfilled row whose stored clock the driver cannot read back exactly', async () => {
+            // The migration backfills `queuedAt = createdAt`, and `createdAt`
+            // is stamped by the DATABASE clock: microsecond precision on
+            // Postgres, whole seconds on sqlite. What TypeORM hands the
+            // service is a JS Date that only approximates the stored value,
+            // so the CAS must be a "still older than the cutoff" check, never
+            // "equal to the instant we read". Modelled here as a scan that
+            // returns a snapshot 1 ms off the row's own clock — the smallest
+            // drift a JS Date can express.
+            const job = makeJob({ queuedAt: new Date(Date.now() - 48 * HOUR) });
+            table.push(job);
+            // Kind-aware: the scan runs once per kind and this row is an
+            // `agent-task`, so it must surface under the 24h pass only.
+            jobs.findQueuedOlderThan.mockImplementation(async (kind: string) =>
+                kind === 'agent-task'
+                    ? [{ ...job, queuedAt: new Date(job.queuedAt!.getTime() - 1) } as FleetJob]
+                    : [],
+            );
+
+            const scanStartedAt = Date.now();
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 1 });
+
+            expect(job.status).toBe('failed');
+            expect(completions()).toHaveLength(1);
+            // The CAS was pinned to the kind's cutoff (now - 24h), not to the
+            // row's clock.
+            const [, pinnedTo] = jobs.failQueuedExpired.mock.calls[0];
+            expect(pinnedTo).toBeInstanceOf(Date);
+            expect(pinnedTo.getTime()).toBeGreaterThan(job.queuedAt!.getTime());
+            expect(pinnedTo.getTime()).toBeGreaterThanOrEqual(scanStartedAt - 24 * HOUR);
+            expect(pinnedTo.getTime()).toBeLessThanOrEqual(Date.now() - 24 * HOUR);
+        });
+
+        it('is best-effort per row: one bad row does not abort the sweep', async () => {
+            const bad = makeJob();
+            const good = makeJob();
+            table.push(bad, good);
+            jobs.failQueuedExpired.mockImplementationOnce(async () => {
+                throw new Error('deadlock');
+            });
+
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 2, expired: 1 });
+            expect(bad.status).toBe('queued');
+            expect(good.status).toBe('failed');
+        });
+
+        it('is owner-scoped on the lease path and global on the cron', async () => {
+            const mine = makeJob();
+            const theirs = makeJob({ userId: OTHER_OWNER });
+            table.push(mine, theirs);
+
+            // The lease poll runs the owner-scoped expiry inline and never
+            // offers the expired row.
+            const leased = await service.lease({ nodeId: NODE_A, secret: secretA, max: 5 });
+            expect(leased).toEqual([]);
+            expect(mine.status).toBe('failed');
+            expect(theirs.status).toBe('queued');
+            expect(jobs.findQueuedOlderThan).toHaveBeenCalledWith(
+                'agent-task',
+                expect.any(Date),
+                expect.any(Number),
+                OWNER,
+            );
+
+            // The cron reaches the owner whose runners are all offline.
+            await expect(service.expireQueued()).resolves.toEqual({ scanned: 1, expired: 1 });
+            expect(theirs.status).toBe('failed');
+        });
+
+        it('never refuses a healthy node its work when the SLA scan itself fails', async () => {
+            const fresh = makeJob({ queuedAt: new Date() });
+            table.push(fresh);
+            jobs.findQueuedOlderThan.mockRejectedValue(new Error('column missing'));
+
+            const leased = await service.lease({ nodeId: NODE_A, secret: secretA });
+
+            expect(leased).toHaveLength(1);
+            expect(leased![0].id).toBe(fresh.id);
+        });
+    });
+
+    describe('promoteWaitingForNode', () => {
+        const waiting = (over: Partial<FleetJob> = {}): FleetJob =>
+            makeJob({
+                queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER,
+                queuedAt: new Date(Date.now() - HOUR),
+                ...over,
+            });
+
+        it('clears waiting-for-runner only on the rows this node could lease', async () => {
+            const unbound = waiting();
+            const pinnedHere = waiting({ targetNodeId: NODE_A });
+            const pinnedElsewhere = waiting({ targetNodeId: NODE_B });
+            const tagMismatch = waiting({ requiredCapabilities: ['gpu'] });
+            const tagMatch = waiting({ requiredCapabilities: ['claude-code'] });
+            const otherOwner = waiting({ userId: OTHER_OWNER });
+            const cancelled = waiting({ cancelRequestedAt: new Date() });
+            const notWaiting = makeJob({ queuedAt: new Date() });
+            table.push(
+                unbound,
+                pinnedHere,
+                pinnedElsewhere,
+                tagMismatch,
+                tagMatch,
+                otherOwner,
+                cancelled,
+                notWaiting,
+            );
+
+            await expect(service.promoteWaitingForNode(NODE_A)).resolves.toBe(3);
+
+            expect(unbound.queuedReason).toBeNull();
+            expect(pinnedHere.queuedReason).toBeNull();
+            expect(tagMatch.queuedReason).toBeNull();
+            expect(pinnedElsewhere.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+            expect(tagMismatch.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+            expect(otherOwner.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+            expect(cancelled.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+            expect(notWaiting.queuedReason).toBeNull();
+            // A promotion does not make the job younger.
+            expect(unbound.queuedAt!.getTime()).toBeLessThan(Date.now() - HOUR + 5_000);
+
+            // Idempotent: nothing left to promote.
+            await expect(service.promoteWaitingForNode(NODE_A)).resolves.toBe(0);
+        });
+
+        it.each([
+            ['offline', { status: 'offline' }],
+            ['paused', { status: 'paused' }],
+            ['disabled', { status: 'disabled' }],
+        ])('promotes nothing for a %s node', async (_label, over) => {
+            nodes = [makeNode(NODE_A, secretA, over)];
+            const row = waiting();
+            table.push(row);
+
+            await expect(service.promoteWaitingForNode(NODE_A)).resolves.toBe(0);
+            expect(row.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+        });
+
+        it('promotes nothing for an unknown or malformed node id', async () => {
+            const row = waiting();
+            table.push(row);
+
+            await expect(service.promoteWaitingForNode(NODE_B)).resolves.toBe(0);
+            await expect(service.promoteWaitingForNode('not-a-uuid')).resolves.toBe(0);
+            expect(row.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+        });
+
+        it('promotes nothing while the node still holds a claim — a busy runner cannot take it', async () => {
+            const running = makeJob({ status: 'running', nodeId: NODE_A });
+            const row = waiting();
+            table.push(running, row);
+
+            await expect(service.promoteWaitingForNode(NODE_A)).resolves.toBe(0);
+            expect(row.queuedReason).toBe(QUEUED_REASON_WAITING_FOR_RUNNER);
+        });
+
+        it('a promoted row still leases normally afterwards', async () => {
+            const row = waiting();
+            table.push(row);
+            await service.promoteWaitingForNode(NODE_A);
+
+            const leased = await service.lease({ nodeId: NODE_A, secret: secretA });
+
+            expect(leased).toHaveLength(1);
+            expect(leased![0]).toMatchObject({ id: row.id, status: 'leased', queuedReason: null });
+            expect(leased![0].queuedAt).toBe(row.queuedAt!.toISOString());
+            expect(emitter.emit).toHaveBeenCalledWith(
+                FleetJobLeasedEvent.EVENT_NAME,
+                expect.any(FleetJobLeasedEvent),
+            );
+        });
+
+        it('never throws — a promotion failure must not fail the beat', async () => {
+            table.push(waiting());
+            jobs.findWaitingForNode.mockRejectedValue(new Error('db down'));
+
+            await expect(service.promoteWaitingForNode(NODE_A)).resolves.toBe(0);
+        });
+    });
+});
+
+/**
+ * The repository's own contribution: the SLA clock is stamped wherever a
+ * row ENTERS `queued`, and the two new conditional writes pin exactly the
+ * preconditions the service relies on. A fake TypeORM repository records
+ * the WHERE / patch pairs, because those pairs are the contract.
+ */
+describe('FleetJobRepository — queue SLA writes', () => {
+    let typeorm: { create: jest.Mock; save: jest.Mock; update: jest.Mock; find: jest.Mock };
+    let repository: FleetJobRepository;
+
+    beforeEach(() => {
+        typeorm = {
+            create: jest.fn((data: unknown) => data),
+            save: jest.fn(async (data: unknown) => data),
+            update: jest.fn(async () => ({ affected: 1 })),
+            find: jest.fn(async () => []),
+        };
+        repository = new FleetJobRepository(typeorm as never);
+    });
+
+    it('stamps queuedAt at create', async () => {
+        await repository.create({ userId: OWNER, kind: 'agent-task' });
+        expect(typeorm.create.mock.calls[0][0]).toMatchObject({
+            status: 'queued',
+            queuedAt: expect.any(Date),
+        });
+    });
+
+    it('re-stamps queuedAt when reclaim and drain return a row to the pool', async () => {
+        const observed = { status: 'running' as const, nodeId: NODE_A, leaseExpiresAt: new Date() };
+        await repository.reclaim('job-1', observed);
+        expect(typeorm.update.mock.calls[0][1]).toMatchObject({
+            status: 'queued',
+            nodeId: null,
+            queuedReason: null,
+            queuedAt: expect.any(Date),
+        });
+
+        await repository.releaseClaimsForNode(OWNER, NODE_A);
+        expect(typeorm.update.mock.calls[1][1]).toMatchObject({
+            status: 'queued',
+            nodeId: null,
+            queuedAt: expect.any(Date),
+        });
+    });
+
+    it('failQueuedExpired pins queued + still-older-than-the-cutoff + not-cancelled, never an exact clock', async () => {
+        const cutoff = new Date('2026-09-01T00:00:00Z');
+        const completedAt = new Date();
+        await repository.failQueuedExpired('job-1', cutoff, 'why', completedAt);
+
+        const [where, patch] = typeorm.update.mock.calls[0];
+        // `LessThan(cutoff)`, not `queuedAt: <the instant the scan read>`:
+        // a backfilled clock comes from the database's own `now()` /
+        // `datetime('now')`, which a JS Date cannot reproduce bit-for-bit
+        // (microseconds on Postgres, no fraction on sqlite), so an
+        // equality pin would never settle the rows the backfill targets.
+        expect(where).toEqual({
+            id: 'job-1',
+            status: 'queued',
+            queuedAt: LessThan(cutoff),
+            cancelRequestedAt: IsNull(),
+        });
+        expect(where.queuedAt).not.toEqual(cutoff);
+        expect(patch).toEqual({
+            status: 'failed',
+            error: 'why',
+            completedAt,
+            leaseExpiresAt: null,
+            queuedReason: null,
+        });
+    });
+
+    it('findQueuedOlderThan scans one kind, oldest first, cancel-free, optionally owner-scoped', async () => {
+        const cutoff = new Date();
+        await repository.findQueuedOlderThan('browser-check', cutoff, 7, OWNER);
+        expect(typeorm.find.mock.calls[0][0]).toEqual({
+            where: {
+                userId: OWNER,
+                kind: 'browser-check',
+                status: 'queued',
+                queuedAt: LessThan(cutoff),
+                cancelRequestedAt: IsNull(),
+            },
+            order: { queuedAt: 'ASC' },
+            take: 7,
+        });
+
+        await repository.findQueuedOlderThan('agent-task', cutoff, 7);
+        expect(typeorm.find.mock.calls[1][0].where).not.toHaveProperty('userId');
+    });
+
+    it('promoteWaiting pins the token so a claim that already cleared it is a no-op', async () => {
+        await repository.promoteWaiting('job-1');
+        expect(typeorm.update.mock.calls[0]).toEqual([
+            { id: 'job-1', status: 'queued', queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER },
+            { queuedReason: null },
+        ]);
+    });
+
+    it('findWaitingForNode reads unbound rows and rows pinned to this node, never another pin', async () => {
+        await repository.findWaitingForNode(OWNER, NODE_A, 9);
+        const { where } = typeorm.find.mock.calls[0][0];
+        expect(where).toEqual([
+            {
+                userId: OWNER,
+                status: 'queued',
+                queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER,
+                targetNodeId: IsNull(),
+            },
+            {
+                userId: OWNER,
+                status: 'queued',
+                queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER,
+                targetNodeId: NODE_A,
+            },
+        ]);
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
@@ -78,6 +78,8 @@ function makeRepos(stores: Stores): {
                 requiredCapabilities: [],
                 createdAt: new Date(),
                 updatedAt: new Date(),
+                // The real repository stamps the SLA clock at create.
+                queuedAt: new Date(),
                 ...data,
             } as unknown as FleetJob;
             stores.jobs.push(row);
@@ -160,6 +162,8 @@ function makeRepos(stores: Stores): {
                 row.status = 'queued';
                 row.nodeId = null;
                 row.leaseExpiresAt = null;
+                // Re-enters `queued`: the real repository restarts the clock.
+                row.queuedAt = new Date();
                 return true;
             },
         ),
@@ -195,6 +199,63 @@ function makeRepos(stores: Stores): {
         ),
         findByUser: jest.fn(async (userId: string, limit: number) =>
             stores.jobs.filter((j) => j.userId === userId).slice(0, limit),
+        ),
+        // Queue SLA + heartbeat promotion (self-build slice S). Mirrored
+        // here so the inline expiry on the lease path is EXERCISED by
+        // this suite rather than swallowed as a missing method.
+        findQueuedOlderThan: jest.fn(
+            async (kind: string, cutoff: Date, limit: number, userId?: string) =>
+                stores.jobs
+                    .filter(
+                        (j) =>
+                            (!userId || j.userId === userId) &&
+                            j.kind === kind &&
+                            j.status === 'queued' &&
+                            Boolean(j.queuedAt) &&
+                            j.queuedAt!.getTime() < cutoff.getTime() &&
+                            !j.cancelRequestedAt,
+                    )
+                    .slice(0, limit),
+        ),
+        failQueuedExpired: jest.fn(
+            async (id: string, cutoff: Date, error: string, completedAt: Date) => {
+                const row = stores.jobs.find(
+                    (j) =>
+                        j.id === id &&
+                        j.status === 'queued' &&
+                        Boolean(j.queuedAt) &&
+                        j.queuedAt!.getTime() < cutoff.getTime() &&
+                        !j.cancelRequestedAt,
+                );
+                if (!row) return false;
+                Object.assign(row, {
+                    status: 'failed',
+                    error,
+                    completedAt,
+                    leaseExpiresAt: null,
+                    queuedReason: null,
+                });
+                return true;
+            },
+        ),
+        findWaitingForNode: jest.fn(async (userId: string, nodeId: string, limit: number) =>
+            stores.jobs
+                .filter(
+                    (j) =>
+                        j.userId === userId &&
+                        j.status === 'queued' &&
+                        j.queuedReason === 'waiting-for-runner' &&
+                        (!j.targetNodeId || j.targetNodeId === nodeId),
+                )
+                .slice(0, limit),
+        ),
+        promoteWaiting: jest.fn(
+            async (id: string) =>
+                applyUpdate(
+                    stores.jobs,
+                    { id, status: 'queued', queuedReason: 'waiting-for-runner' } as never,
+                    { queuedReason: null } as never,
+                ) === 1,
         ),
     } as unknown as FleetJobRepository;
 
@@ -269,6 +330,13 @@ describe('FleetJobService', () => {
             expect(view.status).toBe('queued');
             expect(view.nodeId).toBeNull();
             expect(view.requiredCapabilities).toEqual(['workspace']);
+        });
+
+        it('starts the queue SLA clock on the row and exposes it on the view (slice S)', async () => {
+            const view = await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
+
+            expect(stores.jobs[0].queuedAt).toBeInstanceOf(Date);
+            expect(view.queuedAt).toBe(stores.jobs[0].queuedAt!.toISOString());
         });
 
         it('reuses the row on an idempotency-key repeat instead of doubling the work', async () => {
@@ -744,6 +812,26 @@ describe('FleetJobService', () => {
             const summary = await service.reclaimExpired();
             expect(summary).toMatchObject({ requeued: 0, failed: 0 });
             expect(stores.jobs[0].status).toBe('leased');
+        });
+
+        it('a reclaimed row re-enters the queue with a fresh SLA clock, and is re-offered (slice S)', async () => {
+            await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
+            await service.lease({ nodeId: NODE_A, secret: secretA });
+            const firstClock = stores.jobs[0].queuedAt!.getTime();
+            stores.jobs[0].leaseExpiresAt = new Date(Date.now() - 1_000);
+            // Pretend the row had been queued for a long time before the
+            // lease: the reclaim must not carry that age forward.
+            stores.jobs[0].queuedAt = new Date(firstClock - 48 * 60 * 60 * 1000);
+
+            await service.reclaimExpired();
+
+            expect(stores.jobs[0].status).toBe('queued');
+            expect(stores.jobs[0].queuedAt!.getTime()).toBeGreaterThanOrEqual(firstClock);
+            // Which is why the next poll leases it instead of the SLA
+            // failing a job that was actively being worked seconds ago.
+            const again = await service.lease({ nodeId: NODE_A, secret: secretA });
+            expect(again).toHaveLength(1);
+            expect(again![0].status).toBe('leased');
         });
 
         it.each([

--- a/packages/agent/src/fleet/fleet-job.repository.ts
+++ b/packages/agent/src/fleet/fleet-job.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, LessThan, Not, Repository } from 'typeorm';
 import type { FleetJobKind, FleetJobStatus } from '@ever-works/contracts';
-import { FLEET_JOB_ACTIVE_STATUSES } from '@ever-works/contracts';
+import { FLEET_JOB_ACTIVE_STATUSES, QUEUED_REASON_WAITING_FOR_RUNNER } from '@ever-works/contracts';
 import { FleetJob } from '../entities/fleet-job.entity';
 
 export interface CreateFleetJobData {
@@ -68,6 +68,8 @@ export class FleetJobRepository {
                 requiredCapabilities: data.requiredCapabilities ?? [],
                 attempts: 0,
                 maxAttempts: data.maxAttempts ?? 3,
+                // The queue SLA clock starts here (see `queuedAt`).
+                queuedAt: new Date(),
             }),
         );
     }
@@ -230,6 +232,109 @@ export class FleetJobRepository {
     }
 
     /**
+     * Queue SLA (self-build slice S) — `queued` rows of one `kind` that
+     * entered the queue before `cutoff`. One query per kind because each
+     * kind has its own max age; ordered oldest-first so the batch limit
+     * never starves the rows that have waited longest. Owner-scoped on
+     * the lease path, global on the cron — the same split as
+     * {@link findExpiredLeases}.
+     *
+     * A row with `queuedAt IS NULL` (written before the column existed)
+     * never matches: an unknown age is not an old age.
+     */
+    async findQueuedOlderThan(
+        kind: FleetJobKind,
+        cutoff: Date,
+        limit: number,
+        userId?: string,
+    ): Promise<FleetJob[]> {
+        return this.repository.find({
+            where: {
+                ...(userId ? { userId } : {}),
+                kind,
+                status: 'queued',
+                queuedAt: LessThan(cutoff),
+                cancelRequestedAt: IsNull(),
+            },
+            order: { queuedAt: 'ASC' },
+            take: limit,
+        });
+    }
+
+    /**
+     * Queue SLA — fail a job NO node ever took. The WHERE clause pins the
+     * row to `queued`, to "still older than the scan's cutoff" and to
+     * "not cancelled", so a claim, a reclaim (which re-stamps `queuedAt`
+     * to now, which is never older than the cutoff) or a cancel that
+     * lands between the scan and this write wins and the caller sees
+     * `false`. Exactly one writer ever settles the row, which is what
+     * makes the completion event fire exactly once.
+     *
+     * Pinned with `LessThan(cutoff)` rather than equality on the
+     * `queuedAt` the scan read back, on purpose: the migration backfills
+     * `queuedAt` from `createdAt`, whose default is the DATABASE clock
+     * (Postgres `now()` carries microseconds; sqlite `datetime('now')`
+     * carries no fraction at all), and a JS `Date` cannot round-trip
+     * either exactly — an equality pin would silently never match the
+     * very rows the backfill exists to settle.
+     */
+    async failQueuedExpired(
+        id: string,
+        cutoff: Date,
+        error: string,
+        completedAt: Date,
+    ): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, status: 'queued', queuedAt: LessThan(cutoff), cancelRequestedAt: IsNull() },
+            { status: 'failed', error, completedAt, leaseExpiresAt: null, queuedReason: null },
+        );
+        return (result.affected ?? 0) === 1;
+    }
+
+    /**
+     * Heartbeat promotion (self-build slice S) — the owner's queued rows
+     * still stamped `waiting-for-runner` that THIS node could lease:
+     * unbound, or pinned to it. Capability filtering happens in the
+     * service, for the same JSON-column reason as the lease scan.
+     */
+    async findWaitingForNode(userId: string, nodeId: string, limit: number): Promise<FleetJob[]> {
+        return this.repository.find({
+            where: [
+                {
+                    userId,
+                    status: 'queued',
+                    queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER,
+                    targetNodeId: IsNull(),
+                },
+                {
+                    userId,
+                    status: 'queued',
+                    queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER,
+                    targetNodeId: nodeId,
+                },
+            ],
+            order: { createdAt: 'ASC' },
+            take: limit,
+        });
+    }
+
+    /**
+     * Clear `waiting-for-runner` on a row an eligible runner can now take.
+     * Pinned to `queued` + the token, so a claim that already cleared it
+     * (or a row that moved on) is a no-op rather than a stale write.
+     * `queuedAt` is deliberately NOT touched: a promotion does not make
+     * the job younger, and the SLA still bounds a node that is online but
+     * never actually leases.
+     */
+    async promoteWaiting(id: string): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, status: 'queued', queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER },
+            { queuedReason: null },
+        );
+        return (result.affected ?? 0) === 1;
+    }
+
+    /**
      * Return one lapsed claim to the pool. Pins the previous status so a
      * job that completed between the scan and the write is never
      * resurrected.
@@ -246,8 +351,15 @@ export class FleetJobRepository {
             // job: the reason it originally waited (no free runner) is
             // not necessarily why it is waiting now, and carrying a
             // stale token forward would misreport a lapsed lease as a
-            // capacity problem.
-            { status: 'queued', nodeId: null, leaseExpiresAt: null, queuedReason: null },
+            // capacity problem. The row re-ENTERS `queued`, so the queue
+            // SLA clock restarts too.
+            {
+                status: 'queued',
+                nodeId: null,
+                leaseExpiresAt: null,
+                queuedReason: null,
+                queuedAt: new Date(),
+            },
         );
         return (result.affected ?? 0) === 1;
     }
@@ -331,7 +443,8 @@ export class FleetJobRepository {
     async releaseClaimsForNode(userId: string, nodeId: string): Promise<number> {
         const result = await this.repository.update(
             { userId, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]) },
-            { status: 'queued', nodeId: null, leaseExpiresAt: null },
+            // Re-enters `queued`: the SLA clock restarts with it.
+            { status: 'queued', nodeId: null, leaseExpiresAt: null, queuedAt: new Date() },
         );
         return result.affected ?? 0;
     }

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -10,14 +10,17 @@ import type {
 import {
     clampLeaseTtlSec,
     clampMaxAttempts,
+    FLEET_JOB_KINDS,
     FLEET_JOB_MAX_ERROR_LENGTH,
     FLEET_JOB_MAX_LEASE_BATCH,
     FLEET_JOB_MAX_PAYLOAD_BYTES,
     FLEET_JOB_MAX_REQUIRED_CAPABILITIES,
     FLEET_JOB_MAX_RESULT_BYTES,
+    FLEET_JOB_QUEUE_EXPIRED_REASON,
     isFleetJobKind,
     nodeSatisfiesCapabilities,
 } from '@ever-works/contracts';
+import { config } from '../config';
 import { FleetJob } from '../entities/fleet-job.entity';
 import { FleetJobCompletedEvent, FleetJobLeasedEvent } from '../events/fleet-job.events';
 import { FleetJobRepository } from './fleet-job.repository';
@@ -66,6 +69,14 @@ export interface ReclaimSummary {
     scanned: number;
     requeued: number;
     failed: number;
+}
+
+/** What one queue-SLA pass did (see {@link FleetJobService.expireQueued}). */
+export interface QueueExpirySummary {
+    /** Queued rows older than their kind's max age that the scan returned. */
+    scanned: number;
+    /** Of those, the rows this pass actually settled `failed`. */
+    expired: number;
 }
 
 /** Error text a job settles with when an operator cancels it before any node claimed it. */
@@ -187,8 +198,9 @@ export class FleetJobService {
      * the job would silently un-pin exactly the runs the owner bound.
      *
      * Public because the run router asks the same question BEFORE the
-     * job exists, to judge availability against the bound node instead
-     * of the whole fleet; both callers must agree on the answer.
+     * job exists (`FleetRunRouterService.routeAgentTask`, self-build
+     * slice S), to judge availability against the bound node instead of
+     * the whole fleet; both callers must agree on the answer.
      */
     async resolveAgentTaskTarget(userId: string, agentId: unknown): Promise<string | null> {
         if (typeof agentId !== 'string' || !isUUID(agentId)) {
@@ -226,6 +238,18 @@ export class FleetJobService {
         // Inline reclaim before the scan: a job whose holder died is
         // eligible again on the very next poll, with no cron in the loop.
         await this.reclaimExpired(node.userId);
+        // Queue SLA on the same poll (owner-scoped, bounded): a job nobody
+        // eligible ever took must not be re-offered forever. Best-effort —
+        // an SLA scan that fails must never refuse a healthy node its work.
+        try {
+            await this.expireQueued(node.userId);
+        } catch (error) {
+            this.logger.warn(
+                `fleet queue expiry skipped on lease for owner ${node.userId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
 
         const capabilities = Array.isArray(input.capabilities)
             ? normalizeCapabilities(input.capabilities, FLEET_JOB_MAX_REQUIRED_CAPABILITIES * 4)
@@ -584,6 +608,152 @@ export class FleetJobService {
     }
 
     /**
+     * Queue SLA (self-build slice S / EW-775) — fail every `queued` job
+     * that has waited longer than its kind's max queued age
+     * (`config.fleetNode.getQueuedMaxAgeSeconds`) for an eligible runner.
+     *
+     * Why this exists: reclaim only ever looks at ACTIVE statuses, so a
+     * job no node could take — pinned to a machine that never came back,
+     * or requiring a tag no node advertises — sat `queued` forever, and
+     * its AgentRun with it. Eligibility-aware routing stops the common
+     * case at the door; this is the backstop for everything that slips
+     * past (a runner that went offline between the decision and the
+     * lease, a `local-wait` job whose machine never returns).
+     *
+     * Per row: the `failQueuedExpired` CAS pins `queued` + `queuedAt`
+     * still older than the kind's cutoff + not-cancelled, so a claim, a
+     * reclaim (which re-stamps the clock to now) or a cancel that lands
+     * first wins and NO event fires here. A row settled here emits
+     * exactly one `fleet.job.completed` with source `queue-expired` and
+     * the stable {@link FLEET_JOB_QUEUE_EXPIRED_REASON} prefix, which is
+     * what lets the API-side reconciler settle the run and file the one
+     * Inbox notice. Rows with an unknown age (`queuedAt IS NULL`, written
+     * before the column existed) are never touched.
+     *
+     * Scoped to one owner on the lease path, global on the cron, and
+     * best-effort per row — one bad row must not abort the sweep.
+     */
+    async expireQueued(userId?: string): Promise<QueueExpirySummary> {
+        const now = new Date();
+        const summary: QueueExpirySummary = { scanned: 0, expired: 0 };
+
+        for (const kind of FLEET_JOB_KINDS) {
+            const maxAgeSec = config.fleetNode.getQueuedMaxAgeSeconds(kind);
+            const cutoff = new Date(now.getTime() - maxAgeSec * 1000);
+            const stale = await this.jobs.findQueuedOlderThan(
+                kind,
+                cutoff,
+                FLEET_JOB_RECLAIM_BATCH,
+                userId,
+            );
+            summary.scanned += stale.length;
+
+            for (const job of stale) {
+                try {
+                    // Belt on top of the query: an unknown age is not an
+                    // old age, and this transition is destructive.
+                    if (!job.queuedAt || job.cancelRequestedAt) continue;
+                    const error = describeQueueExpiry(job, maxAgeSec);
+                    // The CAS re-checks the AGE against the same cutoff the
+                    // scan used, not the exact instant the driver read back
+                    // (see `FleetJobRepository.failQueuedExpired`).
+                    const settled = await this.jobs.failQueuedExpired(job.id, cutoff, error, now);
+                    if (!settled) continue;
+                    summary.expired += 1;
+                    this.emit(
+                        FleetJobCompletedEvent.EVENT_NAME,
+                        new FleetJobCompletedEvent(
+                            toJobView({
+                                ...job,
+                                status: 'failed',
+                                error,
+                                completedAt: now,
+                                leaseExpiresAt: null,
+                                queuedReason: null,
+                            } as FleetJob),
+                            job.userId,
+                            'queue-expired',
+                            null,
+                            null,
+                            error,
+                        ),
+                    );
+                } catch (error) {
+                    this.logger.warn(
+                        `fleet queue expiry failed for ${job.id}: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                }
+            }
+        }
+
+        if (summary.expired > 0) {
+            this.logger.log(
+                `fleet queue expiry: expired=${summary.expired} scanned=${summary.scanned}`,
+            );
+        }
+        return summary;
+    }
+
+    /**
+     * Heartbeat promotion (self-build slice S) — clear `waiting-for-runner`
+     * on the owner's queued jobs that `nodeId` can now take, because it
+     * just beat as ONLINE and holds no claim.
+     *
+     * The token is what the Fleet UI reads. The lease CAS already clears
+     * it when the node's next poll claims the job, so promotion buys no
+     * correctness — it buys honesty in the window between "the laptop
+     * woke up" and "it polled", and it must never make the UI lie the
+     * other way: a node that is online but BUSY is not "able to take it"
+     * (the token stays true), and `queuedAt` is left alone (a promotion
+     * does not make the job younger, so a node that is online but never
+     * leases is still bounded by the SLA).
+     *
+     * Eligibility is judged the way the lease scan judges it — unbound
+     * or pinned to this node, every required tag advertised — from the
+     * node ROW (owner, status, tags), never from a caller-supplied
+     * shape, so a node id that travelled cannot promote another owner's
+     * work. Never throws: a promotion failure must not fail the beat.
+     */
+    async promoteWaitingForNode(nodeId: string): Promise<number> {
+        try {
+            if (typeof nodeId !== 'string' || !isUUID(nodeId)) return 0;
+            const node = await this.nodes.findById(nodeId);
+            if (!node || node.status !== 'online') return 0;
+
+            const active = await this.jobs.findActiveForUser(node.userId);
+            if (active.some((job) => job.nodeId === node.id)) return 0;
+
+            const waiting = await this.jobs.findWaitingForNode(
+                node.userId,
+                node.id,
+                FLEET_JOB_RECLAIM_BATCH,
+            );
+            const capabilities = node.capabilities ?? [];
+            let promoted = 0;
+            for (const job of waiting) {
+                if (job.cancelRequestedAt) continue;
+                if (!nodeSatisfiesCapabilities(capabilities, job.requiredCapabilities)) continue;
+                if (await this.jobs.promoteWaiting(job.id)) promoted += 1;
+            }
+            if (promoted > 0) {
+                this.logger.log(
+                    `fleet node ${node.id} back online: ${promoted} waiting job(s) promoted for owner ${node.userId}`,
+                );
+            }
+            return promoted;
+        } catch (error) {
+            this.logger.warn(
+                `fleet waiting-job promotion failed for node ${nodeId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return 0;
+        }
+    }
+
+    /**
      * Per-node load for the Fleet settings page: how many live claims
      * each node holds and what the oldest one is. Keyed by node id;
      * nodes with nothing in flight are simply absent (the UI renders
@@ -713,9 +883,35 @@ export function toJobView(job: FleetJob): FleetJobView {
         createdAt: job.createdAt ? toIso(job.createdAt) : null,
         startedAt: job.startedAt ? toIso(job.startedAt) : null,
         completedAt: job.completedAt ? toIso(job.completedAt) : null,
+        queuedAt: job.queuedAt ? toIso(job.queuedAt) : null,
         queuedReason: job.queuedReason ?? null,
         cancelRequestedAt: job.cancelRequestedAt ? toIso(job.cancelRequestedAt) : null,
     };
+}
+
+/**
+ * The error a queue-SLA failure settles with: the stable machine token
+ * first, then the human sentence, then the facts an owner needs to fix
+ * it (which node it was pinned to, which tags it needed). Length-capped
+ * like every other stored error.
+ */
+function describeQueueExpiry(job: FleetJob, maxAgeSec: number): string {
+    const parts = [
+        `${FLEET_JOB_QUEUE_EXPIRED_REASON}: no eligible runner took the job within ${formatDuration(maxAgeSec)}`,
+    ];
+    if (job.targetNodeId) {
+        parts.push(`(pinned to node ${job.targetNodeId})`);
+    }
+    if (Array.isArray(job.requiredCapabilities) && job.requiredCapabilities.length > 0) {
+        parts.push(`[requires ${job.requiredCapabilities.join(', ')}]`);
+    }
+    return truncate(parts.join(' '), FLEET_JOB_MAX_ERROR_LENGTH) ?? FLEET_JOB_QUEUE_EXPIRED_REASON;
+}
+
+function formatDuration(seconds: number): string {
+    if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+    if (seconds % 60 === 0) return `${seconds / 60}m`;
+    return `${seconds}s`;
 }
 
 /**

--- a/packages/agent/src/notifications/__tests__/fleet-runner-fallback.spec.ts
+++ b/packages/agent/src/notifications/__tests__/fleet-runner-fallback.spec.ts
@@ -121,6 +121,98 @@ describe('NotificationService.notifyFleetRunnerFallback', () => {
         expect(new Set(keys).size).toBe(2);
     });
 
+    describe('eligibility-aware reasons (self-build slice S)', () => {
+        const NODE = '22222222-2222-4222-8222-222222222222';
+
+        it.each([
+            ['pinned-runner-offline', 'the runner this Agent is pinned to is offline'],
+            ['no-eligible-runners', 'none of your 6 enrolled runner(s) can take this job'],
+        ])('explains the %s reason in plain language', async (reason, expected) => {
+            await build().notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason,
+                runnerCount: reason === 'pinned-runner-offline' ? 1 : 0,
+                fleetRunnerCount: 6,
+                pinnedNodeId: reason === 'pinned-runner-offline' ? NODE : null,
+            });
+
+            expect(repository.create.mock.calls[0][0].message).toContain(expected);
+        });
+
+        it('stores the PRECISE eligible count next to the whole fleet and the pinned node', async () => {
+            // The follow-up this closes: `runnerCount` used to be the
+            // fleet-wide total, so an Agent pinned to one of six machines
+            // read "6" for a decision that was about exactly one of them.
+            await build().notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'pinned-runner-offline',
+                runnerCount: 1,
+                fleetRunnerCount: 6,
+                pinnedNodeId: NODE,
+            });
+
+            expect(repository.create.mock.calls[0][0].metadata).toMatchObject({
+                reason: 'pinned-runner-offline',
+                runnerCount: 1,
+                fleetRunnerCount: 6,
+                pinnedNodeId: NODE,
+            });
+        });
+
+        it('reports the fleet count as the runner count when no subset was involved', async () => {
+            await build().notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'runners-busy',
+                runnerCount: 4,
+            });
+
+            expect(repository.create.mock.calls[0][0].metadata).toMatchObject({
+                runnerCount: 4,
+                fleetRunnerCount: 4,
+                pinnedNodeId: null,
+            });
+        });
+
+        it('sanitizes the pinned node id like every other interpolated value', async () => {
+            await build().notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'pinned-runner-offline',
+                runnerCount: 1,
+                pinnedNodeId: '<b>node</b>',
+            });
+
+            const stored = repository.create.mock.calls[0][0].metadata.pinnedNodeId as string;
+            expect(stored).not.toContain('<');
+            expect(stored).not.toContain('>');
+        });
+
+        it('keeps the per-(task, reason) dedup so the new reasons are news too', async () => {
+            const service = build();
+            await service.notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'runners-busy',
+                runnerCount: 1,
+            });
+            await service.notifyFleetRunnerFallback({
+                userId: 'user-1',
+                taskId: 'task-1',
+                reason: 'pinned-runner-offline',
+                runnerCount: 1,
+            });
+
+            const keys = repository.create.mock.calls.map((call) => call[0].deduplicationKey);
+            expect(keys).toEqual([
+                'fleet_runner_fallback_task-1_runners-busy',
+                'fleet_runner_fallback_task-1_pinned-runner-offline',
+            ]);
+        });
+    });
+
     it('sanitizes the reason token before it reaches the message or the key', async () => {
         // The reason is platform-written today, but it is INTERPOLATED
         // into rendered text, so it goes through the same label sanitizer

--- a/packages/agent/src/notifications/notification.service.ts
+++ b/packages/agent/src/notifications/notification.service.ts
@@ -665,18 +665,38 @@ export class NotificationService {
     async notifyFleetRunnerFallback(args: {
         userId: string;
         taskId?: string | null;
-        /** Machine token: `no-runners` | `runners-offline` | `runners-busy`. */
+        /**
+         * Machine token — one of `FLEET_FALLBACK_REASONS`: `no-runners` |
+         * `runners-offline` | `runners-busy` | `no-eligible-runners` |
+         * `pinned-runner-offline`.
+         */
         reason: string;
-        /** Enrolled runners at decision time (0 when none). */
+        /**
+         * Runners that could have taken THIS job at decision time (0 when
+         * none). Since self-build slice S this is the ELIGIBLE count —
+         * the pinned node, or the nodes advertising the required tags —
+         * which is the precise figure the copy can stand behind.
+         */
         runnerCount: number;
+        /** Every enrolled runner, when the count above is a subset of them. */
+        fleetRunnerCount?: number;
+        /** The node the Agent is pinned to, when the decision was taken against one. */
+        pinnedNodeId?: string | null;
     }): Promise<void> {
         const safeReason = this.sanitizeLabel(args.reason);
+        const fleetRunnerCount =
+            typeof args.fleetRunnerCount === 'number' ? args.fleetRunnerCount : args.runnerCount;
+        const safePinnedNodeId = args.pinnedNodeId ? this.sanitizeLabel(args.pinnedNodeId) : null;
         const detail =
             args.reason === 'no-runners'
                 ? 'no local runner is enrolled'
                 : args.reason === 'runners-offline'
                   ? 'your local runner is offline'
-                  : 'your local runner was busy';
+                  : args.reason === 'pinned-runner-offline'
+                    ? 'the runner this Agent is pinned to is offline'
+                    : args.reason === 'no-eligible-runners'
+                      ? `none of your ${fleetRunnerCount} enrolled runner(s) can take this job (its pinned runner is gone, or no runner advertises the tools it requires)`
+                      : 'your local runner was busy';
         const title = 'Local runner fallback → cloud';
         const message =
             `A run that preferred your local runner ran in the cloud instead because ${detail}. ` +
@@ -694,6 +714,8 @@ export class NotificationService {
                 taskId: args.taskId ?? null,
                 reason: safeReason,
                 runnerCount: args.runnerCount,
+                fleetRunnerCount,
+                pinnedNodeId: safePinnedNodeId,
             },
             deduplicationKey: `fleet_runner_fallback_${args.taskId ?? 'unknown'}_${safeReason}`,
         });

--- a/packages/contracts/src/__tests__/fleet-execution-preference.spec.ts
+++ b/packages/contracts/src/__tests__/fleet-execution-preference.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_FLEET_EXECUTION_MODE,
 	decideFleetRouting,
+	FLEET_FALLBACK_REASONS,
 	isFleetExecutionMode,
 	isLocalExecutionMode,
 	QUEUED_REASON_WAITING_FOR_RUNNER,
@@ -164,5 +165,96 @@ describe('summarizeRunnerStatus', () => {
 	it('reports busy only when EVERY online runner is holding work', () => {
 		expect(summarizeRunnerStatus({ total: 2, online: 2, busy: 2 })).toBe('busy');
 		expect(summarizeRunnerStatus({ total: 2, online: 2, busy: 1 })).toBe('online');
+	});
+});
+
+describe('decideFleetRouting — eligibility (self-build slice S / EW-775)', () => {
+	const PINNED = '22222222-2222-4222-8222-222222222222';
+	/** The R5 snapshot: the eligible set is the pinned node, it is down, five siblings idle. */
+	const PINNED_OFFLINE: FleetRunnerAvailability = {
+		total: 1,
+		online: 0,
+		free: 0,
+		fleetTotal: 6,
+		pinnedNodeId: PINNED
+	};
+
+	it('REGRESSION: a pin to an offline node with five idle siblings is a fallback, not a placement', () => {
+		// The counts are over the ELIGIBLE set, so `free` is 0 however many
+		// siblings are idle — and the reason names the pinned runner, with
+		// the precise 1-of-6 the notice stores.
+		expect(decideFleetRouting('local-fallback', PINNED_OFFLINE)).toEqual({
+			target: 'cloud',
+			mode: 'local-fallback',
+			fallbackReason: 'pinned-runner-offline',
+			runnerCount: 1,
+			fleetRunnerCount: 6,
+			pinnedNodeId: PINNED
+		});
+	});
+
+	it('the same pin under local-wait waits, visibly', () => {
+		expect(decideFleetRouting('local-wait', PINNED_OFFLINE)).toEqual({
+			target: 'fleet-waiting',
+			mode: 'local-wait',
+			queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER
+		});
+	});
+
+	it('names no-eligible-runners when the fleet has runners but none could take the job', () => {
+		// A pinned node that was unenrolled, or a tag no machine advertises:
+		// "enrol a runner" would be the wrong advice for an owner with three.
+		expect(decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0, fleetTotal: 3 })).toEqual({
+			target: 'cloud',
+			mode: 'local-fallback',
+			fallbackReason: 'no-eligible-runners',
+			runnerCount: 0,
+			fleetRunnerCount: 3
+		});
+	});
+
+	it('keeps no-runners when the whole fleet is empty', () => {
+		expect(decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0, fleetTotal: 0 })).toEqual({
+			target: 'cloud',
+			mode: 'local-fallback',
+			fallbackReason: 'no-runners',
+			runnerCount: 0,
+			fleetRunnerCount: 0
+		});
+	});
+
+	it('a pinned runner that is online but busy is runners-busy, with the pin attached', () => {
+		expect(
+			decideFleetRouting('local-fallback', { total: 1, online: 1, free: 0, fleetTotal: 2, pinnedNodeId: PINNED })
+		).toEqual({
+			target: 'cloud',
+			mode: 'local-fallback',
+			fallbackReason: 'runners-busy',
+			runnerCount: 1,
+			fleetRunnerCount: 2,
+			pinnedNodeId: PINNED
+		});
+	});
+
+	it('a pinned runner that is online and idle is placed exactly as before', () => {
+		expect(
+			decideFleetRouting('local-fallback', { total: 1, online: 1, free: 1, fleetTotal: 6, pinnedNodeId: PINNED })
+		).toEqual({ target: 'fleet', mode: 'local-fallback' });
+	});
+
+	it('an unpinned eligible set that is all offline is still runners-offline', () => {
+		expect(
+			decideFleetRouting('local-fallback', { total: 2, online: 0, free: 0, fleetTotal: 4, pinnedNodeId: null })
+		).toMatchObject({ fallbackReason: 'runners-offline', runnerCount: 2, fleetRunnerCount: 4 });
+	});
+
+	it('lists the five fallback reasons, eligibility-aware ones last', () => {
+		expect(FLEET_FALLBACK_REASONS).toEqual([
+			'no-runners',
+			'runners-offline',
+			'runners-busy',
+			'no-eligible-runners',
+			'pinned-runner-offline'
+		]);
 	});
 });

--- a/packages/contracts/src/fleet/__tests__/fleet-execution-preference.resolution.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-execution-preference.resolution.spec.ts
@@ -5,6 +5,7 @@ import {
 	decideFleetRouting,
 	FLEET_EXECUTION_MODES,
 	FLEET_EXECUTION_SCOPE_TYPES,
+	FLEET_FALLBACK_REASONS,
 	isFleetExecutionMode,
 	isLocalExecutionMode,
 	QUEUED_REASON_WAITING_FOR_RUNNER,
@@ -437,5 +438,77 @@ describe('decideFleetRouting — the whole 3 x 4 grid', () => {
 		// on purpose — the detail assertions live in the describes above and in
 		// the upstream spec, and duplicating them here would just add noise.
 		expect(decideFleetRouting(mode, availability).target).toBe(expected);
+	});
+});
+
+describe('decideFleetRouting — eligibility-aware decision shapes (self-build slice S)', () => {
+	const PINNED = '22222222-2222-4222-8222-222222222222';
+
+	it('adds fleetRunnerCount only when the snapshot carried fleetTotal', () => {
+		// Exact keys, both ways: the legacy three-field snapshot must yield
+		// the legacy four-key decision (every `toEqual` above depends on
+		// it), and a fleet-aware snapshot must carry the count through.
+		expect(Object.keys(decideFleetRouting('local-fallback', ALL_BUSY)).sort()).toEqual(
+			['fallbackReason', 'mode', 'runnerCount', 'target'].sort()
+		);
+		expect(Object.keys(decideFleetRouting('local-fallback', { ...ALL_BUSY, fleetTotal: 2 })).sort()).toEqual(
+			['fallbackReason', 'fleetRunnerCount', 'mode', 'runnerCount', 'target'].sort()
+		);
+	});
+
+	it('adds pinnedNodeId only when the snapshot carried a pin, and treats null as unpinned', () => {
+		const unpinned = decideFleetRouting('local-fallback', { ...ALL_OFFLINE, fleetTotal: 2, pinnedNodeId: null });
+		expect(unpinned).not.toHaveProperty('pinnedNodeId');
+		expect(unpinned.fallbackReason).toBe('runners-offline');
+
+		const pinned = decideFleetRouting('local-fallback', { total: 1, online: 0, free: 0, pinnedNodeId: PINNED });
+		expect(pinned.pinnedNodeId).toBe(PINNED);
+		expect(pinned.fallbackReason).toBe('pinned-runner-offline');
+		// No fleetTotal on the snapshot: no fleetRunnerCount on the decision.
+		expect(pinned).not.toHaveProperty('fleetRunnerCount');
+	});
+
+	it('never leaks fleetRunnerCount / pinnedNodeId onto a waiting or placed decision', () => {
+		const snapshot = { ...ALL_BUSY, fleetTotal: 9, pinnedNodeId: PINNED };
+		expect(decideFleetRouting('local-wait', snapshot)).toEqual({
+			target: 'fleet-waiting',
+			mode: 'local-wait',
+			queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER
+		});
+		expect(decideFleetRouting('local-wait', { ...FREE, fleetTotal: 9, pinnedNodeId: PINNED })).toEqual({
+			target: 'fleet',
+			mode: 'local-wait'
+		});
+		expect(decideFleetRouting('cloud', snapshot)).toEqual({ target: 'cloud', mode: 'cloud' });
+	});
+
+	it('no-eligible-runners needs the fleet to be non-empty; total<=0 alone stays no-runners', () => {
+		expect(decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0 }).fallbackReason).toBe(
+			'no-runners'
+		);
+		expect(
+			decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0, fleetTotal: 0 }).fallbackReason
+		).toBe('no-runners');
+		expect(
+			decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0, fleetTotal: 1 }).fallbackReason
+		).toBe('no-eligible-runners');
+		// A negative eligible total with a live fleet is still "none could take it".
+		expect(
+			decideFleetRouting('local-fallback', { total: -1, online: 0, free: 0, fleetTotal: 1 }).fallbackReason
+		).toBe('no-eligible-runners');
+	});
+
+	it('every reason the rule can emit is in FLEET_FALLBACK_REASONS, which has five unique members', () => {
+		expect(new Set(FLEET_FALLBACK_REASONS).size).toBe(5);
+		const emitted = new Set(
+			[
+				decideFleetRouting('local-fallback', NONE),
+				decideFleetRouting('local-fallback', ALL_OFFLINE),
+				decideFleetRouting('local-fallback', ALL_BUSY),
+				decideFleetRouting('local-fallback', { total: 0, online: 0, free: 0, fleetTotal: 1 }),
+				decideFleetRouting('local-fallback', { total: 1, online: 0, free: 0, pinnedNodeId: PINNED })
+			].map((decision) => decision.fallbackReason)
+		);
+		expect([...emitted].sort()).toEqual([...FLEET_FALLBACK_REASONS].sort());
 	});
 });

--- a/packages/contracts/src/fleet/__tests__/fleet-jobs.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-jobs.spec.ts
@@ -4,6 +4,7 @@ import { INBOX_MAX_BODY_CHARS, INBOX_MAX_TITLE_CHARS } from '../../inbox/inbox.t
 import {
 	clampLeaseTtlSec,
 	clampMaxAttempts,
+	clampQueuedMaxAgeSec,
 	FLEET_AGENT_TASK_MAX_STEPS,
 	FLEET_AGENT_TASK_META_DIR,
 	FLEET_AGENT_TASK_QUESTION_FILE,
@@ -15,21 +16,26 @@ import {
 	FLEET_JOB_ACTIVE_STATUSES,
 	FLEET_JOB_DEFAULT_LEASE_TTL_SEC,
 	FLEET_JOB_DEFAULT_MAX_ATTEMPTS,
+	FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC,
 	FLEET_JOB_KINDS,
 	FLEET_JOB_MAX_ATTEMPTS_CEILING,
 	FLEET_JOB_MAX_ERROR_LENGTH,
 	FLEET_JOB_MAX_LEASE_BATCH,
 	FLEET_JOB_MAX_LEASE_TTL_SEC,
 	FLEET_JOB_MAX_PAYLOAD_BYTES,
+	FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC,
 	FLEET_JOB_MAX_REQUIRED_CAPABILITIES,
 	FLEET_JOB_MAX_RESULT_BYTES,
 	FLEET_JOB_MIN_LEASE_TTL_SEC,
+	FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC,
+	FLEET_JOB_QUEUE_EXPIRED_REASON,
 	FLEET_JOB_STATUSES,
 	FLEET_JOB_TERMINAL_STATUSES,
 	isFleetJobActive,
 	isFleetJobKind,
 	isFleetJobTerminal,
 	isNodeBusy,
+	isQueueExpiredError,
 	nodeSatisfiesCapabilities,
 	normalizeFleetAgentTaskQuestion,
 	parseFleetAgentTaskQuestionMarkdown,
@@ -844,5 +850,81 @@ describe('normalizeFleetAgentTaskQuestion (self-build slice Q)', () => {
 			mountDir: 'template'
 		});
 		expect(normalizeFleetAgentTaskQuestion(once)).toEqual(once);
+	});
+});
+
+describe('clampQueuedMaxAgeSec (queue SLA, self-build slice S)', () => {
+	it('defaults per kind: a day for agent-task, two hours for the checks', () => {
+		expect(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC).toEqual({
+			'agent-task': 86_400,
+			'acceptance-checks': 7_200,
+			'browser-check': 7_200
+		});
+		for (const kind of FLEET_JOB_KINDS) {
+			expect(clampQueuedMaxAgeSec(kind)).toBe(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC[kind]);
+			expect(clampQueuedMaxAgeSec(kind, undefined)).toBe(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC[kind]);
+		}
+	});
+
+	it('covers every kind — a new kind without a default would be a compile error, not a silent "forever"', () => {
+		expect(Object.keys(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC).sort()).toEqual([...FLEET_JOB_KINDS].sort());
+		expect(Object.isFrozen(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC)).toBe(true);
+	});
+
+	it('orders the bounds min < every default <= max', () => {
+		expect(FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC).toBe(60);
+		expect(FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC).toBe(7 * 86_400);
+		for (const value of Object.values(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC)) {
+			expect(value).toBeGreaterThan(FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC);
+			expect(value).toBeLessThanOrEqual(FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC);
+		}
+	});
+
+	it.each([
+		['null', null],
+		['a numeric string', '3600'],
+		['NaN', Number.NaN],
+		['Infinity', Number.POSITIVE_INFINITY],
+		['zero', 0],
+		['a negative number', -5],
+		['an object', { seconds: 60 }]
+	] as Array<[string, unknown]>)(
+		'falls back to the kind default for %s (fail closed — never "disabled")',
+		(_label, value) => {
+			expect(clampQueuedMaxAgeSec('agent-task', value)).toBe(86_400);
+			expect(clampQueuedMaxAgeSec('browser-check', value)).toBe(7_200);
+		}
+	);
+
+	it('clamps into [min, max] and rounds', () => {
+		expect(clampQueuedMaxAgeSec('agent-task', 1)).toBe(FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC);
+		expect(clampQueuedMaxAgeSec('agent-task', 59.4)).toBe(FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC);
+		expect(clampQueuedMaxAgeSec('agent-task', 90.6)).toBe(91);
+		expect(clampQueuedMaxAgeSec('agent-task', 10 ** 9)).toBe(FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC);
+		expect(clampQueuedMaxAgeSec('acceptance-checks', 3_600)).toBe(3_600);
+	});
+
+	it('uses the SHORTEST default for an unknown kind (fail closed)', () => {
+		expect(clampQueuedMaxAgeSec('teleport' as unknown as FleetJobKind)).toBe(7_200);
+	});
+});
+
+describe('FLEET_JOB_QUEUE_EXPIRED_REASON / isQueueExpiredError', () => {
+	it('is a short machine token, never free text', () => {
+		expect(FLEET_JOB_QUEUE_EXPIRED_REASON).toBe('queued-max-age-exceeded');
+		expect(FLEET_JOB_QUEUE_EXPIRED_REASON).toMatch(/^[a-z-]+$/);
+		expect(FLEET_JOB_QUEUE_EXPIRED_REASON.length).toBeLessThanOrEqual(64);
+	});
+
+	it('matches the stored prefix form and nothing else', () => {
+		expect(isQueueExpiredError(FLEET_JOB_QUEUE_EXPIRED_REASON)).toBe(true);
+		expect(
+			isQueueExpiredError(`${FLEET_JOB_QUEUE_EXPIRED_REASON}: no eligible runner took the job within 24h`)
+		).toBe(true);
+		expect(isQueueExpiredError('Lease expired 3 time(s) without a result')).toBe(false);
+		expect(isQueueExpiredError(` ${FLEET_JOB_QUEUE_EXPIRED_REASON}`)).toBe(false);
+		expect(isQueueExpiredError('')).toBe(false);
+		expect(isQueueExpiredError(null)).toBe(false);
+		expect(isQueueExpiredError(undefined)).toBe(false);
 	});
 });

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -32,7 +32,8 @@ const EXECUTION_PREFERENCE_EXPORTS = [
 	'FLEET_EXECUTION_SCOPE_TYPES',
 	'QUEUED_REASON_WAITING_FOR_RUNNER',
 	'resolveFleetExecutionMode',
-	'decideFleetRouting'
+	'decideFleetRouting',
+	'FLEET_FALLBACK_REASONS'
 ] as const;
 
 const JOB_EXPORTS = [
@@ -59,7 +60,13 @@ const JOB_EXPORTS = [
 	'clampMaxAttempts',
 	'nodeSatisfiesCapabilities',
 	'FLEET_AGENT_TASK_MAX_STEPS',
-	'isNodeBusy'
+	'isNodeBusy',
+	'FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC',
+	'FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC',
+	'FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC',
+	'clampQueuedMaxAgeSec',
+	'FLEET_JOB_QUEUE_EXPIRED_REASON',
+	'isQueueExpiredError'
 ] as const;
 
 const NODE_EXPORTS = [
@@ -159,6 +166,8 @@ const FUNCTION_EXPORTS = [
 	'isFleetJobKind',
 	'clampLeaseTtlSec',
 	'clampMaxAttempts',
+	'clampQueuedMaxAgeSec',
+	'isQueueExpiredError',
 	'nodeSatisfiesCapabilities',
 	'isNodeBusy',
 	'isFleetEnrollableNodeKind',
@@ -188,12 +197,12 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 92 runtime symbols', () => {
+	it('exposes exactly these 99 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(92);
+		expect(Object.keys(fleet)).toHaveLength(99);
 	});
 
 	it.each([

--- a/packages/contracts/src/fleet/fleet-execution-preference.types.ts
+++ b/packages/contracts/src/fleet/fleet-execution-preference.types.ts
@@ -147,14 +147,41 @@ export function resolveFleetExecutionMode(
  */
 export type FleetRunTarget = 'fleet' | 'fleet-waiting' | 'cloud';
 
-/** Why a run that asked for the fleet ended up somewhere else. */
+/**
+ * Why a run that asked for the fleet ended up somewhere else.
+ *
+ * The first three describe the owner's fleet as a whole. The last two
+ * exist because a job is not judged against the whole fleet (self-build
+ * slice S / EW-775): an `agent-task` may be PINNED to one node by an
+ * Agent affinity, and every job carries capability tags. Availability is
+ * computed over the ELIGIBLE set — the nodes that could actually take
+ * this job — so five idle siblings can no longer make a job pinned to a
+ * closed laptop look placeable.
+ */
 export type FleetFallbackReason =
 	/** No enrolled runner at all. */
 	| 'no-runners'
 	/** Runners exist, but none is online. */
 	| 'runners-offline'
 	/** Every online runner is already holding work. */
-	| 'runners-busy';
+	| 'runners-busy'
+	/**
+	 * Runners are enrolled, but none could take THIS job: the Agent is
+	 * pinned to a node that is no longer enrolled, or no node advertises
+	 * the capability tags the job requires.
+	 */
+	| 'no-eligible-runners'
+	/** The Agent is pinned to one node and that node is not online. */
+	| 'pinned-runner-offline';
+
+/** Canonical fallback-reason list — one source of truth for notices, sanitizers and tests. */
+export const FLEET_FALLBACK_REASONS: readonly FleetFallbackReason[] = [
+	'no-runners',
+	'runners-offline',
+	'runners-busy',
+	'no-eligible-runners',
+	'pinned-runner-offline'
+];
 
 /** The router's verdict for one dispatch. */
 export interface FleetRunRoutingDecision {
@@ -170,18 +197,44 @@ export interface FleetRunRoutingDecision {
 	 * guessed count in a stored notification is worse than none.
 	 */
 	runnerCount?: number;
+	/**
+	 * Every enrolled runner the owner had, when {@link runnerCount} was
+	 * computed over an eligible subset. Set alongside {@link fallbackReason}
+	 * only when the availability snapshot carried `fleetTotal`; equal to
+	 * `runnerCount` when the counts were already fleet-wide.
+	 */
+	fleetRunnerCount?: number;
+	/** The node the job was pinned to, when the decision was taken against one. Fallback decisions only. */
+	pinnedNodeId?: string;
 	/** Set only when `target === 'fleet-waiting'`. */
 	queuedReason?: typeof QUEUED_REASON_WAITING_FOR_RUNNER;
 }
 
-/** Snapshot of runner availability the routing rule reads. */
+/**
+ * Snapshot of runner availability the routing rule reads.
+ *
+ * The three counts describe the runners that could take THE JOB BEING
+ * ROUTED. With no eligibility filter that is the whole fleet, and the
+ * shape is exactly the three-field one it always was. When the caller
+ * narrowed the set — an Agent affinity pins the job to one node, or the
+ * job requires capability tags — the counts are over that subset and
+ * `fleetTotal` / `pinnedNodeId` say so, which is what lets the fallback
+ * reason and the stored notice be precise instead of "1 of 6 offline".
+ */
 export interface FleetRunnerAvailability {
-	/** Enrolled runners this owner has. */
+	/** Eligible runners this owner has (every enrolled runner when unfiltered). */
 	total: number;
 	/** Of those, currently online. */
 	online: number;
 	/** Online runners with no live job claim. */
 	free: number;
+	/**
+	 * Every enrolled runner the owner has, regardless of eligibility.
+	 * Absent when the counts above are already fleet-wide.
+	 */
+	fleetTotal?: number;
+	/** The node the job is pinned to, when an affinity narrowed the set to one. */
+	pinnedNodeId?: string | null;
 }
 
 /**
@@ -201,8 +254,7 @@ export function decideFleetRouting(
 	if (availability.free > 0) {
 		return { target: 'fleet', mode };
 	}
-	const fallbackReason: FleetFallbackReason =
-		availability.total <= 0 ? 'no-runners' : availability.online <= 0 ? 'runners-offline' : 'runners-busy';
+	const fallbackReason = classifyFallback(availability);
 	if (mode === 'local-wait') {
 		// The whole point of the mode: hold the work for the machine that
 		// is supposed to run it, and make the waiting visible instead of
@@ -210,5 +262,41 @@ export function decideFleetRouting(
 		// executes.
 		return { target: 'fleet-waiting', mode, queuedReason: QUEUED_REASON_WAITING_FOR_RUNNER };
 	}
-	return { target: 'cloud', mode, fallbackReason, runnerCount: availability.total };
+	const decision: FleetRunRoutingDecision = {
+		target: 'cloud',
+		mode,
+		fallbackReason,
+		runnerCount: availability.total
+	};
+	// Only echoed when the snapshot carried them, so an unfiltered
+	// (fleet-wide) snapshot yields exactly the decision it always did.
+	if (typeof availability.fleetTotal === 'number') {
+		decision.fleetRunnerCount = availability.fleetTotal;
+	}
+	if (availability.pinnedNodeId) {
+		decision.pinnedNodeId = availability.pinnedNodeId;
+	}
+	return decision;
+}
+
+/**
+ * Name the reason nothing could take the job. Precedence is the original
+ * one (`total`, then `online`, then busy) with the two eligibility-aware
+ * refinements slotted in where they are the more precise statement:
+ *
+ *   - no eligible runner while the fleet has runners at all is
+ *     `no-eligible-runners`, not `no-runners` — "enrol a machine" would be
+ *     the wrong advice for an owner with six of them;
+ *   - the eligible set being exactly the pinned node, and it being down,
+ *     is `pinned-runner-offline` — the actionable fact is WHICH machine.
+ */
+function classifyFallback(availability: FleetRunnerAvailability): FleetFallbackReason {
+	const fleetTotal = typeof availability.fleetTotal === 'number' ? availability.fleetTotal : availability.total;
+	if (availability.total <= 0) {
+		return fleetTotal > 0 ? 'no-eligible-runners' : 'no-runners';
+	}
+	if (availability.online <= 0) {
+		return availability.pinnedNodeId ? 'pinned-runner-offline' : 'runners-offline';
+	}
+	return 'runners-busy';
 }

--- a/packages/contracts/src/fleet/fleet-jobs.types.ts
+++ b/packages/contracts/src/fleet/fleet-jobs.types.ts
@@ -168,6 +168,66 @@ export function clampMaxAttempts(value: unknown): number {
 }
 
 /**
+ * Queue SLA (self-build slice S / EW-775) — the longest a `queued` job
+ * may wait for an eligible runner before the platform FAILS it.
+ *
+ * Nothing used to bound a queued row's age: the reclaim sweep only scans
+ * ACTIVE statuses, so a job pinned to a node that never came back, or
+ * requiring a tag no node advertises, sat `queued` forever with its
+ * AgentRun waiting on a verdict that was never coming. The SLA is the
+ * backstop behind eligibility-aware routing: routing stops the common
+ * case from being enqueued at all, and the SLA settles whatever slips
+ * past it (a runner that went offline between the decision and the
+ * lease, a `local-wait` job whose machine never returns).
+ *
+ * Per kind, because the honest wait differs: an `agent-task` under
+ * `local-wait` is deliberately held for one machine and a day is a
+ * plausible wait for a closed laptop; a check that has not run in two
+ * hours is stale evidence. Deliberately NOT disableable — the floor and
+ * ceiling below clamp any operator value, and "unset" means the kind's
+ * default, never "wait forever". A tenant that genuinely wants longer
+ * raises `FLEET_NODE_QUEUE_MAX_AGE_SECONDS[_<KIND>]` up to the ceiling.
+ */
+export const FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC: Readonly<Record<FleetJobKind, number>> = Object.freeze({
+	'agent-task': 24 * 60 * 60,
+	'acceptance-checks': 2 * 60 * 60,
+	'browser-check': 2 * 60 * 60
+});
+
+/** Floor/ceiling clamps applied to any operator-supplied queued max age. */
+export const FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC = 60;
+export const FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC = 7 * 24 * 60 * 60;
+
+/**
+ * Clamp an operator-supplied queued max age for `kind` into the supported
+ * range. Unset / NaN / non-positive is the kind's default (fail closed:
+ * a typo in the deploy manifest must not turn into an unbounded wait);
+ * an unknown kind gets the SHORTEST default, for the same reason.
+ */
+export function clampQueuedMaxAgeSec(kind: FleetJobKind, value?: unknown): number {
+	const fallback =
+		FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC[kind] ?? Math.min(...Object.values(FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC));
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+		return fallback;
+	}
+	return Math.min(Math.max(Math.round(value), FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC), FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC);
+}
+
+/**
+ * Stable machine-readable token a queue-SLA failure is recorded under.
+ * It is the PREFIX of `fleet_jobs.error` (and, through the reconciler, of
+ * `agent_runs.failureReason`), followed by a human sentence — the same
+ * discipline the stuck-run sweeper's prefix follows, so a UI can switch
+ * on it and a log search can find every occurrence.
+ */
+export const FLEET_JOB_QUEUE_EXPIRED_REASON = 'queued-max-age-exceeded';
+
+/** True when a job / run error was written by the queue SLA. */
+export function isQueueExpiredError(error: string | null | undefined): boolean {
+	return typeof error === 'string' && error.startsWith(FLEET_JOB_QUEUE_EXPIRED_REASON);
+}
+
+/**
  * Capability-tag filter: a node may only lease a job whose every
  * required tag is present in the node's own advertised capability set.
  *
@@ -206,6 +266,16 @@ export interface FleetJobView {
 	createdAt: string | null;
 	startedAt: string | null;
 	completedAt: string | null;
+	/**
+	 * ISO timestamp the row last ENTERED `queued`: set at enqueue, reset
+	 * when a lapsed or drained claim returns to the pool, untouched by a
+	 * heartbeat promotion. The queue SLA (`FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC`)
+	 * is measured from it. Null on rows written before the column existed
+	 * — an unknown age is never destructively failed.
+	 *
+	 * Optional on the wire so an older API build still satisfies this type.
+	 */
+	queuedAt?: string | null;
 	/**
 	 * Why a `queued` job has not started — today only
 	 * `waiting-for-runner` (see `QUEUED_REASON_WAITING_FOR_RUNNER`),

--- a/packages/tasks/src/tasks/trigger/fleet-job-lease-sweeper.task.ts
+++ b/packages/tasks/src/tasks/trigger/fleet-job-lease-sweeper.task.ts
@@ -24,6 +24,13 @@ import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-inte
  * laptop slept and the build moved to the desktop". Cron offset off the
  * minute boundary per the sweeper-family rationale (see
  * agent-run-sweeper) so it does not collide with the per-minute crons.
+ *
+ * The same tick runs the QUEUE SLA (`expireQueued`, self-build slice S):
+ * a job no eligible runner took within its kind's max queued age is
+ * failed with a stable reason so its run settles. Like reclaim it also
+ * runs inline on the lease path, and like reclaim this cron is the only
+ * path that reaches an owner whose every runner is offline — which is
+ * exactly the fleet a job pinned to a closed laptop is waiting on.
  */
 export const fleetJobLeaseSweeperTask = schedules.task({
     id: 'fleet-job-lease-sweeper',
@@ -47,7 +54,22 @@ export const fleetJobLeaseSweeperTask = schedules.task({
                         scanned: summary.scanned,
                     });
                 }
-                return { status: 'completed' as const, ...summary };
+                // Global, like the reclaim above (no userId). The method
+                // is on `FleetJobService`'s prototype, so the internal
+                // RPC allow-list already admits it.
+                const expiry = await svc.expireQueued();
+                if (expiry.expired > 0) {
+                    logger.warn('fleet-job-lease-sweeper failed queued jobs past their max age', {
+                        expired: expiry.expired,
+                        scanned: expiry.scanned,
+                    });
+                }
+                return {
+                    status: 'completed' as const,
+                    ...summary,
+                    queueScanned: expiry.scanned,
+                    queueExpired: expiry.expired,
+                };
             },
             TriggerInternalModule,
         );


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **S** (program note §6, findings R5 / R6 / OPS-03). Refs **EW-775**. Depends on B and E, both merged.

`decideFleetRouting` judged a fleet-wide `{ total, online, free }` while `FleetJobService.enqueue` pinned the job to one node through agent affinity. With an agent pinned to an offline PC, the five idle machines made `free > 0`, the decision was `fleet`, `local-fallback` never fired, and the job sat queued forever with `queuedReason` null.

### What changes

- **Router over the eligible set.** `FleetRunnerStatusService.availability(userId, eligibility)` counts only nodes that could take *this* job (affinity pin + required capability tags — the same two rules the lease applies). `decideFleetRouting` therefore sees the eligible set; new fallback reasons `no-eligible-runners` and `pinned-runner-offline`; the fallback notice carries the precise runner count and the pinned node. `resolveAgentTaskTarget` finally has a caller outside its spec.
- **Queued-job SLA.** `fleet_jobs.queued_at` (migration `1788200000000-AddFleetJobQueuedAt`: nullable timestamp, backfilled from `created_at` for queued rows, `(status, queued_at)` index, full down) plus a per-kind max queued age in config. `expireQueued` fails an over-age job with the stable reason `queued-max-age-exceeded` through a CAS pinned to `status = 'queued' AND cancel_requested_at IS NULL AND queued_at < cutoff`, emits `fleet.job.completed` so the run settles, and the reconciler marks the run failed and files **exactly one** Inbox notice. Runs inline on the lease path and from the lease sweeper task.
- **Promote-on-online.** An accepted heartbeat that leaves the node online clears `waiting-for-runner` on queued jobs that node is eligible for (conditional UPDATE pinned on status + reason; never touches status or `queued_at`, so the SLA still bounds a node that never leases).
- **e2e** `apps/web/e2e/flow-fleet-runner-pill.spec.ts` written for the routing pill — type-checked and prettier-checked only.

### Adversarial review (fixed before this PR)

- The expiry CAS pinned `queued_at` by **equality** against the Date read back. A backfilled `queued_at = created_at` comes from the database clock (microseconds on Postgres, whole seconds on sqlite) and never round-trips through a JS Date exactly, so every backfilled stuck row — the rows the SLA exists for — would have stayed queued forever. Now pins `queued_at < cutoff`; every race guarantee is kept (claim changes status; reclaim/drain re-stamp `queued_at` to now; cancel changes status or sets `cancel_requested_at`).
- Double-fire impossible (event only on `affected === 1`); promotion vs concurrent claim safe in both orders; notice once (`toHaveBeenCalledTimes(1)` asserted).

### Verified locally

- `tsc --noEmit`: `apps/api` (build tsconfig) 0, `packages/contracts` src + speccheck 0, `packages/tasks` 0; `packages/agent` only pre-existing errors in untouched files (`@ever-works/agent-plugins`, `isomorphic-git`, `undici` not linked in this worktree; identical in a clean worktree).
- Specs: `packages/contracts` 4 files / 474 tests; `packages/agent` fleet + notifications + events + entities 35 suites / 590 tests; `apps/api` `src/fleet/` 11 suites / 202 tests (two suites need the same `@ever-works/agent-plugins` source mapper `packages/agent/jest.config.js` already carries; CI has the built package), `migrations-directory-contract` + `AddFleetJobQueuedAt` green.
- `prettier --check` on all 35 changed files: clean.

### Not verified locally

- The Playwright spec (stage-only gate).
- The migration against a real Postgres (unit spec + better-sqlite3 only).
- Full monorepo suites (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
