### PR TITLE
feat(agent): release the MCP tool source on every exit path of a run (AP-14 prerequisite)

### DIFF
--- a/packages/agent/src/agents/__tests__/agent-run-mcp-release.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-mcp-release.spec.ts
@@ -1,0 +1,209 @@
+import { AgentRunService } from '../agent-run.service';
+import { PromptAssemblerService } from '../prompt-assembler.service';
+import {
+    AgentAvatarMode,
+    AgentIdleBehavior,
+    AgentScope,
+    AgentStatus,
+} from '../../entities/agent.entity';
+import type { Agent } from '../../entities/agent.entity';
+import type { AgentAiDispatchFacade, AgentAiDispatchResult } from '../agent-ai-dispatch-facade';
+import type { AgentRunChatBackPoster, AgentRunTaskFinisher } from '../agent-run-post-processor';
+
+/**
+ * AP-14 prerequisite — the MCP tool source is released on EVERY exit path
+ * of the tool loop.
+ *
+ * `buildTools` may acquire per-run resources (the stdio slice launches a
+ * subprocess per run). Nothing in the run path used to hand the run back,
+ * so a launched server would have outlived its run for the lifetime of the
+ * pod. These pin the three exits that matter: a completed loop, a loop the
+ * model broke, and — the one the inner `finally` cannot see — tool
+ * resolution throwing before the loop even starts.
+ *
+ * Same harness as the session-detail capture spec: real service over
+ * mocked repositories, driven through `execute()`.
+ */
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.TENANT,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        name: 'Builder',
+        slug: 'builder',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: 'gpt-4o-mini',
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: {
+            canCreateAgents: false,
+            canAssignTasks: false,
+            canEditSkills: false,
+            canEditAgentFiles: false,
+            canSpend: false,
+            canCommitToRepo: false,
+            canOpenPullRequests: false,
+            canCallExternalTools: true,
+        },
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Who I am\nA builder.',
+        agentsMd: null,
+        heartbeatMd: '# Each tick\nBuild.',
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+describe('AgentRunService — MCP run resources are released on every exit path', () => {
+    let agents: any;
+    let runs: any;
+    let runLogs: any;
+    let budgets: any;
+    let skillBindings: any;
+    let activity: any;
+    let assembler: PromptAssemblerService;
+    let chatBackPoster: jest.Mocked<AgentRunChatBackPoster>;
+    let taskFinisher: jest.Mocked<AgentRunTaskFinisher>;
+    let ai: jest.Mocked<AgentAiDispatchFacade>;
+    let toolService: { resolveGrantedTools: jest.Mock; releaseMcpRun: jest.Mock };
+
+    function aiResponse(over: Partial<AgentAiDispatchResult> = {}): AgentAiDispatchResult {
+        return {
+            text: 'Working on it.',
+            toolCalls: [],
+            finishReason: 'stop',
+            usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+            model: 'gpt-4o-mini',
+            ...over,
+        };
+    }
+
+    beforeEach(() => {
+        agents = { findById: jest.fn().mockResolvedValue(makeAgent()) };
+        runs = {
+            findByAgent: jest.fn().mockResolvedValue([]),
+            findById: jest.fn().mockResolvedValue({ status: 'running' }),
+            markFailed: jest.fn().mockResolvedValue(undefined),
+            markCompleted: jest.fn().mockResolvedValue(undefined),
+            addTokens: jest.fn().mockResolvedValue(undefined),
+            mergeFilesTouched: jest.fn().mockResolvedValue(undefined),
+            takeSteeringSignals: jest
+                .fn()
+                .mockResolvedValue({ pendingInput: [], interruptRequested: false }),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        budgets = { findByAgentId: jest.fn().mockResolvedValue(null) };
+        skillBindings = { resolveActive: jest.fn().mockResolvedValue([]) };
+        activity = { log: jest.fn().mockResolvedValue(undefined) };
+        assembler = new PromptAssemblerService();
+        chatBackPoster = { postReply: jest.fn().mockResolvedValue({ messageId: 'm1' }) };
+        taskFinisher = { finishTask: jest.fn().mockResolvedValue({ status: 'done' }) };
+        ai = { dispatch: jest.fn().mockResolvedValue(aiResponse()) };
+        toolService = {
+            resolveGrantedTools: jest.fn().mockResolvedValue({ tools: [], refused: [] }),
+            releaseMcpRun: jest.fn().mockResolvedValue(undefined),
+        };
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    function makeSvc(): AgentRunService {
+        return new AgentRunService(
+            agents,
+            runs,
+            runLogs,
+            budgets,
+            assembler,
+            skillBindings,
+            activity,
+            chatBackPoster,
+            taskFinisher,
+            toolService as any,
+            ai,
+        );
+    }
+
+    const ctx = {
+        runId: 'r1',
+        agentId: 'a1',
+        userId: 'u1',
+        kind: 'task' as const,
+        taskId: 't1',
+        immediateInput: 'Ship it.',
+    };
+
+    it('releases the run after a completed loop, exactly once, with the run id', async () => {
+        const result = await makeSvc().execute(ctx);
+
+        expect(result.status).toBe('dispatched');
+        expect(toolService.releaseMcpRun).toHaveBeenCalledTimes(1);
+        expect(toolService.releaseMcpRun).toHaveBeenCalledWith('r1');
+    });
+
+    it('releases the run when the model dispatch throws mid-loop', async () => {
+        ai.dispatch.mockRejectedValue(new Error('provider exploded'));
+
+        await makeSvc().execute(ctx);
+
+        expect(toolService.releaseMcpRun).toHaveBeenCalledWith('r1');
+    });
+
+    it('releases the run when tool resolution itself throws — before the loop has a try to fail in', async () => {
+        toolService.resolveGrantedTools.mockRejectedValue(new Error('grant matrix down'));
+
+        // `execute()` has no try around the loop: a run that cannot get its
+        // tools propagates to the worker. The release must have happened
+        // anyway — that is the whole point of the outer wrapper.
+        await expect(makeSvc().execute(ctx)).rejects.toThrow('grant matrix down');
+
+        expect(toolService.releaseMcpRun).toHaveBeenCalledWith('r1');
+    });
+
+    it('a release that fails never rewrites the run outcome', async () => {
+        toolService.releaseMcpRun.mockRejectedValue(new Error('process already gone'));
+
+        const result = await makeSvc().execute(ctx);
+
+        expect(result.status).toBe('dispatched');
+        expect(runs.markCompleted).toHaveBeenCalled();
+        expect(runs.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('a runtime whose tool service predates the release hook still runs', async () => {
+        const legacy = { resolveGrantedTools: toolService.resolveGrantedTools };
+        const svc = new AgentRunService(
+            agents,
+            runs,
+            runLogs,
+            budgets,
+            assembler,
+            skillBindings,
+            activity,
+            chatBackPoster,
+            taskFinisher,
+            legacy as any,
+            ai,
+        );
+
+        await expect(svc.execute(ctx)).resolves.toMatchObject({ status: 'dispatched' });
+    });
+});

--- a/packages/agent/src/agents/__tests__/agent-tool-mcp-funnel.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-mcp-funnel.spec.ts
@@ -122,7 +122,7 @@ function mcpDescriptor(name: string, invoke = jest.fn(async () => ({ ok: true })
 }
 
 function sourceReturning(...tools: AgentToolDescriptor[]): AgentMcpToolSource {
-    return { buildTools: jest.fn(async () => tools) };
+    return { buildTools: jest.fn(async () => tools), releaseRun: jest.fn(async () => undefined) };
 }
 
 describe('AgentToolService — MCP tool source (Agent Plugins T26)', () => {
@@ -145,6 +145,7 @@ describe('AgentToolService — MCP tool source (Agent Plugins T26)', () => {
         // model-supplied identity.
         expect(source.buildTools).toHaveBeenCalledWith(
             expect.objectContaining({ id: 'a-7', userId: 'owner-9' }),
+            { runId: 'no-run' },
         );
     });
 
@@ -193,6 +194,7 @@ describe('AgentToolService — MCP tool source (Agent Plugins T26)', () => {
     it('never fails run assembly when the MCP source throws', async () => {
         const source: AgentMcpToolSource = {
             buildTools: jest.fn().mockRejectedValue(new Error('mcp registry exploded')),
+            releaseRun: jest.fn(async () => undefined),
         };
         const svc = makeSvc({ mcpTools: source });
 
@@ -219,5 +221,43 @@ describe('AgentToolService — MCP tool source (Agent Plugins T26)', () => {
         // Unresolvable → refused BEFORE the outbound call happens.
         expect(invoke).not.toHaveBeenCalled();
         expect(result.error).toContain(`${ENV_CREDENTIAL_PREFIX}API_TOKEN`);
+    });
+});
+
+describe('AgentToolService — MCP run lifecycle (AP-14 prerequisite)', () => {
+    it('hands the run id to the source when building, so acquisitions are keyed by run', async () => {
+        const source = sourceReturning(mcpDescriptor('mcp__github__create_issue'));
+        const svc = makeSvc({ mcpTools: source });
+
+        await svc.resolveGrantedTools(makeAgent(), {
+            runId: 'run-42',
+            editsThisRunByFile: new Set(),
+        });
+
+        expect(source.buildTools).toHaveBeenCalledWith(expect.anything(), { runId: 'run-42' });
+    });
+
+    it('releaseMcpRun hands the same run id back to the source', async () => {
+        const source = sourceReturning();
+        const svc = makeSvc({ mcpTools: source });
+
+        await svc.releaseMcpRun('run-42');
+
+        expect(source.releaseRun).toHaveBeenCalledWith('run-42');
+    });
+
+    it('releaseMcpRun is a no-op without a source', async () => {
+        await expect(makeSvc().releaseMcpRun('run-42')).resolves.toBeUndefined();
+    });
+
+    it('releaseMcpRun never throws when the source cannot clean up — the run already ended', async () => {
+        const source: AgentMcpToolSource = {
+            buildTools: jest.fn(async () => []),
+            releaseRun: jest.fn().mockRejectedValue(new Error('process already gone')),
+        };
+        const svc = makeSvc({ mcpTools: source });
+
+        await expect(svc.releaseMcpRun('run-42')).resolves.toBeUndefined();
+        expect(source.releaseRun).toHaveBeenCalledWith('run-42');
     });
 });

--- a/packages/agent/src/agents/agent-mcp-tool-source.ts
+++ b/packages/agent/src/agents/agent-mcp-tool-source.ts
@@ -20,6 +20,15 @@ import type { AgentToolDescriptor } from './agent-tool.service';
  */
 export const AGENT_MCP_TOOL_SOURCE = 'AGENT_MCP_TOOL_SOURCE' as const;
 
+/**
+ * The run the tools are being built FOR. Everything a source acquires on
+ * the run's behalf — a launched stdio server, an open client — is held under
+ * this id and let go by `releaseRun(runId)`.
+ */
+export interface AgentMcpRunHandle {
+    readonly runId: string;
+}
+
 export interface AgentMcpToolSource {
     /**
      * Resolve the agent's bound + enabled MCP connections into tool
@@ -27,5 +36,16 @@ export interface AgentMcpToolSource {
      * isolated: a dead server or a resolution error yields fewer (or
      * zero) tools, never a rejection that fails run assembly.
      */
-    buildTools(agent: Agent): Promise<AgentToolDescriptor[]>;
+    buildTools(agent: Agent, run: AgentMcpRunHandle): Promise<AgentToolDescriptor[]>;
+
+    /**
+     * Release everything `buildTools` acquired for this run (AP-14
+     * prerequisite). `AgentRunService` calls it on EVERY exit path of the
+     * tool loop — completion, error, cancel, interrupt, and a throw from
+     * tool resolution itself — so a launched stdio server can never outlive
+     * its run. MUST be idempotent and MUST NOT throw: a source that cannot
+     * clean up logs and moves on, it does not fail a run that already
+     * ended.
+     */
+    releaseRun(runId: string): Promise<void>;
 }

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -696,7 +696,41 @@ export class AgentRunService {
         }
     }
 
-    private async runToolLoop(
+    /**
+     * The tool loop, with the MCP tool source released on EVERY exit path
+     * (AP-14 prerequisite). Tool resolution happens before the loop's own
+     * try/catch, so a throw from it would escape the inner `finally`; this
+     * wrapper is what makes the release unconditional — a launched stdio
+     * server must never outlive its run, whether the run completed, errored,
+     * was cancelled, was interrupted, or never got its tools at all.
+     */
+    private async runToolLoop(context: AgentRunContext, agent: Agent, prompt: AssembledPrompt) {
+        try {
+            return await this.runToolLoopInner(context, agent, prompt);
+        } finally {
+            await this.releaseRunTools(context.runId);
+        }
+    }
+
+    /**
+     * Best-effort by construction: the run's outcome is already decided by
+     * the time this runs, and a cleanup failure must not rewrite it.
+     */
+    private async releaseRunTools(runId: string): Promise<void> {
+        const release = this.toolService?.releaseMcpRun;
+        if (typeof release !== 'function') return;
+        try {
+            await release.call(this.toolService, runId);
+        } catch (err) {
+            this.logger.warn(
+                `Run ${runId}: releasing MCP run resources failed: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
+    }
+
+    private async runToolLoopInner(
         context: AgentRunContext,
         agent: Agent,
         prompt: AssembledPrompt,

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -674,7 +674,9 @@ export class AgentToolService {
         // broken source contributes zero tools — never a failed run.
         if (this.mcpTools) {
             try {
-                const mcpDescriptors = await this.mcpTools.buildTools(agent);
+                const mcpDescriptors = await this.mcpTools.buildTools(agent, {
+                    runId: runContext.runId,
+                });
                 const existing = new Set(tools.map((tool) => tool.name));
                 for (const descriptor of mcpDescriptors) {
                     // A server-supplied name must never shadow a built-in —
@@ -734,6 +736,29 @@ export class AgentToolService {
                 }`,
             );
             return { tools, refused: [] };
+        }
+    }
+
+    /**
+     * AP-14 prerequisite — the run-end half of the MCP tool source.
+     *
+     * `buildTools` may acquire per-run resources (a launched stdio server,
+     * an open client); this hands the run id back so the source can let
+     * them go. `AgentRunService` calls it on EVERY exit path of the tool
+     * loop. Failure-isolated: a source that cannot clean up is logged —
+     * the run already ended, and failing it now would report a working run
+     * as broken.
+     */
+    async releaseMcpRun(runId: string): Promise<void> {
+        if (!this.mcpTools) return;
+        try {
+            await this.mcpTools.releaseRun(runId);
+        } catch (err) {
+            this.logger.warn(
+                `Run ${runId}: MCP tool source release failed (resources may linger until shutdown): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
         }
     }
 

--- a/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
+++ b/packages/agent/src/mcp/__tests__/mcp-tool-source.spec.ts
@@ -105,6 +105,8 @@ function makeSource(options: {
     };
 }
 
+const RUN = { runId: 'r1' };
+
 describe('McpToolSource', () => {
     describe('binding resolution matrix', () => {
         it('tenant binding enabled → the agent inherits the connection', async () => {
@@ -112,7 +114,7 @@ describe('McpToolSource', () => {
                 connections: [makeConnection()],
                 bindings: [makeBinding({ targetType: 'tenant', targetId: null, enabled: true })],
             });
-            const tools = await source.buildTools(makeAgent());
+            const tools = await source.buildTools(makeAgent(), RUN);
             expect(tools.map((t) => t.name)).toEqual(['mcp__github__search_issues']);
         });
 
@@ -129,7 +131,7 @@ describe('McpToolSource', () => {
                     }),
                 ],
             });
-            const tools = await source.buildTools(makeAgent());
+            const tools = await source.buildTools(makeAgent(), RUN);
             expect(tools).toEqual([]);
         });
 
@@ -140,7 +142,7 @@ describe('McpToolSource', () => {
                     makeBinding({ targetType: 'agent', targetId: 'agent-1', enabled: true }),
                 ],
             });
-            const tools = await source.buildTools(makeAgent());
+            const tools = await source.buildTools(makeAgent(), RUN);
             expect(tools.map((t) => t.name)).toEqual(['mcp__github__search_issues']);
         });
 
@@ -149,14 +151,14 @@ describe('McpToolSource', () => {
                 connections: [makeConnection({ enabled: false })],
                 bindings: [makeBinding({ targetType: 'tenant', targetId: null, enabled: true })],
             });
-            const tools = await source.buildTools(makeAgent());
+            const tools = await source.buildTools(makeAgent(), RUN);
             expect(tools).toEqual([]);
             expect(client.listTools).not.toHaveBeenCalled();
         });
 
         it('no bindings at all → no tools', async () => {
             const { source } = makeSource({ connections: [makeConnection()], bindings: [] });
-            expect(await source.buildTools(makeAgent())).toEqual([]);
+            expect(await source.buildTools(makeAgent(), RUN)).toEqual([]);
         });
     });
 
@@ -167,7 +169,7 @@ describe('McpToolSource', () => {
                 bindings: [makeBinding()],
             });
             const agent = makeAgent({ permissions: { canCallExternalTools: false } as never });
-            expect(await source.buildTools(agent)).toEqual([]);
+            expect(await source.buildTools(agent, RUN)).toEqual([]);
             expect(client.listTools).not.toHaveBeenCalled();
         });
 
@@ -186,7 +188,7 @@ describe('McpToolSource', () => {
                     c2: [{ name: 'ping', description: 'Ping', inputSchema: {} }],
                 },
             });
-            const tools = await source.buildTools(makeAgent());
+            const tools = await source.buildTools(makeAgent(), RUN);
             expect(tools.map((t) => t.name)).toEqual(['mcp__alive__ping']);
         });
     });
@@ -197,7 +199,7 @@ describe('McpToolSource', () => {
                 connections: [makeConnection()],
                 bindings: [makeBinding()],
             });
-            const [tool] = await source.buildTools(makeAgent());
+            const [tool] = await source.buildTools(makeAgent(), RUN);
             expect(tool.description).toBe('[github] Search issues');
             expect(tool.parameters).toEqual({
                 type: 'object',
@@ -220,7 +222,7 @@ describe('McpToolSource', () => {
                     ],
                 },
             });
-            const [tool] = await source.buildTools(makeAgent());
+            const [tool] = await source.buildTools(makeAgent(), RUN);
             expect(tool.name).toBe('mcp__github__evil_name__x');
             expect(tool.name).toMatch(/^[A-Za-z0-9_-]+$/);
             expect(tool.description).toBe('[github] line1  line2');
@@ -231,7 +233,7 @@ describe('McpToolSource', () => {
                 connections: [makeConnection()],
                 bindings: [makeBinding()],
             });
-            const [tool] = await source.buildTools(makeAgent());
+            const [tool] = await source.buildTools(makeAgent(), RUN);
             await tool.invoke({ q: 'bug' });
             expect(client.callTool).toHaveBeenCalledWith(
                 expect.objectContaining({ id: 'c1' }),
@@ -258,7 +260,7 @@ describe('usage accounting (T28)', () => {
             usage,
         });
 
-        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }), RUN);
         await tools[0].invoke({ q: 'x' });
         await flush();
 
@@ -282,7 +284,7 @@ describe('usage accounting (T28)', () => {
         });
         (client.callTool as jest.Mock).mockRejectedValue(new Error('server down'));
 
-        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }), RUN);
         await expect(tools[0].invoke({ q: 'x' })).rejects.toThrow('server down');
         await flush();
 
@@ -299,7 +301,7 @@ describe('usage accounting (T28)', () => {
             usage,
         });
 
-        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }), RUN);
 
         // Trading a working tool for a complete ledger is the wrong way round.
         await expect(tools[0].invoke({ q: 'x' })).resolves.toEqual({ ok: true });
@@ -318,7 +320,7 @@ describe('usage accounting (T28)', () => {
         // on a table five other capabilities write to — a larger change than
         // this feature should make alone, so such agents are simply not
         // counted, and the gap is stated rather than hidden.
-        const tools = await source.buildTools(makeAgent({ workId: null }));
+        const tools = await source.buildTools(makeAgent({ workId: null }), RUN);
         await tools[0].invoke({ q: 'x' });
         await flush();
 
@@ -341,7 +343,7 @@ describe('usage accounting (T28)', () => {
             usage,
         });
 
-        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }), RUN);
 
         // The write never settles. If `invoke` awaited it, this would hang —
         // a stalled accounting write would hold every successful tool
@@ -357,7 +359,48 @@ describe('usage accounting (T28)', () => {
             bindings: [makeBinding()],
         });
 
-        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }));
+        const tools = await source.buildTools(makeAgent({ workId: 'work-1' }), RUN);
         await expect(tools[0].invoke({ q: 'x' })).resolves.toEqual({ ok: true });
+    });
+});
+
+describe('McpToolSource — releaseRun (AP-14 prerequisite)', () => {
+    type Registrable = {
+        registerRunResource(runId: string, resource: { close(): Promise<void> }): void;
+    };
+
+    it('is a no-op for a run that acquired nothing', async () => {
+        const { source } = makeSource({ connections: [], bindings: [] });
+
+        await expect(source.releaseRun('r-none')).resolves.toBeUndefined();
+    });
+
+    it('closes every registered resource exactly once, tolerating a closer that rejects', async () => {
+        const { source } = makeSource({ connections: [], bindings: [] });
+        const ok = { close: jest.fn().mockResolvedValue(undefined) };
+        const bad = { close: jest.fn().mockRejectedValue(new Error('already gone')) };
+        (source as unknown as Registrable).registerRunResource('r1', ok);
+        (source as unknown as Registrable).registerRunResource('r1', bad);
+
+        await expect(source.releaseRun('r1')).resolves.toBeUndefined();
+        expect(ok.close).toHaveBeenCalledTimes(1);
+        expect(bad.close).toHaveBeenCalledTimes(1);
+
+        // Idempotent: the second release finds nothing left to close.
+        await source.releaseRun('r1');
+        expect(ok.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps runs apart — releasing one run leaves another run’s resources alone', async () => {
+        const { source } = makeSource({ connections: [], bindings: [] });
+        const mine = { close: jest.fn().mockResolvedValue(undefined) };
+        const theirs = { close: jest.fn().mockResolvedValue(undefined) };
+        (source as unknown as Registrable).registerRunResource('r1', mine);
+        (source as unknown as Registrable).registerRunResource('r2', theirs);
+
+        await source.releaseRun('r1');
+
+        expect(mine.close).toHaveBeenCalledTimes(1);
+        expect(theirs.close).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/mcp/mcp-tool-source.ts
+++ b/packages/agent/src/mcp/mcp-tool-source.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import type { Agent } from '../entities/agent.entity';
 import type { McpServerConnection } from '../entities/mcp-server-connection.entity';
 import type { AgentToolDescriptor, AgentToolParameterSchema } from '../agents/agent-tool.service';
-import type { AgentMcpToolSource } from '../agents/agent-mcp-tool-source';
+import type { AgentMcpRunHandle, AgentMcpToolSource } from '../agents/agent-mcp-tool-source';
 import { PluginUsageRepository } from '../database/repositories/plugin-usage.repository';
 import { PluginUsageCapability } from '../entities/plugin-usage-event.entity';
 import { McpClientService, type McpToolInfo } from './mcp-client.service';
@@ -33,6 +33,16 @@ const MCP_DESCRIPTION_MAX = 1024;
 @Injectable()
 export class McpToolSource implements AgentMcpToolSource {
     private readonly logger = new Logger(McpToolSource.name);
+
+    /**
+     * Per-run resources `buildTools` acquired, keyed by run id and let go by
+     * `releaseRun`. Today nothing is registered — HTTP clients are opened and
+     * closed inside `McpClientService.listTools` — so this is the seam the
+     * stdio slice (AP-14) registers each launched server into. An entry only
+     * exists once something is registered, so a runtime that never releases
+     * (there is none, but the contract allows it) accumulates nothing.
+     */
+    private readonly runResources = new Map<string, Array<{ close(): Promise<void> }>>();
 
     constructor(
         private readonly connections: McpConnectionsService,
@@ -81,7 +91,7 @@ export class McpToolSource implements AgentMcpToolSource {
         }
     }
 
-    async buildTools(agent: Agent): Promise<AgentToolDescriptor[]> {
+    async buildTools(agent: Agent, run: AgentMcpRunHandle): Promise<AgentToolDescriptor[]> {
         if (!agent.permissions?.canCallExternalTools) return [];
 
         let effective: McpServerConnection[];
@@ -89,7 +99,7 @@ export class McpToolSource implements AgentMcpToolSource {
             effective = await this.connections.resolveEffectiveConnections(agent.userId, agent.id);
         } catch (err) {
             this.logger.warn(
-                `Agent ${agent.id}: MCP connection resolution failed (no MCP tools this run): ${
+                `Agent ${agent.id} run ${run.runId}: MCP connection resolution failed (no MCP tools this run): ${
                     err instanceof Error ? err.message : String(err)
                 }`,
             );
@@ -106,7 +116,7 @@ export class McpToolSource implements AgentMcpToolSource {
             } catch (err) {
                 // Dead server → zero tools + WARN, never a failed run.
                 this.logger.warn(
-                    `Agent ${agent.id}: MCP server "${connection.name}" unavailable (skipped): ${
+                    `Agent ${agent.id} run ${run.runId}: MCP server "${connection.name}" unavailable (skipped): ${
                         err instanceof Error ? err.message : String(err)
                     }`,
                 );
@@ -126,6 +136,39 @@ export class McpToolSource implements AgentMcpToolSource {
             }
         }
         return out;
+    }
+
+    /**
+     * AP-14 prerequisite. Closes everything registered for the run, once,
+     * tolerating a closer that rejects (logged, never thrown — the run is
+     * already over). A second call for the same run is a no-op.
+     */
+    async releaseRun(runId: string): Promise<void> {
+        const resources = this.runResources.get(runId);
+        this.runResources.delete(runId);
+        if (!resources?.length) return;
+        const results = await Promise.allSettled(resources.map((resource) => resource.close()));
+        for (const result of results) {
+            if (result.status === 'rejected') {
+                this.logger.warn(
+                    `Run ${runId}: MCP run resource failed to close: ${
+                        result.reason instanceof Error
+                            ? result.reason.message
+                            : String(result.reason)
+                    }`,
+                );
+            }
+        }
+    }
+
+    /** Hold a resource for the run until `releaseRun(runId)`. */
+    protected registerRunResource(runId: string, resource: { close(): Promise<void> }): void {
+        const existing = this.runResources.get(runId);
+        if (existing) {
+            existing.push(resource);
+        } else {
+            this.runResources.set(runId, [resource]);
+        }
     }
 
     // ── internals ─────────────────────────────────────────────────


### PR DESCRIPTION
First of two slices for [EW-797](https://evertech.atlassian.net/browse/EW-797) (AP-14, the one **Partial** row in the Agent Plugins conformance statement). This slice is the lifecycle; the stdio slice lands on top of it.

## Why a lifecycle first

`AgentMcpToolSource` was a single `buildTools(agent)` call with no way to hand a run back, and there is no run lifecycle anywhere in `agents/` or `mcp/` to borrow (zero matches for `onRunEnd|runFinished|disposeRun|cleanupRun|onModuleDestroy`). A source that acquires per-run resources — the stdio slice launches one subprocess per run — would have leaked them for the lifetime of the pod, invisible until an OOM kill. That is why AP-14 was left Partial rather than "wired".

## What changes

| Seam | Change |
|---|---|
| `AgentMcpToolSource` | `buildTools(agent, { runId })` + `releaseRun(runId)` — idempotent, never throws. |
| `AgentToolService` | passes the run id into the source; new `releaseMcpRun(runId)`, failure-isolated (a cleanup failure is logged; it never fails a run that already ended). |
| `AgentRunService` | `runToolLoop` is now a thin wrapper whose `finally` releases the run. Tool resolution happens **before** the loop's own `try/catch`, so this is the only place that covers every exit: completion, error, cancel, interrupt, and a throw from tool resolution itself (`execute()` propagates that one to the worker — the release still happens). |
| `McpToolSource` | per-run resource registry (`registerRunResource` / `releaseRun`) the stdio slice registers launched servers into. **Nothing is registered yet** — HTTP clients are still opened and closed inside `listTools` — so runtime behaviour is unchanged. The two "no MCP tools this run" logs now carry the run id, so a leak is greppable from one line. |

Acceptance criteria 1, 2 and 4 of EW-797 (contract, run-end call site, failure paths). Criterion 3 (per-run state) has its home here and is populated by the stdio slice. **AP-14 stays Partial** in `conformance.md` until then — deliberately.

## Verification

- 7 suites / 73 tests green across the funnel, run-service (capture, execute, abort, delegation) and MCP source specs; `tsc` clean for `packages/agent`; Prettier clean.
- **Mutation**: removing `await this.releaseRunTools(context.runId)` from the wrapper's `finally` → `3 failed / 2 passed` in the new `agent-run-mcp-release.spec.ts` (the completed, errored and tool-resolution-throws paths). Restored.
- A runtime whose tool service predates the hook (a partial in older specs) still runs — pinned.
- Full agent suite and the `@ever-works/agent` build + `apps/api` type-check are running as I open this; results in a follow-up comment.

Behind `FEATURE_AGENT_PLUGINS` / `AGENT_PLUGINS_STDIO` only in the sense that nothing acquires resources yet; the lifecycle itself runs for every agent run, as it must.


[EW-797]: https://evertech.atlassian.net/browse/EW-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ