### PR TITLE
feat(fleet): owner drain-all, global stop flag, cancel-in-flight (EW-778)

### DIFF
--- a/apps/api/src/agents/agents.module.spec.ts
+++ b/apps/api/src/agents/agents.module.spec.ts
@@ -40,6 +40,8 @@ jest.mock('@ever-works/agent/agents', () => ({
     AGENT_MCP_TOOL_SOURCE: 'AGENT_MCP_TOOL_SOURCE',
     // Skill files (#2080) — the uploads-spine content-reader seam.
     SKILL_FILE_CONTENT_READER: 'SKILL_FILE_CONTENT_READER',
+    // Panic controls (EW-778) — the global stop flag seam.
+    RUN_KILL_SWITCH: 'RUN_KILL_SWITCH',
 }));
 jest.mock('@ever-works/agent/mcp', () => ({
     McpModule: class McpModule {},
@@ -90,6 +92,8 @@ jest.mock('@ever-works/agent/meetings', () => ({
 jest.mock('@ever-works/agent/fleet', () => ({
     FleetModule: class FleetModule {},
     FleetService: class FleetService {},
+    FleetJobService: class FleetJobService {},
+    FleetKillSwitchService: class FleetKillSwitchService {},
 }));
 jest.mock('@ever-works/agent/pr-review', () => ({
     PrReviewModule: class PrReviewModule {},
@@ -273,6 +277,22 @@ describe('api-side AgentsModule — domain chat-tool wiring', () => {
         );
         expect(provider).toBeDefined();
         expect(meta('exports')).toContain('SKILL_FILE_CONTENT_READER');
+    });
+
+    /**
+     * Panic controls (EW-778) — the dispatch gate reads the GLOBAL STOP
+     * FLAG through `@Optional() @Inject(RUN_KILL_SWITCH)`. Unbound, or
+     * bound but not exported from this @Global() module, it resolves to
+     * `undefined` and every new run sails through a set flag: the switch
+     * would exist, be flipped, be audited — and stop nothing.
+     */
+    it('binds + exports RUN_KILL_SWITCH to the fleet kill-switch service', () => {
+        const provider = (
+            meta('providers') as Array<{ provide?: unknown; useExisting?: unknown }>
+        ).find((p) => p && typeof p === 'object' && p.provide === 'RUN_KILL_SWITCH');
+        expect(provider).toBeDefined();
+        expect((provider?.useExisting as { name?: string })?.name).toBe('FleetKillSwitchService');
+        expect(meta('exports')).toContain('RUN_KILL_SWITCH');
     });
 
     it('binds all three Task membership repositories (the commentOnTask gate is fail-closed)', () => {

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -14,6 +14,7 @@ import {
     AGENT_DOMAIN_TOOL_SOURCES,
     AGENT_MCP_TOOL_SOURCE,
     SKILL_FILE_CONTENT_READER,
+    RUN_KILL_SWITCH,
     AgentEscalationService,
     RunSteeringService,
     WorkflowGraphExecutorService,
@@ -77,7 +78,12 @@ import {
 import { EventIngestModule, IngestedEventRepository } from '@ever-works/agent/ingest';
 import { DigestModule, DigestService } from '@ever-works/agent/digest';
 import { MeetingsModule, MeetingRepository } from '@ever-works/agent/meetings';
-import { FleetJobService, FleetModule, FleetService } from '@ever-works/agent/fleet';
+import {
+    FleetJobService,
+    FleetKillSwitchService,
+    FleetModule,
+    FleetService,
+} from '@ever-works/agent/fleet';
 import { createFleetAwareAgentRunCanceller } from '../fleet/fleet-agent-run-canceller';
 import { PrReviewModule, PrReviewService } from '@ever-works/agent/pr-review';
 import {
@@ -264,6 +270,15 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         // TasksDomainModule, and neither package gains a runtime import of
         // the other.
         { provide: RUN_STEERING_PORT, useExisting: RunSteeringService },
+        // Panic controls (EW-778) — bind the GLOBAL STOP FLAG port the
+        // dispatch gate consults. Same @Global() reasoning as
+        // RUN_CREDITS_PRECHECK in SubscriptionsModule: the gate lives in
+        // the agent-side AgentsModule and reads this token through an
+        // @Optional() @Inject(), which would silently resolve to undefined
+        // — and leave the stop flag dark for every new run — if this
+        // binding were not global AND exported. `FleetModule` (imported
+        // above) exports FleetKillSwitchService.
+        { provide: RUN_KILL_SWITCH, useExisting: FleetKillSwitchService },
         // Streaming terminal — the two halves of the session dispatch.
         //
         // TERMINAL_SESSION_DISPATCHER is the job-runtime producer for the
@@ -938,6 +953,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         RUN_STEERING_PORT,
         TERMINAL_SESSION_DISPATCHER,
         TERMINAL_SESSION_STARTER,
+        RUN_KILL_SWITCH,
     ],
 })
 export class AgentsModule {}

--- a/apps/api/src/fleet/__tests__/fleet-kill-switch-routing.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-kill-switch-routing.spec.ts
@@ -1,0 +1,264 @@
+import type {
+    AgentTaskExecuteDispatcher,
+    AgentTaskExecuteDispatchPayload,
+} from '@ever-works/agent/tasks-domain';
+import { FleetKillSwitchService } from '@ever-works/agent/fleet';
+import { NodeDispatcherFactory, NodeJobRuntimePlugin } from '@ever-works/job-runtime-node-plugin';
+import { createFleetAwareAgentTaskExecuteDispatcher } from '../fleet-agent-task.dispatcher';
+import { FleetKillSwitchActiveError } from '../fleet-kill-switch.error';
+import { FleetRunRouterService } from '../fleet-run-router.service';
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG on the routing seam.
+ *
+ * The routing wrapper has a documented fallback: a routing decision that
+ * THROWS is sent to the platform (cloud) dispatcher. That is exactly
+ * what a stop must never become. So the load-bearing assertions here
+ * are the negative ones — `delegate.enqueue` and the fleet store are
+ * NEVER called while the flag is set, whether the flag was read by the
+ * wrapper, by the router, or could not be read at all.
+ *
+ * The end-to-end half (through `TaskTransitionService.dispatchAgentRun`,
+ * the run row ends `dispatch-failed`) lives in
+ * `fleet-kill-switch-transition.spec.ts`, which loads the tasks domain.
+ */
+
+function payload(
+    overrides: Partial<AgentTaskExecuteDispatchPayload> = {},
+): AgentTaskExecuteDispatchPayload {
+    return {
+        agentId: 'agent-1',
+        userId: 'user-1',
+        taskId: 'task-1',
+        dedupKey: 'task-1:agent-1:1',
+        runId: 'run-1',
+        tenantId: null,
+        organizationId: null,
+        ...overrides,
+    };
+}
+
+describe('fleet routing under the global stop flag (EW-778)', () => {
+    const originalEnv = process.env;
+
+    let store: { enqueue: jest.Mock; findById: jest.Mock };
+    let delegate: AgentTaskExecuteDispatcher & { enqueue: jest.Mock };
+    let killSwitch: { isStopped: jest.Mock };
+
+    const buildRouter = (routerSwitch?: unknown): FleetRunRouterService => {
+        const factory = new NodeDispatcherFactory({ store });
+        const plugin = new NodeJobRuntimePlugin().useDispatcherFactory(factory);
+        // The switch is the SEVENTH positional argument (appended LAST, after slice S's `jobs`).
+        return new FleetRunRouterService(
+            factory,
+            plugin,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            routerSwitch as never,
+        );
+    };
+
+    /** The real kill-switch service over a repository that cannot read the row. */
+    const unreadableSwitch = (): FleetKillSwitchService => {
+        const service = new FleetKillSwitchService(
+            { read: jest.fn(async () => Promise.reject(new Error('db down'))) } as never,
+            { record: jest.fn() } as never,
+        );
+        jest.spyOn(
+            (service as never as { logger: { error: () => void } }).logger,
+            'error',
+        ).mockImplementation(() => undefined);
+        return service;
+    };
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.EVER_WORKS_JOB_RUNTIME;
+        delete process.env.FLEET_NODE_RUNTIME_ENABLED;
+        delete process.env.FLEET_NODE_AGENT_TASK_COMMAND;
+        store = {
+            enqueue: jest.fn(async () => ({
+                id: 'fleet-job-1',
+                kind: 'agent-task',
+                status: 'queued',
+                nodeId: null,
+                requiredCapabilities: [],
+                payload: null,
+                leaseExpiresAt: null,
+                attempts: 0,
+                maxAttempts: 3,
+                createdAt: null,
+                startedAt: null,
+                completedAt: null,
+            })),
+            findById: jest.fn(async () => null),
+        };
+        delegate = { enqueue: jest.fn(async () => ({ runId: 'trigger-run-1' })) };
+        killSwitch = { isStopped: jest.fn(async () => false) };
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    /**
+     * The dispatch gate (packages/agent) cannot import this error class;
+     * it recognises a dispatcher that refused on the stop flag by
+     * `Error.name` (`KILL_SWITCH_ACTIVE_ERROR_NAME` in
+     * `packages/agent/src/agents/run-kill-switch.ts`) and RE-PARKS the run
+     * instead of failing it. The literal is pinned on BOTH sides — here and
+     * in `run-dispatch-gate.kill-switch.spec.ts` — rather than imported
+     * across the agents barrel, which drags the facades chain into this
+     * deliberately light suite.
+     */
+    describe('FleetKillSwitchActiveError', () => {
+        it('carries the Error.name the dispatch gate re-parks on', () => {
+            const error = new FleetKillSwitchActiveError('task-1');
+            expect(error.name).toBe('FleetKillSwitchActiveError');
+            expect(error).toBeInstanceOf(Error);
+            expect(error.taskId).toBe('task-1');
+        });
+    });
+
+    describe('FleetRunRouterService', () => {
+        it('routes as before while the flag is clear', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+            const decision = await buildRouter(killSwitch).routeAgentTask(payload());
+            expect(decision.target).toBe('fleet');
+        });
+
+        it('refuses to route with the typed error while the flag is set — even a cloud-bound tenant', async () => {
+            killSwitch.isStopped.mockResolvedValue(true);
+            // No fleet runtime selected: the ordinary answer would be `cloud`.
+            await expect(buildRouter(killSwitch).routeAgentTask(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+        });
+
+        it('refuses to enqueue directly while the flag is set', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+            killSwitch.isStopped.mockResolvedValue(true);
+            await expect(
+                buildRouter(killSwitch).enqueueAgentTask(payload()),
+            ).rejects.toBeInstanceOf(FleetKillSwitchActiveError);
+            expect(store.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('refuses (fail-closed) when the flag CANNOT be read', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+            await expect(
+                buildRouter(unreadableSwitch()).routeAgentTask(payload()),
+            ).rejects.toBeInstanceOf(FleetKillSwitchActiveError);
+        });
+
+        it('refuses (fail-closed) when the switch itself throws', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+            killSwitch.isStopped.mockRejectedValue(new Error('boom'));
+            await expect(buildRouter(killSwitch).routeAgentTask(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+        });
+
+        it('routes as before with no switch bound (positional-arity compatibility)', async () => {
+            process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+            const decision = await buildRouter(undefined).routeAgentTask(payload());
+            expect(decision.target).toBe('fleet');
+        });
+    });
+
+    describe('fleet-aware dispatcher (the cloud-fallback seam)', () => {
+        /**
+         * THE load-bearing test. The wrapper's routing catch sends a
+         * throwing decision to the cloud. Revert-check: remove either the
+         * pre-routing check or the `isFleetKillSwitchActiveError` rethrow
+         * and one of these goes RED.
+         */
+        it('never falls back to the platform dispatcher while the flag is set (read by the wrapper)', async () => {
+            killSwitch.isStopped.mockResolvedValue(true);
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(
+                delegate,
+                buildRouter(undefined),
+                { killSwitch },
+            );
+            await expect(dispatcher.enqueue(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+            expect(delegate.enqueue).not.toHaveBeenCalled();
+            expect(store.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('never falls back to the platform dispatcher while the flag is set (read by the router)', async () => {
+            killSwitch.isStopped.mockResolvedValue(true);
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(
+                delegate,
+                buildRouter(killSwitch),
+                {},
+            );
+            await expect(dispatcher.enqueue(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+            expect(delegate.enqueue).not.toHaveBeenCalled();
+            expect(store.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('refuses (fail-closed) when the flag cannot be read, and still never falls back', async () => {
+            const unreadable = unreadableSwitch();
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(
+                delegate,
+                buildRouter(unreadable),
+                { killSwitch: unreadable },
+            );
+            await expect(dispatcher.enqueue(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+            expect(delegate.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('refuses (fail-closed) when the wrapper-side switch throws', async () => {
+            killSwitch.isStopped.mockRejectedValue(new Error('boom'));
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(
+                delegate,
+                buildRouter(undefined),
+                { killSwitch },
+            );
+            await expect(dispatcher.enqueue(payload())).rejects.toBeInstanceOf(
+                FleetKillSwitchActiveError,
+            );
+            expect(delegate.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('dispatches to the cloud as before while the flag is clear', async () => {
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(
+                delegate,
+                buildRouter(killSwitch),
+                { killSwitch },
+            );
+            await expect(dispatcher.enqueue(payload())).resolves.toEqual({
+                runId: 'trigger-run-1',
+            });
+            expect(delegate.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('still treats an ORDINARY routing failure as a cloud fallback', async () => {
+            const overlay = { findOne: jest.fn().mockRejectedValue(new Error('db down')) };
+            const factory = new NodeDispatcherFactory({ store });
+            const plugin = new NodeJobRuntimePlugin().useDispatcherFactory(factory);
+            const router = new FleetRunRouterService(
+                factory,
+                plugin,
+                overlay as never,
+                undefined,
+                undefined,
+                undefined,
+                killSwitch as never,
+            );
+            const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(delegate, router, {
+                killSwitch,
+            });
+            await dispatcher.enqueue(payload({ tenantId: 'tenant-1' }));
+            expect(delegate.enqueue).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/apps/api/src/fleet/__tests__/fleet-kill-switch-transition.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-kill-switch-transition.spec.ts
@@ -1,0 +1,152 @@
+import type { AgentTaskExecuteDispatcher } from '@ever-works/agent/tasks-domain';
+import { Task, TaskStatus, TaskTransitionService } from '@ever-works/agent/tasks-domain';
+import { NodeDispatcherFactory, NodeJobRuntimePlugin } from '@ever-works/job-runtime-node-plugin';
+import { createFleetAwareAgentTaskExecuteDispatcher } from '../fleet-agent-task.dispatcher';
+import { FleetRunRouterService } from '../fleet-run-router.service';
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG, end to end through
+ * `TaskTransitionService.dispatchAgentRun` (the single implementation
+ * every dispatch enters), the routing wrapper and the router.
+ *
+ * Sibling of `fleet-kill-switch-routing.spec.ts`, split out because
+ * loading the tasks domain drags the whole agent module graph under
+ * Jest; the routing assertions stay runnable without it.
+ *
+ * What is pinned: a dispatch attempted while the flag is set REFUSES —
+ * the run row is marked `dispatch-failed`, nothing reaches the fleet
+ * store, nothing reaches the platform dispatcher, no remote id is
+ * stamped. That is "refuse", not "proceed".
+ */
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+    return {
+        id: 'task-1',
+        userId: 'user-1',
+        slug: 'TSK-1',
+        title: 'Stopped work',
+        status: TaskStatus.IN_PROGRESS,
+        workId: null,
+        tenantId: null,
+        organizationId: null,
+        recurrenceOccurredCount: 0,
+        ...overrides,
+    } as unknown as Task;
+}
+
+describe('dispatchAgentRun under the global stop flag (EW-778)', () => {
+    const originalEnv = process.env;
+
+    let store: { enqueue: jest.Mock; findById: jest.Mock };
+    let delegate: AgentTaskExecuteDispatcher & { enqueue: jest.Mock };
+    let killSwitch: { isStopped: jest.Mock };
+    let runs: {
+        createQueued: jest.Mock;
+        setTriggerRunId: jest.Mock;
+        markDispatchFailed: jest.Mock;
+    };
+
+    const buildRouter = (): FleetRunRouterService => {
+        const factory = new NodeDispatcherFactory({ store });
+        const plugin = new NodeJobRuntimePlugin().useDispatcherFactory(factory);
+        return new FleetRunRouterService(
+            factory,
+            plugin,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            killSwitch as never,
+        );
+    };
+
+    const buildTransition = (dispatcher: AgentTaskExecuteDispatcher): TaskTransitionService =>
+        new TaskTransitionService(
+            { findById: jest.fn() } as never,
+            { findByTaskId: jest.fn().mockResolvedValue([]) } as never,
+            { allApproved: jest.fn().mockResolvedValue(true) } as never,
+            undefined,
+            runs as never,
+            dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+                findByIdAndUser: jest.fn().mockImplementation((id, userId, scope) =>
+                    Promise.resolve({
+                        id,
+                        userId,
+                        tenantId: scope?.tenantId ?? null,
+                        organizationId: scope?.organizationId ?? null,
+                    }),
+                ),
+            } as never,
+        );
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.FLEET_NODE_RUNTIME_ENABLED;
+        delete process.env.FLEET_NODE_AGENT_TASK_COMMAND;
+        process.env.EVER_WORKS_JOB_RUNTIME = 'node';
+        store = {
+            enqueue: jest.fn(async () => ({
+                id: 'fleet-job-1',
+                kind: 'agent-task',
+                status: 'queued',
+                nodeId: null,
+                requiredCapabilities: [],
+                payload: null,
+                leaseExpiresAt: null,
+                attempts: 0,
+                maxAttempts: 3,
+                createdAt: null,
+                startedAt: null,
+                completedAt: null,
+            })),
+            findById: jest.fn(async () => null),
+        };
+        delegate = { enqueue: jest.fn(async () => ({ runId: 'trigger-run-1' })) };
+        killSwitch = { isStopped: jest.fn(async () => false) };
+        runs = {
+            createQueued: jest.fn().mockResolvedValue({ id: 'run-1' }),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('REFUSES: the run is marked dispatch-failed and nothing runs anywhere', async () => {
+        killSwitch.isStopped.mockResolvedValue(true);
+        const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(delegate, buildRouter(), {
+            killSwitch,
+        });
+
+        const result = await buildTransition(dispatcher).dispatchAgentRun(buildTask(), 'agent-1');
+
+        expect(result.dispatched).toBe(false);
+        expect(delegate.enqueue).not.toHaveBeenCalled();
+        expect(store.enqueue).not.toHaveBeenCalled();
+        expect(runs.setTriggerRunId).not.toHaveBeenCalled();
+        expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+            'run-1',
+            expect.stringContaining('global stop flag'),
+        );
+    });
+
+    it('dispatches onto the fleet as before while the flag is clear', async () => {
+        const dispatcher = createFleetAwareAgentTaskExecuteDispatcher(delegate, buildRouter(), {
+            killSwitch,
+        });
+
+        const result = await buildTransition(dispatcher).dispatchAgentRun(buildTask(), 'agent-1');
+
+        expect(result).toEqual({ runId: 'run-1', dispatched: true, parked: false });
+        expect(store.enqueue).toHaveBeenCalledTimes(1);
+        expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/fleet/dto/fleet-kill-switch.dto.ts
+++ b/apps/api/src/fleet/dto/fleet-kill-switch.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import {
+    FLEET_AUDIT_DEFAULT_LIMIT,
+    FLEET_AUDIT_MAX_LIMIT,
+    FLEET_KILL_SWITCH_REASON_MAX_LENGTH,
+} from '@ever-works/contracts';
+
+/**
+ * Panic controls (EW-778) — request shapes. Every bound comes from the
+ * shared contract so the web tier and the API agree on it at compile
+ * time.
+ */
+
+/** Body for `POST /api/fleet/kill-switch/stop` (platform admin). */
+export class StopFleetKillSwitchDto {
+    @ApiProperty({
+        required: false,
+        maxLength: FLEET_KILL_SWITCH_REASON_MAX_LENGTH,
+        description:
+            'Why the fleet is being stopped. Shown in the banner and recorded in the audit row.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(FLEET_KILL_SWITCH_REASON_MAX_LENGTH)
+    reason?: string;
+}
+
+/** Query for `GET /api/fleet/kill-switch/audit` (platform admin). */
+export class FleetAuditQueryDto {
+    @ApiProperty({
+        required: false,
+        minimum: 1,
+        maximum: FLEET_AUDIT_MAX_LIMIT,
+        default: FLEET_AUDIT_DEFAULT_LIMIT,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(FLEET_AUDIT_MAX_LIMIT)
+    limit?: number;
+}
+
+/**
+ * Body for `POST /api/fleet/cancel-in-flight` (owner).
+ *
+ * `includeQueued` defaults to FALSE on purpose: the queued rows a
+ * drain-all just returned to the pool are a separate decision from the
+ * work that is actually executing right now.
+ */
+export class CancelFleetInFlightDto {
+    @ApiProperty({
+        required: false,
+        default: false,
+        description:
+            'Also fail every job still QUEUED for this owner (nothing has started them). Default false: only leased / running work is cancelled.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    includeQueued?: boolean;
+}

--- a/apps/api/src/fleet/fleet-admin.types.ts
+++ b/apps/api/src/fleet/fleet-admin.types.ts
@@ -13,4 +13,11 @@ export type {
     FleetNodeDetailView,
     FleetNodeDrainResult,
     FleetEnrollmentTokenView,
+    // Panic controls (EW-778).
+    FleetAuditView,
+    FleetCancelInFlightResult,
+    FleetDrainAllResult,
+    FleetKillSwitchAdminState,
+    FleetKillSwitchChangeResult,
+    FleetKillSwitchState,
 } from '@ever-works/contracts';

--- a/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
@@ -38,13 +38,13 @@ import {
     type GateStatus,
     type TaskCheckResult,
 } from '@ever-works/contracts';
+import {
+    correlateAgentTaskJob,
+    type FleetAgentTaskCorrelation,
+} from './fleet-agent-task.correlation';
 
-/** What an `agent-task` job correlates to on the platform side. */
-export interface FleetAgentTaskCorrelation {
-    runId: string;
-    taskId: string;
-    agentId: string | null;
-}
+/** What an `agent-task` job correlates to on the platform side (declared in the leaf). */
+export type { FleetAgentTaskCorrelation };
 
 /** Longest run summary / chat body the reconciler will store. */
 const MAX_SUMMARY_CHARS = 4000;
@@ -140,19 +140,14 @@ export class FleetAgentTaskReconcilerService {
         @Optional() private readonly costCeiling?: FleetCostCeilingService,
     ) {}
 
-    /** The platform identities an `agent-task` job carries, or null for any other job. */
+    /**
+     * The platform identities an `agent-task` job carries, or null for
+     * any other job. The rule itself lives in the leaf
+     * `fleet-agent-task.correlation.ts` so the panic controls
+     * (cancel-in-flight, EW-778) share it without importing this graph.
+     */
     static correlate(job: FleetJobView): FleetAgentTaskCorrelation | null {
-        if (job.kind !== 'agent-task') return null;
-        const payload = job.payload;
-        if (!payload || typeof payload !== 'object') return null;
-        const runId = typeof payload.runId === 'string' ? payload.runId.trim() : '';
-        const taskId = typeof payload.taskId === 'string' ? payload.taskId.trim() : '';
-        if (!runId || !taskId) return null;
-        const agentId =
-            typeof payload.agentId === 'string' && payload.agentId.trim()
-                ? payload.agentId.trim()
-                : null;
-        return { runId, taskId, agentId };
+        return correlateAgentTaskJob(job);
     }
 
     @OnEvent(FleetJobLeasedEvent.EVENT_NAME, { async: true })

--- a/apps/api/src/fleet/fleet-agent-task.correlation.ts
+++ b/apps/api/src/fleet/fleet-agent-task.correlation.ts
@@ -1,0 +1,31 @@
+import type { FleetJobView } from '@ever-works/contracts';
+
+/** The platform identities an `agent-task` fleet job carries. */
+export interface FleetAgentTaskCorrelation {
+    runId: string;
+    taskId: string;
+    agentId: string | null;
+}
+
+/**
+ * Job → (run, task, agent) correlation for an `agent-task` fleet job, or
+ * null for any other job (or a malformed payload).
+ *
+ * A leaf so the panic controls (cancel-in-flight) and the reconciler
+ * read a job's identities through ONE function without the panic
+ * service importing the reconciler's whole dependency graph.
+ * `FleetAgentTaskReconcilerService.correlate` delegates here.
+ */
+export function correlateAgentTaskJob(job: FleetJobView): FleetAgentTaskCorrelation | null {
+    if (job.kind !== 'agent-task') return null;
+    const payload = job.payload;
+    if (!payload || typeof payload !== 'object') return null;
+    const runId = typeof payload.runId === 'string' ? payload.runId.trim() : '';
+    const taskId = typeof payload.taskId === 'string' ? payload.taskId.trim() : '';
+    if (!runId || !taskId) return null;
+    const agentId =
+        typeof payload.agentId === 'string' && payload.agentId.trim()
+            ? payload.agentId.trim()
+            : null;
+    return { runId, taskId, agentId };
+}

--- a/apps/api/src/fleet/fleet-agent-task.dispatcher.ts
+++ b/apps/api/src/fleet/fleet-agent-task.dispatcher.ts
@@ -12,6 +12,11 @@ import type {
     FleetTaskWorkspaceSpec,
     TaskAcceptanceCheck,
 } from '@ever-works/contracts';
+import type { FleetKillSwitchService } from '@ever-works/agent/fleet';
+import {
+    FleetKillSwitchActiveError,
+    isFleetKillSwitchActiveError,
+} from './fleet-kill-switch.error';
 import type { FleetRunRouterService } from './fleet-run-router.service';
 
 /**
@@ -85,6 +90,13 @@ export interface FleetAwareDispatcherDeps {
      * run. Absent = every fleet run is the legacy command job.
      */
     planner?: FleetAgentTaskPlanner;
+    /**
+     * Panic controls (EW-778) — the GLOBAL STOP FLAG. Consulted BEFORE
+     * routing, and its refusal is the one error the routing catch below
+     * must never turn into a cloud fallback. Absent = not gated here
+     * (the dispatch gate upstream still parks every run).
+     */
+    killSwitch?: Pick<FleetKillSwitchService, 'isStopped'>;
 }
 
 /**
@@ -129,6 +141,16 @@ export interface FleetAwareDispatcherDeps {
  * infrastructure hiccup must not cost the user a run. An enqueue that
  * throws after the decision is a real failure and propagates, so the
  * transition service records it on the run row where a human can see it.
+ *
+ * ONE exception to that fallback (EW-778): the GLOBAL STOP FLAG. A stop
+ * is not an infrastructure hiccup, it is an operator's decision, and
+ * "send it to the cloud instead" is precisely the outcome it forbids. So
+ * the flag is checked BEFORE routing, its refusal is a typed error, and
+ * that error is rethrown out of the routing catch — never swallowed. It
+ * then lands on the run row as `dispatch-failed: …` through the callers'
+ * existing loud-degradation path. (The dispatch gate upstream parks every
+ * run first; this seam is defence in depth for a gate that is absent or
+ * mis-wired.)
  */
 export function createFleetAwareAgentTaskExecuteDispatcher(
     delegate: AgentTaskExecuteDispatcher,
@@ -138,6 +160,28 @@ export function createFleetAwareAgentTaskExecuteDispatcher(
     // (deps.planner is read per dispatch below — see FleetAgentTaskPlanner.)
     return {
         async enqueue(payload: AgentTaskExecuteDispatchPayload): Promise<{ runId: string }> {
+            // EW-778 — refuse BEFORE routing, outside the fallback try.
+            // Fail closed: a switch that cannot be read counts as set
+            // (the service already folds read errors into `true`; the
+            // catch here covers a stub or a future implementation that
+            // throws instead).
+            if (deps.killSwitch) {
+                let stopped: boolean;
+                try {
+                    stopped = await deps.killSwitch.isStopped();
+                } catch (err) {
+                    logger.error(
+                        `Global stop flag could not be read for task ${payload.taskId} — refusing dispatch (fail-closed): ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    );
+                    stopped = true;
+                }
+                if (stopped) {
+                    throw new FleetKillSwitchActiveError(payload.taskId);
+                }
+            }
+
             let decision: FleetRunRoutingDecision = { target: 'cloud', mode: 'cloud' };
             try {
                 const scope = await resolveScope(deps.scopeResolver, payload.taskId);
@@ -148,6 +192,11 @@ export function createFleetAwareAgentTaskExecuteDispatcher(
                     requirements ? { requiredCapabilities: requirements.requiredCapabilities } : {},
                 );
             } catch (err) {
+                if (isFleetKillSwitchActiveError(err)) {
+                    // The router read the flag itself. A stop is never a
+                    // reason to run in the cloud instead.
+                    throw err;
+                }
                 logger.warn(
                     `Fleet routing check failed for task ${payload.taskId} — using the platform dispatcher: ${
                         err instanceof Error ? err.message : String(err)

--- a/apps/api/src/fleet/fleet-kill-switch.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-kill-switch.controller.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Panic controls (EW-778) — the platform-admin half: set / clear the
+ * global stop flag and read the audit trail.
+ *
+ * The heavy agent barrels are stubbed at module scope (the same posture
+ * `agents.module.spec.ts` takes) so the decorator metadata and the
+ * forwarding can be asserted without loading the DI graph.
+ */
+jest.mock('@ever-works/agent/agents', () => ({
+    QUEUED_REASON_KILL_SWITCH: 'kill-switch',
+    RunDispatchGateService: class RunDispatchGateService {},
+}));
+jest.mock('@ever-works/agent/fleet', () => ({
+    FleetAuditService: class FleetAuditService {},
+    FleetKillSwitchService: class FleetKillSwitchService {},
+}));
+jest.mock('../auth/guards/platform-admin.guard', () => ({
+    IsPlatformAdminGuard: class IsPlatformAdminGuard {},
+}));
+
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { IsPlatformAdminGuard } from '../auth/guards/platform-admin.guard';
+import { FleetAuditQueryDto, StopFleetKillSwitchDto } from './dto/fleet-kill-switch.dto';
+import { FleetKillSwitchController } from './fleet-kill-switch.controller';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+
+const admin = { userId: 'admin-1' } as AuthenticatedUser;
+
+describe('FleetKillSwitchController', () => {
+    let killSwitch: { stop: jest.Mock; clear: jest.Mock };
+    let audit: { recent: jest.Mock };
+    let dispatchGate: { promoteParked: jest.Mock };
+    let controller: FleetKillSwitchController;
+
+    const changeResult = (stopped: boolean) => ({
+        state: {
+            stopped,
+            reason: stopped ? 'incident' : null,
+            since: '2026-09-05T02:00:00.000Z',
+            unverified: false,
+            setByUserId: 'admin-1',
+        },
+        changed: true,
+        auditFailed: false,
+    });
+
+    beforeEach(() => {
+        killSwitch = {
+            stop: jest.fn(async () => changeResult(true)),
+            clear: jest.fn(async () => changeResult(false)),
+        };
+        audit = { recent: jest.fn(async () => []) };
+        dispatchGate = {
+            promoteParked: jest.fn(async () => ({ promoted: 0, works: 0, budgetExhausted: false })),
+        };
+        controller = new FleetKillSwitchController(
+            killSwitch as never,
+            audit as never,
+            dispatchGate as never,
+        );
+    });
+
+    it('is gated on FLEET_ENABLED first and then on platform admin, and is not public', () => {
+        const guards = Reflect.getMetadata('__guards__', FleetKillSwitchController) ?? [];
+        expect(guards).toEqual([FleetEnabledGuard, IsPlatformAdminGuard]);
+        expect(Reflect.getMetadata(IS_PUBLIC_KEY, FleetKillSwitchController)).toBeFalsy();
+        for (const route of ['stop', 'clear', 'recentAudit'] as const) {
+            expect(Reflect.getMetadata(IS_PUBLIC_KEY, controller[route])).toBeFalsy();
+        }
+    });
+
+    it('stop forwards the SESSION actor and the reason', async () => {
+        const result = await controller.stop(admin, { reason: 'incident' });
+        expect(killSwitch.stop).toHaveBeenCalledWith('admin-1', 'incident');
+        expect(result.state.stopped).toBe(true);
+    });
+
+    it('stop with no reason forwards null', async () => {
+        await controller.stop(admin, {});
+        expect(killSwitch.stop).toHaveBeenCalledWith('admin-1', null);
+    });
+
+    it('stop only flips the flag — it never promotes or cancels anything', async () => {
+        await controller.stop(admin, { reason: 'incident' });
+        expect(dispatchGate.promoteParked).not.toHaveBeenCalled();
+        // No cancel surface is even reachable from this controller.
+        const paramTypes = (Reflect.getMetadata('design:paramtypes', FleetKillSwitchController) ??
+            []) as Array<{ name?: string }>;
+        expect(paramTypes.map((type) => type?.name)).toEqual([
+            'FleetKillSwitchService',
+            'FleetAuditService',
+            'RunDispatchGateService',
+        ]);
+    });
+
+    it('clear forwards the SESSION actor, answers immediately, then resumes the parked runs', async () => {
+        let resolvePromotion: () => void = () => undefined;
+        dispatchGate.promoteParked.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolvePromotion = resolve;
+                }),
+        );
+
+        const result = await controller.clear(admin);
+
+        expect(killSwitch.clear).toHaveBeenCalledWith('admin-1');
+        expect(result.state.stopped).toBe(false);
+        // The response did not wait on the promotion (it is still pending).
+        expect(dispatchGate.promoteParked).toHaveBeenCalledWith('kill-switch');
+        resolvePromotion();
+    });
+
+    it('clear survives a promotion that rejects', async () => {
+        dispatchGate.promoteParked.mockRejectedValue(new Error('boom'));
+        await expect(controller.clear(admin)).resolves.toMatchObject({ changed: true });
+        // Let the rejected promise settle inside the catch.
+        await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    it('audit forwards the limit and defaults it', async () => {
+        await controller.recentAudit({ limit: 7 });
+        expect(audit.recent).toHaveBeenCalledWith(7);
+        await controller.recentAudit({});
+        expect(audit.recent).toHaveBeenLastCalledWith(50);
+    });
+});
+
+describe('kill-switch DTO validation', () => {
+    it('StopFleetKillSwitchDto accepts an empty body and bounds the reason', async () => {
+        await expect(validate(plainToInstance(StopFleetKillSwitchDto, {}))).resolves.toHaveLength(
+            0,
+        );
+        await expect(
+            validate(plainToInstance(StopFleetKillSwitchDto, { reason: 'incident' })),
+        ).resolves.toHaveLength(0);
+        const tooLong = await validate(
+            plainToInstance(StopFleetKillSwitchDto, { reason: 'x'.repeat(501) }),
+        );
+        expect(tooLong.map((error) => error.property)).toContain('reason');
+    });
+
+    it('FleetAuditQueryDto coerces and bounds the limit', async () => {
+        const ok = plainToInstance(FleetAuditQueryDto, { limit: '25' });
+        expect(ok.limit).toBe(25);
+        await expect(validate(ok)).resolves.toHaveLength(0);
+        const tooMany = await validate(plainToInstance(FleetAuditQueryDto, { limit: 999 }));
+        expect(tooMany.map((error) => error.property)).toContain('limit');
+        const zero = await validate(plainToInstance(FleetAuditQueryDto, { limit: 0 }));
+        expect(zero.map((error) => error.property)).toContain('limit');
+    });
+});

--- a/apps/api/src/fleet/fleet-kill-switch.controller.ts
+++ b/apps/api/src/fleet/fleet-kill-switch.controller.ts
@@ -1,0 +1,97 @@
+import {
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Post,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { QUEUED_REASON_KILL_SWITCH, RunDispatchGateService } from '@ever-works/agent/agents';
+import { FleetAuditService, FleetKillSwitchService } from '@ever-works/agent/fleet';
+import type { FleetAuditView, FleetKillSwitchChangeResult } from '@ever-works/contracts';
+import { FLEET_AUDIT_DEFAULT_LIMIT } from '@ever-works/contracts';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import { IsPlatformAdminGuard } from '../auth/guards/platform-admin.guard';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { FleetAuditQueryDto, StopFleetKillSwitchDto } from './dto/fleet-kill-switch.dto';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+
+/**
+ * Panic controls (EW-778) — the PLATFORM-ADMIN half: the global stop flag.
+ *
+ *   POST   /api/fleet/kill-switch/stop    { reason? } — set the flag
+ *   POST   /api/fleet/kill-switch/clear   clear it, then resume parked runs
+ *   GET    /api/fleet/kill-switch/audit   ?limit — recent fleet_audit rows
+ *
+ * Two verbs rather than one boolean PUT: at 2am a fat-fingered `false`
+ * must not be able to un-stop a fleet.
+ *
+ * Guard order matters: `FleetEnabledGuard` first, so a deployment with
+ * the fleet off answers 404 here exactly as it does everywhere under
+ * `/api/fleet` (never confirming the surface exists), then
+ * `IsPlatformAdminGuard` (403 for everyone who is not the platform
+ * owner). The read of the flag itself is deliberately NOT here — every
+ * signed-in user may ask whether the platform is stopped
+ * (`GET /api/fleet/kill-switch` on `FleetPanicController`), they just
+ * never learn who stopped it.
+ */
+@ApiTags('fleet')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/fleet/kill-switch')
+@UseGuards(FleetEnabledGuard, IsPlatformAdminGuard)
+export class FleetKillSwitchController {
+    constructor(
+        private readonly killSwitch: FleetKillSwitchService,
+        private readonly audit: FleetAuditService,
+        private readonly dispatchGate: RunDispatchGateService,
+    ) {}
+
+    @Post('stop')
+    @ApiOperation({
+        summary:
+            'Set the platform-wide stop flag: no new agent run is dispatched, no run is routed to a fleet node, and no node is leased work until it is cleared. Running work is NOT cancelled. Writes an audit row with the actor.',
+    })
+    @ApiResponse({ status: 403, description: 'Caller is not a platform admin' })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async stop(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: StopFleetKillSwitchDto,
+    ): Promise<FleetKillSwitchChangeResult> {
+        return this.killSwitch.stop(auth.userId, body.reason ?? null);
+    }
+
+    @Post('clear')
+    @ApiOperation({
+        summary:
+            'Clear the platform-wide stop flag and resume the runs it parked (best-effort, bounded). Writes an audit row with the actor.',
+    })
+    @ApiResponse({ status: 403, description: 'Caller is not a platform admin' })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async clear(@CurrentUser() auth: AuthenticatedUser): Promise<FleetKillSwitchChangeResult> {
+        const result = await this.killSwitch.clear(auth.userId);
+        // Resume the runs the flag parked. Fire-and-forget by design —
+        // the flag is already off (that is what the caller asked for),
+        // `promoteParked` never throws by contract, and a clear response
+        // must not wait on up to 200 fresh dispatches. Same posture as
+        // the cancel route's `drainForWork`.
+        void this.dispatchGate.promoteParked(QUEUED_REASON_KILL_SWITCH).catch(() => undefined);
+        return result;
+    }
+
+    @Get('audit')
+    @ApiOperation({
+        summary:
+            'Recent fleet audit rows (every stop / clear / drain-all / cancel-in-flight, newest first) with actor and time.',
+    })
+    @ApiResponse({ status: 403, description: 'Caller is not a platform admin' })
+    @HttpCode(HttpStatus.OK)
+    async recentAudit(@Query() query: FleetAuditQueryDto): Promise<FleetAuditView[]> {
+        return this.audit.recent(query.limit ?? FLEET_AUDIT_DEFAULT_LIMIT);
+    }
+}

--- a/apps/api/src/fleet/fleet-kill-switch.error.ts
+++ b/apps/api/src/fleet/fleet-kill-switch.error.ts
@@ -1,0 +1,31 @@
+/**
+ * Panic controls (EW-778) — thrown by the fleet run router and the
+ * fleet-aware dispatcher when the GLOBAL STOP FLAG is set (or cannot be
+ * read) and a run has nonetheless reached routing.
+ *
+ * A leaf file (no imports) so the dispatcher — which must stay a leaf on
+ * the dispatch path — can recognise the error without importing the
+ * router's DI graph. Recognised by `name` as well as by `instanceof`, the
+ * same posture as `JobRuntimeNotConfiguredError`, so a copy that crossed
+ * a module boundary still counts.
+ *
+ * Deliberately NOT a Nest HttpException: it surfaces on the run row as
+ * `dispatch-failed: …` (the callers' existing loud-degradation path),
+ * never as an HTTP status.
+ */
+export class FleetKillSwitchActiveError extends Error {
+    readonly taskId: string | null;
+
+    constructor(taskId?: string | null) {
+        super(`Dispatch refused: the global stop flag is set${taskId ? ` (task ${taskId})` : ''}`);
+        this.name = 'FleetKillSwitchActiveError';
+        this.taskId = taskId ?? null;
+    }
+}
+
+export function isFleetKillSwitchActiveError(error: unknown): error is FleetKillSwitchActiveError {
+    return (
+        error instanceof FleetKillSwitchActiveError ||
+        (error instanceof Error && error.name === 'FleetKillSwitchActiveError')
+    );
+}

--- a/apps/api/src/fleet/fleet-panic.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-panic.controller.spec.ts
@@ -1,0 +1,433 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { FleetJobView, FleetNodeView } from '@ever-works/contracts';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { CancelFleetInFlightDto } from './dto/fleet-kill-switch.dto';
+import { FleetPanicController } from './fleet-panic.controller';
+import { FleetPanicService } from './fleet-panic.service';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+
+const auth = { userId: 'user-1' } as AuthenticatedUser;
+const otherAuth = { userId: 'user-2' } as AuthenticatedUser;
+
+function node(over: Partial<FleetNodeView> = {}): FleetNodeView {
+    return {
+        id: 'node-online',
+        name: 'PC',
+        kind: 'node',
+        status: 'online',
+        platform: 'win32/x64',
+        version: '1.0.0',
+        capabilities: [],
+        lastHeartbeatAt: null,
+        createdAt: null,
+        persisted: true,
+        capabilitiesPinned: false,
+        ...over,
+    } as FleetNodeView;
+}
+
+function job(over: Partial<FleetJobView> = {}): FleetJobView {
+    return {
+        id: 'job-1',
+        kind: 'agent-task',
+        status: 'running',
+        nodeId: 'node-online',
+        targetNodeId: null,
+        requiredCapabilities: [],
+        payload: { taskId: 'task-1', runId: 'run-1', agentId: 'agent-1' },
+        leaseExpiresAt: null,
+        attempts: 1,
+        maxAttempts: 3,
+        createdAt: null,
+        startedAt: null,
+        completedAt: null,
+        queuedReason: null,
+        ...over,
+    } as FleetJobView;
+}
+
+/**
+ * Panic controls (EW-778) — the owner half: drain-all and the explicit
+ * cancel-in-flight, through `FleetPanicService` and its controller.
+ *
+ * What is pinned: everything is keyed by the SESSION user (the node
+ * list, every drain, every job read, every run cancel); the per-node
+ * order (disable BEFORE requeue) is preserved by drain-all; enrolling and
+ * disabled nodes are skipped; the audit row is written with the actor
+ * and its failure never undoes the action; and cancel-in-flight runs the
+ * DB-first order per job while leaving the concurrency queue alone.
+ */
+describe('FleetPanicService', () => {
+    let calls: string[];
+    let fleet: { listEnrolledForUser: jest.Mock; setDisabledForUser: jest.Mock };
+    let jobs: {
+        releaseClaimsForNode: jest.Mock;
+        activeForUser: jest.Mock;
+        queuedForUser: jest.Mock;
+        cancel: jest.Mock;
+    };
+    let agentRuns: { cancel: jest.Mock };
+    let audit: { record: jest.Mock };
+    let service: FleetPanicService;
+
+    beforeEach(() => {
+        calls = [];
+        fleet = {
+            listEnrolledForUser: jest.fn(async () => [
+                node({ id: 'node-online' }),
+                node({ id: 'node-busy', status: 'online' }),
+                node({ id: 'node-enrolling', status: 'enrolling' }),
+                node({ id: 'node-disabled', status: 'disabled' }),
+            ]),
+            setDisabledForUser: jest.fn(async (_user: string, id: string, disabled: boolean) => {
+                calls.push(`disable:${id}`);
+                return node({ id, status: disabled ? 'disabled' : 'offline' });
+            }),
+        };
+        jobs = {
+            releaseClaimsForNode: jest.fn(async (_user: string, id: string) => {
+                calls.push(`release:${id}`);
+                return id === 'node-busy' ? 2 : 1;
+            }),
+            activeForUser: jest.fn(async () => [
+                job({ id: 'job-1', payload: { taskId: 'task-1', runId: 'run-1' } }),
+                job({
+                    id: 'job-2',
+                    status: 'leased',
+                    payload: { taskId: 'task-2', runId: 'run-2' },
+                }),
+                job({ id: 'job-3', kind: 'acceptance-checks', payload: null }),
+            ]),
+            queuedForUser: jest.fn(async () => [
+                job({
+                    id: 'job-q',
+                    status: 'queued',
+                    nodeId: null,
+                    payload: { taskId: 't', runId: 'run-q' },
+                }),
+            ]),
+            cancel: jest.fn(async (id: string) => {
+                calls.push(`job-cancel:${id}`);
+                return id === 'job-q'
+                    ? { cancelled: true, state: 'queued-dropped' }
+                    : { cancelled: true, state: 'cancel-requested' };
+            }),
+        };
+        agentRuns = {
+            cancel: jest.fn(async (runId: string) => {
+                calls.push(`run-cancel:${runId}`);
+                return { found: true, previousStatus: 'running', triggerRunId: null, workId: 'w' };
+            }),
+        };
+        audit = { record: jest.fn(async () => ({ id: 'audit-1' })) };
+        service = new FleetPanicService(
+            fleet as never,
+            jobs as never,
+            agentRuns as never,
+            audit as never,
+        );
+        for (const level of ['warn', 'error', 'log'] as const) {
+            jest.spyOn(
+                (service as never as { logger: Record<string, () => void> }).logger,
+                level,
+            ).mockImplementation(() => undefined);
+        }
+    });
+
+    describe('drainNodeForUser (the per-node drain, shared with the :id/drain route)', () => {
+        it('disables FIRST, then requeues the claims', async () => {
+            const result = await service.drainNodeForUser('user-1', 'node-online', true);
+            expect(calls).toEqual(['disable:node-online', 'release:node-online']);
+            expect(fleet.setDisabledForUser).toHaveBeenCalledWith('user-1', 'node-online', true);
+            expect(jobs.releaseClaimsForNode).toHaveBeenCalledWith('user-1', 'node-online');
+            expect(result).toEqual({
+                node: expect.objectContaining({ status: 'disabled' }),
+                releasedJobs: 1,
+            });
+        });
+
+        it('returning to service requeues nothing', async () => {
+            const result = await service.drainNodeForUser('user-1', 'node-online', false);
+            expect(jobs.releaseClaimsForNode).not.toHaveBeenCalled();
+            expect(result.releasedJobs).toBe(0);
+        });
+    });
+
+    describe('drainAllForUser', () => {
+        it('drains only the caller’s drainable nodes, in disable-then-requeue order, and sums the releases', async () => {
+            const result = await service.drainAllForUser('user-1');
+
+            expect(fleet.listEnrolledForUser).toHaveBeenCalledWith('user-1');
+            // Enrolling + disabled are skipped; the two online nodes drain.
+            expect(fleet.setDisabledForUser).toHaveBeenCalledTimes(2);
+            expect(fleet.setDisabledForUser).toHaveBeenCalledWith('user-1', 'node-online', true);
+            expect(fleet.setDisabledForUser).toHaveBeenCalledWith('user-1', 'node-busy', true);
+            expect(fleet.setDisabledForUser).not.toHaveBeenCalledWith(
+                'user-1',
+                'node-enrolling',
+                expect.anything(),
+            );
+            expect(fleet.setDisabledForUser).not.toHaveBeenCalledWith(
+                'user-1',
+                'node-disabled',
+                expect.anything(),
+            );
+            expect(calls).toEqual([
+                'disable:node-online',
+                'release:node-online',
+                'disable:node-busy',
+                'release:node-busy',
+            ]);
+            expect(result).toMatchObject({
+                drainedNodes: 2,
+                skippedNodes: 2,
+                releasedJobs: 3,
+                auditFailed: false,
+            });
+            expect(result.nodes).toHaveLength(4);
+            expect(result.nodes.find((n) => n.id === 'node-online')?.status).toBe('disabled');
+            expect(result.nodes.find((n) => n.id === 'node-enrolling')?.status).toBe('enrolling');
+        });
+
+        it('is scoped to the SESSION user — a different session drains a different owner', async () => {
+            fleet.listEnrolledForUser.mockResolvedValueOnce([]);
+            const result = await service.drainAllForUser('user-2');
+            expect(fleet.listEnrolledForUser).toHaveBeenCalledWith('user-2');
+            expect(fleet.listEnrolledForUser).not.toHaveBeenCalledWith('user-1');
+            expect(fleet.setDisabledForUser).not.toHaveBeenCalled();
+            expect(result.drainedNodes).toBe(0);
+        });
+
+        it('writes ONE audit row carrying the actor, the owner and the counts', async () => {
+            await service.drainAllForUser('user-1');
+            expect(audit.record).toHaveBeenCalledTimes(1);
+            expect(audit.record).toHaveBeenCalledWith({
+                action: 'drain-all',
+                actorUserId: 'user-1',
+                ownerUserId: 'user-1',
+                details: {
+                    drainedNodes: 2,
+                    skippedNodes: 2,
+                    releasedJobs: 3,
+                    nodeIds: ['node-online', 'node-busy'],
+                    failedNodeIds: [],
+                },
+            });
+        });
+
+        it('keeps draining the rest when one node fails, and records the failure', async () => {
+            fleet.setDisabledForUser.mockImplementationOnce(async () => {
+                throw new Error('registry hiccup');
+            });
+            const result = await service.drainAllForUser('user-1');
+            expect(result).toMatchObject({ drainedNodes: 1, skippedNodes: 3, releasedJobs: 2 });
+            expect(audit.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    details: expect.objectContaining({ failedNodeIds: ['node-online'] }),
+                }),
+            );
+        });
+
+        it('never undoes a drain because the audit write failed — it reports it', async () => {
+            audit.record.mockRejectedValue(new Error('audit down'));
+            const result = await service.drainAllForUser('user-1');
+            expect(result.drainedNodes).toBe(2);
+            expect(result.auditFailed).toBe(true);
+        });
+
+        it('never cancels anything — draining is not killing', async () => {
+            await service.drainAllForUser('user-1');
+            expect(jobs.cancel).not.toHaveBeenCalled();
+            expect(agentRuns.cancel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cancelInFlightForUser', () => {
+        it('cancels the run row FIRST, then the job, for every active job the caller owns', async () => {
+            const result = await service.cancelInFlightForUser('user-1');
+
+            expect(jobs.activeForUser).toHaveBeenCalledWith('user-1');
+            expect(jobs.queuedForUser).not.toHaveBeenCalled();
+            expect(agentRuns.cancel).toHaveBeenCalledWith('run-1', 'user-1');
+            expect(agentRuns.cancel).toHaveBeenCalledWith('run-2', 'user-1');
+            expect(agentRuns.cancel).toHaveBeenCalledTimes(2);
+            expect(calls).toEqual([
+                'run-cancel:run-1',
+                'job-cancel:job-1',
+                'run-cancel:run-2',
+                'job-cancel:job-2',
+                'job-cancel:job-3',
+            ]);
+            expect(result).toEqual({
+                requested: 3,
+                cancelled: 3,
+                runsCancelled: 2,
+                byState: {
+                    'queued-dropped': 0,
+                    'cancel-requested': 3,
+                    terminal: 0,
+                    'not-found': 0,
+                },
+                jobIds: ['job-1', 'job-2', 'job-3'],
+                auditFailed: false,
+            });
+        });
+
+        it('includeQueued defaults to false and, when set, adds the queued rows', async () => {
+            const result = await service.cancelInFlightForUser('user-1', { includeQueued: true });
+            expect(jobs.queuedForUser).toHaveBeenCalledWith('user-1');
+            expect(result.requested).toBe(4);
+            expect(result.byState['queued-dropped']).toBe(1);
+            expect(agentRuns.cancel).toHaveBeenCalledWith('run-q', 'user-1');
+        });
+
+        it('is scoped to the SESSION user', async () => {
+            jobs.activeForUser.mockResolvedValueOnce([]);
+            await service.cancelInFlightForUser('user-2');
+            expect(jobs.activeForUser).toHaveBeenCalledWith('user-2');
+            expect(jobs.cancel).not.toHaveBeenCalled();
+        });
+
+        it('writes ONE audit row carrying the actor and per-state counts', async () => {
+            await service.cancelInFlightForUser('user-1');
+            expect(audit.record).toHaveBeenCalledTimes(1);
+            expect(audit.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'cancel-in-flight',
+                    actorUserId: 'user-1',
+                    ownerUserId: 'user-1',
+                    details: expect.objectContaining({
+                        includeQueued: false,
+                        requested: 3,
+                        cancelled: 3,
+                        runsCancelled: 2,
+                        byState: expect.objectContaining({ 'cancel-requested': 3 }),
+                    }),
+                }),
+            );
+        });
+
+        it('counts a run that was already terminal as not cancelled, and still cancels the job', async () => {
+            agentRuns.cancel.mockResolvedValueOnce({ found: true, previousStatus: 'completed' });
+            const result = await service.cancelInFlightForUser('user-1');
+            expect(result.runsCancelled).toBe(1);
+            expect(jobs.cancel).toHaveBeenCalledTimes(3);
+        });
+
+        it('a run cancel that throws does not stop the job cancel or the rest of the batch', async () => {
+            agentRuns.cancel.mockRejectedValueOnce(new Error('db blip'));
+            const result = await service.cancelInFlightForUser('user-1');
+            expect(jobs.cancel).toHaveBeenCalledTimes(3);
+            expect(result.cancelled).toBe(3);
+        });
+
+        it('reports an audit failure without undoing the cancel', async () => {
+            audit.record.mockRejectedValue(new Error('audit down'));
+            const result = await service.cancelInFlightForUser('user-1');
+            expect(result.cancelled).toBe(3);
+            expect(result.auditFailed).toBe(true);
+        });
+    });
+});
+
+describe('FleetPanicController', () => {
+    let panic: { drainAllForUser: jest.Mock; cancelInFlightForUser: jest.Mock };
+    let killSwitch: { publicState: jest.Mock; state: jest.Mock };
+    let controller: FleetPanicController;
+
+    beforeEach(() => {
+        panic = {
+            drainAllForUser: jest.fn(async () => ({
+                drainedNodes: 1,
+                skippedNodes: 0,
+                releasedJobs: 0,
+                nodes: [],
+                auditFailed: false,
+            })),
+            cancelInFlightForUser: jest.fn(async () => ({
+                requested: 0,
+                cancelled: 0,
+                runsCancelled: 0,
+                byState: {
+                    'queued-dropped': 0,
+                    'cancel-requested': 0,
+                    terminal: 0,
+                    'not-found': 0,
+                },
+                jobIds: [],
+                auditFailed: false,
+            })),
+        };
+        killSwitch = {
+            publicState: jest.fn(async () => ({
+                stopped: true,
+                reason: 'incident',
+                since: '2026-09-05T02:00:00.000Z',
+                unverified: false,
+            })),
+            state: jest.fn(),
+        };
+        controller = new FleetPanicController(panic as never, killSwitch as never);
+    });
+
+    it('drain-all is scoped to the SESSION user', async () => {
+        await controller.drainAll(auth);
+        expect(panic.drainAllForUser).toHaveBeenCalledWith('user-1');
+        await controller.drainAll(otherAuth);
+        expect(panic.drainAllForUser).toHaveBeenLastCalledWith('user-2');
+    });
+
+    it('cancel-in-flight is scoped to the session user and defaults includeQueued to false', async () => {
+        await controller.cancelInFlight(auth, {});
+        expect(panic.cancelInFlightForUser).toHaveBeenCalledWith('user-1', {
+            includeQueued: false,
+        });
+        await controller.cancelInFlight(auth, { includeQueued: true });
+        expect(panic.cancelInFlightForUser).toHaveBeenLastCalledWith('user-1', {
+            includeQueued: true,
+        });
+    });
+
+    it('drain-all never triggers cancel-in-flight (two routes, two decisions)', async () => {
+        await controller.drainAll(auth);
+        expect(panic.cancelInFlightForUser).not.toHaveBeenCalled();
+    });
+
+    it('GET kill-switch answers the PUBLIC projection — the actor is never in it', async () => {
+        const state = await controller.killSwitchState();
+        expect(killSwitch.publicState).toHaveBeenCalledTimes(1);
+        expect(killSwitch.state).not.toHaveBeenCalled();
+        expect(state).not.toHaveProperty('setByUserId');
+        expect(state.stopped).toBe(true);
+    });
+
+    it('is gated on FLEET_ENABLED and is NOT a public controller', () => {
+        const guards = Reflect.getMetadata('__guards__', FleetPanicController) ?? [];
+        expect(guards).toContain(FleetEnabledGuard);
+        expect(Reflect.getMetadata(IS_PUBLIC_KEY, FleetPanicController)).toBeFalsy();
+        for (const route of ['drainAll', 'cancelInFlight', 'killSwitchState'] as const) {
+            expect(Reflect.getMetadata(IS_PUBLIC_KEY, controller[route])).toBeFalsy();
+        }
+    });
+});
+
+describe('CancelFleetInFlightDto', () => {
+    it('accepts an empty body and a boolean includeQueued', async () => {
+        await expect(validate(plainToInstance(CancelFleetInFlightDto, {}))).resolves.toHaveLength(
+            0,
+        );
+        await expect(
+            validate(plainToInstance(CancelFleetInFlightDto, { includeQueued: true })),
+        ).resolves.toHaveLength(0);
+    });
+
+    it('rejects a non-boolean includeQueued', async () => {
+        const errors = await validate(
+            plainToInstance(CancelFleetInFlightDto, { includeQueued: 'yes' }),
+        );
+        expect(errors.map((error) => error.property)).toContain('includeQueued');
+    });
+});

--- a/apps/api/src/fleet/fleet-panic.controller.ts
+++ b/apps/api/src/fleet/fleet-panic.controller.ts
@@ -1,0 +1,82 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { FleetKillSwitchService } from '@ever-works/agent/fleet';
+import type {
+    FleetCancelInFlightResult,
+    FleetDrainAllResult,
+    FleetKillSwitchState,
+} from '@ever-works/contracts';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { CancelFleetInFlightDto } from './dto/fleet-kill-switch.dto';
+import { FleetPanicService } from './fleet-panic.service';
+import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
+
+/**
+ * Panic controls (EW-778) — the OWNER-scoped half.
+ *
+ *   POST   /api/fleet/drain-all          disable every node I own and
+ *                                        requeue their in-flight claims
+ *   POST   /api/fleet/cancel-in-flight   { includeQueued? } — cancel my
+ *                                        running fleet jobs + their runs
+ *   GET    /api/fleet/kill-switch        is the global stop flag set?
+ *                                        (any session; actor not leaked)
+ *
+ * Drain-all and cancel-in-flight are two DIFFERENT decisions on two
+ * different routes on purpose: stopping new work is not killing running
+ * work, and the stop flag never implies the cancel. The admin half (set
+ * / clear the flag, read the audit trail) lives on
+ * `FleetKillSwitchController`.
+ *
+ * Same scoping rule as `FleetController`: the owner comes from the
+ * session, never from the caller, and every service call is keyed by it.
+ */
+@ApiTags('fleet')
+@Controller('api/fleet')
+@UseGuards(FleetEnabledGuard)
+export class FleetPanicController {
+    constructor(
+        private readonly panic: FleetPanicService,
+        private readonly killSwitch: FleetKillSwitchService,
+    ) {}
+
+    @Post('drain-all')
+    @ApiOperation({
+        summary:
+            'Drain EVERY node I own: disable each one and return its in-flight claims to the queue. Nodes still enrolling or already disabled are skipped. Nothing is cancelled — use cancel-in-flight for that.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async drainAll(@CurrentUser() auth: AuthenticatedUser): Promise<FleetDrainAllResult> {
+        return this.panic.drainAllForUser(auth.userId);
+    }
+
+    @Post('cancel-in-flight')
+    @ApiOperation({
+        summary:
+            'Cancel my running fleet jobs and the agent runs behind them (an EXPLICIT second step — never implied by draining or by the global stop flag). A node learns of the cancel through its next refused heartbeat, so this is "cancel requested", not an instant kill.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async cancelInFlight(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: CancelFleetInFlightDto,
+    ): Promise<FleetCancelInFlightResult> {
+        return this.panic.cancelInFlightForUser(auth.userId, {
+            includeQueued: body.includeQueued === true,
+        });
+    }
+
+    @Get('kill-switch')
+    @ApiOperation({
+        summary:
+            'Whether the platform-wide stop flag is set (no new work is dispatched, routed or leased while it is). `unverified: true` means the flag could not be read and dispatch is refusing on that basis.',
+    })
+    @HttpCode(HttpStatus.OK)
+    // Polled by the fleet page banner every 30s; sized like runner-status.
+    @Throttle({ long: { limit: 120, ttl: 60_000 } })
+    async killSwitchState(): Promise<FleetKillSwitchState> {
+        return this.killSwitch.publicState();
+    }
+}

--- a/apps/api/src/fleet/fleet-panic.service.ts
+++ b/apps/api/src/fleet/fleet-panic.service.ts
@@ -1,0 +1,249 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AgentRunRepository } from '@ever-works/agent/database';
+import { FleetAuditService, FleetJobService, FleetService } from '@ever-works/agent/fleet';
+import type {
+    FleetAuditAction,
+    FleetCancelInFlightResult,
+    FleetDrainAllResult,
+    FleetJobCancelState,
+    FleetJobView,
+    FleetNodeDrainResult,
+    FleetNodeView,
+} from '@ever-works/contracts';
+import { FLEET_CANCEL_IN_FLIGHT_MAX_IDS, FLEET_JOB_CANCEL_STATES } from '@ever-works/contracts';
+import { correlateAgentTaskJob } from './fleet-agent-task.correlation';
+
+export interface CancelInFlightOptions {
+    /** Also fail every job still `queued` for the owner. Default false. */
+    includeQueued?: boolean;
+}
+
+/**
+ * Panic controls (EW-778) — the OWNER-scoped controls: drain everything,
+ * and — as an explicit, separate second step — cancel everything that
+ * is running.
+ *
+ * ## One drain, two routes
+ *
+ * `drainNodeForUser` IS the per-node drain `POST /api/fleet/nodes/:id/drain`
+ * has always performed (it moved here verbatim). `drainAllForUser` calls
+ * it once per node, so the two routes cannot drift on what "drain" means
+ * — in particular on the ORDER: disable FIRST, so the node stops being
+ * able to lease the instant its status flips, and only then requeue its
+ * claims, which the same machine can therefore never re-claim.
+ *
+ * ## Owner scoping
+ *
+ * Every read and write is keyed by the SESSION user: the node list comes
+ * from `FleetService.listEnrolledForUser`, each drain goes through the
+ * owner-scoped `setDisabledForUser` (404 for a foreign id), the job set
+ * comes from the owner-scoped job reads, and the run cancel is
+ * `AgentRunRepository.cancel(runId, userId)`, which re-checks ownership
+ * in its own WHERE clause. No id supplied by anyone else is ever trusted.
+ *
+ * ## Audit posture
+ *
+ * Act first, then audit. A drain or a cancel must never be reverted
+ * because bookkeeping failed, so an audit write failure is logged at
+ * error level and reported as `auditFailed: true` on the result — the
+ * opposite of `TenantJobRuntimeService.emitAudit`, where the audited
+ * write can be rolled back, and deliberately so.
+ */
+@Injectable()
+export class FleetPanicService {
+    private readonly logger = new Logger(FleetPanicService.name);
+
+    constructor(
+        private readonly fleet: FleetService,
+        private readonly jobs: FleetJobService,
+        private readonly agentRuns: AgentRunRepository,
+        private readonly audit: FleetAuditService,
+    ) {}
+
+    /**
+     * Drain (or return to service) ONE node. Disable first, requeue
+     * second — see the class docblock for why the order is load-bearing.
+     */
+    async drainNodeForUser(
+        userId: string,
+        nodeId: string,
+        drain: boolean,
+    ): Promise<FleetNodeDrainResult> {
+        const node = await this.fleet.setDisabledForUser(userId, nodeId, drain);
+        const releasedJobs = drain ? await this.jobs.releaseClaimsForNode(userId, nodeId) : 0;
+        return { node, releasedJobs };
+    }
+
+    /**
+     * Drain EVERY enrolled node the caller owns. Nodes still `enrolling`
+     * (no credential yet, nothing to drain) and nodes already `disabled`
+     * are skipped; a node whose drain throws is skipped too and the rest
+     * still drain — one bad row must not leave five machines running.
+     */
+    async drainAllForUser(userId: string): Promise<FleetDrainAllResult> {
+        const nodes = await this.fleet.listEnrolledForUser(userId);
+        const views: FleetNodeView[] = [];
+        const drainedIds: string[] = [];
+        const failedIds: string[] = [];
+        let skippedNodes = 0;
+        let releasedJobs = 0;
+
+        for (const node of nodes) {
+            if (node.status === 'enrolling' || node.status === 'disabled') {
+                skippedNodes += 1;
+                views.push(node);
+                continue;
+            }
+            try {
+                const result = await this.drainNodeForUser(userId, node.id, true);
+                drainedIds.push(node.id);
+                releasedJobs += result.releasedJobs;
+                views.push(result.node);
+            } catch (error) {
+                skippedNodes += 1;
+                failedIds.push(node.id);
+                views.push(node);
+                this.logger.error(
+                    `drain-all: node ${node.id} could not be drained for ${userId}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
+        this.logger.warn(
+            `drain-all by ${userId}: drained ${drainedIds.length} node(s), skipped ${skippedNodes}, requeued ${releasedJobs} job(s)`,
+        );
+        const auditFailed = !(await this.tryAudit('drain-all', userId, {
+            drainedNodes: drainedIds.length,
+            skippedNodes,
+            releasedJobs,
+            nodeIds: drainedIds,
+            failedNodeIds: failedIds,
+        }));
+
+        return {
+            drainedNodes: drainedIds.length,
+            skippedNodes,
+            releasedJobs,
+            nodes: views,
+            auditFailed,
+        };
+    }
+
+    /**
+     * Cancel the caller's in-flight fleet work: every `leased` /
+     * `running` job (plus the `queued` ones when asked) and the agent run
+     * behind each. Per job the order is the one `AgentsController.cancelRun`
+     * uses — DB run row FIRST, then the remote job — so a node that
+     * reports after this can never resurrect a row.
+     *
+     * Deliberately does NOT drain the concurrency queue afterwards: a
+     * panic must not promote parked work into the slots it just freed.
+     * And it is never called by the stop flag — cancelling is its own
+     * decision, on its own route.
+     */
+    async cancelInFlightForUser(
+        userId: string,
+        options: CancelInFlightOptions = {},
+    ): Promise<FleetCancelInFlightResult> {
+        const includeQueued = options.includeQueued === true;
+        const active = await this.jobs.activeForUser(userId);
+        const queued = includeQueued ? await this.jobs.queuedForUser(userId) : [];
+
+        const seen = new Set<string>();
+        const candidates: FleetJobView[] = [];
+        for (const job of [...active, ...queued]) {
+            if (seen.has(job.id)) continue;
+            seen.add(job.id);
+            candidates.push(job);
+        }
+
+        const byState = Object.fromEntries(
+            FLEET_JOB_CANCEL_STATES.map((state) => [state, 0]),
+        ) as Record<FleetJobCancelState, number>;
+        const jobIds: string[] = [];
+        let cancelled = 0;
+        let runsCancelled = 0;
+
+        for (const job of candidates) {
+            const ctx = correlateAgentTaskJob(job);
+            if (ctx?.runId) {
+                try {
+                    // Owner re-checked by the repository's own WHERE clause.
+                    const outcome = await this.agentRuns.cancel(ctx.runId, userId);
+                    if (
+                        outcome.found &&
+                        (outcome.previousStatus === 'queued' ||
+                            outcome.previousStatus === 'running')
+                    ) {
+                        runsCancelled += 1;
+                    }
+                } catch (error) {
+                    this.logger.error(
+                        `cancel-in-flight: run ${ctx.runId} for job ${job.id} could not be cancelled: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                }
+            }
+            try {
+                const outcome = await this.jobs.cancel(job.id);
+                byState[outcome.state] += 1;
+                if (outcome.cancelled) cancelled += 1;
+                if (jobIds.length < FLEET_CANCEL_IN_FLIGHT_MAX_IDS) jobIds.push(job.id);
+            } catch (error) {
+                this.logger.error(
+                    `cancel-in-flight: job ${job.id} could not be cancelled: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
+        this.logger.warn(
+            `cancel-in-flight by ${userId}: requested ${candidates.length}, cancelled ${cancelled}, runs ${runsCancelled}, includeQueued=${includeQueued}`,
+        );
+        const auditFailed = !(await this.tryAudit('cancel-in-flight', userId, {
+            includeQueued,
+            requested: candidates.length,
+            cancelled,
+            runsCancelled,
+            byState,
+            jobIds,
+        }));
+
+        return {
+            requested: candidates.length,
+            cancelled,
+            runsCancelled,
+            byState,
+            jobIds,
+            auditFailed,
+        };
+    }
+
+    /** Audit after the action; a failure is logged and reported, never thrown. */
+    private async tryAudit(
+        action: FleetAuditAction,
+        userId: string,
+        details: Record<string, unknown>,
+    ): Promise<boolean> {
+        try {
+            await this.audit.record({
+                action,
+                actorUserId: userId,
+                ownerUserId: userId,
+                details,
+            });
+            return true;
+        } catch (error) {
+            this.logger.error(
+                `fleet audit row for ${action} by ${userId} could not be written: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+}

--- a/apps/api/src/fleet/fleet-run-router.service.ts
+++ b/apps/api/src/fleet/fleet-run-router.service.ts
@@ -3,7 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { config } from '@ever-works/agent/config';
 import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
-import { FleetExecutionPreferenceService, FleetJobService } from '@ever-works/agent/fleet';
+import {
+    FleetExecutionPreferenceService,
+    FleetJobService,
+    FleetKillSwitchService,
+} from '@ever-works/agent/fleet';
 import type { AgentTaskExecuteDispatchPayload } from '@ever-works/agent/tasks-domain';
 import { decideFleetRouting, DEFAULT_FLEET_EXECUTION_MODE } from '@ever-works/contracts';
 import type {
@@ -18,6 +22,7 @@ import type {
 } from '@ever-works/job-runtime-node-plugin';
 import { agentTaskRequiredCapabilities } from './fleet-agent-task-capabilities';
 import type { FleetAgentTaskPlan } from './fleet-agent-task.dispatcher';
+import { FleetKillSwitchActiveError } from './fleet-kill-switch.error';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
 import {
     NODE_JOB_RUNTIME_DISPATCHER_FACTORY,
@@ -143,7 +148,32 @@ export class FleetRunRouterService {
         // positional-arity rule; absent = every job is judged unpinned.
         @Optional()
         private readonly jobs?: FleetJobService,
+        // Panic controls (EW-778) — the GLOBAL STOP FLAG. Same appended-
+        // LAST + @Optional() posture. Present, `routeAgentTask` and
+        // `enqueueAgentTask` REFUSE (typed error, never a cloud fallback)
+        // while the flag is set or cannot be read.
+        @Optional()
+        private readonly killSwitch?: FleetKillSwitchService,
     ) {}
+
+    /**
+     * True when no new work may be routed: the flag is set OR could not
+     * be read. The service folds read failures into `true` itself; the
+     * catch covers a stub or a future implementation that throws.
+     */
+    private async halted(): Promise<boolean> {
+        if (!this.killSwitch) return false;
+        try {
+            return await this.killSwitch.isStopped();
+        } catch (err) {
+            this.logger.error(
+                `Global stop flag could not be read — refusing to route (fail-closed): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return true;
+        }
+    }
 
     /**
      * The runtime id that should service work for `tenantId`. Mirrors
@@ -174,9 +204,13 @@ export class FleetRunRouterService {
     /**
      * True when this run should be enqueued onto the owner's fleet.
      *
-     * `FLEET_NODE_RUNTIME_ENABLED=false` is the kill switch and wins
-     * over the selector — an operator draining the fleet gets the
-     * platform default back without editing every tenant row.
+     * `FLEET_NODE_RUNTIME_ENABLED=false` is a ROUTING SELECTOR that wins
+     * over the tenant overlay — an operator taking the fleet runtime out
+     * of service gets the platform default back without editing every
+     * tenant row. It is NOT a panic control: work FALLS BACK TO THE
+     * CLOUD. The control that stops work is the DB-backed global stop
+     * flag (`FleetKillSwitchService`, EW-778), checked above this in
+     * {@link routeAgentTask}.
      */
     async shouldDispatchToFleet(tenantId?: string | null): Promise<boolean> {
         if ((await this.resolveRuntimeId(tenantId)) !== 'node') {
@@ -197,12 +231,15 @@ export class FleetRunRouterService {
      *
      * Two questions, in this order, and the order matters:
      *
+     *   0. **Is the platform STOPPED?** (EW-778) The global stop flag is
+     *      read first, outside every fallback. Set (or unreadable) ⇒
+     *      {@link FleetKillSwitchActiveError}, which the fleet-aware
+     *      dispatcher rethrows rather than falling back to the cloud.
      *   1. **Is the fleet even on the table?** {@link shouldDispatchToFleet}
-     *      answers that from the runtime selector and the operator kill
-     *      switch. A `no` here is final — an owner cannot opt INTO the
-     *      fleet with a preference row when their tenant is not on the
-     *      fleet runtime, and no preference outranks an operator
-     *      draining the fleet.
+     *      answers that from the runtime selector. A `no` here is final —
+     *      an owner cannot opt INTO the fleet with a preference row when
+     *      their tenant is not on the fleet runtime, and no preference
+     *      outranks an operator taking the runtime out of service.
      *   2. **Given the fleet is available, what does the owner want for
      *      THIS Work / Goal, and can a runner take it right now?** That
      *      is `resolveForUser` + `availability` fed into the pure
@@ -221,7 +258,9 @@ export class FleetRunRouterService {
      * made `free > 0`, and then sat queued forever with no reason and no
      * notice.
      *
-     * Never throws: any failure below step 1 degrades to plain `fleet`,
+     * Never throws below step 0 (the global stop flag, which REFUSES with
+     * a typed error rather than degrading): any failure after step 1
+     * degrades to plain `fleet`,
      * which is byte-for-byte what this path did before preferences
      * existed. Deciding WHERE to run is infrastructure, and an
      * infrastructure hiccup must not cost the user a run. An affinity
@@ -234,6 +273,9 @@ export class FleetRunRouterService {
         scope: FleetExecutionScopeQuery = {},
         hints: FleetRunRoutingHints = {},
     ): Promise<FleetRunRoutingDecision> {
+        if (await this.halted()) {
+            throw new FleetKillSwitchActiveError(payload.taskId);
+        }
         if (!(await this.shouldDispatchToFleet(payload.tenantId))) {
             // Not a fallback: this tenant was never routed to the fleet,
             // so there is nothing to notify anyone about.
@@ -319,6 +361,11 @@ export class FleetRunRouterService {
          */
         plan?: FleetAgentTaskPlan | null,
     ): Promise<{ runId: string }> {
+        // EW-778 — a direct caller (anything that skipped routeAgentTask)
+        // is refused on the same flag. Fail closed.
+        if (await this.halted()) {
+            throw new FleetKillSwitchActiveError(payload.taskId);
+        }
         const steps = plan ? [] : this.buildAgentTaskSteps(payload);
         const workspacePath = plan ? undefined : config.fleetNode.getAgentTaskWorkspacePath();
 

--- a/apps/api/src/fleet/fleet-runner-routes.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-runner-routes.controller.spec.ts
@@ -71,6 +71,7 @@ describe('FleetController runner status + execution preferences', () => {
                 describeForUser: jest.fn(async () => null),
                 setFleetCeilingForUser: jest.fn(async () => null),
             } as never,
+            { drainNodeForUser: jest.fn(async () => null) } as never,
         );
     });
 

--- a/apps/api/src/fleet/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/fleet.controller.spec.ts
@@ -94,6 +94,9 @@ describe('FleetController', () => {
             runnerStub as never,
             preferenceStub as never,
             ceilingStub as never,
+            // EW-778 — the per-node drain now lives in FleetPanicService
+            // (shared with drain-all); its own spec covers it.
+            { drainNodeForUser: jest.fn(async () => null) } as never,
         );
     });
 

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -36,6 +36,7 @@ import type {
     FleetNodeView,
     FleetRunnerStatusView,
 } from '@ever-works/contracts';
+import { FleetPanicService } from './fleet-panic.service';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
 import { Public } from '../auth/decorators/public.decorator';
 import { CurrentUser } from '../auth/decorators/user.decorator';
@@ -87,6 +88,15 @@ const NODE_HISTORY_LIMIT = 25;
  *                                             ceiling + today's spend
  *   PUT    /api/fleet/cost-ceiling            set / clear that ceiling
  *
+ * Panic controls (EW-778), on their own controllers:
+ *   POST   /api/fleet/drain-all               drain EVERY node I own
+ *   POST   /api/fleet/cancel-in-flight        cancel my running fleet work
+ *                                             (explicit second step)
+ *   GET    /api/fleet/kill-switch             is the global stop flag set?
+ *   POST   /api/fleet/kill-switch/stop        platform admin: set it
+ *   POST   /api/fleet/kill-switch/clear       platform admin: clear it
+ *   GET    /api/fleet/kill-switch/audit       platform admin: audit trail
+ *
  * Public, self-authenticating (called by the node apps — throttled,
  * fail-closed: any invalid credential path is one undifferentiated
  * 401, mirroring the terminal internal endpoints' posture):
@@ -118,6 +128,8 @@ export class FleetController {
         private readonly runners: FleetRunnerStatusService,
         private readonly preferences: FleetExecutionPreferenceService,
         private readonly costCeiling: FleetCostCeilingService,
+        // EW-778 — owns the per-node drain so that drain-all reuses it.
+        private readonly panic: FleetPanicService,
     ) {}
 
     @Get('cost-ceiling')
@@ -316,12 +328,10 @@ export class FleetController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: DrainFleetNodeDto,
     ): Promise<FleetNodeDrainResult> {
-        // Order matters: disable FIRST. The node stops being able to
-        // lease the instant its status flips, so a claim requeued after
-        // that cannot be re-claimed by the machine being drained.
-        const node = await this.service.setDisabledForUser(auth.userId, id, body.drain);
-        const releasedJobs = body.drain ? await this.jobs.releaseClaimsForNode(auth.userId, id) : 0;
-        return { node, releasedJobs };
+        // The drain itself (disable FIRST, then requeue — the order is
+        // load-bearing) lives in FleetPanicService so that drain-all
+        // (EW-778) performs exactly this, once per node.
+        return this.panic.drainNodeForUser(auth.userId, id, body.drain);
     }
 
     @Post('nodes/enrollment-token')

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -3,10 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { NotificationsModule } from '@ever-works/agent/notifications';
 import { FleetModule as AgentFleetModule } from '@ever-works/agent/fleet';
+import { AgentsModule as AgentAgentsModule } from '@ever-works/agent/agents';
 import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { IsPlatformAdminGuard } from '../auth/guards/platform-admin.guard';
 import { FleetController } from './fleet.controller';
 import { FleetJobsController } from './fleet-jobs.controller';
 import { FleetAgentAffinityController } from './fleet-agent-affinity.controller';
+import { FleetKillSwitchController } from './fleet-kill-switch.controller';
+import { FleetPanicController } from './fleet-panic.controller';
+import { FleetPanicService } from './fleet-panic.service';
 import { FleetRunRouterService } from './fleet-run-router.service';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
 import {
@@ -24,15 +29,31 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  * repositories, enrollment/heartbeat crypto, the job lease protocol and
  * the offline sweep all live there).
  *
- * Three controllers, two trust boundaries — kept apart deliberately:
+ * Five controllers, three trust boundaries — kept apart deliberately:
  *   - `FleetController` — owner-scoped registry management
  *     (session/API-key auth) plus the public token-authenticated
  *     enroll/heartbeat pair.
  *   - `FleetAgentAffinityController` — owner + active-Organization scoped
  *     Agent-to-node scheduling intent (session/API-key auth).
+ *   - `FleetPanicController` (EW-778) — owner-scoped drain-all and
+ *     cancel-in-flight, plus the read of the global stop flag.
+ *   - `FleetKillSwitchController` (EW-778) — PLATFORM-ADMIN set / clear
+ *     of the global stop flag and the fleet audit trail
+ *     (`IsPlatformAdminGuard`, provided here the way `BudgetsModule`
+ *     does it: the guard only injects `UserRepository`, which the
+ *     imported `DatabaseModule` supplies — deliberately NOT `AuthModule`,
+ *     whose better-auth runtime would otherwise ride into every module
+ *     that imports this one).
  *   - `FleetJobsController` — the node work channel (lease / job
  *     heartbeat / complete), node-secret authenticated, public,
  *     fail-closed to one undifferentiated 401.
+ *
+ * `FleetPanicService` holds the per-node drain that `FleetController`
+ * and drain-all BOTH call (one implementation, two routes), and the
+ * cancel-in-flight walk over `FleetJobService.cancel` +
+ * `AgentRunRepository.cancel`. The clear route resumes parked runs
+ * through `RunDispatchGateService.promoteParked`, which is why the
+ * agent-side `AgentsModule` is imported here.
  *
  * `FleetRunnerStatusService` is the ONE composer behind both the
  * always-visible runner pill and the router's availability check, so
@@ -72,15 +93,32 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
         // where the fallback is actually decided.
         NotificationsModule,
         TypeOrmModule.forFeature([TenantJobRuntimeConfig]),
+        // EW-778 — `RunDispatchGateService` (resume parked runs on clear)
+        // is provided + exported by the agent-side AgentsModule.
+        AgentAgentsModule,
+        // EW-778 — `IsPlatformAdminGuard` (kill-switch routes) resolves
+        // `UserRepository` from `DatabaseModule` above; session auth is the
+        // global APP_GUARD. `AuthModule` is NOT imported on purpose: it
+        // pulls the better-auth runtime (ESM) into `TasksModule` and every
+        // other importer of this module, which is what
+        // `tasks.module.di-contract.spec.ts` guards against.
     ],
-    controllers: [FleetController, FleetJobsController, FleetAgentAffinityController],
+    controllers: [
+        FleetController,
+        FleetJobsController,
+        FleetAgentAffinityController,
+        FleetPanicController,
+        FleetKillSwitchController,
+    ],
     providers: [
         ...buildNodeJobRuntimeProviders(),
         FleetRunnerStatusService,
         FleetRunRouterService,
+        FleetPanicService,
         // Guards are ordinary providers so Nest can inject them.
         FleetEnabledGuard,
         FleetNodeAuthGuard,
+        IsPlatformAdminGuard,
     ],
     exports: [
         AgentFleetModule,
@@ -93,6 +131,7 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
         NODE_JOB_RUNTIME_PLUGIN,
         FleetRunRouterService,
         FleetRunnerStatusService,
+        FleetPanicService,
     ],
 })
 export class FleetApiModule {}

--- a/apps/api/src/migrations/1788150000000-CreateFleetKillSwitchAndAudit.ts
+++ b/apps/api/src/migrations/1788150000000-CreateFleetKillSwitchAndAudit.ts
@@ -1,0 +1,151 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Panic controls (EW-778, closes OPS-16 + security audit 2026-05-17 #25).
+ *
+ * Two tables:
+ *
+ *   - `fleet_kill_switch` — the GLOBAL STOP FLAG. A single row keyed
+ *     `'global'`, SEEDED here so that a missing row can only ever mean
+ *     "this migration has not run". `FleetKillSwitchService` treats a
+ *     missing row (or any read failure) as STOPPED, so an API replica that
+ *     boots ahead of the migration refuses dispatch until the row exists —
+ *     that is the fail-closed contract, and this seed is what keeps it from
+ *     being a permanent outage.
+ *   - `fleet_audit` — append-only trail of every set / clear / drain-all /
+ *     cancel-in-flight, carrying the actor and the time. The minimal shape
+ *     the panic controls need; slice AQ extends it.
+ *
+ * Columns mirror `FleetKillSwitch` / `FleetAudit` in
+ * `packages/agent/src/entities/`. `details` is `text` at the SQL level
+ * (the entity column is `simple-json`) for dialect portability, the same
+ * pattern as `tenant_job_runtime_audit.before/after`.
+ *
+ * Both FKs to `users` are `ON DELETE SET NULL` — an audit row and the
+ * switch itself must survive the purge of the user who touched them — and
+ * are guarded on `hasTable('users')` so the migration also runs against the
+ * bare in-memory harness the spec uses. `fleet_audit.nodeId` deliberately
+ * carries NO FK: history must outlive node deletion.
+ *
+ * Idempotent (`hasTable` guards, seed-if-absent); `down` drops both tables.
+ */
+export class CreateFleetKillSwitchAndAudit1788150000000 implements MigrationInterface {
+    name = 'CreateFleetKillSwitchAndAudit1788150000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+        const hasUsers = await queryRunner.hasTable('users');
+
+        if (!(await queryRunner.hasTable('fleet_kill_switch'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'fleet_kill_switch',
+                    columns: [
+                        { name: 'id', type: 'varchar', length: '32', isPrimary: true },
+                        { name: 'stopped', type: 'boolean', default: false },
+                        { name: 'reason', type: 'varchar', length: '500', isNullable: true },
+                        { name: 'setByUserId', type: 'uuid', isNullable: true },
+                        { name: 'setAt', type: 'timestamp', isNullable: true },
+                        { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    ],
+                }),
+                true,
+            );
+
+            if (hasUsers) {
+                await queryRunner.createForeignKey(
+                    'fleet_kill_switch',
+                    new TableForeignKey({
+                        name: 'fk_fleet_kill_switch_set_by',
+                        columnNames: ['setByUserId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                        onDelete: 'SET NULL',
+                    }),
+                );
+            }
+        }
+
+        // Seed the one row. Relying on the column defaults (rather than
+        // spelling out `false`) keeps the statement identical on Postgres
+        // and sqlite. INSERT-if-absent so a re-run never duplicates it.
+        const existing: unknown[] = await queryRunner.query(
+            `SELECT id FROM fleet_kill_switch WHERE id = 'global'`,
+        );
+        if (existing.length === 0) {
+            await queryRunner.query(`INSERT INTO fleet_kill_switch (id) VALUES ('global')`);
+        }
+
+        if (!(await queryRunner.hasTable('fleet_audit'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'fleet_audit',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: isPostgres ? 'uuid_generate_v4()' : undefined,
+                        },
+                        { name: 'action', type: 'varchar', length: '64' },
+                        { name: 'actorUserId', type: 'uuid', isNullable: true },
+                        { name: 'ownerUserId', type: 'uuid', isNullable: true },
+                        { name: 'nodeId', type: 'uuid', isNullable: true },
+                        { name: 'details', type: 'text', isNullable: true },
+                        { name: 'occurredAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    ],
+                }),
+                true,
+            );
+
+            if (hasUsers) {
+                await queryRunner.createForeignKey(
+                    'fleet_audit',
+                    new TableForeignKey({
+                        name: 'fk_fleet_audit_actor',
+                        columnNames: ['actorUserId'],
+                        referencedTableName: 'users',
+                        referencedColumnNames: ['id'],
+                        onDelete: 'SET NULL',
+                    }),
+                );
+            }
+        }
+
+        const audit = await queryRunner.getTable('fleet_audit');
+        if (
+            audit &&
+            !audit.indices.some((index) => index.name === 'idx_fleet_audit_owner_occurred')
+        ) {
+            await queryRunner.createIndex(
+                'fleet_audit',
+                new TableIndex({
+                    name: 'idx_fleet_audit_owner_occurred',
+                    columnNames: ['ownerUserId', 'occurredAt'],
+                }),
+            );
+        }
+        if (
+            audit &&
+            !audit.indices.some((index) => index.name === 'idx_fleet_audit_action_occurred')
+        ) {
+            await queryRunner.createIndex(
+                'fleet_audit',
+                new TableIndex({
+                    name: 'idx_fleet_audit_action_occurred',
+                    columnNames: ['action', 'occurredAt'],
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('fleet_audit')) {
+            await queryRunner.dropTable('fleet_audit', true);
+        }
+        if (await queryRunner.hasTable('fleet_kill_switch')) {
+            await queryRunner.dropTable('fleet_kill_switch', true);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateFleetKillSwitchAndAudit.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateFleetKillSwitchAndAudit.spec.ts
@@ -1,0 +1,117 @@
+import { DataSource } from 'typeorm';
+import { CreateFleetKillSwitchAndAudit1788150000000 } from '../1788150000000-CreateFleetKillSwitchAndAudit';
+
+/**
+ * Panic controls (EW-778) — the migration behind the global stop flag.
+ *
+ * The property that matters most is the SEED: `FleetKillSwitchService`
+ * fails closed on a missing row, so a migration that created the table
+ * and left it empty would turn every deploy into a dispatch outage until
+ * someone inserted the row by hand.
+ */
+describe('CreateFleetKillSwitchAndAudit1788150000000', () => {
+    let dataSource: DataSource;
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await new CreateFleetKillSwitchAndAudit1788150000000().up(runner);
+        await runner.release();
+    }
+
+    async function runDown(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await new CreateFleetKillSwitchAndAudit1788150000000().down(runner);
+        await runner.release();
+    }
+
+    it('creates the single-row switch table and SEEDS the global row as not stopped', async () => {
+        await runUp();
+
+        const runner = dataSource.createQueryRunner();
+        const table = await runner.getTable('fleet_kill_switch');
+        await runner.release();
+
+        expect(table?.columns.map((column) => column.name).sort()).toEqual(
+            ['id', 'stopped', 'reason', 'setByUserId', 'setAt', 'updatedAt'].sort(),
+        );
+        const rows = await dataSource.query(
+            `SELECT id, stopped, reason, "setByUserId" FROM fleet_kill_switch`,
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0].id).toBe('global');
+        // sqlite stores booleans as 0/1; either way it must be falsy.
+        expect(Boolean(rows[0].stopped)).toBe(false);
+        expect(rows[0].reason).toBeNull();
+        expect(rows[0].setByUserId).toBeNull();
+    });
+
+    it('creates the append-only audit table with both lookup indexes', async () => {
+        await runUp();
+
+        const runner = dataSource.createQueryRunner();
+        const table = await runner.getTable('fleet_audit');
+        await runner.release();
+
+        expect(table?.columns.map((column) => column.name).sort()).toEqual(
+            [
+                'id',
+                'action',
+                'actorUserId',
+                'ownerUserId',
+                'nodeId',
+                'details',
+                'occurredAt',
+            ].sort(),
+        );
+        expect(table?.indices.map((index) => index.name).sort()).toEqual(
+            ['idx_fleet_audit_action_occurred', 'idx_fleet_audit_owner_occurred'].sort(),
+        );
+    });
+
+    it('is idempotent: a re-run neither throws nor duplicates the seeded row', async () => {
+        await runUp();
+        await expect(runUp()).resolves.not.toThrow();
+
+        const rows = await dataSource.query(`SELECT id FROM fleet_kill_switch`);
+        expect(rows).toEqual([{ id: 'global' }]);
+    });
+
+    it('does not overwrite a switch an operator has already thrown', async () => {
+        await runUp();
+        await dataSource.query(
+            `UPDATE fleet_kill_switch SET stopped = 1, reason = 'incident' WHERE id = 'global'`,
+        );
+
+        await runUp();
+
+        const rows = await dataSource.query(
+            `SELECT stopped, reason FROM fleet_kill_switch WHERE id = 'global'`,
+        );
+        expect(Boolean(rows[0].stopped)).toBe(true);
+        expect(rows[0].reason).toBe('incident');
+    });
+
+    it('down drops both tables', async () => {
+        await runUp();
+        await runDown();
+
+        const runner = dataSource.createQueryRunner();
+        expect(await runner.hasTable('fleet_kill_switch')).toBe(false);
+        expect(await runner.hasTable('fleet_audit')).toBe(false);
+        await runner.release();
+    });
+});

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -63,6 +63,7 @@ import {
 // store; `FleetRunRouterService` decides per run whether the resolved
 // runtime is the owner's Fleet and, when it is, writes the lease-able
 // row an enrolled node polls for.
+import { FleetKillSwitchService } from '@ever-works/agent/fleet';
 import { FleetApiModule } from '../fleet/fleet.module';
 import { FleetRunRouterService } from '../fleet/fleet-run-router.service';
 import { createFleetAwareAgentTaskExecuteDispatcher } from '../fleet/fleet-agent-task.dispatcher';
@@ -139,17 +140,23 @@ import { TaskChatController } from './task-chat.controller';
                 scopeResolver: FleetTaskScopeResolverService,
                 notifications: NotificationService,
                 planner: FleetAgentTaskPlannerService,
+                // Panic controls (EW-778) — the global stop flag, checked
+                // before routing so a stop can never become a cloud
+                // fallback. Resolves through FleetApiModule's re-export of
+                // the agent-side FleetModule.
+                killSwitch: FleetKillSwitchService,
             ) =>
                 createFleetAwareAgentTaskExecuteDispatcher(
                     agentTaskExecuteTriggerAdapter,
                     fleetRouter,
-                    { scopeResolver, notifications, planner },
+                    { scopeResolver, notifications, planner, killSwitch },
                 ),
             inject: [
                 FleetRunRouterService,
                 FleetTaskScopeResolverService,
                 NotificationService,
                 FleetAgentTaskPlannerService,
+                FleetKillSwitchService,
             ],
         },
         { provide: AGENT_CHAT_REPLY_DISPATCHER, useValue: agentChatReplyTriggerAdapter },

--- a/apps/web/e2e/flow-fleet-panic-controls.spec.ts
+++ b/apps/web/e2e/flow-fleet-panic-controls.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Panic controls (EW-778) — API CONTRACT.
+ *
+ * ── Routes ──────────────────────────────────────────────────────────
+ *   Owner-scoped (platform session):
+ *     POST   /api/fleet/drain-all          200 FleetDrainAllResult
+ *     POST   /api/fleet/cancel-in-flight   200 FleetCancelInFlightResult
+ *     GET    /api/fleet/kill-switch        200 FleetKillSwitchState
+ *   Platform admin only:
+ *     POST   /api/fleet/kill-switch/stop   200 | 403
+ *     POST   /api/fleet/kill-switch/clear  200 | 403
+ *     GET    /api/fleet/kill-switch/audit  200 | 403
+ *
+ * What a silent regression would break without a unit test noticing:
+ *   - drain-all touches ONLY the caller's nodes (two users, one fleet
+ *     each — the other account's node is exactly as it was);
+ *   - a fresh account's stop flag reads NOT stopped and VERIFIED — if
+ *     this ever reads `unverified`, every dispatch on the stack is
+ *     parked fail-closed and something is wrong with the seed;
+ *   - the actor is never leaked on the public read;
+ *   - every new route is closed to anonymous callers (401) and the admin
+ *     routes are closed to ordinary users (403) — an ordinary user must
+ *     never be able to stop the whole platform.
+ *
+ * The admin set/clear happy path is gated behind
+ * `TEST_FLEET_KILL_SWITCH_ADMIN=1`: throwing the switch parks EVERY
+ * dispatch on the shared e2e stack for the duration, which would make
+ * every parallel agent-run spec flaky. The unit specs cover that path.
+ */
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function enrollNode(
+    request: APIRequestContext,
+    token: string,
+): Promise<{ nodeId: string; secret: string }> {
+    const mint = await request.post(`${API_BASE}/api/fleet/nodes/enrollment-token`, {
+        headers: authedHeaders(token),
+        data: { name: `node-${uniq()}`, kind: 'node' },
+    });
+    expect(mint.status(), await mint.text().catch(() => '')).toBe(201);
+    const minted = await mint.json();
+    const enroll = await request.post(`${API_BASE}/api/fleet/enroll`, {
+        data: { token: minted.token, platform: 'linux/x64', version: '0.0.0-e2e' },
+    });
+    expect(enroll.status(), await enroll.text().catch(() => '')).toBe(201);
+    const enrolled = await enroll.json();
+    return { nodeId: enrolled.nodeId, secret: enrolled.secret };
+}
+
+async function nodeStatus(request: APIRequestContext, token: string, nodeId: string) {
+    const res = await request.get(`${API_BASE}/api/fleet/nodes`, {
+        headers: authedHeaders(token),
+    });
+    expect(res.status()).toBe(200);
+    const nodes = (await res.json()) as Array<{ id: string; status: string }>;
+    return nodes.find((node) => node.id === nodeId)?.status;
+}
+
+test.describe('GET /api/fleet/kill-switch', () => {
+    test('a signed-in user reads a NOT-stopped, VERIFIED flag with no actor in it', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/fleet/kill-switch`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({ stopped: false, unverified: false });
+        expect(body).toHaveProperty('reason');
+        expect(body).toHaveProperty('since');
+        expect(body).not.toHaveProperty('setByUserId');
+    });
+
+    test('anonymous is 401', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/fleet/kill-switch`);
+        expect(res.status()).toBe(401);
+    });
+});
+
+test.describe('POST /api/fleet/drain-all', () => {
+    test('drains ONLY the caller’s nodes, skips an enrolling one, and never touches another account', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+
+        const live = await enrollNode(request, owner.access_token);
+        // A minted-but-unused token is an `enrolling` row — nothing to drain.
+        const pending = await request.post(`${API_BASE}/api/fleet/nodes/enrollment-token`, {
+            headers: authedHeaders(owner.access_token),
+            data: { name: `node-${uniq()}`, kind: 'node' },
+        });
+        expect(pending.status()).toBe(201);
+        const pendingNodeId = (await pending.json()).node.id as string;
+        const strangerNode = await enrollNode(request, stranger.access_token);
+
+        const res = await request.post(`${API_BASE}/api/fleet/drain-all`, {
+            headers: authedHeaders(owner.access_token),
+            data: {},
+        });
+        expect(res.status(), await res.text().catch(() => '')).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({
+            drainedNodes: 1,
+            skippedNodes: 1,
+            releasedJobs: 0,
+            auditFailed: false,
+        });
+        expect(Array.isArray(body.nodes)).toBe(true);
+
+        expect(await nodeStatus(request, owner.access_token, live.nodeId)).toBe('disabled');
+        expect(await nodeStatus(request, owner.access_token, pendingNodeId)).toBe('enrolling');
+        // The stranger's node is exactly as it was.
+        expect(await nodeStatus(request, stranger.access_token, strangerNode.nodeId)).not.toBe(
+            'disabled',
+        );
+
+        // A second drain-all is idempotent: the drained node is now skipped.
+        const again = await request.post(`${API_BASE}/api/fleet/drain-all`, {
+            headers: authedHeaders(owner.access_token),
+            data: {},
+        });
+        expect(again.status()).toBe(200);
+        expect(await again.json()).toMatchObject({ drainedNodes: 0, skippedNodes: 2 });
+    });
+
+    test('a fresh account drains nothing, cleanly', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.post(`${API_BASE}/api/fleet/drain-all`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(res.status()).toBe(200);
+        expect(await res.json()).toEqual({
+            drainedNodes: 0,
+            skippedNodes: 0,
+            releasedJobs: 0,
+            nodes: [],
+            auditFailed: false,
+        });
+    });
+
+    test('anonymous is 401', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/fleet/drain-all`, { data: {} });
+        expect(res.status()).toBe(401);
+    });
+});
+
+test.describe('POST /api/fleet/cancel-in-flight', () => {
+    test('is owner-scoped and explicit: a fresh account cancels nothing, includeQueued is honoured', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.post(`${API_BASE}/api/fleet/cancel-in-flight`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(res.status(), await res.text().catch(() => '')).toBe(200);
+        expect(await res.json()).toMatchObject({
+            requested: 0,
+            cancelled: 0,
+            runsCancelled: 0,
+            jobIds: [],
+            auditFailed: false,
+        });
+
+        const withQueued = await request.post(`${API_BASE}/api/fleet/cancel-in-flight`, {
+            headers: authedHeaders(u.access_token),
+            data: { includeQueued: true },
+        });
+        expect(withQueued.status()).toBe(200);
+        expect(await withQueued.json()).toMatchObject({ requested: 0 });
+    });
+
+    test('rejects a non-boolean includeQueued (400) and anonymous (401)', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const bad = await request.post(`${API_BASE}/api/fleet/cancel-in-flight`, {
+            headers: authedHeaders(u.access_token),
+            data: { includeQueued: 'yes' },
+        });
+        expect(bad.status()).toBe(400);
+        const anon = await request.post(`${API_BASE}/api/fleet/cancel-in-flight`, { data: {} });
+        expect(anon.status()).toBe(401);
+    });
+});
+
+test.describe('admin-only stop / clear / audit', () => {
+    test('an ordinary user can NEVER stop the platform: 403 on stop, clear and audit', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const stop = await request.post(`${API_BASE}/api/fleet/kill-switch/stop`, {
+            headers,
+            data: { reason: 'e2e must not be able to do this' },
+        });
+        expect(stop.status()).toBe(403);
+        const clear = await request.post(`${API_BASE}/api/fleet/kill-switch/clear`, {
+            headers,
+            data: {},
+        });
+        expect(clear.status()).toBe(403);
+        const audit = await request.get(`${API_BASE}/api/fleet/kill-switch/audit`, { headers });
+        expect(audit.status()).toBe(403);
+
+        // And the flag is still clear for everyone.
+        const state = await request.get(`${API_BASE}/api/fleet/kill-switch`, { headers });
+        expect(await state.json()).toMatchObject({ stopped: false });
+    });
+
+    test('anonymous is 401 on every admin route', async ({ request }) => {
+        for (const [method, path] of [
+            ['post', '/api/fleet/kill-switch/stop'],
+            ['post', '/api/fleet/kill-switch/clear'],
+            ['get', '/api/fleet/kill-switch/audit'],
+        ] as const) {
+            const res =
+                method === 'post'
+                    ? await request.post(`${API_BASE}${path}`, { data: {} })
+                    : await request.get(`${API_BASE}${path}`);
+            expect(res.status(), `${method.toUpperCase()} ${path}`).toBe(401);
+        }
+    });
+
+    test('platform admin: stop parks the platform, every user sees it, clear resumes it, both are audited', async ({
+        request,
+    }) => {
+        test.skip(
+            process.env.TEST_FLEET_KILL_SWITCH_ADMIN !== '1',
+            'Throwing the switch parks every dispatch on the shared e2e stack; opt in with TEST_FLEET_KILL_SWITCH_ADMIN=1.',
+        );
+        // The API grants isPlatformAdmin on register for the e2e-admin-* pattern
+        // (EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS on the e2e stack).
+        const admin = await registerUserViaAPI(request, {
+            email: `e2e-admin-${uniq()}@test.local`,
+        });
+        const viewer = await registerUserViaAPI(request);
+        const adminHeaders = authedHeaders(admin.access_token);
+
+        try {
+            const stop = await request.post(`${API_BASE}/api/fleet/kill-switch/stop`, {
+                headers: adminHeaders,
+                data: { reason: 'e2e drill' },
+            });
+            expect(stop.status(), await stop.text().catch(() => '')).toBe(200);
+            const stopped = await stop.json();
+            expect(stopped.state).toMatchObject({
+                stopped: true,
+                reason: 'e2e drill',
+                unverified: false,
+                setByUserId: admin.user.id,
+            });
+            expect(stopped.auditFailed).toBe(false);
+
+            const seen = await request.get(`${API_BASE}/api/fleet/kill-switch`, {
+                headers: authedHeaders(viewer.access_token),
+            });
+            const seenBody = await seen.json();
+            expect(seenBody).toMatchObject({ stopped: true, reason: 'e2e drill' });
+            expect(seenBody).not.toHaveProperty('setByUserId');
+        } finally {
+            const clear = await request.post(`${API_BASE}/api/fleet/kill-switch/clear`, {
+                headers: adminHeaders,
+                data: {},
+            });
+            expect(clear.status(), await clear.text().catch(() => '')).toBe(200);
+            expect((await clear.json()).state).toMatchObject({ stopped: false });
+        }
+
+        const audit = await request.get(`${API_BASE}/api/fleet/kill-switch/audit?limit=10`, {
+            headers: adminHeaders,
+        });
+        expect(audit.status()).toBe(200);
+        const rows = (await audit.json()) as Array<{ action: string; actorUserId: string | null }>;
+        expect(
+            rows.some(
+                (row) => row.action === 'kill-switch.stop' && row.actorUserId === admin.user.id,
+            ),
+        ).toBe(true);
+        expect(
+            rows.some(
+                (row) => row.action === 'kill-switch.clear' && row.actorUserId === admin.user.id,
+            ),
+        ).toBe(true);
+    });
+});

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1036,7 +1036,11 @@
                     "propose": "اقتراح عمليات دمج"
                 },
                 "subtitle": "يدمج المستندات شبه المكررة دوريًا. تذهب المقترحات إلى قائمة المراجعة — لا يُقبل أو يُحذف أي شيء تلقائيًا.",
-                "title": "الدمج المجدول"
+                "title": "الدمج المجدول",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "المؤرشفة"
+                "archived": "المؤرشفة",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "المنظمات",
                 "personalHelp": "سيتم إنشاء المستودع تحت حساب GitHub الشخصي الخاص بك",
                 "organizationHelp": "سيتم إنشاء المستودع تحت المنظمة {org}",
-                "connectRequired": "ربط مزود Git في الشريط الجانبي لاختيار مكان إنشاء مستودعك."
+                "connectRequired": "ربط مزود Git في الشريط الجانبي لاختيار مكان إنشاء مستودعك.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "إنشاء باستخدام الذكاء الاصطناعي",
@@ -6675,7 +6795,11 @@
                 "connected": "متصل",
                 "connecting": "جاري الاتصال...",
                 "connect": "ربط",
-                "connectError": "فشل في الربط"
+                "connectError": "فشل في الربط",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "اتصالات مزود Git",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "تم حفظ وصول المنظمة.",
                 "saveFailed": "فشل في الحفظ.",
                 "removeLabel": "إزالة {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "القوالب",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1036,7 +1036,11 @@
                     "propose": "Предлагай обединения"
                 },
                 "subtitle": "Периодично обединява почти еднакви документи. Предложенията отиват в опашката за преглед — нищо не се приема или изтрива автоматично.",
-                "title": "Планирана консолидация"
+                "title": "Планирана консолидация",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Архивирани"
+                "archived": "Архивирани",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "Организации",
                 "personalHelp": "Хранилището ще бъде създадено под вашата лична GitHub сметка",
                 "organizationHelp": "Хранилището ще бъде създадено под организацията {org}",
-                "connectRequired": "Свържете Git доставчик в страничната лента, за да изберете къде ще бъде създадено хранилището ви."
+                "connectRequired": "Свържете Git доставчик в страничната лента, за да изберете къде ще бъде създадено хранилището ви.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Създай с AI",
@@ -6675,7 +6795,11 @@
                 "connected": "Свързан",
                 "connecting": "Свързване...",
                 "connect": "Свържи",
-                "connectError": "Грешка при свързване"
+                "connectError": "Грешка при свързване",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git доставчик връзки",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "Достъпът до организацията е запазен.",
                 "saveFailed": "Запазването неуспешно.",
                 "removeLabel": "Премахни {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Шаблони",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1036,7 +1036,11 @@
                     "propose": "Zusammenführungen vorschlagen"
                 },
                 "subtitle": "Führt nahezu doppelte Dokumente regelmäßig zusammen. Vorschläge landen in der Prüf-Warteschlange — nichts wird automatisch übernommen oder gelöscht.",
-                "title": "Geplante Konsolidierung"
+                "title": "Geplante Konsolidierung",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Archiviert"
+                "archived": "Archiviert",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "Organisationen",
                 "personalHelp": "Das Repository wird unter Ihrem persönlichen GitHub-Konto erstellt",
                 "organizationHelp": "Das Repository wird unter der {org}-Organisation erstellt",
-                "connectRequired": "Verbinden Sie einen Git-Anbieter in der Seitenleiste, um auszuwählen, wo Ihr Repository erstellt wird."
+                "connectRequired": "Verbinden Sie einen Git-Anbieter in der Seitenleiste, um auszuwählen, wo Ihr Repository erstellt wird.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Mit KI erstellen",
@@ -6675,7 +6795,11 @@
                 "connected": "Verbunden",
                 "connecting": "Verbinde...",
                 "connect": "Verbinden",
-                "connectError": "Verbindung fehlgeschlagen"
+                "connectError": "Verbindung fehlgeschlagen",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git-Provider-Verbindungen",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "Zugriff auf Organisation gespeichert.",
                 "saveFailed": "Speichern fehlgeschlagen.",
                 "removeLabel": "{login} entfernen"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Vorlagen",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3467,6 +3467,41 @@
                             "helper": "Always uses the platform runtime, even when a local runner is free."
                         }
                     }
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1036,7 +1036,11 @@
                     "propose": "Proponer fusiones"
                 },
                 "subtitle": "Fusiona periódicamente documentos casi duplicados. Las propuestas van a la cola de revisión; nada se acepta ni se elimina automáticamente.",
-                "title": "Consolidación programada"
+                "title": "Consolidación programada",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Archivados"
+                "archived": "Archivados",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "Organizaciones",
                 "personalHelp": "El repositorio se creará bajo tu cuenta personal de GitHub",
                 "organizationHelp": "El repositorio se creará bajo la organización {org}",
-                "connectRequired": "Conecta un proveedor de Git en la barra lateral para elegir dónde se creará tu repositorio."
+                "connectRequired": "Conecta un proveedor de Git en la barra lateral para elegir dónde se creará tu repositorio.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Crear con IA",
@@ -6675,7 +6795,11 @@
                 "connected": "Conectado",
                 "connecting": "Conectando...",
                 "connect": "Conectar",
-                "connectError": "Error al conectar"
+                "connectError": "Error al conectar",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Conexiones de Proveedores de Git",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "Acceso a organizaciones guardado.",
                 "saveFailed": "Error al guardar.",
                 "removeLabel": "Eliminar {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Plantillas",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1036,7 +1036,11 @@
                     "propose": "Proposer des fusions"
                 },
                 "subtitle": "Fusionne périodiquement les documents quasi identiques. Les propositions vont dans la file de revue — rien n’est accepté ni supprimé automatiquement.",
-                "title": "Consolidation planifiée"
+                "title": "Consolidation planifiée",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Archivés"
+                "archived": "Archivés",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "Organisations",
                 "personalHelp": "Le dépôt sera créé sous votre compte GitHub personnel",
                 "organizationHelp": "Le dépôt sera créé sous l'organisation {org}",
-                "connectRequired": "Connectez un fournisseur Git dans la barre latérale pour choisir où votre dépôt sera créé."
+                "connectRequired": "Connectez un fournisseur Git dans la barre latérale pour choisir où votre dépôt sera créé.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Créer avec l'IA",
@@ -6675,7 +6795,11 @@
                 "connected": "Connecté",
                 "connecting": "Connexion en cours...",
                 "connect": "Connecter",
-                "connectError": "Échec de la connexion"
+                "connectError": "Échec de la connexion",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Connexions aux fournisseurs Git",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "Accès aux organisations enregistré.",
                 "saveFailed": "Échec de l'enregistrement.",
                 "removeLabel": "Supprimer {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Modèles",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1036,7 +1036,11 @@
                     "propose": "הצע מיזוגים"
                 },
                 "subtitle": "ממזג מעת לעת מסמכים כמעט זהים. ההצעות נכנסות לתור הבדיקה — דבר אינו מאושר או נמחק אוטומטית.",
-                "title": "איחוד מתוזמן"
+                "title": "איחוד מתוזמן",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1200,7 +1204,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "בארכיון"
+                "archived": "בארכיון",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1401,6 +1406,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3162,6 +3172,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3176,7 +3239,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3442,6 +3508,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5620,6 +5721,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6283,7 +6402,8 @@
                 "organizations": "ארגונים",
                 "personalHelp": "המאגר ייווצר תחת חשבון GitHub אישי שלך",
                 "organizationHelp": "המאגר ייווצר תחת הארגון {org}",
-                "connectRequired": "חבר ספק Git בסרגל הצד כדי לבחור היכן ייווצר המאגר שלך."
+                "connectRequired": "חבר ספק Git בסרגל הצד כדי לבחור היכן ייווצר המאגר שלך.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "צור עם AI",
@@ -6675,7 +6795,11 @@
                 "connected": "מחובר",
                 "connecting": "מתחבר...",
                 "connect": "חבר",
-                "connectError": "נכשל בחיבור"
+                "connectError": "נכשל בחיבור",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "חיבורי ספקי Git",
@@ -7440,7 +7564,8 @@
                 "savedSuccess": "גישת ארגון נשמרה.",
                 "saveFailed": "השמירה נכשלה.",
                 "removeLabel": "הסר {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "תבניות",
@@ -8126,7 +8251,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8336,6 +8462,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1005,7 +1005,11 @@
                     "propose": "मर्ज प्रस्तावित करें"
                 },
                 "subtitle": "लगभग समान दस्तावेज़ों को समय-समय पर मर्ज करता है। प्रस्ताव समीक्षा कतार में जाते हैं — कुछ भी स्वतः स्वीकार या हटाया नहीं जाता।",
-                "title": "निर्धारित समेकन"
+                "title": "निर्धारित समेकन",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "संग्रहीत"
+                "archived": "संग्रहीत",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "संगठन",
                 "personalHelp": "रिपॉजिटरी आपके व्यक्तिगत GitHub खाते के अंतर्गत बनाई जाएगी",
                 "organizationHelp": "रिपॉजिटरी {org} संगठन के अंतर्गत बनाई जाएगी",
-                "connectRequired": "साइडबार में एक Git प्रदाता से कनेक्ट करें ताकि आप चुन सकें कि आपकी रिपॉजिटरी कहाँ बनाई जाए।"
+                "connectRequired": "साइडबार में एक Git प्रदाता से कनेक्ट करें ताकि आप चुन सकें कि आपकी रिपॉजिटरी कहाँ बनाई जाए।",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "एआई के साथ बनाएँ",
@@ -6608,7 +6728,11 @@
                 "connected": "कनेक्टेड",
                 "connecting": "कनेक्ट हो रहा है...",
                 "connect": "कनेक्ट करें",
-                "connectError": "कनेक्ट करने में विफल"
+                "connectError": "कनेक्ट करने में विफल",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "गिट प्रदाता कनेक्शन",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "संगठन पहुँच सहेजी गई।",
                 "saveFailed": "सहेजने में विफल।",
                 "removeLabel": "{login} हटाएँ"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "टेम्प्लेट",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1005,7 +1005,11 @@
                     "propose": "Usulkan penggabungan"
                 },
                 "subtitle": "Menggabungkan dokumen yang nyaris sama secara berkala. Usulan masuk ke antrean tinjauan — tidak ada yang diterima atau dihapus otomatis.",
-                "title": "Konsolidasi terjadwal"
+                "title": "Konsolidasi terjadwal",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Diarsipkan"
+                "archived": "Diarsipkan",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Organisasi",
                 "personalHelp": "Repositori akan dibuat di bawah akun GitHub pribadi Anda",
                 "organizationHelp": "Repositori akan dibuat di bawah organisasi {org}",
-                "connectRequired": "Hubungkan penyedia Git di sidebar untuk memilih tempat repositori Anda dibuat."
+                "connectRequired": "Hubungkan penyedia Git di sidebar untuk memilih tempat repositori Anda dibuat.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Buat dengan AI",
@@ -6608,7 +6728,11 @@
                 "connected": "Terhubung",
                 "connecting": "Menghubungkan...",
                 "connect": "Hubungkan",
-                "connectError": "Gagal menghubungkan"
+                "connectError": "Gagal menghubungkan",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Koneksi Penyedia Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Akses organisasi disimpan.",
                 "saveFailed": "Gagal menyimpan.",
                 "removeLabel": "Hapus {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Template",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1005,7 +1005,11 @@
                     "propose": "Proponi unioni"
                 },
                 "subtitle": "Unisce periodicamente documenti quasi duplicati. Le proposte finiscono nella coda di revisione: nulla viene accettato o eliminato automaticamente.",
-                "title": "Consolidamento pianificato"
+                "title": "Consolidamento pianificato",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Archiviati"
+                "archived": "Archiviati",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Organizzazioni",
                 "personalHelp": "Il repository verrà creato sotto il tuo account GitHub personale",
                 "organizationHelp": "Il repository verrà creato sotto l'organizzazione {org}",
-                "connectRequired": "Collega un fornitore Git nella barra laterale per scegliere dove creare il tuo repository."
+                "connectRequired": "Collega un fornitore Git nella barra laterale per scegliere dove creare il tuo repository.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Crea con AI",
@@ -6608,7 +6728,11 @@
                 "connected": "Connesso",
                 "connecting": "Connessione in corso...",
                 "connect": "Collega",
-                "connectError": "Connessione fallita"
+                "connectError": "Connessione fallita",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Connessioni Provider Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Accesso organizzazione salvato.",
                 "saveFailed": "Salvataggio fallito.",
                 "removeLabel": "Rimuovi {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Modelli",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1005,7 +1005,11 @@
                     "propose": "統合を提案"
                 },
                 "subtitle": "ほぼ重複する文書を定期的に統合します。提案はレビュー待ちに入り、自動で承認や削除されることはありません。",
-                "title": "定期統合"
+                "title": "定期統合",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "アーカイブ済み"
+                "archived": "アーカイブ済み",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "組織",
                 "personalHelp": "リポジトリはあなたの個人 GitHub アカウントの下に作成されます",
                 "organizationHelp": "リポジトリは {org} 組織の下に作成されます",
-                "connectRequired": "サイドバーで Git プロバイダーを接続して、リポジトリを作成する場所を選択してください。"
+                "connectRequired": "サイドバーで Git プロバイダーを接続して、リポジトリを作成する場所を選択してください。",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "AI で作成",
@@ -6608,7 +6728,11 @@
                 "connected": "接続済み",
                 "connecting": "接続中...",
                 "connect": "接続",
-                "connectError": "接続に失敗しました"
+                "connectError": "接続に失敗しました",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git プロバイダー接続",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "組織アクセスを保存しました。",
                 "saveFailed": "保存に失敗しました。",
                 "removeLabel": "{login} を削除"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "テンプレート",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1005,7 +1005,11 @@
                     "propose": "병합 제안"
                 },
                 "subtitle": "거의 중복된 문서를 주기적으로 병합합니다. 제안은 검토 대기열로 이동하며 자동으로 수락되거나 삭제되지 않습니다.",
-                "title": "예약된 통합"
+                "title": "예약된 통합",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "보관됨"
+                "archived": "보관됨",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "조직",
                 "personalHelp": "저장소가 개인 GitHub 계정 아래에 생성됩니다",
                 "organizationHelp": "{org} 조직 아래에 저장소가 생성됩니다",
-                "connectRequired": "저장소 생성 위치를 선택하려면 사이드바에서 Git 제공자를 연결하세요."
+                "connectRequired": "저장소 생성 위치를 선택하려면 사이드바에서 Git 제공자를 연결하세요.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "AI로 생성",
@@ -6608,7 +6728,11 @@
                 "connected": "연결됨",
                 "connecting": "연결 중...",
                 "connect": "연결",
-                "connectError": "연결 실패"
+                "connectError": "연결 실패",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git 제공자 연결",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "조직 액세스가 저장되었습니다.",
                 "saveFailed": "저장 실패.",
                 "removeLabel": "{login} 제거"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "템플릿",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1005,7 +1005,11 @@
                     "propose": "Samenvoegingen voorstellen"
                 },
                 "subtitle": "Voegt periodiek bijna-identieke documenten samen. Voorstellen gaan naar de beoordelingswachtrij — niets wordt automatisch geaccepteerd of verwijderd.",
-                "title": "Geplande consolidatie"
+                "title": "Geplande consolidatie",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Gearchiveerd"
+                "archived": "Gearchiveerd",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Organisaties",
                 "personalHelp": "De repository wordt aangemaakt onder je persoonlijke GitHub-account",
                 "organizationHelp": "De repository wordt aangemaakt onder de {org}-organisatie",
-                "connectRequired": "Verbind een Git-provider in de zijbalk om te kiezen waar je repository wordt aangemaakt."
+                "connectRequired": "Verbind een Git-provider in de zijbalk om te kiezen waar je repository wordt aangemaakt.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Aanmaken met AI",
@@ -6608,7 +6728,11 @@
                 "connected": "Verbonden",
                 "connecting": "Verbinden...",
                 "connect": "Verbinden",
-                "connectError": "Verbinding mislukt"
+                "connectError": "Verbinding mislukt",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git-providerverbindingen",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Organisatie-toegang opgeslagen.",
                 "saveFailed": "Opslaan mislukt.",
                 "removeLabel": "Verwijder {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Sjablonen",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1005,7 +1005,11 @@
                     "propose": "Proponuj scalenia"
                 },
                 "subtitle": "Okresowo scala niemal identyczne dokumenty. Propozycje trafiają do kolejki przeglądu — nic nie jest akceptowane ani usuwane automatycznie.",
-                "title": "Zaplanowana konsolidacja"
+                "title": "Zaplanowana konsolidacja",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Zarchiwizowane"
+                "archived": "Zarchiwizowane",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Organizacje",
                 "personalHelp": "Repozytorium zostanie utworzone na Twoim osobistym koncie GitHub",
                 "organizationHelp": "Repozytorium zostanie utworzone w organizacji {org}",
-                "connectRequired": "Połącz dostawcę Git w panelu bocznym, aby wybrać miejsce utworzenia repozytorium."
+                "connectRequired": "Połącz dostawcę Git w panelu bocznym, aby wybrać miejsce utworzenia repozytorium.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Utwórz z AI",
@@ -6608,7 +6728,11 @@
                 "connected": "Podłączony",
                 "connecting": "Łączenie...",
                 "connect": "Podłącz",
-                "connectError": "Nie udało się podłączyć"
+                "connectError": "Nie udało się podłączyć",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Połączenia dostawców Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Zapisano dostęp do organizacji.",
                 "saveFailed": "Zapis nie powiódł się.",
                 "removeLabel": "Usuń {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Szablony",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1005,7 +1005,11 @@
                     "propose": "Propor fusões"
                 },
                 "subtitle": "Funde periodicamente documentos quase duplicados. As propostas vão para a fila de revisão — nada é aceite ou eliminado automaticamente.",
-                "title": "Consolidação agendada"
+                "title": "Consolidação agendada",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Arquivados"
+                "archived": "Arquivados",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Organizações",
                 "personalHelp": "O repositório será criado sob sua conta GitHub pessoal",
                 "organizationHelp": "O repositório será criado sob a organização {org}",
-                "connectRequired": "Conecte um provedor Git na barra lateral para escolher onde seu repositório será criado."
+                "connectRequired": "Conecte um provedor Git na barra lateral para escolher onde seu repositório será criado.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Criar com IA",
@@ -6608,7 +6728,11 @@
                 "connected": "Conectado",
                 "connecting": "Conectando...",
                 "connect": "Conectar",
-                "connectError": "Falha ao conectar"
+                "connectError": "Falha ao conectar",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Conexões de Provedor Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Acesso à organização guardado.",
                 "saveFailed": "Guardar falhou.",
                 "removeLabel": "Remover {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Modelos",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1005,7 +1005,11 @@
                     "propose": "Предлагать объединения"
                 },
                 "subtitle": "Периодически объединяет почти одинаковые документы. Предложения попадают в очередь проверки — ничего не принимается и не удаляется автоматически.",
-                "title": "Плановая консолидация"
+                "title": "Плановая консолидация",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Архив"
+                "archived": "Архив",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Организации",
                 "personalHelp": "Репозиторий будет создан в вашем личном аккаунте GitHub",
                 "organizationHelp": "Репозиторий будет создан в организации {org}",
-                "connectRequired": "Подключите провайдер Git в боковой панели, чтобы выбрать, где будет создан ваш репозиторий."
+                "connectRequired": "Подключите провайдер Git в боковой панели, чтобы выбрать, где будет создан ваш репозиторий.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Создать с помощью ИИ",
@@ -6608,7 +6728,11 @@
                 "connected": "Подключен",
                 "connecting": "Подключение...",
                 "connect": "Подключить",
-                "connectError": "Не удалось подключиться"
+                "connectError": "Не удалось подключиться",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Подключения провайдеров Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Доступ к организациям сохранен.",
                 "saveFailed": "Сохранение не удалось.",
                 "removeLabel": "Удалить {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Шаблоны",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1005,7 +1005,11 @@
                     "propose": "เสนอการรวม"
                 },
                 "subtitle": "รวมเอกสารที่ซ้ำกันเกือบทั้งหมดเป็นระยะ ข้อเสนอจะเข้าคิวตรวจสอบ ไม่มีสิ่งใดถูกยอมรับหรือลบโดยอัตโนมัติ",
-                "title": "การรวมตามกำหนดเวลา"
+                "title": "การรวมตามกำหนดเวลา",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "เก็บถาวรแล้ว"
+                "archived": "เก็บถาวรแล้ว",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "องค์กร",
                 "personalHelp": "Repository จะถูกสร้างภายใต้บัญชี GitHub ส่วนตัวของคุณ",
                 "organizationHelp": "Repository จะถูกสร้างภายใต้องค์กร {org}",
-                "connectRequired": "เชื่อมต่อผู้ให้บริการ Git ในแถบด้านข้างเพื่อเลือกตำแหน่งที่ repository ของคุณจะถูกสร้าง"
+                "connectRequired": "เชื่อมต่อผู้ให้บริการ Git ในแถบด้านข้างเพื่อเลือกตำแหน่งที่ repository ของคุณจะถูกสร้าง",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "สร้างด้วย AI",
@@ -6608,7 +6728,11 @@
                 "connected": "เชื่อมต่อแล้ว",
                 "connecting": "กำลังเชื่อมต่อ...",
                 "connect": "เชื่อมต่อ",
-                "connectError": "เชื่อมต่อล้มเหลว"
+                "connectError": "เชื่อมต่อล้มเหลว",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "การเชื่อมต่อผู้ให้บริการ Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "บันทึกการเข้าถึงองค์กรเรียบร้อยแล้ว",
                 "saveFailed": "บันทึกไม่สำเร็จ",
                 "removeLabel": "ลบ {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "เทมเพลต",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1005,7 +1005,11 @@
                     "propose": "Birleştirme öner"
                 },
                 "subtitle": "Neredeyse aynı belgeleri düzenli olarak birleştirir. Öneriler inceleme kuyruğuna gider; hiçbir şey otomatik kabul edilmez veya silinmez.",
-                "title": "Zamanlanmış birleştirme"
+                "title": "Zamanlanmış birleştirme",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Arşivlenenler"
+                "archived": "Arşivlenenler",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Kuruluşlar",
                 "personalHelp": "Depo kişisel GitHub hesabınızın altında oluşturulacak",
                 "organizationHelp": "Depo {org} kuruluşunun altında oluşturulacak",
-                "connectRequired": "Deponuzun nerede oluşturulacağını seçmek için kenar çubuğunda bir Git sağlayıcısı bağlayın."
+                "connectRequired": "Deponuzun nerede oluşturulacağını seçmek için kenar çubuğunda bir Git sağlayıcısı bağlayın.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "AI ile Oluştur",
@@ -6608,7 +6728,11 @@
                 "connected": "Bağlandı",
                 "connecting": "Bağlanıyor...",
                 "connect": "Bağla",
-                "connectError": "Bağlanmada hata oluştu"
+                "connectError": "Bağlanmada hata oluştu",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git Sağlayıcısı Bağlantıları",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Örgüt erişimi kaydedildi.",
                 "saveFailed": "Kaydetme başarısız.",
                 "removeLabel": "{login} öğesini kaldır"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Şablonlar",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1005,7 +1005,11 @@
                     "propose": "Пропонувати об’єднання"
                 },
                 "subtitle": "Періодично об’єднує майже однакові документи. Пропозиції потрапляють у чергу перевірки — нічого не приймається й не видаляється автоматично.",
-                "title": "Планова консолідація"
+                "title": "Планова консолідація",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Архів"
+                "archived": "Архів",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Організації",
                 "personalHelp": "Репозиторій буде створено в вашому особистому обліковому записі GitHub",
                 "organizationHelp": "Репозиторій буде створено в організації {org}",
-                "connectRequired": "Підключіть постачальника Git у бічній панелі, щоб обрати, де буде створено ваш репозиторій."
+                "connectRequired": "Підключіть постачальника Git у бічній панелі, щоб обрати, де буде створено ваш репозиторій.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Створити за допомогою ШІ",
@@ -6608,7 +6728,11 @@
                 "connected": "Підключено",
                 "connecting": "Підключення...",
                 "connect": "Підключити",
-                "connectError": "Не вдалося підключитися"
+                "connectError": "Не вдалося підключитися",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Підключення постачальників Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Доступ до організації збережено.",
                 "saveFailed": "Збереження не вдалося.",
                 "removeLabel": "Видалити {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Шаблони",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1005,7 +1005,11 @@
                     "propose": "Đề xuất hợp nhất"
                 },
                 "subtitle": "Định kỳ hợp nhất các tài liệu gần trùng. Đề xuất vào hàng chờ duyệt — không có gì được chấp nhận hay xóa tự động.",
-                "title": "Hợp nhất theo lịch"
+                "title": "Hợp nhất theo lịch",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "Sessions",
-                "archived": "Đã lưu trữ"
+                "archived": "Đã lưu trữ",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "Các Tổ Chức",
                 "personalHelp": "Kho lưu trữ sẽ được tạo dưới tài khoản GitHub cá nhân của bạn",
                 "organizationHelp": "Kho lưu trữ sẽ được tạo dưới tổ chức {org}",
-                "connectRequired": "Kết nối nhà cung cấp Git trong thanh bên để chọn nơi kho lưu trữ của bạn sẽ được tạo."
+                "connectRequired": "Kết nối nhà cung cấp Git trong thanh bên để chọn nơi kho lưu trữ của bạn sẽ được tạo.",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "Tạo Bằng AI",
@@ -6608,7 +6728,11 @@
                 "connected": "Đã kết nối",
                 "connecting": "Đang kết nối...",
                 "connect": "Kết nối",
-                "connectError": "Kết nối thất bại"
+                "connectError": "Kết nối thất bại",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Kết nối Nhà cung cấp Git",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "Đã lưu quyền truy cập tổ chức.",
                 "saveFailed": "Lưu thất bại.",
                 "removeLabel": "Xóa {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "Mẫu",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1005,7 +1005,11 @@
                     "propose": "提议合并"
                 },
                 "subtitle": "定期合并高度重复的文档。提议进入待审核队列，不会自动接受或删除任何内容。",
-                "title": "定时合并"
+                "title": "定时合并",
+                "saveFailed": "Could not save the schedule. Your change was not stored — try again."
+            },
+            "meetings": {
+                "hint": "Meetings are one of the richest things the platform learns from — every transcript and summary is ingested straight into Memory."
             }
         },
         "agentsPage": {
@@ -1169,7 +1173,8 @@
             "pageTabs": {
                 "agents": "Agents",
                 "sessions": "会话",
-                "archived": "已归档"
+                "archived": "已归档",
+                "teams": "Teams"
             },
             "sessions": {
                 "title": "Sessions",
@@ -1370,6 +1375,11 @@
                     "routingUnavailable": "Execution routing could not be loaded right now.",
                     "routingChange": "Change in Settings → Fleet"
                 }
+            },
+            "agentsChartCta": "Agents Chart",
+            "skillsBlock": {
+                "title": "Skills",
+                "subtitle": "Skills your Agents can use — installed, available in the catalog, and custom ones you wrote."
             }
         },
         "tasksPage": {
@@ -3094,6 +3104,59 @@
                     "body": "Update your payment method to keep your plan active. Your card details are handled by the payment provider.",
                     "action": "Update payment method",
                     "error": "Could not open the billing portal."
+                },
+                "seats": {
+                    "title": "Seats",
+                    "usage": "{used} of {allowance} seats in use",
+                    "unlimited": "{used} seats in use · unlimited on this plan",
+                    "breakdown": "{members} people · {agents} agents",
+                    "included": "{included} included + {purchased} added",
+                    "totalLabel": "Total seats",
+                    "price": "{price} per additional seat / month",
+                    "notManageable": "Seats are adjusted on a paid plan once card payments are enabled.",
+                    "save": "Save",
+                    "saved": "Seats updated",
+                    "saveError": "Failed to update seats"
+                },
+                "payg": {
+                    "title": "Pay-as-you-go",
+                    "comingSoon": "Pay-as-you-go arrives with the payments launch.",
+                    "needsPaymentMethod": "Buy credits once to save a payment method, then pay-as-you-go can be enabled.",
+                    "description": "When your credits run out, keep going and pay for what you use at the end of the month.",
+                    "toggle": "Enable pay-as-you-go",
+                    "capLabel": "Monthly cap (credits)",
+                    "capHint": "Usage beyond your balance is billed in arrears at the rates below, up to this cap. Runs pause at the cap until you raise it, buy credits, or the cycle resets.",
+                    "capRange": "Between {min} and {max} credits",
+                    "statusOn": "On",
+                    "statusOff": "Off",
+                    "statusPastDue": "Payment failed",
+                    "thisCycle": "This cycle: {used} of {cap} credits · ≈ {estimate}",
+                    "cycleEnds": "Cycle resets {date}",
+                    "capEstimate": "≈ {estimate} / cycle at the cap",
+                    "invoiceThreshold": "Usage is invoiced when it reaches {amount} and at the end of each cycle.",
+                    "tiersTitle": "Pay-as-you-go rates (per cycle)",
+                    "tierRow": "{from}–{to} credits",
+                    "tierRowOpen": "{from}+ credits",
+                    "perCredit": "{rate} per credit",
+                    "pastDue": "Your last pay-as-you-go invoice could not be collected. Pay-as-you-go is paused until it is settled; prepaid credits keep working.",
+                    "save": "Save",
+                    "saved": "Pay-as-you-go updated",
+                    "saveError": "Failed to update pay-as-you-go",
+                    "disableConfirm": "Turning pay-as-you-go off invoices what you have used so far immediately."
+                },
+                "licence": {
+                    "title": "Commercial licence (self-hosted)",
+                    "subtitle": "Run Ever Works on your own infrastructure under a commercial licence.",
+                    "explainer": "A perpetual commercial licence for a deployment you run yourself. It lifts the AGPLv3 obligation for your own installation — it does not change your plan on this hosted service.",
+                    "buyLifetime": "Buy lifetime licence — {price}",
+                    "confirmBody": "You are buying a one-off perpetual licence for your OWN deployment. Your plan and credits on this hosted service stay exactly as they are.",
+                    "confirmCta": "Continue to payment",
+                    "cancel": "Cancel"
+                },
+                "checkoutReturn": {
+                    "confirmed": "Payment confirmed — thank you.",
+                    "settling": "Payment received. It is still settling; this page will reflect it shortly.",
+                    "licenceBody": "Your {name} commercial licence is recorded against this payment. It applies to the deployment you run yourself — your plan and credits on this hosted service are unchanged."
                 }
             },
             "usage": {
@@ -3108,7 +3171,10 @@
                     "tasksCompleted": "Tasks completed",
                     "worksActive": "Works active",
                     "agentRuns": "Agent runs",
-                    "periodNote": "Showing period {period}"
+                    "periodNote": "Showing period {period}",
+                    "expired": "Credits expired",
+                    "pricingNote": "{perDollar} credits = $1 of platform-billed usage.",
+                    "pricingNoteWithMargin": "{perDollar} credits = $1 of platform-billed usage. The platform rate includes a {margin}% service margin over provider list prices."
                 },
                 "charts": {
                     "byDay": "Usage per day",
@@ -3374,6 +3440,41 @@
                     "nodeTripped": "Drained by the ceiling on {day}",
                     "nodeSaved": "Node cost ceiling saved",
                     "nodeCleared": "Node cost ceiling cleared"
+                },
+                "killSwitch": {
+                    "stoppedTitle": "The platform is stopped",
+                    "stoppedBody": "An operator has set the global stop flag. No new agent runs are dispatched, routed or leased to your nodes until it is cleared. Work that is already running continues and keeps reporting.",
+                    "reason": "Reason: {reason}",
+                    "since": "Since {since}",
+                    "unverifiedTitle": "Dispatch is refusing new work: the stop flag could not be read",
+                    "unverifiedBody": "The platform could not read its global stop flag, so it refuses to start anything new (fail-closed). Nobody threw the switch — this usually means a database migration has not run yet or the database is unreachable.",
+                    "unknownTitle": "Stop flag status unavailable",
+                    "unknownBody": "This page could not read the global stop flag: {error}"
+                },
+                "panic": {
+                    "title": "Panic controls",
+                    "description": "Two separate decisions for a bad night: drain every node so nothing new starts on your machines, and — only if you also want to abort what is already running — cancel the in-flight work.",
+                    "drainAll": {
+                        "button": "Drain all nodes",
+                        "hint": "Disables every enrolled node and returns the claims they hold to the queue. Nothing is cancelled; the work waits for a node that may take it.",
+                        "none": "No node to drain.",
+                        "confirmTitle": "Drain all nodes?",
+                        "confirmBody": "{count, plural, one {# node} other {# nodes}} will be disabled and every claim they hold goes back to the queue. Running work is NOT aborted.",
+                        "confirm": "Drain all",
+                        "cancel": "Keep running",
+                        "done": "Drained {nodes, plural, one {# node} other {# nodes}}; {jobs, plural, one {# job} other {# jobs}} returned to the queue."
+                    },
+                    "cancelInFlight": {
+                        "button": "Cancel in-flight work",
+                        "hint": "Aborts the fleet jobs running right now and cancels the agent runs behind them. This is a separate, explicit step — draining never does it.",
+                        "confirmTitle": "Cancel in-flight work?",
+                        "confirmBody": "This ABORTS running work: every leased or running fleet job you own is cancelled and the agent run behind each is marked cancelled. A node learns of it on its next heartbeat, so a job that is about to finish may still report.",
+                        "includeQueued": "Also cancel queued jobs that have not started",
+                        "confirm": "Cancel in-flight work",
+                        "cancel": "Keep running",
+                        "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
+                    },
+                    "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
                 }
             },
             "jobRuntime": {
@@ -5552,6 +5653,24 @@
                     "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
                     "helperSuffix": ".ever.works",
                     "readonlyHint": "Managed subdomain is read-only for this Work."
+                },
+                "runtimeEnvVars": {
+                    "title": "Environment variables",
+                    "description": "Per-site settings the deployed directory reads at runtime (e.g. Stripe payment keys). Only the keys listed here can be set.",
+                    "placeholderSet": "Enter a new value to replace the current one",
+                    "placeholderUnset": "Enter a value",
+                    "saveButton": "Save",
+                    "removeButton": "Remove",
+                    "saveAria": "Save {key}",
+                    "removeAria": "Remove {key}",
+                    "saveSuccess": "Environment variable saved — redeploy to apply it to the live site.",
+                    "saveFailed": "Failed to save environment variable",
+                    "removeSuccess": "Environment variable removed — redeploy to apply it to the live site.",
+                    "removeFailed": "Failed to remove environment variable",
+                    "currentSecret": "Set (value hidden)",
+                    "currentValue": "Set: {masked}",
+                    "notSet": "Not set",
+                    "hint": "Applied on the next deploy. Stored encrypted; values are never shown back in full."
                 }
             },
             "kb": {
@@ -6190,7 +6309,8 @@
                 "organizations": "组织",
                 "personalHelp": "仓库将创建在您的个人 GitHub 账户下",
                 "organizationHelp": "仓库将创建在 {org} 组织下",
-                "connectRequired": "在侧边栏连接 Git 提供商，以选择仓库创建位置。"
+                "connectRequired": "在侧边栏连接 Git 提供商，以选择仓库创建位置。",
+                "managedByEverWorks": "The repository will be created in the managed Ever Works GitHub organization."
             },
             "ai": {
                 "title": "使用 AI 创建",
@@ -6608,7 +6728,11 @@
                 "connected": "已连接",
                 "connecting": "连接中...",
                 "connect": "连接",
-                "connectError": "连接失败"
+                "connectError": "连接失败",
+                "managed": {
+                    "title": "Ever Works Git",
+                    "description": "Your repositories are created in the managed Ever Works GitHub org — nothing to connect. Change this in onboarding under Storage."
+                }
             },
             "settings": {
                 "title": "Git 提供商连接",
@@ -7373,7 +7497,8 @@
                 "savedSuccess": "已保存组织访问权限。",
                 "saveFailed": "保存失败。",
                 "removeLabel": "移除 {login}"
-            }
+            },
+            "enableFailed": "Failed to enable plugin"
         },
         "templates": {
             "title": "模板",
@@ -8096,7 +8221,8 @@
             "created": "Meeting captured",
             "sections": {
                 "provenance": "Where it came from",
-                "transcript": "Transcript"
+                "transcript": "Transcript",
+                "participants": "Participants"
             },
             "sources": {
                 "manual": "Manual",
@@ -8337,6 +8463,13 @@
                 "hour": "{value}h ago",
                 "day": "{value}d ago"
             }
+        },
+        "agentsChartPage": {
+            "title": "Agents Chart",
+            "subtitle": "How your Agents are organized — teams and reporting lines, without human members.",
+            "backToAgents": "Back to Agents",
+            "empty": "No Agents yet. Create an Agent and it will appear here.",
+            "noOrg": "Create an Organization first — the Agents Chart is drawn per Organization."
         }
     },
     "layout": {

--- a/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
@@ -5,6 +5,7 @@ import {
     fleetAPI,
     type FleetEnrollmentTokenView,
     type FleetExecutionPreferenceView,
+    type FleetKillSwitchState,
     type FleetNodeView,
 } from '@/lib/api/fleet';
 import { FleetSettings } from '@/components/settings/FleetSettings';
@@ -46,16 +47,31 @@ export default async function FleetSettingsPage() {
     let tokensError: string | null = null;
     let initialPreferences: FleetExecutionPreferenceView[] = [];
     let preferencesError: string | null = null;
+    let initialKillSwitch: FleetKillSwitchState | null = null;
+    let killSwitchError: string | null = null;
 
     // `allSettled`, not `all`: each read fails INDEPENDENTLY and the page
     // still renders with a per-section banner. A routing-preference
     // hiccup must not take down the node list, which is the page's whole
     // reason to exist.
-    const [nodesResult, tokensResult, preferencesResult] = await Promise.allSettled([
-        fleetAPI.listNodes(),
-        fleetAPI.listOutstandingTokens(),
-        fleetAPI.listExecutionPreferences(),
-    ]);
+    const [nodesResult, tokensResult, preferencesResult, killSwitchResult] =
+        await Promise.allSettled([
+            fleetAPI.listNodes(),
+            fleetAPI.listOutstandingTokens(),
+            fleetAPI.listExecutionPreferences(),
+            // Panic controls (EW-778) — the banner's first paint; the
+            // client keeps polling it afterwards.
+            fleetAPI.killSwitchState(),
+        ]);
+
+    if (killSwitchResult.status === 'fulfilled') {
+        initialKillSwitch = killSwitchResult.value;
+    } else {
+        killSwitchError =
+            killSwitchResult.reason instanceof Error
+                ? killSwitchResult.reason.message
+                : 'Failed to read the stop flag';
+    }
 
     if (nodesResult.status === 'fulfilled') {
         initialNodes = nodesResult.value;
@@ -97,6 +113,8 @@ export default async function FleetSettingsPage() {
             nodeDownloadUrl={downloads.node}
             initialPreferences={initialPreferences}
             preferencesError={preferencesError}
+            initialKillSwitch={initialKillSwitch}
+            killSwitchError={killSwitchError}
         />
     );
 }

--- a/apps/web/src/app/actions/settings/fleet.ts
+++ b/apps/web/src/app/actions/settings/fleet.ts
@@ -7,11 +7,16 @@ import { getAuthFromCookie } from '@/lib/auth';
 import { ApiResponseError } from '@/lib/api/server-api';
 import {
     fleetAPI,
+    type CancelFleetInFlightPayload,
     type CreateFleetEnrollmentTokenPayload,
     type CreateFleetEnrollmentTokenResponse,
     type FleetAgentNodeAffinityView,
     type FleetCostCeilingView,
+    type FleetCancelInFlightResult,
+    type FleetDrainAllResult,
     type FleetEnrollmentTokenView,
+    type FleetKillSwitchChangeResult,
+    type FleetKillSwitchState,
     type FleetNodeDetailView,
     type FleetNodeDrainResult,
     type FleetExecutionPreferenceView,
@@ -240,6 +245,106 @@ export async function setFleetCostCeilingAction(
             success: false,
             data: null,
             error: errorMessage(error, 'Failed to update the fleet cost ceiling'),
+        };
+    }
+}
+
+/**
+ * Panic controls (EW-778) — drain EVERY node the caller owns. Nothing is
+ * cancelled; that is `cancelFleetInFlightAction`, a separate decision.
+ */
+export async function drainAllFleetNodesAction(): Promise<FleetActionResult<FleetDrainAllResult>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.drainAll();
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to drain the fleet'),
+        };
+    }
+}
+
+/**
+ * Panic controls (EW-778) — cancel the caller's running fleet work and
+ * the agent runs behind it. Explicit and separate from draining and from
+ * the stop flag, on purpose.
+ */
+export async function cancelFleetInFlightAction(
+    payload: CancelFleetInFlightPayload = {},
+): Promise<FleetActionResult<FleetCancelInFlightResult>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.cancelInFlight(payload);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to cancel in-flight work'),
+        };
+    }
+}
+
+/**
+ * Panic controls (EW-778) — is the platform-wide stop flag set? Polled by
+ * the fleet page banner, so like runner status it deliberately does NOT
+ * `revalidatePath`.
+ */
+export async function getFleetKillSwitchAction(): Promise<FleetActionResult<FleetKillSwitchState>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.killSwitchState();
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to read the stop flag'),
+        };
+    }
+}
+
+/**
+ * Panic controls (EW-778) — set the platform-wide stop flag. Platform
+ * admins only: the API answers 403 for everyone else and this action
+ * simply surfaces that message.
+ */
+export async function stopFleetKillSwitchAction(
+    reason?: string | null,
+): Promise<FleetActionResult<FleetKillSwitchChangeResult>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.stopKillSwitch(reason ?? null);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to set the stop flag'),
+        };
+    }
+}
+
+/** Panic controls (EW-778) — clear the platform-wide stop flag (platform admins only). */
+export async function clearFleetKillSwitchAction(): Promise<
+    FleetActionResult<FleetKillSwitchChangeResult>
+> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.clearKillSwitch();
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to clear the stop flag'),
         };
     }
 }

--- a/apps/web/src/components/settings/FleetKillSwitchBanner.tsx
+++ b/apps/web/src/components/settings/FleetKillSwitchBanner.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, ShieldAlert } from 'lucide-react';
+import type { FleetKillSwitchState } from '@/lib/api/fleet';
+import { useKillSwitchPolling } from '@/lib/hooks/use-kill-switch-polling';
+
+interface FleetKillSwitchBannerProps {
+    /** First paint from the server page; the banner keeps polling afterwards. */
+    initial: FleetKillSwitchState | null;
+    initialError: string | null;
+}
+
+function formatSince(value: string | null): string {
+    if (!value) return '';
+    try {
+        return new Date(value).toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * Panic controls (EW-778) — the banner that says the platform is STOPPED.
+ *
+ * Three states, three different sentences, because they ask for three
+ * different responses from whoever is reading:
+ *
+ *   - `stopped`    — an operator threw the switch. Shows the reason and
+ *                    the time; nothing the reader does here will start
+ *                    work until it is cleared.
+ *   - `unverified` — the API could not READ the flag and is refusing
+ *                    dispatch on that basis (fail-closed). Nobody threw
+ *                    the switch; the reader should not go looking for
+ *                    who did. Usually "migration not run yet".
+ *   - `unknown`    — this PAGE could not reach the API for the flag at
+ *                    all. Rendered muted: it says nothing about dispatch.
+ *
+ * Polled every 30s so an operator throwing the switch is visible without
+ * a reload. Renders nothing while the flag is clear.
+ */
+export function FleetKillSwitchBanner({ initial, initialError }: FleetKillSwitchBannerProps) {
+    const t = useTranslations('dashboard.settings.fleet.killSwitch');
+    const { state, error } = useKillSwitchPolling(initial, initialError);
+
+    if (state?.stopped) {
+        const unverified = state.unverified === true;
+        return (
+            <div
+                role="alert"
+                className="flex items-start gap-3 p-4 bg-danger/10 border border-danger/30 rounded-lg"
+                data-testid="fleet-kill-switch-banner"
+                data-variant={unverified ? 'unverified' : 'stopped'}
+            >
+                <ShieldAlert className="w-5 h-5 text-danger flex-shrink-0 mt-0.5" />
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold text-text dark:text-text-dark">
+                        {unverified ? t('unverifiedTitle') : t('stoppedTitle')}
+                    </p>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {unverified ? t('unverifiedBody') : t('stoppedBody')}
+                    </p>
+                    {!unverified && state.reason && (
+                        <p
+                            className="text-sm text-text dark:text-text-dark"
+                            data-testid="fleet-kill-switch-reason"
+                        >
+                            {t('reason', { reason: state.reason })}
+                        </p>
+                    )}
+                    {!unverified && state.since && (
+                        <p
+                            className="text-xs text-text-muted dark:text-text-muted-dark"
+                            data-testid="fleet-kill-switch-since"
+                        >
+                            {t('since', { since: formatSince(state.since) })}
+                        </p>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
+    if (!state && error) {
+        return (
+            <div
+                className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg"
+                data-testid="fleet-kill-switch-banner"
+                data-variant="unknown"
+            >
+                <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                <div>
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('unknownTitle')}
+                    </p>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('unknownBody', { error })}
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return null;
+}

--- a/apps/web/src/components/settings/FleetKillSwitchBanner.unit.spec.tsx
+++ b/apps/web/src/components/settings/FleetKillSwitchBanner.unit.spec.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { FleetKillSwitchState } from '@ever-works/contracts';
+import { FleetKillSwitchBanner } from './FleetKillSwitchBanner';
+
+/**
+ * Panic controls (EW-778) — the stop-flag banner.
+ *
+ * Pins the three variants (stopped / unverified / unknown), that a clear
+ * flag renders nothing, and the polling contract that matters: an
+ * operator throwing the switch shows up WITHOUT a reload, and a failed
+ * poll keeps the last-known state instead of blanking the warning.
+ */
+
+const getFleetKillSwitchAction = vi.fn();
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+        values ? `${key}:${Object.values(values).join(',')}` : key,
+}));
+vi.mock('@/app/actions/settings/fleet', () => ({
+    getFleetKillSwitchAction: (...args: unknown[]) => getFleetKillSwitchAction(...args),
+}));
+
+function state(over: Partial<FleetKillSwitchState> = {}): FleetKillSwitchState {
+    return {
+        stopped: false,
+        reason: null,
+        since: null,
+        unverified: false,
+        ...over,
+    };
+}
+
+beforeEach(() => {
+    getFleetKillSwitchAction.mockReset();
+    getFleetKillSwitchAction.mockResolvedValue({ success: true, data: state(), error: null });
+});
+
+describe('FleetKillSwitchBanner', () => {
+    it('renders nothing while the flag is clear', async () => {
+        render(<FleetKillSwitchBanner initial={state()} initialError={null} />);
+        await waitFor(() => expect(getFleetKillSwitchAction).toHaveBeenCalled());
+        expect(screen.queryByTestId('fleet-kill-switch-banner')).toBeNull();
+    });
+
+    it('renders the STOPPED variant with the reason and the time', async () => {
+        const stopped = state({
+            stopped: true,
+            reason: 'incident on prod',
+            since: '2026-09-05T02:00:00.000Z',
+        });
+        getFleetKillSwitchAction.mockResolvedValue({ success: true, data: stopped, error: null });
+        render(<FleetKillSwitchBanner initial={stopped} initialError={null} />);
+
+        const banner = screen.getByTestId('fleet-kill-switch-banner');
+        expect(banner).toHaveAttribute('data-variant', 'stopped');
+        expect(banner).toHaveAttribute('role', 'alert');
+        expect(screen.getByText('stoppedTitle')).toBeInTheDocument();
+        expect(screen.getByTestId('fleet-kill-switch-reason')).toHaveTextContent(
+            'reason:incident on prod',
+        );
+        expect(screen.getByTestId('fleet-kill-switch-since')).toBeInTheDocument();
+    });
+
+    it('renders the UNVERIFIED variant (dispatch refusing because the flag could not be read)', async () => {
+        const unverified = state({ stopped: true, unverified: true });
+        getFleetKillSwitchAction.mockResolvedValue({
+            success: true,
+            data: unverified,
+            error: null,
+        });
+        render(<FleetKillSwitchBanner initial={unverified} initialError={null} />);
+
+        const banner = screen.getByTestId('fleet-kill-switch-banner');
+        expect(banner).toHaveAttribute('data-variant', 'unverified');
+        expect(screen.getByText('unverifiedTitle')).toBeInTheDocument();
+        expect(screen.getByText('unverifiedBody')).toBeInTheDocument();
+        // No reason / since lines: nobody threw the switch.
+        expect(screen.queryByTestId('fleet-kill-switch-reason')).toBeNull();
+        expect(screen.queryByTestId('fleet-kill-switch-since')).toBeNull();
+    });
+
+    it('appears WITHOUT a reload when a poll reports the switch was thrown', async () => {
+        getFleetKillSwitchAction.mockResolvedValue({
+            success: true,
+            data: state({ stopped: true, reason: 'thrown later' }),
+            error: null,
+        });
+        render(<FleetKillSwitchBanner initial={state()} initialError={null} />);
+
+        expect(screen.queryByTestId('fleet-kill-switch-banner')).toBeNull();
+        expect(await screen.findByTestId('fleet-kill-switch-banner')).toHaveAttribute(
+            'data-variant',
+            'stopped',
+        );
+    });
+
+    it('keeps the last-known STOPPED state when a poll fails', async () => {
+        getFleetKillSwitchAction.mockResolvedValue({
+            success: false,
+            data: null,
+            error: 'network blip',
+        });
+        render(
+            <FleetKillSwitchBanner
+                initial={state({ stopped: true, reason: 'incident' })}
+                initialError={null}
+            />,
+        );
+        await waitFor(() => expect(getFleetKillSwitchAction).toHaveBeenCalled());
+        expect(screen.getByTestId('fleet-kill-switch-banner')).toHaveAttribute(
+            'data-variant',
+            'stopped',
+        );
+    });
+
+    it('renders the muted UNKNOWN variant when the page has no state and only an error', async () => {
+        getFleetKillSwitchAction.mockResolvedValue({
+            success: false,
+            data: null,
+            error: 'api unreachable',
+        });
+        render(<FleetKillSwitchBanner initial={null} initialError="api unreachable" />);
+
+        const banner = screen.getByTestId('fleet-kill-switch-banner');
+        expect(banner).toHaveAttribute('data-variant', 'unknown');
+        expect(screen.getByText('unknownBody:api unreachable')).toBeInTheDocument();
+    });
+});

--- a/apps/web/src/components/settings/FleetPanicControls.tsx
+++ b/apps/web/src/components/settings/FleetPanicControls.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Ban, ShieldAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type { FleetNodeView } from '@/lib/api/fleet';
+import { cancelFleetInFlightAction, drainAllFleetNodesAction } from '@/app/actions/settings/fleet';
+
+interface FleetPanicControlsProps {
+    /** The current node list, so the drain button can say how many it will touch. */
+    nodes: FleetNodeView[];
+    /** Called with the node views the API returned after a drain-all. */
+    onNodesDrained: (nodes: FleetNodeView[]) => void;
+}
+
+/**
+ * Panic controls (EW-778) — the two owner-scoped controls for a bad night.
+ *
+ * They are two CARDS, two BUTTONS and two CONFIRM DIALOGS on purpose,
+ * because they are two different decisions:
+ *
+ *   1. **Drain all nodes** — every enrolled node is disabled and its
+ *      in-flight claims go back to the queue. Nothing is aborted; the
+ *      work waits for a node that may take it. This is the one to reach
+ *      for first.
+ *   2. **Cancel in-flight work** — aborts the fleet jobs running right
+ *      now and cancels the agent runs behind them. Its copy says
+ *      "aborts" in so many words, it has its own confirmation, and
+ *      draining never triggers it. The optional checkbox extends it to
+ *      queued jobs nothing has started — the rows a drain just returned
+ *      to the pool are a separate decision again.
+ *
+ * The platform-wide stop flag (set / clear) is an operator control and
+ * deliberately NOT on this page; the banner above shows it when set.
+ */
+export function FleetPanicControls({ nodes, onNodesDrained }: FleetPanicControlsProps) {
+    const t = useTranslations('dashboard.settings.fleet.panic');
+    const [isPending, startTransition] = useTransition();
+    const [drainOpen, setDrainOpen] = useState(false);
+    const [cancelOpen, setCancelOpen] = useState(false);
+    const [includeQueued, setIncludeQueued] = useState(false);
+
+    const drainable = useMemo(
+        () =>
+            nodes.filter(
+                (node) =>
+                    node.persisted && node.status !== 'enrolling' && node.status !== 'disabled',
+            ).length,
+        [nodes],
+    );
+
+    const handleDrainAll = () => {
+        startTransition(async () => {
+            const result = await drainAllFleetNodesAction();
+            if (result.success) {
+                onNodesDrained(result.data.nodes);
+                setDrainOpen(false);
+                toast.success(
+                    t('drainAll.done', {
+                        nodes: result.data.drainedNodes,
+                        jobs: result.data.releasedJobs,
+                    }),
+                );
+                if (result.data.auditFailed) toast.error(t('auditFailed'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const closeCancel = () => {
+        setCancelOpen(false);
+        setIncludeQueued(false);
+    };
+
+    const handleCancelInFlight = () => {
+        startTransition(async () => {
+            const result = await cancelFleetInFlightAction({ includeQueued });
+            if (result.success) {
+                closeCancel();
+                toast.success(
+                    t('cancelInFlight.done', {
+                        cancelled: result.data.cancelled,
+                        requested: result.data.requested,
+                        runs: result.data.runsCancelled,
+                    }),
+                );
+                if (result.data.auditFailed) toast.error(t('auditFailed'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    return (
+        <div className="space-y-3" data-testid="fleet-panic-section">
+            <div className="flex items-center gap-2">
+                <ShieldAlert className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+            </div>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark max-w-2xl">
+                {t('description')}
+            </p>
+
+            <div className="grid gap-3 md:grid-cols-2">
+                <div className="p-4 rounded-lg border border-border dark:border-border-dark space-y-3">
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('drainAll.button')}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('drainAll.hint')}
+                    </p>
+                    <Button
+                        variant="secondary"
+                        onClick={() => setDrainOpen(true)}
+                        disabled={isPending || drainable === 0}
+                        data-testid="fleet-drain-all"
+                    >
+                        {t('drainAll.button')}
+                    </Button>
+                    {drainable === 0 && (
+                        <p
+                            className="text-xs text-text-muted dark:text-text-muted-dark"
+                            data-testid="fleet-drain-all-none"
+                        >
+                            {t('drainAll.none')}
+                        </p>
+                    )}
+                </div>
+
+                <div className="p-4 rounded-lg border border-danger/30 space-y-3">
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('cancelInFlight.button')}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('cancelInFlight.hint')}
+                    </p>
+                    <Button
+                        variant="danger"
+                        onClick={() => setCancelOpen(true)}
+                        disabled={isPending}
+                        data-testid="fleet-cancel-in-flight"
+                    >
+                        <Ban className="w-4 h-4" />
+                        {t('cancelInFlight.button')}
+                    </Button>
+                </div>
+            </div>
+
+            {/* Drain all — confirm. Says explicitly that nothing is aborted. */}
+            <Dialog open={drainOpen} onOpenChange={(open) => !open && setDrainOpen(false)}>
+                <DialogContent>
+                    <DialogClose onClose={() => setDrainOpen(false)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('drainAll.confirmTitle')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p
+                        className="text-sm text-text-muted dark:text-text-muted-dark"
+                        data-testid="fleet-drain-all-body"
+                    >
+                        {t('drainAll.confirmBody', { count: drainable })}
+                    </p>
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setDrainOpen(false)}>
+                            {t('drainAll.cancel')}
+                        </Button>
+                        <Button
+                            onClick={handleDrainAll}
+                            loading={isPending}
+                            data-testid="fleet-drain-all-confirm"
+                        >
+                            {t('drainAll.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Cancel in-flight — its OWN confirm, with "aborts" in the copy. */}
+            <Dialog open={cancelOpen} onOpenChange={(open) => !open && closeCancel()}>
+                <DialogContent>
+                    <DialogClose onClose={closeCancel} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('cancelInFlight.confirmTitle')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p
+                        className="text-sm text-text-muted dark:text-text-muted-dark"
+                        data-testid="fleet-cancel-in-flight-body"
+                    >
+                        {t('cancelInFlight.confirmBody')}
+                    </p>
+                    <Checkbox
+                        label={t('cancelInFlight.includeQueued')}
+                        checked={includeQueued}
+                        onChange={(event) => setIncludeQueued(event.target.checked)}
+                        data-testid="fleet-cancel-include-queued"
+                    />
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={closeCancel}>
+                            {t('cancelInFlight.cancel')}
+                        </Button>
+                        <Button
+                            variant="danger"
+                            onClick={handleCancelInFlight}
+                            loading={isPending}
+                            data-testid="fleet-cancel-in-flight-confirm"
+                        >
+                            {t('cancelInFlight.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/FleetPanicControls.unit.spec.tsx
+++ b/apps/web/src/components/settings/FleetPanicControls.unit.spec.tsx
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { FleetNodeView } from '@ever-works/contracts';
+import { FleetPanicControls } from './FleetPanicControls';
+
+/**
+ * Panic controls (EW-778) — the two owner controls stay two decisions.
+ *
+ * Pins that draining never opens (let alone triggers) the cancel, that
+ * each confirm calls its own action with the right payload, that the
+ * cancel copy says it aborts running work, and that the parent receives
+ * the drained node views.
+ */
+
+const drainAllFleetNodesAction = vi.fn();
+const cancelFleetInFlightAction = vi.fn();
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+        values ? `${key}:${Object.values(values).join(',')}` : key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+vi.mock('sonner', () => ({
+    toast: {
+        error: (...args: unknown[]) => toastError(...args),
+        success: (...args: unknown[]) => toastSuccess(...args),
+    },
+}));
+vi.mock('@/app/actions/settings/fleet', () => ({
+    drainAllFleetNodesAction: (...args: unknown[]) => drainAllFleetNodesAction(...args),
+    cancelFleetInFlightAction: (...args: unknown[]) => cancelFleetInFlightAction(...args),
+}));
+// The dialog primitive is not what is under test; render children in place.
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+        open ? <div>{children}</div> : null,
+    DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+    DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogClose: ({ onClose }: { onClose: () => void }) => (
+        <button type="button" onClick={onClose}>
+            close
+        </button>
+    ),
+}));
+
+function node(over: Partial<FleetNodeView> = {}): FleetNodeView {
+    return {
+        id: 'node-1',
+        name: 'PC',
+        kind: 'node',
+        status: 'online',
+        platform: 'win32/x64',
+        version: '1.0.0',
+        capabilities: [],
+        lastHeartbeatAt: null,
+        createdAt: null,
+        persisted: true,
+        capabilitiesPinned: false,
+        ...over,
+    } as FleetNodeView;
+}
+
+beforeEach(() => {
+    drainAllFleetNodesAction.mockReset();
+    cancelFleetInFlightAction.mockReset();
+    toastError.mockReset();
+    toastSuccess.mockReset();
+    drainAllFleetNodesAction.mockResolvedValue({
+        success: true,
+        data: {
+            drainedNodes: 1,
+            skippedNodes: 0,
+            releasedJobs: 2,
+            nodes: [node({ status: 'disabled' })],
+            auditFailed: false,
+        },
+        error: null,
+    });
+    cancelFleetInFlightAction.mockResolvedValue({
+        success: true,
+        data: {
+            requested: 2,
+            cancelled: 2,
+            runsCancelled: 2,
+            byState: { 'queued-dropped': 0, 'cancel-requested': 2, terminal: 0, 'not-found': 0 },
+            jobIds: ['job-1', 'job-2'],
+            auditFailed: false,
+        },
+        error: null,
+    });
+});
+
+describe('FleetPanicControls', () => {
+    it('drain-all opens ITS dialog only, and confirming calls only the drain action', async () => {
+        const user = userEvent.setup();
+        const onNodesDrained = vi.fn();
+        render(<FleetPanicControls nodes={[node()]} onNodesDrained={onNodesDrained} />);
+
+        await user.click(screen.getByTestId('fleet-drain-all'));
+        expect(screen.getByTestId('fleet-drain-all-body')).toHaveTextContent(
+            'drainAll.confirmBody:1',
+        );
+        // The cancel dialog is NOT open — draining is not cancelling.
+        expect(screen.queryByTestId('fleet-cancel-in-flight-confirm')).toBeNull();
+
+        await user.click(screen.getByTestId('fleet-drain-all-confirm'));
+
+        await waitFor(() => expect(drainAllFleetNodesAction).toHaveBeenCalledTimes(1));
+        expect(cancelFleetInFlightAction).not.toHaveBeenCalled();
+        expect(onNodesDrained).toHaveBeenCalledWith([
+            expect.objectContaining({ status: 'disabled' }),
+        ]);
+        expect(toastSuccess).toHaveBeenCalledWith('drainAll.done:1,2');
+    });
+
+    it('cancel-in-flight opens its OWN dialog with the "aborts" copy and defaults includeQueued to false', async () => {
+        const user = userEvent.setup();
+        render(<FleetPanicControls nodes={[node()]} onNodesDrained={vi.fn()} />);
+
+        await user.click(screen.getByTestId('fleet-cancel-in-flight'));
+        expect(screen.getByTestId('fleet-cancel-in-flight-body')).toHaveTextContent(
+            'cancelInFlight.confirmBody',
+        );
+        expect(screen.queryByTestId('fleet-drain-all-confirm')).toBeNull();
+
+        await user.click(screen.getByTestId('fleet-cancel-in-flight-confirm'));
+
+        await waitFor(() => expect(cancelFleetInFlightAction).toHaveBeenCalledTimes(1));
+        expect(cancelFleetInFlightAction).toHaveBeenCalledWith({ includeQueued: false });
+        expect(drainAllFleetNodesAction).not.toHaveBeenCalled();
+        expect(toastSuccess).toHaveBeenCalledWith('cancelInFlight.done:2,2,2');
+    });
+
+    it('ticking the checkbox sends includeQueued: true', async () => {
+        const user = userEvent.setup();
+        render(<FleetPanicControls nodes={[node()]} onNodesDrained={vi.fn()} />);
+
+        await user.click(screen.getByTestId('fleet-cancel-in-flight'));
+        await user.click(screen.getByTestId('fleet-cancel-include-queued'));
+        await user.click(screen.getByTestId('fleet-cancel-in-flight-confirm'));
+
+        await waitFor(() =>
+            expect(cancelFleetInFlightAction).toHaveBeenCalledWith({ includeQueued: true }),
+        );
+    });
+
+    it('disables drain-all when nothing can be drained (enrolling / disabled / cluster rows)', () => {
+        render(
+            <FleetPanicControls
+                nodes={[
+                    node({ id: 'a', status: 'enrolling' }),
+                    node({ id: 'b', status: 'disabled' }),
+                    node({ id: 'c', kind: 'k8s', persisted: false }),
+                ]}
+                onNodesDrained={vi.fn()}
+            />,
+        );
+        expect(screen.getByTestId('fleet-drain-all')).toBeDisabled();
+        expect(screen.getByTestId('fleet-drain-all-none')).toBeInTheDocument();
+        // Cancelling is not gated on nodes: running work may belong to a node that has since gone.
+        expect(screen.getByTestId('fleet-cancel-in-flight')).not.toBeDisabled();
+    });
+
+    it('surfaces an action failure as a toast and leaves the dialog open', async () => {
+        const user = userEvent.setup();
+        drainAllFleetNodesAction.mockResolvedValue({ success: false, data: null, error: 'nope' });
+        const onNodesDrained = vi.fn();
+        render(<FleetPanicControls nodes={[node()]} onNodesDrained={onNodesDrained} />);
+
+        await user.click(screen.getByTestId('fleet-drain-all'));
+        await user.click(screen.getByTestId('fleet-drain-all-confirm'));
+
+        await waitFor(() => expect(toastError).toHaveBeenCalledWith('nope'));
+        expect(onNodesDrained).not.toHaveBeenCalled();
+        expect(screen.getByTestId('fleet-drain-all-confirm')).toBeInTheDocument();
+    });
+
+    it('warns when the action succeeded but its audit row failed', async () => {
+        const user = userEvent.setup();
+        drainAllFleetNodesAction.mockResolvedValue({
+            success: true,
+            data: {
+                drainedNodes: 1,
+                skippedNodes: 0,
+                releasedJobs: 0,
+                nodes: [],
+                auditFailed: true,
+            },
+            error: null,
+        });
+        render(<FleetPanicControls nodes={[node()]} onNodesDrained={vi.fn()} />);
+
+        await user.click(screen.getByTestId('fleet-drain-all'));
+        await user.click(screen.getByTestId('fleet-drain-all-confirm'));
+
+        await waitFor(() => expect(toastError).toHaveBeenCalledWith('auditFailed'));
+    });
+});

--- a/apps/web/src/components/settings/FleetSettings.tsx
+++ b/apps/web/src/components/settings/FleetSettings.tsx
@@ -31,6 +31,7 @@ import type {
     CreateFleetEnrollmentTokenResponse,
     FleetEnrollmentTokenView,
     FleetExecutionPreferenceView,
+    FleetKillSwitchState,
     FleetNodeDetailView,
     FleetNodeKind,
     FleetNodeView,
@@ -49,7 +50,9 @@ import { formatBytes } from '@/components/dashboard/runner-status.shared';
 import { FleetCostCeiling } from './FleetCostCeiling';
 import { FleetEnrollHandoff } from './FleetEnrollHandoff';
 import { FleetExecutionPreferences } from './FleetExecutionPreferences';
+import { FleetKillSwitchBanner } from './FleetKillSwitchBanner';
 import { FleetNodeDrawer } from './FleetNodeDrawer';
+import { FleetPanicControls } from './FleetPanicControls';
 import { FleetTokensSection } from './FleetTokensSection';
 
 interface FleetSettingsProps {
@@ -65,6 +68,9 @@ interface FleetSettingsProps {
     /** Execution routing preferences (account-wide + narrower overrides). */
     initialPreferences: FleetExecutionPreferenceView[];
     preferencesError: string | null;
+    /** Panic controls (EW-778) — the stop flag's first paint; polled afterwards. */
+    initialKillSwitch?: FleetKillSwitchState | null;
+    killSwitchError?: string | null;
 }
 
 const ENROLLABLE_KINDS: Exclude<FleetNodeKind, 'k8s'>[] = ['desktop-node', 'node'];
@@ -110,6 +116,8 @@ export function FleetSettings({
     nodeDownloadUrl,
     initialPreferences,
     preferencesError,
+    initialKillSwitch = null,
+    killSwitchError = null,
 }: FleetSettingsProps) {
     const t = useTranslations('dashboard.settings.fleet');
     const [nodes, setNodes] = useState<FleetNodeView[]>(initialNodes);
@@ -401,6 +409,9 @@ export function FleetSettings({
                 </Button>
             </div>
 
+            {/* Panic controls (EW-778) — visible the moment an operator stops the platform. */}
+            <FleetKillSwitchBanner initial={initialKillSwitch} initialError={killSwitchError} />
+
             {loadError && (
                 <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
                     <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
@@ -630,6 +641,16 @@ export function FleetSettings({
                     </table>
                 </div>
             )}
+
+            {/* Panic controls (EW-778) — drain everything; cancel running work as a separate step. */}
+            <FleetPanicControls
+                nodes={nodes}
+                onNodesDrained={(drained) =>
+                    setNodes((prev) =>
+                        prev.map((entry) => drained.find((node) => node.id === entry.id) ?? entry),
+                    )
+                }
+            />
 
             <FleetExecutionPreferences
                 initialPreferences={initialPreferences}

--- a/apps/web/src/lib/api/fleet-panic.unit.spec.ts
+++ b/apps/web/src/lib/api/fleet-panic.unit.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `fleetAPI` panic-control helpers (EW-778) — the endpoint shape.
+ *
+ * Same double-prefix guard every other `lib/api` spec carries (paths are
+ * relative to `/api`), plus the two contracts that matter here: the two
+ * owner controls are two ROUTES, and the set/clear verbs are separate
+ * routes rather than one boolean.
+ */
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./fleet');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({});
+    serverMutationMock.mockResolvedValue({});
+});
+afterEach(() => vi.resetModules());
+
+describe('fleetAPI panic controls — endpoint shape', () => {
+    it('drainAll POSTs /fleet/drain-all WITHOUT a leading /api', async () => {
+        const { fleetAPI } = await importApi();
+        await fleetAPI.drainAll();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/fleet/drain-all',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('cancelInFlight POSTs /fleet/cancel-in-flight with an explicit boolean, defaulting to false', async () => {
+        const { fleetAPI } = await importApi();
+        await fleetAPI.cancelInFlight();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/fleet/cancel-in-flight',
+            data: { includeQueued: false },
+            method: 'POST',
+            wrapInData: false,
+        });
+        await fleetAPI.cancelInFlight({ includeQueued: true });
+        expect(serverMutationMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ data: { includeQueued: true } }),
+        );
+    });
+
+    it('killSwitchState GETs /fleet/kill-switch', async () => {
+        const { fleetAPI } = await importApi();
+        await fleetAPI.killSwitchState();
+        expect(serverFetchMock).toHaveBeenCalledWith('/fleet/kill-switch');
+    });
+
+    it('stop and clear are two POST routes, and stop only sends a reason when given', async () => {
+        const { fleetAPI } = await importApi();
+        await fleetAPI.stopKillSwitch('incident');
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/fleet/kill-switch/stop',
+            data: { reason: 'incident' },
+            method: 'POST',
+            wrapInData: false,
+        });
+        await fleetAPI.stopKillSwitch();
+        expect(serverMutationMock).toHaveBeenLastCalledWith(expect.objectContaining({ data: {} }));
+        await fleetAPI.clearKillSwitch();
+        expect(serverMutationMock).toHaveBeenLastCalledWith({
+            endpoint: '/fleet/kill-switch/clear',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('killSwitchAudit GETs /fleet/kill-switch/audit with an optional bounded limit', async () => {
+        const { fleetAPI } = await importApi();
+        await fleetAPI.killSwitchAudit();
+        expect(serverFetchMock).toHaveBeenCalledWith('/fleet/kill-switch/audit');
+        await fleetAPI.killSwitchAudit(25);
+        expect(serverFetchMock).toHaveBeenLastCalledWith('/fleet/kill-switch/audit?limit=25');
+    });
+});

--- a/apps/web/src/lib/api/fleet.ts
+++ b/apps/web/src/lib/api/fleet.ts
@@ -23,6 +23,11 @@ import { serverFetch, serverMutation } from './server-api';
 import type {
     FleetAgentNodeAffinityView,
     FleetCostCeilingView,
+    FleetAuditView,
+    FleetCancelInFlightResult,
+    FleetDrainAllResult,
+    FleetKillSwitchChangeResult,
+    FleetKillSwitchState,
     FleetNodeDetailView,
     FleetNodeDrainResult,
     FleetEnrollmentTokenView,
@@ -35,9 +40,14 @@ import type {
 export type {
     FleetAgentNodeAffinityView,
     FleetCostCeilingView,
+    FleetAuditView,
+    FleetCancelInFlightResult,
+    FleetDrainAllResult,
     FleetJobKind,
     FleetJobStatus,
     FleetJobView,
+    FleetKillSwitchChangeResult,
+    FleetKillSwitchState,
     FleetNodeKind,
     FleetNodeStatus,
     FleetNodeView,
@@ -52,6 +62,12 @@ export type {
     FleetRunnerNodeView,
     FleetRunnerStatusView,
 } from '@ever-works/contracts';
+
+/** Body of `POST /api/fleet/cancel-in-flight`. */
+export interface CancelFleetInFlightPayload {
+    /** Also fail queued jobs nothing has started. Default false. */
+    includeQueued?: boolean;
+}
 
 export interface CreateFleetEnrollmentTokenPayload {
     name: string;
@@ -226,6 +242,58 @@ export const fleetAPI = {
             method: 'PUT',
             wrapInData: false,
         });
+    },
+
+    /**
+     * Panic controls (EW-778). Draining and cancelling are two routes on
+     * purpose — stopping new work is not killing running work — and the
+     * stop flag is READ here by any session while SET/CLEAR are platform-
+     * admin routes (the API answers 403 for everyone else).
+     */
+    drainAll: async () => {
+        return serverMutation<FleetDrainAllResult>({
+            endpoint: `${BASE}/drain-all`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    cancelInFlight: async (payload: CancelFleetInFlightPayload = {}) => {
+        return serverMutation<FleetCancelInFlightResult>({
+            endpoint: `${BASE}/cancel-in-flight`,
+            data: { includeQueued: payload.includeQueued === true },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /** Polled by the fleet page banner; a read, so no cache invalidation. */
+    killSwitchState: async () => {
+        return serverFetch<FleetKillSwitchState>(`${BASE}/kill-switch`);
+    },
+
+    stopKillSwitch: async (reason?: string | null) => {
+        return serverMutation<FleetKillSwitchChangeResult>({
+            endpoint: `${BASE}/kill-switch/stop`,
+            data: reason ? { reason } : {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    clearKillSwitch: async () => {
+        return serverMutation<FleetKillSwitchChangeResult>({
+            endpoint: `${BASE}/kill-switch/clear`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    killSwitchAudit: async (limit?: number) => {
+        const query = typeof limit === 'number' && limit > 0 ? `?limit=${Math.trunc(limit)}` : '';
+        return serverFetch<FleetAuditView[]>(`${BASE}/kill-switch/audit${query}`);
     },
 
     /**

--- a/apps/web/src/lib/hooks/use-kill-switch-polling.ts
+++ b/apps/web/src/lib/hooks/use-kill-switch-polling.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FleetKillSwitchState } from '@/lib/api/fleet';
+import { getFleetKillSwitchAction } from '@/app/actions/settings/fleet';
+
+/** The API has no cadence field for this read; match the runner pill. */
+export const KILL_SWITCH_POLL_INTERVAL_MS = 30_000;
+
+export interface KillSwitchPollingResult {
+    state: FleetKillSwitchState | null;
+    /** True until the FIRST response settles — never during re-polls. */
+    loading: boolean;
+    /** Last poll failure, or null. The previous state keeps rendering. */
+    error: string | null;
+    /** Force an immediate re-read. */
+    refresh: () => void;
+}
+
+/**
+ * Panic controls (EW-778) — poll the platform-wide stop flag.
+ *
+ * Same shape as `use-runner-status-polling`, for the same reasons: it
+ * polls unconditionally while mounted (an operator throwing the switch
+ * is precisely the event the banner exists to show, and it is invisible
+ * from the last payload), and a failed poll keeps the last-known state
+ * rather than blanking it. The server-side page hands in the first
+ * paint so the banner is correct before the first tick.
+ */
+export function useKillSwitchPolling(
+    initialState: FleetKillSwitchState | null = null,
+    initialError: string | null = null,
+): KillSwitchPollingResult {
+    const [state, setState] = useState<FleetKillSwitchState | null>(initialState);
+    const [loading, setLoading] = useState(initialState === null && initialError === null);
+    const [error, setError] = useState<string | null>(initialError);
+
+    const inFlight = useRef(false);
+    const cancelled = useRef(false);
+
+    const tick = useCallback(async () => {
+        if (inFlight.current) return;
+        inFlight.current = true;
+        try {
+            const result = await getFleetKillSwitchAction();
+            if (cancelled.current) return;
+            if (result.success) {
+                setState(result.data);
+                setError(null);
+            } else {
+                setError(result.error);
+            }
+        } catch {
+            if (!cancelled.current) setError('Failed to read the stop flag');
+        } finally {
+            inFlight.current = false;
+            if (!cancelled.current) setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        cancelled.current = false;
+        void tick();
+        const interval = setInterval(() => void tick(), KILL_SWITCH_POLL_INTERVAL_MS);
+        return () => {
+            cancelled.current = true;
+            clearInterval(interval);
+        };
+    }, [tick]);
+
+    const refresh = useCallback(() => {
+        void tick();
+    }, [tick]);
+
+    return { state, loading, error, refresh };
+}

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -73,6 +73,27 @@ The **node drawer** on the Fleet page (the details action on a row) renders the 
 
 Everything here is owner-scoped: another account's node id is indistinguishable from one that does not exist.
 
+## Panic controls
+
+Every control above is per node. Stopping six autonomous machines at 2am must not mean six drain calls or an ArgoCD sync, so three controls exist that act on the whole fleet — and they are three **different decisions**, kept on three different routes on purpose.
+
+```
+POST   /api/fleet/drain-all           owner: disable EVERY node I own, requeue their in-flight claims
+POST   /api/fleet/cancel-in-flight    owner: { includeQueued? } cancel my running fleet jobs + their agent runs
+GET    /api/fleet/kill-switch         any session: is the platform-wide stop flag set?
+POST   /api/fleet/kill-switch/stop    platform admin: { reason? } set the stop flag
+POST   /api/fleet/kill-switch/clear   platform admin: clear it and resume the runs it parked
+GET    /api/fleet/kill-switch/audit   platform admin: ?limit — recent audit rows (actor + time)
+```
+
+**Drain all** is the per-node drain applied to every enrolled node you own (nodes still enrolling or already disabled are skipped). Nothing is cancelled: the work goes back to the queue and waits for a node that may take it. The Fleet page carries it under **Panic controls**.
+
+**Cancel in-flight** is the explicit second step. It cancels every leased / running fleet job you own and the agent run behind each (run row first, then the job, the same order the per-run cancel uses). A node learns of it through its next refused heartbeat, so this is "cancel requested", not an instant kill — a job that is about to finish may still report. `includeQueued: true` extends it to queued jobs nothing has started. It is never implied by draining, and never by the stop flag.
+
+**The global stop flag** is a DB-backed switch (`fleet_kill_switch`, one row) checked at three points before any new unit of work can start: the run dispatch gate (every new agent run is parked with `queuedReason: kill-switch`), the fleet run router (a run that reaches routing is refused, never sent to the cloud instead) and every lease request (a node polling for work gets an empty batch). Running work keeps running and keeps reporting; heartbeats and completions are not gated, so a stopped fleet can still settle. **Reads fail closed**: a flag that cannot be read — missing row, unreachable database — counts as set, and the Fleet page banner says so distinctly (`unverified`) so nobody goes looking for who threw the switch. Clearing the flag resumes the parked runs (bounded, best effort; runs without a Work wait for their schedule's next tick), and runs parked by the flag are exempt from the stuck-run sweeper for as long as it is set. Every set and clear, every drain-all and every cancel-in-flight writes one `fleet_audit` row with the actor and the time.
+
+Setting and clearing the flag is a platform-admin operation (`User.isPlatformAdmin`); there is no button for it on the owner's Fleet page, only the banner. `FLEET_NODE_RUNTIME_ENABLED` is **not** a panic control: it is a routing selector, and work it turns away from the fleet runs in the cloud instead.
+
 ## Capabilities
 
 A node advertises capability tags (up to 16) such as `terminal`, `workspace` or `docker`. These describe what the node can host.
@@ -128,7 +149,7 @@ With a node chosen, every `agent-task` job dispatched for that agent is stamped 
 | `local-fallback` _(default)_ | Runs on your fleet | Runs on the platform runtime instead, and you get a fallback notification        |
 | `cloud`                      | Platform runtime   | Platform runtime — an explicit opt-out for work you do not want on your machines |
 
-`local-wait` is for work that is only correct on that machine; `local-fallback` is the default because its failure mode is "slower, elsewhere" rather than "nothing ran". The preference chooses fleet-vs-cloud only for an account whose resolved job runtime is the fleet, and it never overrides the `FLEET_NODE_RUNTIME_ENABLED` kill switch. The agent's **Capabilities → Execution** section shows the account-wide rule in force, read-only, with a link back to Settings → Fleet to change it.
+`local-wait` is for work that is only correct on that machine; `local-fallback` is the default because its failure mode is "slower, elsewhere" rather than "nothing ran". The preference chooses fleet-vs-cloud only for an account whose resolved job runtime is the fleet, and it never overrides the `FLEET_NODE_RUNTIME_ENABLED` routing selector (which sends work to the cloud, not nowhere — the control that stops work is the global stop flag under **Panic controls** above). The agent's **Capabilities → Execution** section shows the account-wide rule in force, read-only, with a link back to Settings → Fleet to change it.
 
 ## Running agents on your machines
 

--- a/packages/agent/src/agents/__tests__/run-admission-chain.kill-switch.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.kill-switch.spec.ts
@@ -1,0 +1,115 @@
+import {
+    composeRunAdmission,
+    DEFAULT_RUN_ADMISSION_CHAIN,
+    killSwitchAdmission,
+    QUEUED_REASON_CONCURRENCY,
+    QUEUED_REASON_KILL_SWITCH,
+    RUN_ADMISSION_ADMITTED,
+    type RunAdmissionContext,
+} from '../run-admission-chain';
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG as the FIRST admission
+ * middleware.
+ *
+ * Three properties, each of which would silently reopen the hole if
+ * lost:
+ *   1. it is index 0 of the shipped chain, so a stopped platform parks
+ *      before any counter is consulted;
+ *   2. a port that THROWS parks the run (fail-closed) — `admit()` swallows
+ *      a throwing chain and ADMITS, so the conversion has to happen here;
+ *   3. an absent port is a pass-through, so fleet-less installs and every
+ *      existing unit test are untouched.
+ */
+describe('run admission chain — kill switch (EW-778)', () => {
+    const counters = () => ({
+        countInFlightForWork: jest.fn().mockResolvedValue(0),
+        countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+        countInFlightForUser: jest.fn().mockResolvedValue(0),
+    });
+
+    const makeContext = (over: Partial<RunAdmissionContext> = {}): RunAdmissionContext => ({
+        input: { userId: 'user-1', workId: 'work-1', organizationId: null },
+        counters: counters(),
+        logger: { log: jest.fn(), warn: jest.fn() },
+        resolveWorkLimit: () => 10,
+        resolveOrgLimit: () => 25,
+        isCreditsEnforcementEnabled: () => false,
+        isPlanConcurrencyEnabled: () => false,
+        ...over,
+    });
+
+    it('is the FIRST middleware of the shipped chain', () => {
+        expect(DEFAULT_RUN_ADMISSION_CHAIN[0]).toBe(killSwitchAdmission);
+    });
+
+    it('passes through when no port is bound', async () => {
+        const next = jest.fn(async () => RUN_ADMISSION_ADMITTED);
+        await expect(killSwitchAdmission(makeContext(), next)).resolves.toEqual(
+            RUN_ADMISSION_ADMITTED,
+        );
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes through when the flag is clear', async () => {
+        const next = jest.fn(async () => RUN_ADMISSION_ADMITTED);
+        const context = makeContext({
+            killSwitch: { shouldHaltDispatch: jest.fn().mockResolvedValue(false) },
+        });
+        await expect(killSwitchAdmission(context, next)).resolves.toEqual(RUN_ADMISSION_ADMITTED);
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('parks with `kill-switch` when the flag is set, without calling next()', async () => {
+        const next = jest.fn(async () => RUN_ADMISSION_ADMITTED);
+        const context = makeContext({
+            killSwitch: { shouldHaltDispatch: jest.fn().mockResolvedValue(true) },
+        });
+        await expect(killSwitchAdmission(context, next)).resolves.toEqual({
+            admitted: false,
+            queuedReason: QUEUED_REASON_KILL_SWITCH,
+        });
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    /**
+     * THE load-bearing test. `RunDispatchGateService.admit()` turns a
+     * throwing chain into `{ admitted: true }`. Revert-check: remove the
+     * try/catch in `killSwitchAdmission` and this goes RED.
+     */
+    it('parks (fail-closed) when the port THROWS, and never propagates', async () => {
+        const next = jest.fn(async () => RUN_ADMISSION_ADMITTED);
+        const context = makeContext({
+            killSwitch: { shouldHaltDispatch: jest.fn().mockRejectedValue(new Error('db down')) },
+        });
+        await expect(killSwitchAdmission(context, next)).resolves.toEqual({
+            admitted: false,
+            queuedReason: QUEUED_REASON_KILL_SWITCH,
+        });
+        expect(next).not.toHaveBeenCalled();
+        expect(context.logger.warn).toHaveBeenCalledWith(expect.stringContaining('fail-closed'));
+    });
+
+    it('through the shipped chain: a stopped platform parks before ANY counter is consulted', async () => {
+        const context = makeContext({
+            killSwitch: { shouldHaltDispatch: jest.fn().mockResolvedValue(true) },
+        });
+        const verdict = await composeRunAdmission(DEFAULT_RUN_ADMISSION_CHAIN)(context);
+        expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_KILL_SWITCH });
+        expect(context.counters.countInFlightForWork).not.toHaveBeenCalled();
+        expect(context.counters.countInFlightForOrganization).not.toHaveBeenCalled();
+        expect(context.counters.countInFlightForUser).not.toHaveBeenCalled();
+    });
+
+    it('through the shipped chain: a clear flag hands over to the concurrency valves', async () => {
+        const context = makeContext({
+            killSwitch: { shouldHaltDispatch: jest.fn().mockResolvedValue(false) },
+            counters: {
+                ...counters(),
+                countInFlightForWork: jest.fn().mockResolvedValue(10),
+            },
+        });
+        const verdict = await composeRunAdmission(DEFAULT_RUN_ADMISSION_CHAIN)(context);
+        expect(verdict).toEqual({ admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY });
+    });
+});

--- a/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-admission-chain.spec.ts
@@ -1,6 +1,7 @@
 import {
     composeRunAdmission,
     creditsAdmission,
+    killSwitchAdmission,
     orgConcurrencyAdmission,
     workConcurrencyAdmission,
     DEFAULT_RUN_ADMISSION_CHAIN,
@@ -444,8 +445,11 @@ describe('run admission chain', () => {
     });
 
     describe('DEFAULT_RUN_ADMISSION_CHAIN', () => {
-        it('is the shipped order: Work valve, org/user valve, credits', () => {
+        // EW-778 — the global stop flag leads the chain (fail-closed, and
+        // before any counter is spent); below it the order is unchanged.
+        it('is the shipped order: stop flag, Work valve, org/user valve, credits', () => {
             expect(DEFAULT_RUN_ADMISSION_CHAIN).toEqual([
+                killSwitchAdmission,
                 workConcurrencyAdmission,
                 orgConcurrencyAdmission,
                 creditsAdmission,

--- a/packages/agent/src/agents/__tests__/run-dispatch-gate.kill-switch.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-dispatch-gate.kill-switch.spec.ts
@@ -1,0 +1,399 @@
+import {
+    QUEUED_REASON_CONCURRENCY,
+    QUEUED_REASON_KILL_SWITCH,
+    RunDispatchGateService,
+} from '../run-dispatch-gate.service';
+import { KILL_SWITCH_ACTIVE_ERROR_NAME } from '../run-kill-switch';
+import { AgentRunSweeperService } from '../agent-run-sweeper.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Panic controls (EW-778) — the dispatch gate with the `RUN_KILL_SWITCH`
+ * port bound, and the two things that make a stop RECOVERABLE:
+ *
+ *   - `drainForWork(workId, 'kill-switch')` promotes a parked run through
+ *     the SAME claim / enqueue / stamp path as a concurrency drain, and
+ *     relabels one the chain now refuses for another reason;
+ *   - `promoteParked` walks every Work with a parked run, bounded;
+ *   - the stuck-run sweeper leaves `kill-switch`-parked rows alone, or a
+ *     stop longer than the stuck timeout would fail every parked run and a
+ *     clear would resume nothing.
+ */
+describe('RunDispatchGateService — kill switch (EW-778)', () => {
+    const ENV_KEYS = [
+        'AGENT_MAX_CONCURRENT_RUNS_PER_WORK',
+        'AGENT_MAX_CONCURRENT_RUNS_PER_ORG',
+        'CREDITS_ENFORCEMENT',
+    ] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    let runs: any;
+    let dispatcher: any;
+    let killSwitch: { shouldHaltDispatch: jest.Mock };
+
+    const parkedRun = (over: Record<string, unknown> = {}) => ({
+        id: 'run-parked',
+        agentId: 'agent-1',
+        userId: 'user-1',
+        taskId: 'task-1',
+        workId: 'work-1',
+        organizationId: null,
+        status: 'queued',
+        queuedReason: QUEUED_REASON_KILL_SWITCH,
+        ...over,
+    });
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+        runs = {
+            countInFlightForWork: jest.fn().mockResolvedValue(0),
+            countInFlightForUser: jest.fn().mockResolvedValue(0),
+            countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+            findOldestQueuedForConcurrency: jest.fn().mockResolvedValue(null),
+            claimQueuedForDispatch: jest.fn().mockResolvedValue(true),
+            restoreQueuedReason: jest.fn().mockResolvedValue(undefined),
+            relabelQueuedReason: jest.fn().mockResolvedValue(true),
+            findQueuedWorkIdsByReason: jest.fn().mockResolvedValue([]),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+        killSwitch = { shouldHaltDispatch: jest.fn().mockResolvedValue(false) };
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (savedEnv[key] === undefined) delete process.env[key];
+            else process.env[key] = savedEnv[key];
+        }
+    });
+
+    // The port is the SIXTH positional argument (appended LAST).
+    const makeGate = () =>
+        new RunDispatchGateService(
+            runs,
+            dispatcher,
+            undefined,
+            undefined,
+            undefined,
+            killSwitch as never,
+        );
+
+    describe('admit', () => {
+        it('parks every new run with `kill-switch` while the flag is set', async () => {
+            killSwitch.shouldHaltDispatch.mockResolvedValue(true);
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result).toEqual({ admitted: false, queuedReason: QUEUED_REASON_KILL_SWITCH });
+            expect(runs.countInFlightForWork).not.toHaveBeenCalled();
+        });
+
+        it('admits as before while the flag is clear', async () => {
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result).toEqual({ admitted: true });
+            expect(killSwitch.shouldHaltDispatch).toHaveBeenCalledTimes(1);
+        });
+
+        /**
+         * The critical-section path is the one that FAILS OPEN on a
+         * throwing chain. A port that throws must still reach `reserve`
+         * as a PARK verdict — that is the fail-closed contract crossing
+         * the fail-open seam.
+         */
+        it('reserves a PARKED row when the port throws, even through the fail-open wrapper', async () => {
+            killSwitch.shouldHaltDispatch.mockRejectedValue(new Error('db down'));
+            const reserve = jest.fn().mockResolvedValue(undefined);
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' }, reserve);
+            expect(result).toEqual({ admitted: false, queuedReason: QUEUED_REASON_KILL_SWITCH });
+            expect(reserve).toHaveBeenCalledTimes(1);
+            expect(reserve).toHaveBeenCalledWith({
+                admitted: false,
+                queuedReason: QUEUED_REASON_KILL_SWITCH,
+            });
+        });
+    });
+
+    describe('drainForWork(workId, "kill-switch")', () => {
+        // Pinned on BOTH sides: `apps/api`'s `FleetKillSwitchActiveError`
+        // sets this exact `name` (its routing spec asserts the literal), and
+        // the gate re-parks on it. Two packages, one literal, two pins.
+        it('recognises the api-side error by the pinned Error.name', () => {
+            expect(KILL_SWITCH_ACTIVE_ERROR_NAME).toBe('FleetKillSwitchActiveError');
+        });
+
+        it('promotes a kill-switch-parked run through the same claim + enqueue path', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            const result = await makeGate().drainForWork('work-1', QUEUED_REASON_KILL_SWITCH);
+
+            expect(runs.findOldestQueuedForConcurrency).toHaveBeenCalledWith(
+                'work-1',
+                QUEUED_REASON_KILL_SWITCH,
+            );
+            expect(runs.claimQueuedForDispatch).toHaveBeenCalledWith(
+                'run-parked',
+                QUEUED_REASON_KILL_SWITCH,
+            );
+            expect(dispatcher.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({ runId: 'run-parked', taskId: 'task-1' }),
+            );
+            expect(runs.setTriggerRunId).toHaveBeenCalledWith('run-parked', 'trd-1');
+            expect(result).toEqual({ dispatched: true, runId: 'run-parked' });
+            expect(runs.relabelQueuedReason).not.toHaveBeenCalled();
+        });
+
+        it('leaves the run parked (no relabel) while the flag is STILL set', async () => {
+            killSwitch.shouldHaltDispatch.mockResolvedValue(true);
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            const result = await makeGate().drainForWork('work-1', QUEUED_REASON_KILL_SWITCH);
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(runs.claimQueuedForDispatch).not.toHaveBeenCalled();
+            expect(runs.relabelQueuedReason).not.toHaveBeenCalled();
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('relabels to `concurrency-limit` when the flag is clear but the Work is saturated', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            runs.countInFlightForWork.mockResolvedValueOnce(10); // default limit 10
+            const result = await makeGate().drainForWork('work-1', QUEUED_REASON_KILL_SWITCH);
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(runs.relabelQueuedReason).toHaveBeenCalledWith(
+                'run-parked',
+                QUEUED_REASON_KILL_SWITCH,
+                QUEUED_REASON_CONCURRENCY,
+            );
+            expect(runs.claimQueuedForDispatch).not.toHaveBeenCalled();
+        });
+
+        it('the default reason is still `concurrency-limit` and never relabels', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(
+                parkedRun({ queuedReason: QUEUED_REASON_CONCURRENCY }),
+            );
+            runs.countInFlightForWork.mockResolvedValueOnce(10);
+            const result = await makeGate().drainForWork('work-1');
+            expect(runs.findOldestQueuedForConcurrency).toHaveBeenCalledWith(
+                'work-1',
+                QUEUED_REASON_CONCURRENCY,
+            );
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(runs.relabelQueuedReason).not.toHaveBeenCalled();
+        });
+
+        /**
+         * Clear → promote → re-stop: admission passed (flag clear), then
+         * the dispatcher read the flag again and refused. A stop must PARK
+         * work, never fail it — the run goes back to `kill-switch` so the
+         * next clear resumes it, and nothing is stamped.
+         */
+        it('re-parks (never fails) a promoted run the dispatcher refuses on the stop flag', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            const refused = new Error('Dispatch refused: the global stop flag is set');
+            refused.name = KILL_SWITCH_ACTIVE_ERROR_NAME;
+            dispatcher.enqueue.mockRejectedValueOnce(refused);
+
+            const result = await makeGate().drainForWork('work-1', QUEUED_REASON_KILL_SWITCH);
+
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(runs.restoreQueuedReason).toHaveBeenCalledWith(
+                'run-parked',
+                QUEUED_REASON_KILL_SWITCH,
+            );
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+            expect(runs.setTriggerRunId).not.toHaveBeenCalled();
+        });
+
+        it('re-parks a CONCURRENCY-drained run too when the dispatcher refuses on the stop flag', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(
+                parkedRun({ queuedReason: QUEUED_REASON_CONCURRENCY }),
+            );
+            const refused = new Error('Dispatch refused: the global stop flag is set');
+            refused.name = KILL_SWITCH_ACTIVE_ERROR_NAME;
+            dispatcher.enqueue.mockRejectedValueOnce(refused);
+
+            const result = await makeGate().drainForWork('work-1');
+
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            // Parked under the reason that actually holds it now.
+            expect(runs.restoreQueuedReason).toHaveBeenCalledWith(
+                'run-parked',
+                QUEUED_REASON_KILL_SWITCH,
+            );
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+        });
+
+        it('still fails a promoted run whose enqueue throws for any OTHER reason', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            dispatcher.enqueue.mockRejectedValueOnce(new Error('runtime down'));
+
+            const result = await makeGate().drainForWork('work-1', QUEUED_REASON_KILL_SWITCH);
+
+            expect(result).toEqual({ dispatched: false, reason: 'dispatch-failed' });
+            expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+                'run-parked',
+                expect.stringContaining('runtime down'),
+            );
+            expect(runs.restoreQueuedReason).not.toHaveBeenCalled();
+        });
+
+        it('a concurrency drain does NOT promote while the flag is set', async () => {
+            killSwitch.shouldHaltDispatch.mockResolvedValue(true);
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(
+                parkedRun({ queuedReason: QUEUED_REASON_CONCURRENCY }),
+            );
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('promoteParked', () => {
+        const seed = (perWork: Record<string, string[]>) => {
+            const remaining: Record<string, string[]> = Object.fromEntries(
+                Object.entries(perWork).map(([workId, ids]) => [workId, [...ids]]),
+            );
+            runs.findQueuedWorkIdsByReason.mockResolvedValue(Object.keys(perWork));
+            runs.findOldestQueuedForConcurrency.mockImplementation(async (workId: string) => {
+                const next = remaining[workId]?.shift();
+                return next ? parkedRun({ id: next, workId }) : null;
+            });
+        };
+
+        it('promotes every parked run across every Work, oldest first per Work', async () => {
+            seed({ 'work-a': ['a-1', 'a-2'], 'work-b': ['b-1'] });
+            const result = await makeGate().promoteParked(QUEUED_REASON_KILL_SWITCH, 10);
+            expect(result).toEqual({ promoted: 3, works: 2, budgetExhausted: false });
+            expect(runs.findQueuedWorkIdsByReason).toHaveBeenCalledWith(
+                QUEUED_REASON_KILL_SWITCH,
+                10,
+            );
+            expect(
+                dispatcher.enqueue.mock.calls.map(([p]: [{ runId: string }]) => p.runId),
+            ).toEqual(['a-1', 'a-2', 'b-1']);
+        });
+
+        it('stops at the promotion budget and says so', async () => {
+            seed({ 'work-a': ['a-1', 'a-2'], 'work-b': ['b-1'] });
+            const result = await makeGate().promoteParked(QUEUED_REASON_KILL_SWITCH, 2);
+            expect(result).toEqual({ promoted: 2, works: 2, budgetExhausted: true });
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(2);
+        });
+
+        it('moves on to the next Work when one refuses (saturated)', async () => {
+            seed({ 'work-a': ['a-1'], 'work-b': ['b-1'] });
+            runs.countInFlightForWork.mockImplementation(async (workId: string) =>
+                workId === 'work-a' ? 10 : 0,
+            );
+            const result = await makeGate().promoteParked(QUEUED_REASON_KILL_SWITCH, 10);
+            expect(result).toEqual({ promoted: 1, works: 2, budgetExhausted: false });
+            expect(runs.relabelQueuedReason).toHaveBeenCalledWith(
+                'a-1',
+                QUEUED_REASON_KILL_SWITCH,
+                QUEUED_REASON_CONCURRENCY,
+            );
+        });
+
+        it('never throws — a failing Work lookup reports zero promotions', async () => {
+            runs.findQueuedWorkIdsByReason.mockRejectedValue(new Error('db down'));
+            await expect(makeGate().promoteParked(QUEUED_REASON_KILL_SWITCH, 10)).resolves.toEqual({
+                promoted: 0,
+                works: 0,
+                budgetExhausted: false,
+            });
+        });
+
+        it('a zero budget is a no-op that touches nothing', async () => {
+            const result = await makeGate().promoteParked(QUEUED_REASON_KILL_SWITCH, 0);
+            expect(result).toEqual({ promoted: 0, works: 0, budgetExhausted: false });
+            expect(runs.findQueuedWorkIdsByReason).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('AgentRunSweeperService — kill-switch-parked runs are never reaped (EW-778)', () => {
+    const ENV_KEYS = [
+        'AGENT_RUN_SWEEPER_ENABLED',
+        'AGENT_RUN_STUCK_SWEEP_MINUTES',
+        'AGENT_RUN_STUCK_SWEEP_BATCH',
+        'AGENT_RUN_STALE_PARK_ENABLED',
+    ];
+    const saved: Record<string, string | undefined> = {};
+    let runs: any;
+
+    const row = (over: Record<string, unknown> = {}) => ({
+        id: 'r1',
+        agentId: 'a1',
+        triggerKind: 'task',
+        status: 'queued',
+        startedAt: null,
+        createdAt: new Date(Date.now() - 24 * 60 * 60_000),
+        workId: 'work-1',
+        awaitingInput: false,
+        queuedReason: null,
+        ...over,
+    });
+
+    const makeSvc = () => {
+        const svc = new AgentRunSweeperService(runs);
+        for (const level of ['warn', 'log'] as const) {
+            jest.spyOn(
+                (svc as never as { logger: Record<string, () => void> }).logger,
+                level,
+            ).mockImplementation(() => undefined);
+        }
+        return svc;
+    };
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            saved[key] = process.env[key];
+            delete process.env[key];
+        }
+        runs = {
+            findStuckNonTerminal: jest.fn().mockResolvedValue([]),
+            markStuckFailed: jest.fn().mockResolvedValue(0),
+            parkStaleRunning: jest.fn().mockResolvedValue(0),
+            findQueuedTooLong: jest.fn().mockResolvedValue([]),
+            setAttention: jest.fn().mockResolvedValue(true),
+            findById: jest.fn().mockResolvedValue(null),
+        };
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (saved[key] === undefined) delete process.env[key];
+            else process.env[key] = saved[key];
+        }
+    });
+
+    it('asks the repository to exempt kill-switch-parked rows in the SQL', async () => {
+        await makeSvc().sweepStuckRuns();
+        expect(runs.findStuckNonTerminal).toHaveBeenCalledWith(
+            expect.any(Date),
+            expect.any(Number),
+            [QUEUED_REASON_KILL_SWITCH],
+        );
+    });
+
+    it('re-asserts the exemption in the service: a parked row handed back is not reaped', async () => {
+        runs.findStuckNonTerminal.mockResolvedValue([
+            row({ id: 'parked', queuedReason: QUEUED_REASON_KILL_SWITCH }),
+        ]);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.swept).toBe(0);
+        expect(summary.scanned).toBe(0);
+        expect(runs.markStuckFailed).not.toHaveBeenCalled();
+    });
+
+    it('still reaps a genuinely stuck queued row in the same batch', async () => {
+        runs.findStuckNonTerminal.mockResolvedValue([
+            row({ id: 'parked', queuedReason: QUEUED_REASON_KILL_SWITCH }),
+            row({ id: 'dead', queuedReason: null }),
+        ]);
+        runs.markStuckFailed.mockResolvedValue(1);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.swept).toBe(1);
+        expect(runs.markStuckFailed).toHaveBeenCalledWith(['dead'], expect.any(String));
+    });
+});

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -6,7 +6,7 @@ import {
     AgentRunRepository,
     STALE_PARK_SUMMARY_PREFIX,
 } from '../database/repositories/agent-run.repository';
-import { RunDispatchGateService } from './run-dispatch-gate.service';
+import { QUEUED_REASON_KILL_SWITCH, RunDispatchGateService } from './run-dispatch-gate.service';
 import { AgentEscalationService } from './agent-escalation.service';
 import { NotificationService } from '../notifications/notification.service';
 import type { AgentRun } from '../entities/agent-run.entity';
@@ -135,7 +135,12 @@ export class AgentRunSweeperService {
         const now = Date.now();
         const cutoff = new Date(now - cutoffMinutes * 60_000);
 
-        const scanned = await this.runs.findStuckNonTerminal(cutoff, limit);
+        // Panic controls (EW-778) — a run the global stop flag parked is
+        // waiting for an operator, not stuck. Excluded in the SQL AND
+        // re-asserted below, exactly like `awaitingInput`.
+        const scanned = await this.runs.findStuckNonTerminal(cutoff, limit, [
+            QUEUED_REASON_KILL_SWITCH,
+        ]);
         // Run steering (Wave 4 M5) — THE hard rule of this plan: a run parked
         // on a human question must NEVER be reaped by a TTL sweep. It is not
         // stuck, it is waiting, possibly for days, and killing it destroys
@@ -144,11 +149,20 @@ export class AgentRunSweeperService {
         // this service is the last gate before `markStuckFailed`, and an
         // older API replica (or a future second caller) handing back an
         // awaiting row must still not reap it.
-        const stuck = scanned.filter((row) => row.awaitingInput !== true);
-        const skippedAwaiting = scanned.length - stuck.length;
+        const notAwaiting = scanned.filter((row) => row.awaitingInput !== true);
+        const skippedAwaiting = scanned.length - notAwaiting.length;
         if (skippedAwaiting > 0) {
             this.logger.log(
                 `AgentRun sweep: skipped ${skippedAwaiting} run(s) awaiting human input (never reaped).`,
+            );
+        }
+        const stuck = notAwaiting.filter(
+            (row) => !(row.status === 'queued' && row.queuedReason === QUEUED_REASON_KILL_SWITCH),
+        );
+        const skippedKillSwitch = notAwaiting.length - stuck.length;
+        if (skippedKillSwitch > 0) {
+            this.logger.log(
+                `AgentRun sweep: skipped ${skippedKillSwitch} run(s) parked by the global stop flag (never reaped).`,
             );
         }
         if (stuck.length === 0) {

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -21,6 +21,7 @@ export * from './run-capture';
 export {
     composeRunAdmission,
     creditsAdmission,
+    killSwitchAdmission,
     orgConcurrencyAdmission,
     workConcurrencyAdmission,
     DEFAULT_RUN_ADMISSION_CHAIN,
@@ -51,6 +52,8 @@ export * from './sub-agent-delegation.port';
 export * from './sub-agent-delegation.service';
 export * from './run-steering.service';
 export * from './run-credits-precheck';
+// Panic controls (EW-778) — the global stop flag port the gate consults.
+export * from './run-kill-switch';
 export * from './seat-guard';
 export * from './run-plan-limits';
 export * from './terminal-session-dispatcher';

--- a/packages/agent/src/agents/run-admission-chain.ts
+++ b/packages/agent/src/agents/run-admission-chain.ts
@@ -1,4 +1,5 @@
 import type { RunCreditsPrecheck } from './run-credits-precheck';
+import type { RunKillSwitch } from './run-kill-switch';
 import type { RunPlanLimits } from './run-plan-limits';
 
 /**
@@ -16,8 +17,9 @@ import type { RunPlanLimits } from './run-plan-limits';
  * order is data (`DEFAULT_RUN_ADMISSION_CHAIN`) rather than control flow.
  *
  * The refactor that introduced this file was a STRUCTURAL change only.
- * The shipped order today is: Work valve, org/user valve, then the
- * (kill-switched, fail-open) credits precheck.
+ * The shipped order today is: the global stop flag (EW-778, fail-CLOSED),
+ * then the Work valve, the org/user valve, and the (env-gated, fail-open)
+ * credits precheck.
  *
  * The org valve additionally folds in the plan's `max-concurrent-runs`
  * entitlement as a RAISE-ONLY adjustment — see its docblock for why it
@@ -29,6 +31,14 @@ export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
 
 /** Stamped when the soft credits precheck parks a run. Re-exported by the gate service. */
 export const QUEUED_REASON_INSUFFICIENT_CREDITS = 'insufficient-credits' as const;
+
+/**
+ * Panic controls (EW-778) — stamped when the GLOBAL STOP FLAG parks a
+ * run. Re-exported by the gate service. Promoted by
+ * `RunDispatchGateService.promoteParked` once the flag is cleared, and
+ * exempt from the stuck-run sweeper for as long as it is set.
+ */
+export const QUEUED_REASON_KILL_SWITCH = 'kill-switch' as const;
 
 export interface RunAdmissionInput {
     userId: string;
@@ -70,6 +80,8 @@ export interface RunAdmissionContext {
     readonly creditsPrecheck?: RunCreditsPrecheck;
     readonly isPlanConcurrencyEnabled: () => boolean;
     readonly planLimits?: RunPlanLimits;
+    /** EW-778 — the global stop flag port. Absent = no fleet stack bound. */
+    readonly killSwitch?: RunKillSwitch;
 }
 
 export type RunAdmissionNext = () => Promise<RunAdmissionVerdict>;
@@ -105,6 +117,39 @@ export function composeRunAdmission(
         return dispatch(0);
     };
 }
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG, first in the chain.
+ *
+ * When the flag is set, EVERY new run is parked with `kill-switch`
+ * before any counter is consulted — a stopped platform must not spend a
+ * count query, and a parked run must carry the reason an operator will
+ * look for. Absent port ⇒ pass-through (no fleet stack bound).
+ *
+ * 🛑 FAIL CLOSED, and NEVER THROW. `RunDispatchGateService.admit()`
+ * swallows a throwing chain and admits the run (the concurrency valves
+ * are fail-open by design, and that catch protects them). A stop flag
+ * that could not be read must therefore be converted into a PARK verdict
+ * right here, or the very failure it exists to survive would let work
+ * through.
+ */
+export const killSwitchAdmission: RunAdmissionMiddleware = async (context, next) => {
+    const { input, logger, killSwitch } = context;
+    if (!killSwitch) return next();
+    let halted: boolean;
+    try {
+        halted = await killSwitch.shouldHaltDispatch();
+    } catch (err) {
+        logger.warn(
+            `Dispatch gate: global stop flag could not be read for user ${input.userId} ` +
+                `— queueing (fail-closed): ${err}`,
+        );
+        halted = true;
+    }
+    if (!halted) return next();
+    logger.log(`Dispatch gate: global stop flag is set — queueing run for user ${input.userId}.`);
+    return { admitted: false, queuedReason: QUEUED_REASON_KILL_SWITCH };
+};
 
 /**
  * Per-Work concurrency valve. A limit of `<= 0` disables it entirely —
@@ -265,11 +310,14 @@ export const creditsAdmission: RunAdmissionMiddleware = async (context, next) =>
 };
 
 /**
- * The shipped order. Concurrency wins over credits by construction —
- * a saturated Work parks with `concurrency-limit` and never spends a
- * billing query, which is exactly what the pre-refactor ladder did.
+ * The shipped order. The stop flag outranks everything (a stopped
+ * platform parks with `kill-switch` and spends no count query at all);
+ * below it, concurrency wins over credits by construction — a saturated
+ * Work parks with `concurrency-limit` and never spends a billing query,
+ * which is exactly what the pre-refactor ladder did.
  */
 export const DEFAULT_RUN_ADMISSION_CHAIN: readonly RunAdmissionMiddleware[] = [
+    killSwitchAdmission,
     workConcurrencyAdmission,
     orgConcurrencyAdmission,
     creditsAdmission,

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -9,12 +9,18 @@ import {
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
 import { RUN_CREDITS_PRECHECK, type RunCreditsPrecheck } from './run-credits-precheck';
+import {
+    KILL_SWITCH_ACTIVE_ERROR_NAME,
+    RUN_KILL_SWITCH,
+    type RunKillSwitch,
+} from './run-kill-switch';
 import { RUN_PLAN_LIMITS, type RunPlanLimits } from './run-plan-limits';
 import {
     composeRunAdmission,
     DEFAULT_RUN_ADMISSION_CHAIN,
     QUEUED_REASON_CONCURRENCY,
     QUEUED_REASON_INSUFFICIENT_CREDITS,
+    QUEUED_REASON_KILL_SWITCH,
     type RunAdmissionMiddleware,
 } from './run-admission-chain';
 
@@ -40,6 +46,17 @@ export { QUEUED_REASON_CONCURRENCY };
  */
 export { QUEUED_REASON_INSUFFICIENT_CREDITS };
 
+/**
+ * Panic controls (EW-778) — stamped when the GLOBAL STOP FLAG parks a
+ * run. Drained by {@link RunDispatchGateService.promoteParked} once the
+ * flag is cleared (the api-side clear route calls it), and exempt from
+ * the stuck-run sweeper for as long as the flag is set.
+ */
+export { QUEUED_REASON_KILL_SWITCH };
+
+/** Upper bound on one `promoteParked` pass, so a clear cannot stampede. */
+export const PROMOTE_PARKED_MAX_PROMOTIONS = 200;
+
 export interface RunDispatchAdmitInput {
     userId: string;
     workId?: string | null;
@@ -48,7 +65,10 @@ export interface RunDispatchAdmitInput {
 
 export interface RunDispatchAdmitResult {
     admitted: boolean;
-    /** Set only when `admitted === false`; today always `concurrency-limit`. */
+    /**
+     * Set only when `admitted === false`: `concurrency-limit`,
+     * `insufficient-credits`, or `kill-switch` (EW-778).
+     */
     queuedReason?: string;
 }
 
@@ -56,6 +76,16 @@ export interface RunDispatchDrainResult {
     dispatched: boolean;
     runId?: string;
     reason?: 'no-candidate' | 'over-limit' | 'claim-lost' | 'no-dispatcher' | 'dispatch-failed';
+}
+
+/** Outcome of one {@link RunDispatchGateService.promoteParked} pass. */
+export interface RunDispatchPromoteResult {
+    /** Runs handed to a runtime. */
+    promoted: number;
+    /** Distinct Works that had at least one parked run. */
+    works: number;
+    /** True when the promotion budget ran out with candidates left. */
+    budgetExhausted: boolean;
 }
 
 /**
@@ -193,6 +223,14 @@ export class RunDispatchGateService {
         @Optional()
         @Inject(RUN_PLAN_LIMITS)
         private readonly planLimits?: RunPlanLimits,
+        // Panic controls (EW-778) — the GLOBAL STOP FLAG. Bound (to
+        // FleetKillSwitchService) by the api-side @Global() AgentsModule;
+        // absent in unit tests and fleet-less installs, where the
+        // kill-switch middleware simply passes every run through. Same
+        // @Optional() + appended-LAST posture as every seam above.
+        @Optional()
+        @Inject(RUN_KILL_SWITCH)
+        private readonly killSwitch?: RunKillSwitch,
     ) {}
 
     /** Env default today; per-Work override column when it lands. */
@@ -265,23 +303,37 @@ export class RunDispatchGateService {
             isPlanConcurrencyEnabled: () => config.agents.isPlanConcurrencyEnforcementEnabled(),
             ...(this.creditsPrecheck ? { creditsPrecheck: this.creditsPrecheck } : {}),
             ...(this.planLimits ? { planLimits: this.planLimits } : {}),
+            ...(this.killSwitch ? { killSwitch: this.killSwitch } : {}),
         });
     }
 
     /**
-     * Promote the oldest concurrency-parked run for a Work, if capacity
-     * allows. One promotion per call on purpose: every terminal
-     * transition frees at most one slot, and the next terminal (or the
-     * sweeper net) drains the next row. Best-effort by contract — every
-     * failure is logged and reported in the result, never thrown, so a
-     * drain hiccup can never fail the terminal transition that hosts it.
+     * Promote the oldest parked run for a Work, if capacity allows. One
+     * promotion per call on purpose: every terminal transition frees at
+     * most one slot, and the next terminal (or the sweeper net) drains
+     * the next row. Best-effort by contract — every failure is logged
+     * and reported in the result, never thrown, so a drain hiccup can
+     * never fail the terminal transition that hosts it.
+     *
+     * `queuedReason` selects WHICH parked rows are candidates. The
+     * default — and what every terminal-transition caller passes — is
+     * `concurrency-limit`. {@link promoteParked} passes `kill-switch`
+     * (EW-778) after the global stop flag is cleared, so a clear resumes
+     * parked work through this SAME claim / enqueue / stamp / rollback
+     * path rather than a second drain implementation.
+     *
+     * A `kill-switch`-parked run the chain now refuses for a DIFFERENT
+     * reason (the Work is saturated, credits ran out) is RELABELLED to
+     * that reason, so the ordinary terminal-transition drain (or the
+     * credits top-up) picks it up later. Without that it would stay
+     * parked with a reason nothing drains once the flag is off.
      */
-    async drainForWork(workId: string): Promise<RunDispatchDrainResult> {
+    async drainForWork(
+        workId: string,
+        queuedReason: string = QUEUED_REASON_CONCURRENCY,
+    ): Promise<RunDispatchDrainResult> {
         try {
-            const candidate = await this.runs.findOldestQueuedForConcurrency(
-                workId,
-                QUEUED_REASON_CONCURRENCY,
-            );
+            const candidate = await this.runs.findOldestQueuedForConcurrency(workId, queuedReason);
             if (!candidate) return { dispatched: false, reason: 'no-candidate' };
             if (!candidate.taskId) {
                 // Every parking path is Task-keyed (task fan-out, board
@@ -304,7 +356,30 @@ export class RunDispatchGateService {
                 workId,
                 organizationId: candidate.organizationId ?? null,
             });
-            if (!admission.admitted) return { dispatched: false, reason: 'over-limit' };
+            if (!admission.admitted) {
+                if (
+                    queuedReason === QUEUED_REASON_KILL_SWITCH &&
+                    admission.queuedReason &&
+                    admission.queuedReason !== QUEUED_REASON_KILL_SWITCH &&
+                    typeof this.runs.relabelQueuedReason === 'function'
+                ) {
+                    // The flag is off but something else now parks this
+                    // run. Hand it to the reason that will actually drain
+                    // it (CAS — a raced promotion is a harmless no-op).
+                    try {
+                        await this.runs.relabelQueuedReason(
+                            candidate.id,
+                            QUEUED_REASON_KILL_SWITCH,
+                            admission.queuedReason,
+                        );
+                    } catch (relabelErr) {
+                        this.logger.warn(
+                            `Dispatch gate: failed to relabel parked run ${candidate.id}: ${relabelErr}`,
+                        );
+                    }
+                }
+                return { dispatched: false, reason: 'over-limit' };
+            }
 
             if (viaChat ? !this.chatDispatcher : !this.dispatcher) {
                 // Nothing to dispatch through — leave the row parked (it
@@ -312,10 +387,7 @@ export class RunDispatchGateService {
                 return { dispatched: false, reason: 'no-dispatcher' };
             }
 
-            const claimed = await this.runs.claimQueuedForDispatch(
-                candidate.id,
-                QUEUED_REASON_CONCURRENCY,
-            );
+            const claimed = await this.runs.claimQueuedForDispatch(candidate.id, queuedReason);
             if (!claimed) return { dispatched: false, reason: 'claim-lost' };
 
             try {
@@ -363,6 +435,34 @@ export class RunDispatchGateService {
                 return { dispatched: true, runId: candidate.id };
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
+                if (
+                    err instanceof Error &&
+                    err.name === KILL_SWITCH_ACTIVE_ERROR_NAME &&
+                    typeof this.runs.restoreQueuedReason === 'function'
+                ) {
+                    // Panic controls (EW-778) — the dispatcher (the fleet-
+                    // aware wrapper, or the router under it) read the
+                    // global stop flag AFTER admission passed: an operator
+                    // re-threw the switch in the window between the two
+                    // reads. A stop PARKS work, it never fails it — put the
+                    // run back exactly where the flag left it (CAS: only a
+                    // still-queued, still-unlabelled row is touched) so the
+                    // next clear resumes it.
+                    this.logger.warn(
+                        `Dispatch gate: drain of ${candidate.id} refused by the global stop flag — re-parking: ${message}`,
+                    );
+                    try {
+                        await this.runs.restoreQueuedReason(
+                            candidate.id,
+                            QUEUED_REASON_KILL_SWITCH,
+                        );
+                    } catch (restoreErr) {
+                        this.logger.warn(
+                            `Dispatch gate: failed to re-park run ${candidate.id} after the stop flag refused it: ${restoreErr}`,
+                        );
+                    }
+                    return { dispatched: false, reason: 'over-limit' };
+                }
                 const notConfigured =
                     err instanceof Error && err.name === 'JobRuntimeNotConfiguredError';
                 const reason = notConfigured
@@ -387,5 +487,54 @@ export class RunDispatchGateService {
             this.logger.warn(`Dispatch gate: drainForWork(${workId}) failed: ${err}`);
             return { dispatched: false, reason: 'dispatch-failed' };
         }
+    }
+
+    /**
+     * Panic controls (EW-778) — promote runs parked with `queuedReason`
+     * across EVERY Work that has one, oldest first per Work, until a
+     * Work has no more candidates (or refuses one) or the promotion
+     * budget is spent. Called by the api-side clear route after the
+     * global stop flag is lifted; best-effort and bounded by contract,
+     * never throws.
+     *
+     * Reuses {@link drainForWork} for every promotion, so the claim CAS,
+     * the chat-vs-task dispatch split and the dispatch-failed rollback
+     * are stated exactly once. Work-less parked runs (heartbeat runs
+     * carry `workId: null`) cannot be promoted by the Work-keyed drain
+     * and wait for their schedule's next tick — a documented limitation.
+     */
+    async promoteParked(
+        queuedReason: string,
+        maxPromotions: number = PROMOTE_PARKED_MAX_PROMOTIONS,
+    ): Promise<RunDispatchPromoteResult> {
+        const budget = Math.max(0, Math.trunc(maxPromotions));
+        const result: RunDispatchPromoteResult = { promoted: 0, works: 0, budgetExhausted: false };
+        if (budget === 0 || typeof this.runs.findQueuedWorkIdsByReason !== 'function') {
+            return result;
+        }
+        try {
+            const workIds = await this.runs.findQueuedWorkIdsByReason(queuedReason, budget);
+            result.works = workIds.length;
+            for (const workId of workIds) {
+                // Per-Work loop: `drainForWork` promotes ONE run, so keep
+                // asking until the Work runs dry or refuses, each answer
+                // consuming budget only when a run actually went out.
+                for (;;) {
+                    if (result.promoted >= budget) {
+                        result.budgetExhausted = true;
+                        return result;
+                    }
+                    const drained = await this.drainForWork(workId, queuedReason);
+                    if (!drained.dispatched) break;
+                    result.promoted += 1;
+                }
+            }
+            this.logger.log(
+                `Dispatch gate: promoted ${result.promoted} run(s) parked as '${queuedReason}' across ${result.works} Work(s).`,
+            );
+        } catch (err) {
+            this.logger.warn(`Dispatch gate: promoteParked('${queuedReason}') failed: ${err}`);
+        }
+        return result;
     }
 }

--- a/packages/agent/src/agents/run-kill-switch.ts
+++ b/packages/agent/src/agents/run-kill-switch.ts
@@ -1,0 +1,39 @@
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG port for the run
+ * dispatch gate.
+ *
+ * Token + contract only (leaf file, zero imports — same circular-dep
+ * dodge as `run-credits-precheck.ts`, see
+ * `docs/architecture/agent-injection-tokens.md`).
+ * `RunDispatchGateService` consumes it via `@Optional() @Inject(...)`;
+ * the implementation (`FleetKillSwitchService`, agent-side FleetModule)
+ * is bound to the token by the api-side `@Global()` AgentsModule.
+ *
+ * Unbound (unit tests, installs without the fleet stack) the gate's
+ * kill-switch middleware simply passes every run through.
+ *
+ * Unlike the credits precheck this port is FAIL-CLOSED at the consumer:
+ * the middleware parks the run when `shouldHaltDispatch()` resolves true
+ * AND when it throws. Implementations should still never throw — the
+ * fleet service folds every read failure into `true` itself — but the
+ * gate does not depend on that.
+ */
+export interface RunKillSwitch {
+    /**
+     * True ⇒ the global stop flag is set (or cannot be read) ⇒ the gate
+     * parks the run (`queuedReason='kill-switch'`) instead of
+     * dispatching it.
+     */
+    shouldHaltDispatch(): Promise<boolean>;
+}
+
+export const RUN_KILL_SWITCH = 'RUN_KILL_SWITCH' as const;
+
+/**
+ * `Error.name` carried by the api-side `FleetKillSwitchActiveError` (the
+ * class lives in `apps/api`, which this package cannot import). The gate
+ * recognises a dispatcher that refused on the stop flag by this name and
+ * RE-PARKS the run instead of failing it — a stop parks work, never fails
+ * it. Pinned on both sides by spec.
+ */
+export const KILL_SWITCH_ACTIVE_ERROR_NAME = 'FleetKillSwitchActiveError' as const;

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -199,8 +199,10 @@ export const config = {
      *
      * Nothing in this group turns the fleet runtime ON by itself — that
      * is still `EVER_WORKS_JOB_RUNTIME=node` (or a tenant overlay row).
-     * `FLEET_NODE_RUNTIME_ENABLED=false` is the kill switch that wins
-     * over both.
+     * `FLEET_NODE_RUNTIME_ENABLED=false` is a ROUTING SELECTOR that wins
+     * over both — work falls back to the cloud. It is NOT a panic control;
+     * the control that stops work is the DB-backed global stop flag
+     * (`FleetKillSwitchService`, EW-778).
      */
     fleetNode: {
         /**

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -143,6 +143,8 @@ import { FleetAgentNodeAffinity } from '../entities/fleet-agent-node-affinity.en
 import { TerminalTranscriptChunk } from '../entities/terminal-transcript-chunk.entity';
 
 import { FleetJob } from '../entities/fleet-job.entity';
+import { FleetKillSwitch } from '../entities/fleet-kill-switch.entity';
+import { FleetAudit } from '../entities/fleet-audit.entity';
 import { FleetExecutionPreference } from '../entities/fleet-execution-preference.entity';
 import { FleetCostPolicy } from '../entities/fleet-cost-policy.entity';
 import { ToolGrant } from '../entities/tool-grant.entity';
@@ -358,6 +360,11 @@ export const ENTITIES = [
     // Fleet job runtime (Desktop PRD M4) — the lease-able work queue
     // whose workers are the enrolled nodes above.
     FleetJob,
+    // Panic controls (EW-778) — the single-row global stop flag read by
+    // the dispatch gate, the run router and every lease request, and the
+    // append-only audit trail every panic action writes to.
+    FleetKillSwitch,
+    FleetAudit,
     // Inbox (operator message center) — messages addressed to the human:
     // blocking questions, approval requests, escalation mirrors, notices.
     InboxItem,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -86,11 +86,13 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // Event-ingest spine — external tracker issue → platform Task mapping
     'ExternalIssueLink',
     'FleetAgentNodeAffinity',
+    'FleetAudit',
     // Fleet local-runner routing — local-vs-cloud execution preference
     'FleetExecutionPreference',
     'FleetCostPolicy',
     // Fleet job runtime (Desktop PRD M4) — lease-able work for nodes
     'FleetJob',
+    'FleetKillSwitch',
     // Fleet (Wave 12, slice 1) — enrolled execution nodes w/ heartbeat
     'FleetNode',
     'GitHubAppInstallation',

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -362,10 +362,18 @@ export class AgentRunRepository {
      * COALESCE is also defence against a future second writer.
      *
      * Bounded by `limit` on purpose — see {@link markStuckFailed}.
+     *
+     * `exemptQueuedReasons` (EW-778) — `queued` rows parked for one of
+     * these reasons are NOT stuck either: a run the global stop flag
+     * parked is waiting for an operator, possibly for hours, and reaping
+     * it would leave nothing to resume when the flag is cleared. Same
+     * belt-and-braces as `awaitingInput`: excluded here AND re-asserted
+     * in `AgentRunSweeperService`.
      */
     async findStuckNonTerminal(
         cutoff: Date,
         limit: number,
+        exemptQueuedReasons: readonly string[] = [],
     ): Promise<
         Pick<
             AgentRun,
@@ -377,39 +385,48 @@ export class AgentRunRepository {
             | 'createdAt'
             | 'workId'
             | 'awaitingInput'
+            | 'queuedReason'
         >[]
     > {
-        return (
-            this.repository
-                .createQueryBuilder('run')
-                .select([
-                    'run.id',
-                    'run.agentId',
-                    'run.triggerKind',
-                    'run.status',
-                    'run.startedAt',
-                    'run.createdAt',
-                    // Wave 4 M2 — the sweeper drains the concurrency queue for
-                    // every Work whose stuck run it just reaped.
-                    'run.workId',
-                    // Wave 4 M5 — selected so the sweeper can re-assert the
-                    // never-reap-awaiting_input rule in the service layer too.
-                    'run.awaitingInput',
-                ])
-                .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
-                // Wave 4 M5 — a run parked on a human question is NOT stuck; it is
-                // waiting, possibly for days. Reaping it is the production bug this
-                // predicate exists to prevent, so the exemption lives in the SQL
-                // (and again in `AgentRunSweeperService`, belt-and-braces). The
-                // NULL arm covers rows written before the column existed.
-                .andWhere('(run.awaitingInput IS NULL OR run.awaitingInput = :notAwaiting)', {
-                    notAwaiting: false,
-                })
-                .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
-                .orderBy('COALESCE(run.startedAt, run.createdAt)', 'ASC')
-                .limit(limit)
-                .getMany()
-        );
+        const query = this.repository
+            .createQueryBuilder('run')
+            .select([
+                'run.id',
+                'run.agentId',
+                'run.triggerKind',
+                'run.status',
+                'run.startedAt',
+                'run.createdAt',
+                // Wave 4 M2 — the sweeper drains the concurrency queue for
+                // every Work whose stuck run it just reaped.
+                'run.workId',
+                // Wave 4 M5 — selected so the sweeper can re-assert the
+                // never-reap-awaiting_input rule in the service layer too.
+                'run.awaitingInput',
+                // EW-778 — selected so the sweeper can re-assert the
+                // never-reap-kill-switch-parked rule in the service layer too.
+                'run.queuedReason',
+            ])
+            .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
+            // Wave 4 M5 — a run parked on a human question is NOT stuck; it is
+            // waiting, possibly for days. Reaping it is the production bug this
+            // predicate exists to prevent, so the exemption lives in the SQL
+            // (and again in `AgentRunSweeperService`, belt-and-braces). The
+            // NULL arm covers rows written before the column existed.
+            .andWhere('(run.awaitingInput IS NULL OR run.awaitingInput = :notAwaiting)', {
+                notAwaiting: false,
+            });
+        if (exemptQueuedReasons.length > 0) {
+            query.andWhere(
+                '(run.queuedReason IS NULL OR run.queuedReason NOT IN (:...exemptQueuedReasons))',
+                { exemptQueuedReasons: [...exemptQueuedReasons] },
+            );
+        }
+        return query
+            .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
+            .orderBy('COALESCE(run.startedAt, run.createdAt)', 'ASC')
+            .limit(limit)
+            .getMany();
     }
 
     /**
@@ -1171,6 +1188,44 @@ export class AgentRunRepository {
             .where('id = :id', { id: runId })
             .andWhere('status = :status', { status: 'queued' satisfies AgentRunStatus })
             .andWhere('queuedReason = :queuedReason', { queuedReason })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Panic controls (EW-778) — the distinct Works that have at least
+     * one run parked with `queuedReason`, so a clear of the global stop
+     * flag can promote them Work by Work through the ordinary drain.
+     * Work-less parked runs are invisible here by construction (the
+     * drain is Work-keyed).
+     */
+    async findQueuedWorkIdsByReason(queuedReason: string, limit: number): Promise<string[]> {
+        const rows: Array<{ workId: string | null }> = await this.repository
+            .createQueryBuilder('run')
+            .select('run.workId', 'workId')
+            .distinct(true)
+            .where('run.status = :status', { status: 'queued' satisfies AgentRunStatus })
+            .andWhere('run.queuedReason = :queuedReason', { queuedReason })
+            .andWhere('run.workId IS NOT NULL')
+            .limit(Math.max(1, Math.trunc(limit)))
+            .getRawMany();
+        return rows.map((row) => row.workId).filter((workId): workId is string => !!workId);
+    }
+
+    /**
+     * Panic controls (EW-778) — CAS-relabel a parked run from one
+     * reason to another (kill-switch → concurrency-limit when the flag
+     * is off but the Work is saturated). Only a still-`queued` row still
+     * carrying `from` is touched, so a raced promotion is a no-op.
+     */
+    async relabelQueuedReason(runId: string, from: string, to: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ queuedReason: to })
+            .where('id = :id', { id: runId })
+            .andWhere('status = :status', { status: 'queued' satisfies AgentRunStatus })
+            .andWhere('queuedReason = :from', { from })
             .execute();
         return (result.affected ?? 0) > 0;
     }

--- a/packages/agent/src/entities/fleet-audit.entity.ts
+++ b/packages/agent/src/entities/fleet-audit.entity.ts
@@ -1,0 +1,65 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Panic controls (EW-778) — append-only audit trail for the fleet's
+ * operator-level actions.
+ *
+ * Every set / clear of the global stop flag, every drain-all and every
+ * cancel-in-flight writes one row here with the ACTOR and the TIME.
+ * This is the minimal shape the panic controls need; slice AQ extends
+ * it (per-node actions, retention) rather than replacing it, which is
+ * why the table is named `fleet_audit` and not something narrower.
+ *
+ * Modelled on `tenant_job_runtime_audit`:
+ *   - `actorUserId` nullable (NULL = system actor, or a since-purged
+ *     user — the FK is ON DELETE SET NULL so the trail survives);
+ *   - `action` is `varchar(64)`, not an enum, so a new action is a code
+ *     change and not a type-altering migration;
+ *   - `details` is `simple-json` (text at the SQL level) for sqlite
+ *     parity in the test suite.
+ *
+ * `ownerUserId` is the OWNER SCOPE of an owner action (drain-all,
+ * cancel-in-flight); NULL for global actions (the stop flag). `nodeId`
+ * is reserved for per-node rows and carries NO foreign key: history must
+ * survive node deletion, for the same reason `fleet_jobs.nodeId` has none.
+ *
+ * Raw uuid references only (no @ManyToOne, per the EW-654 cycle-avoidance
+ * rule); the `users` FK lives in the migration.
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this repo
+ * has no `autoLoadEntities`, so a forFeature'd-but-unregistered entity
+ * throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'fleet_audit' })
+@Index('idx_fleet_audit_owner_occurred', ['ownerUserId', 'occurredAt'])
+@Index('idx_fleet_audit_action_occurred', ['action', 'occurredAt'])
+export class FleetAudit {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /**
+     * `'kill-switch.stop' | 'kill-switch.clear' | 'drain-all' |
+     * 'cancel-in-flight'` today (`FleetAuditAction` in contracts).
+     */
+    @Column({ type: 'varchar', length: 64 })
+    action: string;
+
+    /** Who did it. NULL = system, or a user purged since. */
+    @Column({ type: 'uuid', nullable: true })
+    actorUserId: string | null;
+
+    /** Owner scope of an owner action; NULL for global actions. */
+    @Column({ type: 'uuid', nullable: true })
+    ownerUserId: string | null;
+
+    /** Per-node rows only (slice AQ). No FK — history outlives the node. */
+    @Column({ type: 'uuid', nullable: true })
+    nodeId: string | null;
+
+    /** Reason, counts, bounded id lists — whatever the action recorded. */
+    @Column({ type: 'simple-json', nullable: true })
+    details: Record<string, unknown> | null;
+
+    @CreateDateColumn()
+    occurredAt: Date;
+}

--- a/packages/agent/src/entities/fleet-kill-switch.entity.ts
+++ b/packages/agent/src/entities/fleet-kill-switch.entity.ts
@@ -1,0 +1,62 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG.
+ *
+ * One row, id `'global'` (`FLEET_KILL_SWITCH_ID` in `@ever-works/contracts`),
+ * seeded by the migration that creates the table. It is read by three
+ * places, before any new unit of work can start:
+ *
+ *   - `RunDispatchGateService` (through the `RUN_KILL_SWITCH` port) —
+ *     every new agent run is PARKED with `queuedReason='kill-switch'`;
+ *   - `FleetRunRouterService` / the fleet-aware dispatcher — a run that
+ *     somehow reaches routing is REFUSED, never sent to the cloud;
+ *   - `FleetJobService.lease` — a node polling for work gets `[]`.
+ *
+ * ## Fail closed
+ *
+ * The migration SEEDS the row so that "row missing" can only mean
+ * "migration not applied". `FleetKillSwitchService.state()` treats a
+ * missing row — or any read error — as `stopped: true, unverified: true`.
+ * A safety control whose absence meant "go" would not be one.
+ *
+ * ## What it does NOT do
+ *
+ * Setting the flag never cancels running work; that is the explicit,
+ * separate `cancel-in-flight` step. Heartbeats and job completions keep
+ * being accepted while the flag is set so a stopped fleet can still
+ * settle.
+ *
+ * `setByUserId` is a raw uuid reference (no @ManyToOne, per the EW-654
+ * cycle-avoidance rule); the FK to `users` (ON DELETE SET NULL) lives in
+ * the migration.
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this repo
+ * has no `autoLoadEntities`, so a forFeature'd-but-unregistered entity
+ * throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'fleet_kill_switch' })
+export class FleetKillSwitch {
+    /** Always `'global'` — a single-row table keyed by a fixed id. */
+    @PrimaryColumn({ type: 'varchar', length: 32 })
+    id: string;
+
+    @Column({ type: 'boolean', default: false })
+    stopped: boolean;
+
+    /** Free-text reason recorded with a stop; cleared on clear. */
+    @Column({ type: 'varchar', length: 500, nullable: true })
+    reason: string | null;
+
+    /** Who last flipped the switch (set OR clear). NULL = never touched / user purged. */
+    @Column({ type: 'uuid', nullable: true })
+    setByUserId: string | null;
+
+    /** When the switch was last flipped (set OR clear). */
+    @PortableDateColumn({ nullable: true })
+    setAt: Date | null;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -160,6 +160,9 @@ export * from './terminal-transcript-chunk.entity';
 
 export * from './fleet-job.entity';
 export * from './fleet-agent-node-affinity.entity';
+// Panic controls (EW-778) — the global stop flag + the fleet audit trail.
+export * from './fleet-kill-switch.entity';
+export * from './fleet-audit.entity';
 // Fleet local-runner routing — per Work / Goal / account execution
 // preference (local runner vs cloud) read by the fleet run router.
 export * from './fleet-execution-preference.entity';

--- a/packages/agent/src/fleet/__tests__/fleet-job.kill-switch.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.kill-switch.spec.ts
@@ -1,0 +1,206 @@
+import { createHash, randomBytes } from 'crypto';
+import { FleetJob } from '../../entities/fleet-job.entity';
+import { FleetJobService } from '../fleet-job.service';
+import { FleetKillSwitchService } from '../fleet-kill-switch.service';
+
+/**
+ * Panic controls (EW-778) — EVERY lease consults the global stop flag.
+ *
+ * What is pinned:
+ *   - a stopped fleet answers `[]` to a valid node and never claims;
+ *   - a flag that CANNOT be read counts as stopped (fail-closed) — the
+ *     real `FleetKillSwitchService` over a throwing repository, not a
+ *     stub that happens to say true;
+ *   - a bad credential is STILL a 401 (null), never "no work", so the
+ *     flag cannot be used to tell the two apart;
+ *   - heartbeat and complete keep working while stopped, or a stopped
+ *     fleet could never settle the work it already holds;
+ *   - without the service (positional-arity compatibility) the lease
+ *     protocol is byte-for-byte what it was.
+ */
+
+const NODE = '11111111-1111-4111-8111-111111111111';
+const JOB = '55555555-5555-4555-8555-555555555555';
+const USER = 'user-1';
+const sha256Hex = (value: string): string =>
+    createHash('sha256').update(value, 'utf8').digest('hex');
+
+function makeNode(secret: string) {
+    return {
+        id: NODE,
+        userId: USER,
+        status: 'online',
+        enrollmentTokenHash: sha256Hex(secret),
+        capabilities: ['workspace'],
+    };
+}
+
+function makeJob(over: Partial<FleetJob> = {}): FleetJob {
+    return {
+        id: JOB,
+        userId: USER,
+        organizationId: null,
+        nodeId: null,
+        targetNodeId: null,
+        kind: 'agent-task',
+        status: 'queued',
+        payload: { taskId: 'task-1', runId: 'run-1', agentId: 'agent-1' },
+        requiredCapabilities: [],
+        leaseExpiresAt: null,
+        attempts: 0,
+        maxAttempts: 3,
+        idempotencyKey: null,
+        result: null,
+        error: null,
+        queuedReason: null,
+        cancelRequestedAt: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: new Date('2026-09-05T10:00:00Z'),
+        updatedAt: new Date('2026-09-05T10:00:00Z'),
+        ...over,
+    } as FleetJob;
+}
+
+describe('FleetJobService — global stop flag on the lease path', () => {
+    const secret = randomBytes(24).toString('base64url');
+    let job: FleetJob;
+    let jobs: Record<string, jest.Mock>;
+    let nodes: { findById: jest.Mock };
+    let killSwitch: { isStopped: jest.Mock };
+
+    const build = (switchImpl?: unknown) =>
+        new FleetJobService(
+            jobs as never,
+            nodes as never,
+            { findForOwnedAgent: jest.fn(async () => null) } as never,
+            undefined,
+            switchImpl as never,
+        );
+
+    beforeEach(() => {
+        job = makeJob();
+        jobs = {
+            findById: jest.fn(async (id: string) => (id === job.id ? job : null)),
+            findQueuedForNode: jest.fn(async () => [job]),
+            claim: jest.fn(async (_id: string, patch: Partial<FleetJob>) => {
+                Object.assign(job, patch);
+                return true;
+            }),
+            extendLease: jest.fn(async () => true),
+            complete: jest.fn(async () => true),
+            findExpiredLeases: jest.fn(async () => []),
+        };
+        nodes = {
+            findById: jest.fn(async (id: string) => (id === NODE ? makeNode(secret) : null)),
+        };
+        killSwitch = { isStopped: jest.fn(async () => false) };
+    });
+
+    it('leases normally while the flag is clear', async () => {
+        const leased = await build(killSwitch).lease({ nodeId: NODE, secret, max: 1 });
+        expect(leased).toHaveLength(1);
+        expect(jobs.claim).toHaveBeenCalledTimes(1);
+    });
+
+    it('answers [] and never claims while the flag is set', async () => {
+        killSwitch.isStopped.mockResolvedValue(true);
+        const leased = await build(killSwitch).lease({ nodeId: NODE, secret, max: 1 });
+        expect(leased).toEqual([]);
+        expect(jobs.claim).not.toHaveBeenCalled();
+        expect(jobs.findQueuedForNode).not.toHaveBeenCalled();
+        // Not even the inline reclaim runs — a stopped fleet writes nothing.
+        expect(jobs.findExpiredLeases).not.toHaveBeenCalled();
+        expect(job.status).toBe('queued');
+    });
+
+    /**
+     * Fail-closed, end to end: the REAL kill-switch service over a
+     * repository that cannot read the row. The service folds that into
+     * "stopped", and the lease honours it.
+     */
+    it('refuses to lease when the flag CANNOT be read (fail-closed)', async () => {
+        const realSwitch = new FleetKillSwitchService(
+            { read: jest.fn(async () => Promise.reject(new Error('db down'))) } as never,
+            { record: jest.fn() } as never,
+        );
+        jest.spyOn(
+            (realSwitch as never as { logger: { error: () => void } }).logger,
+            'error',
+        ).mockImplementation(() => undefined);
+
+        const leased = await build(realSwitch).lease({ nodeId: NODE, secret, max: 1 });
+        expect(leased).toEqual([]);
+        expect(jobs.claim).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Fail-closed at the LEASE, not only inside the service: a port that
+     * throws (a stub, a future implementation) must still mean "no work".
+     */
+    it('refuses to lease when isStopped() itself THROWS (fail-closed)', async () => {
+        killSwitch.isStopped.mockRejectedValueOnce(new Error('boom'));
+        const service = build(killSwitch);
+        jest.spyOn(
+            (service as never as { logger: { error: () => void } }).logger,
+            'error',
+        ).mockImplementation(() => undefined);
+
+        const leased = await service.lease({ nodeId: NODE, secret, max: 1 });
+        expect(leased).toEqual([]);
+        expect(jobs.claim).not.toHaveBeenCalled();
+        expect(jobs.findQueuedForNode).not.toHaveBeenCalled();
+        expect(jobs.findExpiredLeases).not.toHaveBeenCalled();
+    });
+
+    it('refuses to lease when the row is missing (migration not applied)', async () => {
+        const realSwitch = new FleetKillSwitchService(
+            { read: jest.fn(async () => null) } as never,
+            { record: jest.fn() } as never,
+        );
+        jest.spyOn(
+            (realSwitch as never as { logger: { error: () => void } }).logger,
+            'error',
+        ).mockImplementation(() => undefined);
+
+        await expect(build(realSwitch).lease({ nodeId: NODE, secret, max: 1 })).resolves.toEqual(
+            [],
+        );
+    });
+
+    it('still answers 401 (null) to a bad credential while stopped — never "no work"', async () => {
+        killSwitch.isStopped.mockResolvedValue(true);
+        const leased = await build(killSwitch).lease({ nodeId: NODE, secret: 'wrong-secret' });
+        expect(leased).toBeNull();
+        // Auth comes first; the flag is not even consulted for a stranger.
+        expect(killSwitch.isStopped).not.toHaveBeenCalled();
+    });
+
+    it('keeps accepting job heartbeats while stopped', async () => {
+        killSwitch.isStopped.mockResolvedValue(true);
+        job = makeJob({ nodeId: NODE, status: 'leased', leaseExpiresAt: new Date() });
+        const beat = await build(killSwitch).heartbeatJob(NODE, secret, JOB, 60);
+        expect(beat?.status).toBe('running');
+        expect(jobs.extendLease).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps accepting job completions while stopped', async () => {
+        killSwitch.isStopped.mockResolvedValue(true);
+        job = makeJob({ nodeId: NODE, status: 'running', leaseExpiresAt: new Date() });
+        const done = await build(killSwitch).completeJob({
+            nodeId: NODE,
+            secret,
+            jobId: JOB,
+            success: true,
+            result: { ok: true },
+        });
+        expect(done?.status).toBe('done');
+        expect(jobs.complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('leases as before when no kill switch is bound (positional-arity compatibility)', async () => {
+        const leased = await build(undefined).lease({ nodeId: NODE, secret, max: 1 });
+        expect(leased).toHaveLength(1);
+        expect(jobs.claim).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet-kill-switch.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-kill-switch.service.spec.ts
@@ -1,0 +1,282 @@
+import { FleetKillSwitchService } from '../fleet-kill-switch.service';
+import type { FleetKillSwitch } from '../../entities/fleet-kill-switch.entity';
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG service.
+ *
+ * The contract under test is stated once in the service docblock and
+ * pinned here from every side:
+ *
+ *   - reads FAIL CLOSED: a missing row and a throwing read are both
+ *     `stopped: true, unverified: true`, and `isStopped()` /
+ *     `shouldHaltDispatch()` say true;
+ *   - set / clear write the row AND an audit row carrying the actor;
+ *   - an audit failure is reported (`auditFailed`), never thrown, and
+ *     never undoes the flip;
+ *   - the public projection never leaks who threw the switch.
+ */
+describe('FleetKillSwitchService', () => {
+    const ACTOR = '11111111-1111-4111-8111-111111111111';
+
+    let row: FleetKillSwitch | null;
+    let repository: { read: jest.Mock; write: jest.Mock };
+    let audit: { record: jest.Mock };
+    let service: FleetKillSwitchService;
+
+    const silence = (svc: FleetKillSwitchService) => {
+        for (const level of ['error', 'warn', 'log'] as const) {
+            jest.spyOn(
+                (svc as never as { logger: Record<string, () => void> }).logger,
+                level,
+            ).mockImplementation(() => undefined);
+        }
+        return svc;
+    };
+
+    beforeEach(() => {
+        row = {
+            id: 'global',
+            stopped: false,
+            reason: null,
+            setByUserId: null,
+            setAt: null,
+            updatedAt: new Date('2026-09-05T00:00:00Z'),
+        } as FleetKillSwitch;
+        repository = {
+            read: jest.fn(async () => row),
+            write: jest.fn(async (patch: Partial<FleetKillSwitch>) => {
+                row = { ...(row ?? ({ id: 'global' } as FleetKillSwitch)), ...patch };
+            }),
+        };
+        audit = { record: jest.fn(async () => ({ id: 'audit-1' })) };
+        service = silence(new FleetKillSwitchService(repository as never, audit as never));
+    });
+
+    describe('state() — fail closed', () => {
+        it('reports a seeded, clear row as not stopped and verified', async () => {
+            await expect(service.state()).resolves.toEqual({
+                stopped: false,
+                reason: null,
+                since: null,
+                unverified: false,
+                setByUserId: null,
+            });
+            await expect(service.isStopped()).resolves.toBe(false);
+            await expect(service.shouldHaltDispatch()).resolves.toBe(false);
+        });
+
+        it('treats a MISSING row (migration not applied) as stopped + unverified', async () => {
+            row = null;
+            const state = await service.state();
+            expect(state.stopped).toBe(true);
+            expect(state.unverified).toBe(true);
+            await expect(service.isStopped()).resolves.toBe(true);
+            await expect(service.shouldHaltDispatch()).resolves.toBe(true);
+        });
+
+        /**
+         * THE load-bearing test: the flag exists to survive exactly the
+         * failure that makes it unreadable. Revert-check — make `state()`
+         * return `stopped: false` on a caught error and this goes RED.
+         */
+        it('treats a THROWING read as stopped + unverified and never throws itself', async () => {
+            repository.read.mockRejectedValue(new Error('db down'));
+            await expect(service.state()).resolves.toMatchObject({
+                stopped: true,
+                unverified: true,
+            });
+            await expect(service.isStopped()).resolves.toBe(true);
+            await expect(service.shouldHaltDispatch()).resolves.toBe(true);
+        });
+
+        it('reads a thrown switch back with its reason and timestamp', async () => {
+            row = {
+                ...(row as FleetKillSwitch),
+                stopped: true,
+                reason: 'incident',
+                setByUserId: ACTOR,
+                setAt: new Date('2026-09-05T02:00:00Z'),
+            };
+            await expect(service.state()).resolves.toEqual({
+                stopped: true,
+                reason: 'incident',
+                since: '2026-09-05T02:00:00.000Z',
+                unverified: false,
+                setByUserId: ACTOR,
+            });
+        });
+
+        it('publicState() never carries the actor', async () => {
+            row = { ...(row as FleetKillSwitch), stopped: true, setByUserId: ACTOR };
+            const state = await service.publicState();
+            expect(state).not.toHaveProperty('setByUserId');
+            expect(state.stopped).toBe(true);
+        });
+    });
+
+    describe('stop()', () => {
+        it('flips the row and writes an audit row carrying the actor and the reason', async () => {
+            const result = await service.stop(ACTOR, '  incident on prod  ');
+
+            expect(repository.write).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    stopped: true,
+                    reason: 'incident on prod',
+                    setByUserId: ACTOR,
+                }),
+            );
+            expect(audit.record).toHaveBeenCalledTimes(1);
+            expect(audit.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'kill-switch.stop',
+                    actorUserId: ACTOR,
+                    ownerUserId: null,
+                    details: expect.objectContaining({ reason: 'incident on prod', changed: true }),
+                }),
+            );
+            expect(result.changed).toBe(true);
+            expect(result.auditFailed).toBe(false);
+            expect(result.state).toMatchObject({
+                stopped: true,
+                reason: 'incident on prod',
+                setByUserId: ACTOR,
+                unverified: false,
+            });
+            // The next read sees the switch thrown.
+            await expect(service.isStopped()).resolves.toBe(true);
+        });
+
+        it('is idempotent: a second stop refreshes the row and audits changed:false', async () => {
+            await service.stop(ACTOR, 'first');
+            const again = await service.stop(ACTOR, 'second operator');
+            expect(again.changed).toBe(false);
+            expect(again.state.reason).toBe('second operator');
+            expect(audit.record).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    action: 'kill-switch.stop',
+                    details: expect.objectContaining({ changed: false }),
+                }),
+            );
+        });
+
+        it('caps an over-long reason instead of refusing the stop', async () => {
+            const result = await service.stop(ACTOR, 'x'.repeat(600));
+            expect(result.state.reason).toHaveLength(500);
+            expect(repository.write).toHaveBeenCalledTimes(1);
+        });
+
+        it('still flips the switch when the audit write fails, and says so', async () => {
+            audit.record.mockRejectedValue(new Error('audit table gone'));
+            const result = await service.stop(ACTOR, 'incident');
+            expect(repository.write).toHaveBeenCalledTimes(1);
+            expect(result.auditFailed).toBe(true);
+            expect(result.state.stopped).toBe(true);
+            await expect(service.isStopped()).resolves.toBe(true);
+        });
+
+        it('lands even when the row could not be read first (unverified before)', async () => {
+            repository.read.mockRejectedValueOnce(new Error('db blip'));
+            const result = await service.stop(ACTOR, 'incident');
+            expect(repository.write).toHaveBeenCalledTimes(1);
+            expect(result.changed).toBe(true);
+        });
+    });
+
+    describe('clear()', () => {
+        beforeEach(async () => {
+            await service.stop(ACTOR, 'incident');
+            audit.record.mockClear();
+            repository.write.mockClear();
+        });
+
+        it('flips the row back and writes an audit row carrying the actor', async () => {
+            const clearer = '22222222-2222-4222-8222-222222222222';
+            const result = await service.clear(clearer);
+
+            expect(repository.write).toHaveBeenCalledWith(
+                expect.objectContaining({ stopped: false, reason: null, setByUserId: clearer }),
+            );
+            expect(audit.record).toHaveBeenCalledTimes(1);
+            expect(audit.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'kill-switch.clear',
+                    actorUserId: clearer,
+                    ownerUserId: null,
+                    details: expect.objectContaining({
+                        changed: true,
+                        before: expect.objectContaining({ stopped: true, reason: 'incident' }),
+                        after: expect.objectContaining({ stopped: false }),
+                    }),
+                }),
+            );
+            expect(result.changed).toBe(true);
+            expect(result.auditFailed).toBe(false);
+            await expect(service.isStopped()).resolves.toBe(false);
+        });
+
+        it('is idempotent: clearing a clear switch audits changed:false', async () => {
+            await service.clear(ACTOR);
+            const again = await service.clear(ACTOR);
+            expect(again.changed).toBe(false);
+        });
+
+        it('still clears when the audit write fails, and says so', async () => {
+            audit.record.mockRejectedValue(new Error('audit table gone'));
+            const result = await service.clear(ACTOR);
+            expect(result.auditFailed).toBe(true);
+            expect(result.state.stopped).toBe(false);
+            await expect(service.isStopped()).resolves.toBe(false);
+        });
+    });
+
+    describe('onApplicationBootstrap — the boot-time seed', () => {
+        it('seeds the row when it is missing and reports it', async () => {
+            const seeding = {
+                ensureSeeded: jest.fn(async () => true),
+                read: jest.fn(),
+                write: jest.fn(),
+            };
+            const booted = silence(new FleetKillSwitchService(seeding as never, audit as never));
+            await booted.onApplicationBootstrap();
+            expect(seeding.ensureSeeded).toHaveBeenCalledTimes(1);
+        });
+
+        it('never throws when the table is missing — reads simply stay fail-closed', async () => {
+            const seeding = {
+                ensureSeeded: jest.fn(async () => Promise.reject(new Error('no such table'))),
+                read: jest.fn(async () => Promise.reject(new Error('no such table'))),
+                write: jest.fn(),
+            };
+            const booted = silence(new FleetKillSwitchService(seeding as never, audit as never));
+            await expect(booted.onApplicationBootstrap()).resolves.toBeUndefined();
+            await expect(booted.isStopped()).resolves.toBe(true);
+        });
+    });
+
+    /**
+     * Stopping new work and killing running work are two different
+     * decisions. The stop flag has NO handle on jobs or runs — not as a
+     * dependency, not as a side effect — so it cannot cancel anything
+     * even by accident. `cancel-in-flight` is its own explicit route.
+     */
+    describe('the stop flag never cancels', () => {
+        it('depends on nothing but its own row and the audit trail', () => {
+            const paramTypes = (Reflect.getMetadata('design:paramtypes', FleetKillSwitchService) ??
+                []) as Array<{ name?: string }>;
+            expect(paramTypes.map((type) => type?.name)).toEqual([
+                'FleetKillSwitchRepository',
+                'FleetAuditService',
+            ]);
+        });
+
+        it('stop() touches only the switch row and the audit row', async () => {
+            await service.stop(ACTOR, 'incident');
+            expect(repository.write).toHaveBeenCalledTimes(1);
+            expect(audit.record).toHaveBeenCalledTimes(1);
+            // Nothing else was reached for: the doubles expose no cancel,
+            // and the service asked for none.
+            expect(Object.keys(repository).sort()).toEqual(['read', 'write']);
+            expect(Object.keys(audit)).toEqual(['record']);
+        });
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet.module.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet.module.spec.ts
@@ -31,6 +31,12 @@ jest.mock('../../entities/agent.entity', () => ({
 jest.mock('../../entities/fleet-agent-node-affinity.entity', () => ({
     FleetAgentNodeAffinity: class FleetAgentNodeAffinity {},
 }));
+jest.mock('../../entities/fleet-kill-switch.entity', () => ({
+    FleetKillSwitch: class FleetKillSwitch {},
+}));
+jest.mock('../../entities/fleet-audit.entity', () => ({
+    FleetAudit: class FleetAudit {},
+}));
 jest.mock('../../plugins/services/plugin-registry.service', () => ({
     PluginRegistryService: class PluginRegistryService {},
 }));
@@ -67,6 +73,15 @@ jest.mock('../fleet-cost-policy.repository', () => ({
 jest.mock('../fleet-cost-ceiling.service', () => ({
     FleetCostCeilingService: class FleetCostCeilingService {},
 }));
+jest.mock('../fleet-kill-switch.repository', () => ({
+    FleetKillSwitchRepository: class FleetKillSwitchRepository {},
+}));
+jest.mock('../fleet-kill-switch.service', () => ({
+    FleetKillSwitchService: class FleetKillSwitchService {},
+}));
+jest.mock('../fleet-audit.service', () => ({
+    FleetAuditService: class FleetAuditService {},
+}));
 
 import 'reflect-metadata';
 import { FleetModule } from '../fleet.module';
@@ -80,41 +95,61 @@ import { FleetAgentNodeAffinityRepository } from '../fleet-agent-node-affinity.r
 import { FleetAgentNodeAffinityService } from '../fleet-agent-node-affinity.service';
 import { FleetCostPolicyRepository } from '../fleet-cost-policy.repository';
 import { FleetCostCeilingService } from '../fleet-cost-ceiling.service';
+import { FleetKillSwitchRepository } from '../fleet-kill-switch.repository';
+import { FleetKillSwitchService } from '../fleet-kill-switch.service';
+import { FleetAuditService } from '../fleet-audit.service';
 
 describe('FleetModule', () => {
     const meta = (key: string): unknown[] => Reflect.getMetadata(key, FleetModule) ?? [];
 
-    // Fleet cost accounting (EW-777) appended the cost-policy repository
-    // and the daily-ceiling service to both lists; the pin below grew
-    // with them so the shape stays exact.
-    it('provides the registry, the job-runtime halves, the routing preference and the cost ceilings', () => {
+    // Fleet cost accounting (EW-777) appended the cost-policy repository and
+    // the daily-ceiling service to both lists; panic controls (EW-778) then
+    // appended the kill-switch repository, the audit service and the
+    // kill-switch service. The pin below grew with both so the shape stays
+    // exact — a provider added without updating it fails here.
+    it('provides the registry, the job-runtime halves, the routing preference, the cost ceilings and the panic controls', () => {
         expect(meta('providers')).toEqual([
             FleetNodeRepository,
             FleetJobRepository,
             FleetExecutionPreferenceRepository,
             FleetAgentNodeAffinityRepository,
             FleetCostPolicyRepository,
+            FleetKillSwitchRepository,
             FleetService,
             FleetJobService,
             FleetExecutionPreferenceService,
             FleetAgentNodeAffinityService,
             FleetCostCeilingService,
+            FleetAuditService,
+            FleetKillSwitchService,
         ]);
     });
 
-    it('exports all of them for the API surface + chat-tool assembly', () => {
+    it('exports every provider for the API surface + chat-tool assembly', () => {
         expect(meta('exports')).toEqual([
             FleetNodeRepository,
             FleetJobRepository,
             FleetExecutionPreferenceRepository,
             FleetAgentNodeAffinityRepository,
             FleetCostPolicyRepository,
+            FleetKillSwitchRepository,
             FleetService,
             FleetJobService,
             FleetExecutionPreferenceService,
             FleetAgentNodeAffinityService,
             FleetCostCeilingService,
+            FleetAuditService,
+            FleetKillSwitchService,
         ]);
+    });
+
+    // EW-778 — the api-side AgentsModule binds RUN_KILL_SWITCH to this
+    // service with `useExisting`, which only resolves when the fleet
+    // module EXPORTS it. An unexported service would leave the gate's
+    // @Optional() injection undefined and the stop flag silently dark.
+    it('exports the kill switch so the gate port binding can resolve it', () => {
+        expect(meta('exports')).toContain(FleetKillSwitchService);
+        expect(meta('exports')).toContain(FleetAuditService);
     });
 
     it('imports only the entity feature (plugins resolve via the global module)', () => {
@@ -138,6 +173,9 @@ describe('fleet barrel', () => {
         expect(barrel.FleetAgentNodeAffinityRepository).toBe(FleetAgentNodeAffinityRepository);
         expect(barrel.FleetCostPolicyRepository).toBe(FleetCostPolicyRepository);
         expect(barrel.FleetCostCeilingService).toBe(FleetCostCeilingService);
+        expect(barrel.FleetKillSwitchService).toBe(FleetKillSwitchService);
+        expect(barrel.FleetKillSwitchRepository).toBe(FleetKillSwitchRepository);
+        expect(barrel.FleetAuditService).toBe(FleetAuditService);
         expect(typeof barrel.buildFleetTools).toBe('function');
     });
 

--- a/packages/agent/src/fleet/fleet-audit.service.ts
+++ b/packages/agent/src/fleet/fleet-audit.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { FleetAuditAction, FleetAuditView } from '@ever-works/contracts';
+import { FLEET_AUDIT_DEFAULT_LIMIT, FLEET_AUDIT_MAX_LIMIT } from '@ever-works/contracts';
+import { FleetAudit } from '../entities/fleet-audit.entity';
+
+export interface RecordFleetAuditInput {
+    action: FleetAuditAction;
+    /** Who did it. NULL = system. */
+    actorUserId: string | null;
+    /** Owner scope of an owner action; NULL for global actions. */
+    ownerUserId?: string | null;
+    /** Per-node rows only. */
+    nodeId?: string | null;
+    details?: Record<string, unknown> | null;
+}
+
+/**
+ * Panic controls (EW-778) — the ONE writer of `fleet_audit`.
+ *
+ * Every panic action (stop / clear / drain-all / cancel-in-flight) goes
+ * through `record()`, so slice AQ extends one place when it adds
+ * per-node rows and retention.
+ *
+ * Failures are NOT swallowed here: the caller decides. For a panic
+ * action the right posture is "act first, then audit; a failed audit is
+ * logged and reported, never a reason to undo a drain" — the opposite of
+ * `TenantJobRuntimeService.emitAudit`, where the audited write can and
+ * should be rolled back. That choice belongs to the caller, not to this
+ * service.
+ */
+@Injectable()
+export class FleetAuditService {
+    constructor(
+        @InjectRepository(FleetAudit)
+        private readonly repository: Repository<FleetAudit>,
+    ) {}
+
+    async record(input: RecordFleetAuditInput): Promise<FleetAuditView> {
+        const row = await this.repository.save(
+            this.repository.create({
+                action: input.action,
+                actorUserId: input.actorUserId ?? null,
+                ownerUserId: input.ownerUserId ?? null,
+                nodeId: input.nodeId ?? null,
+                details: input.details ?? null,
+            }),
+        );
+        return toAuditView(row);
+    }
+
+    /** Newest first, every action. Bounded by `FLEET_AUDIT_MAX_LIMIT`. */
+    async recent(limit: number = FLEET_AUDIT_DEFAULT_LIMIT): Promise<FleetAuditView[]> {
+        const take = Math.min(
+            Math.max(Math.trunc(limit) || FLEET_AUDIT_DEFAULT_LIMIT, 1),
+            FLEET_AUDIT_MAX_LIMIT,
+        );
+        const rows = await this.repository.find({ order: { occurredAt: 'DESC' }, take });
+        return rows.map(toAuditView);
+    }
+}
+
+export function toAuditView(row: FleetAudit): FleetAuditView {
+    return {
+        id: row.id,
+        action: row.action,
+        actorUserId: row.actorUserId ?? null,
+        ownerUserId: row.ownerUserId ?? null,
+        nodeId: row.nodeId ?? null,
+        details: row.details ?? null,
+        occurredAt: row.occurredAt ? new Date(row.occurredAt).toISOString() : null,
+    };
+}

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -27,6 +27,10 @@ import { FleetJobRepository } from './fleet-job.repository';
 import { FleetNodeRepository } from './fleet-node.repository';
 import { verifyNodeSecret } from './fleet-node-credential';
 import { FleetAgentNodeAffinityRepository } from './fleet-agent-node-affinity.repository';
+import { FleetKillSwitchService } from './fleet-kill-switch.service';
+
+/** Upper bound on the queued rows `queuedForUser` returns (cancel-in-flight with `includeQueued`). */
+export const FLEET_JOB_QUEUED_SCAN_LIMIT = 500;
 
 /** Batch ceiling on one reclaim pass, so a huge backlog can't stall a poll. */
 export const FLEET_JOB_RECLAIM_BATCH = 200;
@@ -145,6 +149,12 @@ export class FleetJobService {
         // positionally keeps compiling; absent, the lease protocol is
         // byte-for-byte what it was (no consumer, no event).
         @Optional() private readonly events?: EventEmitter2,
+        // Panic controls (EW-778) — the GLOBAL STOP FLAG. Same appended-
+        // LAST + @Optional() posture. Absent (unit tests built
+        // positionally), the lease protocol is byte-for-byte what it was;
+        // present, `lease()` answers `[]` while the flag is set OR cannot
+        // be read — the service folds read failures into "stopped".
+        @Optional() private readonly killSwitch?: FleetKillSwitchService,
     ) {}
 
     /**
@@ -233,6 +243,34 @@ export class FleetJobService {
         const node = await this.authenticateNode(input.nodeId, input.secret);
         if (!node) {
             return null;
+        }
+
+        // Panic controls (EW-778) — EVERY lease consults the global stop
+        // flag, after auth (a bad credential is still a 401, never "no
+        // work") and before anything is claimed. `[]` is the honest
+        // node-side answer: the fleet has nothing for you right now.
+        // Heartbeat and complete are deliberately NOT gated — a stopped
+        // fleet must still settle the work it already holds, or a later
+        // cancel-in-flight could never resolve.
+        if (this.killSwitch) {
+            let stopped: boolean;
+            try {
+                stopped = await this.killSwitch.isStopped();
+            } catch (error) {
+                // The service folds read failures into `true` itself; this
+                // catch covers a stub or a future implementation that
+                // throws. A switch that cannot be consulted counts as SET.
+                this.logger.error(
+                    `fleet lease refused for node ${node.id}: global stop flag could not be read (fail-closed): ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                stopped = true;
+            }
+            if (stopped) {
+                this.logger.log(`fleet lease refused for node ${node.id}: global stop flag is set`);
+                return [];
+            }
         }
 
         // Inline reclaim before the scan: a job whose holder died is
@@ -779,6 +817,30 @@ export class FleetJobService {
             };
         }
         return byNode;
+    }
+
+    /**
+     * Every live claim (`leased` / `running`) held by any of this owner's
+     * nodes, oldest first — the cancel-in-flight candidate set.
+     */
+    async activeForUser(userId: string): Promise<FleetJobView[]> {
+        const rows = await this.jobs.findActiveForUser(userId);
+        return rows.map(toJobView);
+    }
+
+    /**
+     * This owner's `queued` rows, oldest first, bounded — the optional
+     * second half of cancel-in-flight (`includeQueued`).
+     */
+    async queuedForUser(
+        userId: string,
+        limit = FLEET_JOB_QUEUED_SCAN_LIMIT,
+    ): Promise<FleetJobView[]> {
+        const rows = await this.jobs.findQueuedForUser(
+            userId,
+            Math.min(Math.max(limit, 1), FLEET_JOB_QUEUED_SCAN_LIMIT),
+        );
+        return rows.map(toJobView);
     }
 
     /** Owner-scoped job listing (chat tool / future job history UI). */

--- a/packages/agent/src/fleet/fleet-kill-switch.repository.ts
+++ b/packages/agent/src/fleet/fleet-kill-switch.repository.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FLEET_KILL_SWITCH_ID } from '@ever-works/contracts';
+import { FleetKillSwitch } from '../entities/fleet-kill-switch.entity';
+
+/** The columns a flip writes. Everything else on the row is bookkeeping. */
+export interface FleetKillSwitchWrite {
+    stopped: boolean;
+    reason: string | null;
+    setByUserId: string | null;
+    setAt: Date;
+}
+
+/**
+ * Panic controls (EW-778) — feature-owned repository over the one-row
+ * `fleet_kill_switch` table (provided by `FleetModule`, not
+ * `DatabaseModule` — same split as `FleetJobRepository`).
+ *
+ * Deliberately NO cache: a cached read is a window in which the switch
+ * is ignored, and the read is a single primary-key lookup. `read()` is
+ * allowed to throw — `FleetKillSwitchService` is the one place that
+ * turns a failure into the fail-closed verdict.
+ */
+@Injectable()
+export class FleetKillSwitchRepository {
+    constructor(
+        @InjectRepository(FleetKillSwitch)
+        private readonly repository: Repository<FleetKillSwitch>,
+    ) {}
+
+    /** The global row, or null when the migration that seeds it has not run. */
+    async read(): Promise<FleetKillSwitch | null> {
+        return this.repository.findOne({ where: { id: FLEET_KILL_SWITCH_ID } });
+    }
+
+    /**
+     * Insert the global row as NOT stopped when it is missing; leave an
+     * existing row alone. The migration seeds it too — this is the boot-
+     * time belt for stacks whose schema is synchronised rather than
+     * migrated (the e2e harness), where a missing row would otherwise
+     * fail every dispatch closed forever. Throws when the table itself
+     * is missing; the caller logs and reads stay fail-closed.
+     */
+    async ensureSeeded(): Promise<boolean> {
+        const existing = await this.read();
+        if (existing) return false;
+        await this.repository.insert({
+            id: FLEET_KILL_SWITCH_ID,
+            stopped: false,
+            reason: null,
+            setByUserId: null,
+            setAt: null,
+        });
+        return true;
+    }
+
+    /**
+     * Flip the switch. Updates the seeded row; inserts it only when it is
+     * missing (an unmigrated database being operated by hand), so a
+     * stop always lands even in that degraded state.
+     */
+    async write(patch: FleetKillSwitchWrite): Promise<void> {
+        const result = await this.repository.update({ id: FLEET_KILL_SWITCH_ID }, patch);
+        if ((result.affected ?? 0) === 0) {
+            await this.repository.insert({ id: FLEET_KILL_SWITCH_ID, ...patch });
+        }
+    }
+}

--- a/packages/agent/src/fleet/fleet-kill-switch.service.ts
+++ b/packages/agent/src/fleet/fleet-kill-switch.service.ts
@@ -1,0 +1,227 @@
+import { Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
+import type {
+    FleetKillSwitchAdminState,
+    FleetKillSwitchChangeResult,
+    FleetKillSwitchState,
+} from '@ever-works/contracts';
+import { FLEET_KILL_SWITCH_REASON_MAX_LENGTH } from '@ever-works/contracts';
+import type { RunKillSwitch } from '../agents/run-kill-switch';
+import type { FleetKillSwitch } from '../entities/fleet-kill-switch.entity';
+import { FleetAuditService } from './fleet-audit.service';
+import { FleetKillSwitchRepository } from './fleet-kill-switch.repository';
+
+/** The verdict every reader gets when the flag cannot be read. */
+const UNVERIFIED_STOPPED: FleetKillSwitchAdminState = {
+    stopped: true,
+    reason: null,
+    since: null,
+    unverified: true,
+    setByUserId: null,
+};
+
+/**
+ * Panic controls (EW-778) — the GLOBAL STOP FLAG.
+ *
+ * ## The one rule: reads fail CLOSED
+ *
+ * `state()` never throws and never answers `stopped: false` unless it
+ * has actually read a row that says so. A missing row (migration not
+ * applied), a query error, a driver hiccup — every one of them yields
+ * `{ stopped: true, unverified: true }`. This is stated in exactly one
+ * place so the three consumers cannot drift:
+ *
+ *   - `RunDispatchGateService` — through the `RUN_KILL_SWITCH` port
+ *     (`shouldHaltDispatch`), parks every new agent run;
+ *   - `FleetRunRouterService` + the fleet-aware dispatcher — refuse to
+ *     route or enqueue (never fall back to the cloud);
+ *   - `FleetJobService.lease` — answers `[]` to every node.
+ *
+ * No cache, on purpose: the read is one primary-key lookup, and a cache
+ * would be a window in which an operator's stop is ignored.
+ *
+ * ## What set / clear do — and do not do
+ *
+ * `stop()` / `clear()` flip the row and then write ONE `fleet_audit` row
+ * carrying the actor. The switch flips even when the audit write fails
+ * (the failure is logged and reported as `auditFailed`): bookkeeping
+ * must never be the reason a stop did not land. Neither cancels running
+ * work — that is `cancel-in-flight`, an explicit separate step — and
+ * neither promotes parked runs itself; the API-side clear route asks the
+ * gate to do that once the flip has been acknowledged.
+ */
+@Injectable()
+export class FleetKillSwitchService implements RunKillSwitch, OnApplicationBootstrap {
+    private readonly logger = new Logger(FleetKillSwitchService.name);
+
+    constructor(
+        private readonly repository: FleetKillSwitchRepository,
+        private readonly audit: FleetAuditService,
+    ) {}
+
+    /**
+     * Seed the global row as NOT stopped if it is missing. The migration
+     * does this too; the boot-time belt covers schema-synchronised stacks
+     * (the e2e harness), where no migration ever runs and a missing row
+     * would fail every dispatch closed forever. Never overwrites an
+     * existing row — a thrown switch survives a restart — and never
+     * throws: a missing TABLE simply leaves reads fail-closed until the
+     * migration lands.
+     */
+    async onApplicationBootstrap(): Promise<void> {
+        try {
+            if (await this.repository.ensureSeeded()) {
+                this.logger.log('fleet_kill_switch global row seeded (not stopped)');
+            }
+        } catch (error) {
+            this.logger.warn(
+                `fleet_kill_switch could not be seeded at boot — dispatch stays refused until the migration runs: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /** Full state, actor included. Never throws — see the class docblock. */
+    async state(): Promise<FleetKillSwitchAdminState> {
+        let row: FleetKillSwitch | null;
+        try {
+            row = await this.repository.read();
+        } catch (error) {
+            this.logger.error(
+                `fleet kill switch could not be read — refusing dispatch (fail-closed): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { ...UNVERIFIED_STOPPED };
+        }
+        if (!row) {
+            this.logger.error(
+                'fleet_kill_switch has no global row (migration not applied?) — refusing dispatch (fail-closed)',
+            );
+            return { ...UNVERIFIED_STOPPED };
+        }
+        return {
+            stopped: row.stopped === true,
+            reason: row.reason ?? null,
+            since: row.setAt ? new Date(row.setAt).toISOString() : null,
+            unverified: false,
+            setByUserId: row.setByUserId ?? null,
+        };
+    }
+
+    /** The state as any signed-in user may see it — the actor is not leaked. */
+    async publicState(): Promise<FleetKillSwitchState> {
+        const { stopped, reason, since, unverified } = await this.state();
+        return { stopped, reason, since, unverified };
+    }
+
+    /** True when no new work may start: the flag is set OR could not be read. */
+    async isStopped(): Promise<boolean> {
+        return (await this.state()).stopped;
+    }
+
+    /** `RunKillSwitch` port — the dispatch gate's question. */
+    async shouldHaltDispatch(): Promise<boolean> {
+        return this.isStopped();
+    }
+
+    /**
+     * Throw the switch. Idempotent: stopping an already-stopped fleet
+     * refreshes the reason and the actor (a second operator adding
+     * context) and records `changed: false`.
+     */
+    async stop(actorUserId: string, reason?: string | null): Promise<FleetKillSwitchChangeResult> {
+        const before = await this.state();
+        const now = new Date();
+        const cleanReason = normalizeReason(reason);
+        await this.repository.write({
+            stopped: true,
+            reason: cleanReason,
+            setByUserId: actorUserId,
+            setAt: now,
+        });
+        const after: FleetKillSwitchAdminState = {
+            stopped: true,
+            reason: cleanReason,
+            since: now.toISOString(),
+            unverified: false,
+            setByUserId: actorUserId,
+        };
+        const changed = before.unverified || !before.stopped;
+        this.logger.warn(
+            `fleet kill switch SET by ${actorUserId}${cleanReason ? ` — ${cleanReason}` : ''} (changed=${changed})`,
+        );
+        const auditFailed = !(await this.tryAudit('kill-switch.stop', actorUserId, {
+            reason: cleanReason,
+            changed,
+            before: snapshot(before),
+            after: snapshot(after),
+        }));
+        return { state: after, changed, auditFailed };
+    }
+
+    /** Clear the switch. Idempotent; records `changed: false` when it was already clear. */
+    async clear(actorUserId: string): Promise<FleetKillSwitchChangeResult> {
+        const before = await this.state();
+        const now = new Date();
+        await this.repository.write({
+            stopped: false,
+            reason: null,
+            setByUserId: actorUserId,
+            setAt: now,
+        });
+        const after: FleetKillSwitchAdminState = {
+            stopped: false,
+            reason: null,
+            since: now.toISOString(),
+            unverified: false,
+            setByUserId: actorUserId,
+        };
+        const changed = before.unverified || before.stopped;
+        this.logger.warn(`fleet kill switch CLEARED by ${actorUserId} (changed=${changed})`);
+        const auditFailed = !(await this.tryAudit('kill-switch.clear', actorUserId, {
+            changed,
+            before: snapshot(before),
+            after: snapshot(after),
+        }));
+        return { state: after, changed, auditFailed };
+    }
+
+    /** Audit after the flip; a failure is logged and reported, never thrown. */
+    private async tryAudit(
+        action: 'kill-switch.stop' | 'kill-switch.clear',
+        actorUserId: string,
+        details: Record<string, unknown>,
+    ): Promise<boolean> {
+        try {
+            await this.audit.record({ action, actorUserId, ownerUserId: null, details });
+            return true;
+        } catch (error) {
+            this.logger.error(
+                `fleet audit row for ${action} by ${actorUserId} could not be written: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+}
+
+function normalizeReason(reason: string | null | undefined): string | null {
+    if (typeof reason !== 'string') return null;
+    const trimmed = reason.trim();
+    if (!trimmed) return null;
+    return trimmed.length > FLEET_KILL_SWITCH_REASON_MAX_LENGTH
+        ? trimmed.slice(0, FLEET_KILL_SWITCH_REASON_MAX_LENGTH)
+        : trimmed;
+}
+
+function snapshot(state: FleetKillSwitchAdminState): Record<string, unknown> {
+    return {
+        stopped: state.stopped,
+        reason: state.reason,
+        since: state.since,
+        unverified: state.unverified,
+        setByUserId: state.setByUserId,
+    };
+}

--- a/packages/agent/src/fleet/fleet.module.ts
+++ b/packages/agent/src/fleet/fleet.module.ts
@@ -16,6 +16,11 @@ import { FleetAgentNodeAffinityService } from './fleet-agent-node-affinity.servi
 import { FleetCostPolicy } from '../entities/fleet-cost-policy.entity';
 import { FleetCostPolicyRepository } from './fleet-cost-policy.repository';
 import { FleetCostCeilingService } from './fleet-cost-ceiling.service';
+import { FleetKillSwitch } from '../entities/fleet-kill-switch.entity';
+import { FleetAudit } from '../entities/fleet-audit.entity';
+import { FleetKillSwitchRepository } from './fleet-kill-switch.repository';
+import { FleetKillSwitchService } from './fleet-kill-switch.service';
+import { FleetAuditService } from './fleet-audit.service';
 
 /**
  * Fleet (Wave 12, slice 1 + Desktop PRD M4) — agent-side module owning
@@ -41,6 +46,11 @@ import { FleetCostCeilingService } from './fleet-cost-ceiling.service';
  *     through the same disable + requeue pair the drain endpoint uses and
  *     files one Inbox notice per day (the `INBOX_PRODUCER` token is
  *     `@Optional()` — bound by the api-side @Global() InboxModule).
+ *   - `FleetKillSwitchService` (EW-778) — the GLOBAL STOP FLAG, read
+ *     fail-closed by the dispatch gate (via the `RUN_KILL_SWITCH` port
+ *     the api-side AgentsModule binds), the run router and every lease;
+ *     `FleetAuditService` is the one writer of the `fleet_audit` trail
+ *     every panic action records to.
  *
  * Both authenticate nodes through the SAME credential helper
  * (`fleet-node-credential.ts`), so enroll / heartbeat / lease can never
@@ -65,6 +75,8 @@ import { FleetCostCeilingService } from './fleet-cost-ceiling.service';
             FleetExecutionPreference,
             FleetAgentNodeAffinity,
             FleetCostPolicy,
+            FleetKillSwitch,
+            FleetAudit,
         ]),
     ],
     providers: [
@@ -73,11 +85,14 @@ import { FleetCostCeilingService } from './fleet-cost-ceiling.service';
         FleetExecutionPreferenceRepository,
         FleetAgentNodeAffinityRepository,
         FleetCostPolicyRepository,
+        FleetKillSwitchRepository,
         FleetService,
         FleetJobService,
         FleetExecutionPreferenceService,
         FleetAgentNodeAffinityService,
         FleetCostCeilingService,
+        FleetAuditService,
+        FleetKillSwitchService,
     ],
     exports: [
         FleetNodeRepository,
@@ -85,11 +100,14 @@ import { FleetCostCeilingService } from './fleet-cost-ceiling.service';
         FleetExecutionPreferenceRepository,
         FleetAgentNodeAffinityRepository,
         FleetCostPolicyRepository,
+        FleetKillSwitchRepository,
         FleetService,
         FleetJobService,
         FleetExecutionPreferenceService,
         FleetAgentNodeAffinityService,
         FleetCostCeilingService,
+        FleetAuditService,
+        FleetKillSwitchService,
     ],
 })
 export class FleetModule {}

--- a/packages/agent/src/fleet/index.ts
+++ b/packages/agent/src/fleet/index.ts
@@ -16,6 +16,10 @@ export * from './fleet-agent-node-affinity.repository';
 // Fleet cost accounting (EW-777) — daily model-spend ceilings.
 export * from './fleet-cost-ceiling.service';
 export * from './fleet-cost-policy.repository';
+// Panic controls (EW-778) — the global stop flag + the fleet audit trail.
+export * from './fleet-kill-switch.service';
+export * from './fleet-kill-switch.repository';
+export * from './fleet-audit.service';
 export * from './agent-fleet-tools';
 export { FleetNode } from '../entities/fleet-node.entity';
 export { FleetCostPolicy } from '../entities/fleet-cost-policy.entity';
@@ -23,3 +27,5 @@ export type { FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.enti
 export { FleetJob } from '../entities/fleet-job.entity';
 export { FleetExecutionPreference } from '../entities/fleet-execution-preference.entity';
 export { FleetAgentNodeAffinity } from '../entities/fleet-agent-node-affinity.entity';
+export { FleetKillSwitch } from '../entities/fleet-kill-switch.entity';
+export { FleetAudit } from '../entities/fleet-audit.entity';

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -152,7 +152,15 @@ const QUESTION_EXPORTS = [
 	'FLEET_AGENT_TASK_QUESTION_MAX_TEXT_CHARS',
 	'FLEET_AGENT_TASK_QUESTION_MAX_CONTEXT_BYTES',
 	'parseFleetAgentTaskQuestionMarkdown',
-	'normalizeFleetAgentTaskQuestion'
+	'normalizeFleetAgentTaskQuestion',
+	// Panic controls (EW-778) — fleet-panic.types.ts
+	'FLEET_AUDIT_ACTIONS',
+	'FLEET_AUDIT_DEFAULT_LIMIT',
+	'FLEET_AUDIT_MAX_LIMIT',
+	'FLEET_CANCEL_IN_FLIGHT_MAX_IDS',
+	'FLEET_JOB_CANCEL_STATES',
+	'FLEET_KILL_SWITCH_ID',
+	'FLEET_KILL_SWITCH_REASON_MAX_LENGTH'
 ] as const;
 
 const ALL_EXPORTS = [
@@ -211,14 +219,14 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 105 runtime symbols', () => {
+	it('exposes exactly these 112 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
 		// 92 → 98 with fleet cost accounting (EW-777): two node bounds and
 		// four cost-accounting helpers, each pinned in its own spec.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(105);
+		expect(Object.keys(fleet)).toHaveLength(112);
 	});
 
 	it.each([
@@ -226,6 +234,7 @@ describe('fleet barrel', () => {
 		['fleet-execution-preference.types.js', 'FLEET_EXECUTION_MODES'],
 		['fleet-jobs.types.js', 'FLEET_JOB_STATUSES'],
 		['fleet-node.types.js', 'FLEET_NODE_KINDS'],
+		['fleet-panic.types.js', 'FLEET_KILL_SWITCH_ID'],
 		['fleet-runner-status.types.js', 'FLEET_RUNNER_STATUS_REFRESH_SEC'],
 		['fleet-task-workspace.types.js', 'FLEET_TASK_WORKSPACE_MAX_MOUNTS']
 	])('keeps the %s module represented via %s', (_module, sentinel) => {

--- a/packages/contracts/src/fleet/fleet-execution-preference.types.ts
+++ b/packages/contracts/src/fleet/fleet-execution-preference.types.ts
@@ -41,8 +41,9 @@
  * Note the layering: this preference decides FLEET-vs-CLOUD for a run
  * whose tenant already has the fleet available. It never turns the fleet
  * on for a tenant whose resolved runtime is not `node`, and it never
- * overrides the `FLEET_NODE_RUNTIME_ENABLED` kill switch — an operator
- * draining the fleet still wins over every preference row.
+ * overrides the `FLEET_NODE_RUNTIME_ENABLED` routing selector — an operator
+ * taking the fleet runtime out of service still wins over every preference
+ * row. (Stopping work outright is the DB-backed global stop flag, EW-778.)
  */
 
 /** Where a run should execute. */

--- a/packages/contracts/src/fleet/fleet-panic.types.ts
+++ b/packages/contracts/src/fleet/fleet-panic.types.ts
@@ -1,0 +1,131 @@
+/**
+ * Panic controls (EW-778, closes OPS-16 + security audit 2026-05-17 #25)
+ * — the wire shapes for stopping a fleet at 2am.
+ *
+ * Three controls, deliberately separate, because they are three
+ * different decisions:
+ *
+ *   1. **Drain all** (owner) — every node the caller owns is disabled and
+ *      its in-flight claims go back to the queue. Nothing is killed; the
+ *      work waits for a node that is allowed to take it.
+ *   2. **The global stop flag** (platform admin) — a DB-backed switch
+ *      read by the dispatch gate, the run router and every lease
+ *      request. When set, no NEW work is dispatched, routed or leased.
+ *      Running work keeps running and keeps reporting. Reads FAIL
+ *      CLOSED: a flag that cannot be read counts as set.
+ *   3. **Cancel in-flight** (owner) — an EXPLICIT second step that
+ *      cancels the caller's running fleet jobs and their agent runs.
+ *      Never implied by the stop flag.
+ *
+ * Every set / clear / drain-all / cancel-in-flight writes one `fleet_audit`
+ * row carrying the actor and the time.
+ */
+
+import type { FleetNodeView } from './fleet-node.types.js';
+
+/** The one row `fleet_kill_switch` ever holds. */
+export const FLEET_KILL_SWITCH_ID = 'global';
+
+/** Upper bound on the free-text reason stored with a stop. */
+export const FLEET_KILL_SWITCH_REASON_MAX_LENGTH = 500;
+
+/** Paging bounds for the fleet audit read. */
+export const FLEET_AUDIT_DEFAULT_LIMIT = 50;
+export const FLEET_AUDIT_MAX_LIMIT = 200;
+
+/**
+ * Actions recorded in `fleet_audit`. Stored as `varchar(64)` rather than
+ * an enum so slice AQ can extend the log without a type-altering
+ * migration.
+ */
+export type FleetAuditAction = 'kill-switch.stop' | 'kill-switch.clear' | 'drain-all' | 'cancel-in-flight';
+
+export const FLEET_AUDIT_ACTIONS: readonly FleetAuditAction[] = [
+	'kill-switch.stop',
+	'kill-switch.clear',
+	'drain-all',
+	'cancel-in-flight'
+];
+
+/**
+ * The stop flag as any signed-in user may read it (`GET /api/fleet/kill-switch`).
+ *
+ * `unverified: true` means the flag could NOT be read — the row is
+ * missing (migration not applied) or the query failed — and dispatch is
+ * refusing on that basis. The banner renders that case distinctly so an
+ * operator does not go looking for who threw the switch.
+ */
+export interface FleetKillSwitchState {
+	stopped: boolean;
+	reason: string | null;
+	/** ISO timestamp of the last set/clear, or null when never set. */
+	since: string | null;
+	unverified: boolean;
+}
+
+/** Admin projection: the public state plus who last changed it. */
+export interface FleetKillSwitchAdminState extends FleetKillSwitchState {
+	setByUserId: string | null;
+}
+
+/** Result of an admin stop / clear. */
+export interface FleetKillSwitchChangeResult {
+	state: FleetKillSwitchAdminState;
+	/** False when the switch was already in the requested position. */
+	changed: boolean;
+	/** The switch flipped but the audit row could not be written (logged). */
+	auditFailed: boolean;
+}
+
+/** One `fleet_audit` row on the wire. */
+export interface FleetAuditView {
+	id: string;
+	action: FleetAuditAction | string;
+	actorUserId: string | null;
+	ownerUserId: string | null;
+	nodeId: string | null;
+	details: Record<string, unknown> | null;
+	occurredAt: string | null;
+}
+
+/** `POST /api/fleet/drain-all` result. */
+export interface FleetDrainAllResult {
+	/** Nodes disabled by this call. */
+	drainedNodes: number;
+	/** Nodes left alone: still enrolling, already disabled, or a per-node failure. */
+	skippedNodes: number;
+	/** In-flight claims returned to the queue across every drained node. */
+	releasedJobs: number;
+	/** The caller's enrolled nodes after the drain. */
+	nodes: FleetNodeView[];
+	/** The drain happened but the audit row could not be written (logged). */
+	auditFailed: boolean;
+}
+
+/** The per-job outcome states `FleetJobService.cancel` reports. */
+export type FleetJobCancelState = 'queued-dropped' | 'cancel-requested' | 'terminal' | 'not-found';
+
+export const FLEET_JOB_CANCEL_STATES: readonly FleetJobCancelState[] = [
+	'queued-dropped',
+	'cancel-requested',
+	'terminal',
+	'not-found'
+];
+
+/** `POST /api/fleet/cancel-in-flight` result. */
+export interface FleetCancelInFlightResult {
+	/** Jobs the call looked at. */
+	requested: number;
+	/** Jobs whose course was changed (dropped or flagged for the node). */
+	cancelled: number;
+	/** Agent runs flipped to `cancelled` alongside their job. */
+	runsCancelled: number;
+	byState: Record<FleetJobCancelState, number>;
+	/** Ids of the jobs the call touched (bounded). */
+	jobIds: string[];
+	/** The cancel happened but the audit row could not be written (logged). */
+	auditFailed: boolean;
+}
+
+/** Cap on `FleetCancelInFlightResult.jobIds` / audit `jobIds`. */
+export const FLEET_CANCEL_IN_FLIGHT_MAX_IDS = 200;

--- a/packages/contracts/src/fleet/index.ts
+++ b/packages/contracts/src/fleet/index.ts
@@ -2,5 +2,6 @@ export * from './fleet-agent-credentials.types.js';
 export * from './fleet-execution-preference.types.js';
 export * from './fleet-jobs.types.js';
 export * from './fleet-node.types.js';
+export * from './fleet-panic.types.js';
 export * from './fleet-runner-status.types.js';
 export * from './fleet-task-workspace.types.js';


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **V** (program note §6). Refs **EW-778**. Implements security-audit 2026-05-17 recommendation #25 (a DB flag every pipeline checks before starting work).

There was no way to stop the fleet as a whole: each node had its own drain, and the only global lever, `FLEET_NODE_RUNTIME_ENABLED`, is a routing selector read at boot, so nothing could halt autonomous work already routed or queued without a redeploy.

### What changes

- **`POST /api/fleet/drain-all`** (owner). The existing per-node drain (disable **first**, then release claims) moved verbatim into `FleetPanicService.drainNodeForUser`; drain-all iterates the owner's enrolled nodes, skips enrolling/disabled, continues past a per-node failure. No caller-supplied node id anywhere.
- **Global stop flag.** `fleet_kill_switch` (single row `global`, seeded by the migration and by `onApplicationBootstrap` for synchronize stacks such as the e2e harness). `FleetKillSwitchService.state()` **fails closed**: a missing row or any read error is `{ stopped: true, unverified: true }`. Checked *above* each of the three fail-open seams:
  - a `killSwitchAdmission` middleware first in `DEFAULT_RUN_ADMISSION_CHAIN`, which parks with `queuedReason: 'kill-switch'` and never throws (`admit()` fails open on a throw);
  - the run router and the fleet-aware dispatcher throw a typed `FleetKillSwitchActiveError` that is rethrown out of the cloud-fallback catch, so a stop can never become a cloud dispatch;
  - every lease answers `[]` after auth (a bad credential is still 401); heartbeat/complete stay open so a stopped fleet can settle.
- **Clear** promotes `kill-switch`-parked runs through the existing claim/enqueue path; a run refused again on the flag is **re-parked, never failed**. The stuck-run sweeper exempts kill-switch rows.
- **`POST /api/fleet/cancel-in-flight { includeQueued? }`** (owner, explicit). Neither the flag nor drain-all implies a cancel; the web offers two separate confirmation dialogs.
- **`fleet_audit`** table + `FleetAuditService`, the single writer: every stop / clear / drain-all / cancel-in-flight records actor and time. Act first, then audit; an audit failure is reported as `auditFailed: true` and never reverts the action. The per-node drain route deliberately writes no row yet: that is slice AQ's scope, which will build on this table.
- **Admin routes** `POST /api/fleet/kill-switch/stop`, `POST /api/fleet/kill-switch/clear`, `GET /api/fleet/kill-switch`, `GET /api/fleet/kill-switch/audit` behind `FleetEnabledGuard` then `IsPlatformAdminGuard`. `setByUserId` never leaves the server.
- **Web:** `FleetKillSwitchBanner` (stopped / unverified / unknown, polled every 30 s, first paint server-side), `FleetPanicControls`; 27 keys in all 21 locales; Playwright `flow-fleet-panic-controls.spec.ts` written (10 tests registered, not run).
- **Migration** `1788150000000-CreateFleetKillSwitchAndAudit` (idempotent, seeds the row, never overwrites a thrown switch, full down) with spec.

### Blast radius (please read)

While the flag is set, the admission chain parks **every** new agent run, cloud runs included (schedule heartbeats, chat replies, resumes, delegation, assign-task), not only fleet work. That is what audit #25 asked for. Consequences documented in `docs/features/fleet.md`: an API replica booting before the migration lands parks all dispatch and shows the *unverified* banner until the row exists (mitigated by the migration seed plus the boot-time seed); runs parked with no Work (schedule heartbeats pass `workId: null`) are not promoted by clear and wait for their next tick.

### Adversarial review and verify (fixed before this PR)

- `FleetJobService.lease` was the one consumer that trusted the flag service never to throw; now a throwing read is treated as stopped.
- The clear, promote, re-stop race turned a parked run into a **failed** one; it now re-parks via the existing CAS.
- The slice's new `AuthModule` import in `fleet.module.ts` dragged the ESM better-auth runtime into `TasksModule` and broke `tasks.module.di-contract.spec.ts`; removed (the guard only needs `UserRepository` from `DatabaseModule`, the `BudgetsModule` precedent).

### Verified locally

- `tsc`: `apps/web` 0, `apps/api` build tsconfig 0, `packages/contracts` 0; `packages/agent` only pre-existing errors in untouched files (`@ever-works/agent-plugins` and `isomorphic-git` unlinked in this worktree).
- Specs: `apps/api` 17 suites / 201 tests; `packages/agent` 34 suites / 497 tests (incl. 8 sqlite-backed integration suites); `apps/web` 6 files / 73 tests; `migrations-directory-contract` and the migration spec green. Explicit fail-closed tests at lease, gate, router and read.
- `prettier --check` clean on all 82 files; web ESLint clean on the 11 changed web files; i18n keys consistent across 21 locales.

### Not verified locally

- Six `apps/api` suites that transitively load `@ever-works/agent-plugins` ran through a scratchpad-only jest config mapping that package to source (this worktree predates the package; `pnpm install` is off-limits for disk). CI has the built package.
- Playwright e2e (stage-only gate); the migration on a real Postgres; `next build` (settings page and components changed, no route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet panic controls to drain owned nodes and cancel in-flight work, with an option to include queued jobs.
  * Added a platform-wide Fleet kill switch for authorized administrators, including stop, clear, status, and audit history.
  * Added live kill-switch status updates and warnings in Fleet settings.
  * Stopped runs are safely paused and can resume after the kill switch is cleared.
* **Documentation**
  * Documented Fleet panic controls and clarified runtime routing behavior.
* **Localization**
  * Added translated interface text for the new Fleet controls across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->