### PR TITLE
feat(fleet): suspend-safe leases — lease generation + node wake detector (EW-792)

### DIFF
--- a/apps/api/src/fleet/dto/fleet-job.dto.spec.ts
+++ b/apps/api/src/fleet/dto/fleet-job.dto.spec.ts
@@ -1,0 +1,88 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './fleet-job.dto';
+
+/**
+ * Suspend-safe leases (self-build finding R7) at the API edge.
+ *
+ * `leaseGeneration` decides whether a heartbeat or a completion lands, so
+ * it is validated like a credential: required, integer, at least 1. A
+ * node built before the field existed must be refused HERE with a 400 —
+ * the service would refuse it too, but "missing" must never be read as
+ * "whatever claim is current".
+ */
+
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const SECRET = 'a'.repeat(43);
+
+async function failingProperties(dto: object): Promise<string[]> {
+    const errors = await validate(dto);
+    return errors.map((error) => error.property).sort();
+}
+
+describe('fleet job DTOs — leaseGeneration', () => {
+    const REJECTED: Array<[string, unknown]> = [
+        ['missing', undefined],
+        ['null', null],
+        ['zero', 0],
+        ['negative', -1],
+        ['a non-integer', 1.5],
+        ['a numeric string', '1'],
+        ['NaN', Number.NaN],
+    ];
+
+    describe('FleetJobHeartbeatDto', () => {
+        it.each(REJECTED)('rejects a generation that is %s', async (_label, leaseGeneration) => {
+            const dto = plainToInstance(FleetJobHeartbeatDto, {
+                nodeId: NODE_ID,
+                secret: SECRET,
+                leaseGeneration,
+            });
+            expect(await failingProperties(dto)).toEqual(['leaseGeneration']);
+        });
+
+        it('accepts a positive integer generation', async () => {
+            const dto = plainToInstance(FleetJobHeartbeatDto, {
+                nodeId: NODE_ID,
+                secret: SECRET,
+                leaseTtlSec: 300,
+                leaseGeneration: 1,
+            });
+            expect(await failingProperties(dto)).toEqual([]);
+        });
+    });
+
+    describe('CompleteFleetJobDto', () => {
+        it.each(REJECTED)('rejects a generation that is %s', async (_label, leaseGeneration) => {
+            const dto = plainToInstance(CompleteFleetJobDto, {
+                nodeId: NODE_ID,
+                secret: SECRET,
+                success: true,
+                leaseGeneration,
+            });
+            expect(await failingProperties(dto)).toEqual(['leaseGeneration']);
+        });
+
+        it('accepts a positive integer generation on both verdicts', async () => {
+            for (const body of [
+                { success: true, result: { ok: true } },
+                { success: false, error: 'exit 1' },
+            ]) {
+                const dto = plainToInstance(CompleteFleetJobDto, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    leaseGeneration: 7,
+                    ...body,
+                });
+                expect(await failingProperties(dto)).toEqual([]);
+            }
+        });
+    });
+
+    describe('LeaseFleetJobsDto', () => {
+        it('does not require a generation — the lease is what MINTS one', async () => {
+            const dto = plainToInstance(LeaseFleetJobsDto, { nodeId: NODE_ID, secret: SECRET });
+            expect(await failingProperties(dto)).toEqual([]);
+        });
+    });
+});

--- a/apps/api/src/fleet/dto/fleet-job.dto.ts
+++ b/apps/api/src/fleet/dto/fleet-job.dto.ts
@@ -32,6 +32,14 @@ import {
  * The global `ValidationPipe` runs `forbidNonWhitelisted`, so adding a
  * field here is a wire-contract change: the corresponding `apps/web/e2e`
  * rejection specs must be reconciled in the same PR.
+ *
+ * Suspend-safe leases (self-build finding R7): the heartbeat and complete
+ * bodies REQUIRE `leaseGeneration`, the claim identity handed out with
+ * the lease. It is the one thing in this channel that is not a
+ * credential yet still decides whether a write lands, so it is validated
+ * as strictly as one: integer, at least 1, no default. A node built
+ * before this field existed is refused at the edge (400) rather than
+ * quietly accepted against whichever claim happens to be current.
  */
 
 /** Shared credential fields for every node-authenticated job call. */
@@ -100,6 +108,15 @@ export class FleetJobHeartbeatDto extends FleetJobNodeCredentialDto {
     @Min(FLEET_JOB_MIN_LEASE_TTL_SEC)
     @Max(FLEET_JOB_MAX_LEASE_TTL_SEC)
     leaseTtlSec?: number;
+
+    @ApiProperty({
+        minimum: 1,
+        description:
+            'Lease generation returned with the claim. A generation that is not the current one is refused with 409 stale-lease.',
+    })
+    @IsInt()
+    @Min(1)
+    leaseGeneration: number;
 }
 
 /** Request body for the PUBLIC `POST /api/fleet/jobs/:id/complete`. */
@@ -107,6 +124,15 @@ export class CompleteFleetJobDto extends FleetJobNodeCredentialDto {
     @ApiProperty({ description: 'false records a failure; the sweeper may still retry it.' })
     @IsBoolean()
     success: boolean;
+
+    @ApiProperty({
+        minimum: 1,
+        description:
+            'Lease generation returned with the claim. A generation that is not the current one is refused with 409 stale-lease and writes nothing.',
+    })
+    @IsInt()
+    @Min(1)
+    leaseGeneration: number;
 
     @ApiProperty({
         required: false,

--- a/apps/api/src/fleet/fleet-jobs.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.spec.ts
@@ -1,6 +1,8 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import type { FleetJobView } from '@ever-works/contracts';
+import { FLEET_JOB_STALE_LEASE_REASON } from '@ever-works/contracts';
 import { FleetJobsController } from './fleet-jobs.controller';
+import { FleetJobStaleLeaseError } from '@ever-works/agent/fleet';
 import type { FleetJobService } from '@ever-works/agent/fleet';
 
 /**
@@ -20,6 +22,8 @@ import type { FleetJobService } from '@ever-works/agent/fleet';
 const NODE_ID = '11111111-1111-4111-8111-111111111111';
 const JOB_ID = '22222222-2222-4222-8222-222222222222';
 const SECRET = 'a'.repeat(43);
+/** The claim identity every heartbeat/complete body must carry (suspend-safe leases). */
+const GENERATION = 3;
 // Frozen: `jobView()` is called on both sides of several assertions, and a
 // fresh `new Date()` per call would make them differ by a millisecond.
 const LEASE_EXPIRES_AT = '2026-07-26T00:00:00.000Z';
@@ -102,6 +106,7 @@ describe('FleetJobsController', () => {
             const result = await controller.heartbeat(JOB_ID, {
                 nodeId: NODE_ID,
                 secret: SECRET,
+                leaseGeneration: GENERATION,
             });
             expect(result).toEqual({ ok: true, job: jobView({ status: 'running' }) });
         });
@@ -109,19 +114,41 @@ describe('FleetJobsController', () => {
         it('maps a foreign or finished job to the SAME 401 as a bad credential', async () => {
             const controller = makeController({ heartbeatJob: jest.fn(async () => null) });
             await expect(
-                controller.heartbeat(JOB_ID, { nodeId: NODE_ID, secret: SECRET }),
+                controller.heartbeat(JOB_ID, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    leaseGeneration: GENERATION,
+                }),
             ).rejects.toBeInstanceOf(UnauthorizedException);
         });
 
-        it('threads the requested lease extension through', async () => {
+        it('threads the requested lease extension and the lease generation through', async () => {
             const heartbeatJob = jest.fn(async () => jobView());
             const controller = makeController({ heartbeatJob });
             await controller.heartbeat(JOB_ID, {
                 nodeId: NODE_ID,
                 secret: SECRET,
                 leaseTtlSec: 90,
+                leaseGeneration: GENERATION,
             });
-            expect(heartbeatJob).toHaveBeenCalledWith(NODE_ID, SECRET, JOB_ID, 90);
+            expect(heartbeatJob).toHaveBeenCalledWith(NODE_ID, SECRET, JOB_ID, 90, GENERATION);
+        });
+
+        it('surfaces a stale generation as 409 with the stable stale-lease reason', async () => {
+            const controller = makeController({
+                heartbeatJob: jest.fn(async () => {
+                    throw new FleetJobStaleLeaseError();
+                }),
+            });
+            const error: unknown = await controller
+                .heartbeat(JOB_ID, { nodeId: NODE_ID, secret: SECRET, leaseGeneration: 1 })
+                .catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getStatus()).toBe(409);
+            expect((error as ConflictException).getResponse()).toMatchObject({
+                statusCode: 409,
+                reason: FLEET_JOB_STALE_LEASE_REASON,
+            });
         });
     });
 
@@ -134,6 +161,7 @@ describe('FleetJobsController', () => {
                 secret: SECRET,
                 success: true,
                 result: { gateStatus: 'green' },
+                leaseGeneration: GENERATION,
             });
             expect(result.job.status).toBe('done');
             expect(completeJob).toHaveBeenCalledWith(
@@ -142,6 +170,7 @@ describe('FleetJobsController', () => {
                     success: true,
                     result: { gateStatus: 'green' },
                     error: null,
+                    leaseGeneration: GENERATION,
                 }),
             );
         });
@@ -154,9 +183,15 @@ describe('FleetJobsController', () => {
                 secret: SECRET,
                 success: false,
                 error: 'exit 1',
+                leaseGeneration: GENERATION,
             });
             expect(completeJob).toHaveBeenCalledWith(
-                expect.objectContaining({ success: false, error: 'exit 1', result: null }),
+                expect.objectContaining({
+                    success: false,
+                    error: 'exit 1',
+                    result: null,
+                    leaseGeneration: GENERATION,
+                }),
             );
         });
 
@@ -167,8 +202,31 @@ describe('FleetJobsController', () => {
                     nodeId: NODE_ID,
                     secret: SECRET,
                     success: true,
+                    leaseGeneration: GENERATION,
                 }),
             ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('surfaces a stale generation as 409 with the stable stale-lease reason', async () => {
+            const controller = makeController({
+                completeJob: jest.fn(async () => {
+                    throw new FleetJobStaleLeaseError();
+                }),
+            });
+            const error: unknown = await controller
+                .complete(JOB_ID, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    success: true,
+                    leaseGeneration: 1,
+                })
+                .catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getStatus()).toBe(409);
+            expect((error as ConflictException).getResponse()).toMatchObject({
+                statusCode: 409,
+                reason: FLEET_JOB_STALE_LEASE_REASON,
+            });
         });
     });
 
@@ -182,12 +240,18 @@ describe('FleetJobsController', () => {
         const messages: string[] = [];
         for (const call of [
             () => controller.lease({ nodeId: NODE_ID, secret: SECRET }),
-            () => controller.heartbeat(JOB_ID, { nodeId: NODE_ID, secret: SECRET }),
+            () =>
+                controller.heartbeat(JOB_ID, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    leaseGeneration: GENERATION,
+                }),
             () =>
                 controller.complete(JOB_ID, {
                     nodeId: NODE_ID,
                     secret: SECRET,
                     success: true,
+                    leaseGeneration: GENERATION,
                 }),
         ]) {
             await call().catch((error: Error) => messages.push(error.message));

--- a/apps/api/src/fleet/fleet-jobs.controller.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.ts
@@ -34,6 +34,15 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  * 401. That is deliberate — a differentiated error here would let an
  * attacker with a random uuid enumerate which nodes and jobs exist.
  *
+ * The ONE differentiated answer is `409 { reason: 'stale-lease' }`
+ * (suspend-safe leases, self-build finding R7), and it is reachable only
+ * by an authenticated node that IS the recorded holder of an active job
+ * but echoes a `leaseGeneration` that is no longer current — its claim
+ * lapsed while the machine slept and was re-issued. Nothing a foreign,
+ * unknown or superseded node sends can produce it, so it reveals nothing
+ * the 401 posture was protecting. The service throws it; nothing here
+ * catches it.
+ *
  *   POST /api/fleet/jobs/lease          atomic CAS claim, capability-filtered
  *   POST /api/fleet/jobs/:id/heartbeat  extend the claim (leased → running)
  *   POST /api/fleet/jobs/:id/complete   report success or failure
@@ -89,7 +98,7 @@ export class FleetJobsController {
     @Post(':id/heartbeat')
     @ApiOperation({
         summary:
-            'Extend the lease on a job this node holds (public, node-secret-authenticated). The first beat also acknowledges the claim, moving the job from leased to running.',
+            'Extend the lease on a job this node holds (public, node-secret-authenticated). The first beat also acknowledges the claim, moving the job from leased to running. Carries the leaseGeneration returned with the lease; a stale generation is refused with 409 stale-lease.',
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 600, ttl: 60_000 } })
@@ -97,7 +106,13 @@ export class FleetJobsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: FleetJobHeartbeatDto,
     ): Promise<FleetJobHeartbeatResponse> {
-        const job = await this.service.heartbeatJob(body.nodeId, body.secret, id, body.leaseTtlSec);
+        const job = await this.service.heartbeatJob(
+            body.nodeId,
+            body.secret,
+            id,
+            body.leaseTtlSec,
+            body.leaseGeneration,
+        );
         if (!job) {
             throw new UnauthorizedException('Invalid node credential');
         }
@@ -108,7 +123,7 @@ export class FleetJobsController {
     @Post(':id/complete')
     @ApiOperation({
         summary:
-            'Report the terminal outcome of a job this node holds (public, node-secret-authenticated). A reported failure is recorded as failed and NOT auto-retried — only lapsed leases (no verdict at all) go back to the pool.',
+            'Report the terminal outcome of a job this node holds (public, node-secret-authenticated). A reported failure is recorded as failed and NOT auto-retried — only lapsed leases (no verdict at all) go back to the pool. Carries the leaseGeneration returned with the lease; a stale generation is refused with 409 stale-lease and writes nothing.',
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 240, ttl: 60_000 } })
@@ -123,6 +138,7 @@ export class FleetJobsController {
             success: body.success,
             result: body.result ?? null,
             error: body.error ?? null,
+            leaseGeneration: body.leaseGeneration,
         });
         if (!job) {
             throw new UnauthorizedException('Invalid node credential');

--- a/apps/api/src/migrations/1788400000000-AddFleetJobLeaseGeneration.ts
+++ b/apps/api/src/migrations/1788400000000-AddFleetJobLeaseGeneration.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Suspend-safe leases (self-build program note §6, finding R7) —
+ * `fleet_jobs.leaseGeneration`.
+ *
+ * Desk PCs sleep. A suspended node stops heart-beating, its 300 s lease
+ * lapses, the job is reclaimed and leased again — possibly to the SAME
+ * machine once it wakes and polls — while the first model run is still
+ * going and only learns it lost the claim minutes later. `nodeId` alone
+ * cannot tell the two claims apart. This column can: every successful
+ * claim writes `previous + 1`, the node echoes the value on heartbeat
+ * and complete, and `FleetJobRepository.extendLease` / `complete` pin it
+ * in their WHERE clause so a stale holder matches zero rows.
+ *
+ * Additive, `NOT NULL DEFAULT 0`, no index: it is only ever read on the
+ * primary-key path. Every existing row backfills to 0, which is "no
+ * claim minted under the new protocol" — a row that was leased at
+ * deploy time is deliberately refused on its next heartbeat (0 is never
+ * a valid generation) so its in-flight run aborts and the job is
+ * re-offered under generation 1. Forward-only with a guard so a
+ * partially applied database converges; portable `TableColumn` DDL
+ * because the e2e stack and CI run better-sqlite3 while production runs
+ * Postgres.
+ */
+export class AddFleetJobLeaseGeneration1788400000000 implements MigrationInterface {
+    name = 'AddFleetJobLeaseGeneration1788400000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const jobs = await queryRunner.getTable('fleet_jobs');
+        if (jobs && !jobs.findColumnByName('leaseGeneration')) {
+            await queryRunner.addColumn(
+                'fleet_jobs',
+                new TableColumn({
+                    name: 'leaseGeneration',
+                    type: 'int',
+                    default: 0,
+                    isNullable: false,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const jobs = await queryRunner.getTable('fleet_jobs');
+        if (jobs?.findColumnByName('leaseGeneration')) {
+            await queryRunner.dropColumn('fleet_jobs', 'leaseGeneration');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddFleetJobLeaseGeneration.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddFleetJobLeaseGeneration.spec.ts
@@ -1,0 +1,99 @@
+import { DataSource, Table } from 'typeorm';
+import { AddFleetJobLeaseGeneration1788400000000 } from '../1788400000000-AddFleetJobLeaseGeneration';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling fleet migration
+ * specs. What matters: existing jobs survive at generation 0 (no claim
+ * minted under the new protocol — which the service refuses, by design),
+ * the column is NOT NULL so no row can ever read "unknown generation",
+ * re-running is a no-op, and `down()` reverses it without touching rows.
+ */
+describe('AddFleetJobLeaseGeneration1788400000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddFleetJobLeaseGeneration1788400000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'fleet_jobs',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'status', type: 'varchar', length: '16' },
+                    { name: 'nodeId', type: 'uuid', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO fleet_jobs (id, "userId", status, "nodeId") VALUES (?, ?, ?, ?)`,
+            ['job-1', 'user-1', 'running', 'node-1'],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    it('adds a NOT NULL leaseGeneration that backfills existing jobs to generation 0', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        const jobs = await runner.getTable('fleet_jobs');
+        await runner.release();
+        expect(jobs?.findColumnByName('leaseGeneration')).toMatchObject({
+            isNullable: false,
+            type: 'int',
+        });
+        expect(
+            await dataSource.query(
+                `SELECT id, status, "nodeId", "leaseGeneration" FROM fleet_jobs WHERE id = ?`,
+                ['job-1'],
+            ),
+        ).toEqual([{ id: 'job-1', status: 'running', nodeId: 'node-1', leaseGeneration: 0 }]);
+    });
+
+    it('lets a new claim be minted as previous + 1 on the migrated table', async () => {
+        await runUp();
+        // The lease CAS the service performs: pin the generation it read,
+        // write the next one. A plain UPDATE is enough to prove the column
+        // accepts the protocol's writes on this driver.
+        const result: unknown = await dataSource.query(
+            `UPDATE fleet_jobs SET "leaseGeneration" = 1 WHERE id = ? AND "leaseGeneration" = 0`,
+            ['job-1'],
+        );
+        expect(result).toBeDefined();
+        expect(
+            await dataSource.query(`SELECT "leaseGeneration" FROM fleet_jobs WHERE id = ?`, [
+                'job-1',
+            ]),
+        ).toEqual([{ leaseGeneration: 1 }]);
+    });
+
+    it('is idempotent and down() drops the column without touching rows', async () => {
+        await runUp();
+        await expect(runUp()).resolves.not.toThrow();
+
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        const jobs = await runner.getTable('fleet_jobs');
+        await runner.release();
+        expect(jobs?.findColumnByName('leaseGeneration')).toBeUndefined();
+        expect(await dataSource.query(`SELECT id FROM fleet_jobs WHERE id = ?`, ['job-1'])).toEqual(
+            [{ id: 'job-1' }],
+        );
+    });
+});

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -34,7 +34,13 @@ export type FleetErrorKind =
 	| 'rate-limited'
 	| 'server'
 	| 'network'
-	| 'malformed';
+	| 'malformed'
+	/**
+	 * 409 from a job heartbeat/complete: the platform holds a NEWER lease on
+	 * the job than the one this node is renewing or finalizing (suspend-safe
+	 * leases). The claim is void; the worker aborts the run at once.
+	 */
+	| 'stale-lease';
 
 export class FleetClientError extends Error {
 	readonly kind: FleetErrorKind;

--- a/apps/node/src/core/job-client.spec.ts
+++ b/apps/node/src/core/job-client.spec.ts
@@ -58,6 +58,93 @@ describe('FleetJobClient heartbeat lease proof', () => {
 	});
 });
 
+describe('FleetJobClient lease generation (suspend-safe leases)', () => {
+	function capturing(status: number, body: unknown): { fetchFn: FetchLike; bodies: Array<Record<string, unknown>> } {
+		const bodies: Array<Record<string, unknown>> = [];
+		const fetchFn: FetchLike = async (_url, init) => {
+			bodies.push(JSON.parse(init.body) as Record<string, unknown>);
+			return { ok: status < 400, status, text: async () => JSON.stringify(body) };
+		};
+		return { fetchFn, bodies };
+	}
+
+	it('sends the generation on heartbeat and complete when the lease carried one', async () => {
+		const { fetchFn, bodies } = capturing(200, { ok: true, job: job('2026-08-23T00:30:45.123Z') });
+		const client = new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn,
+			timeoutMs: 0
+		});
+
+		await client.heartbeat('job-1', 30, 4);
+		await client.complete('job-1', { success: true, result: { ok: true } }, 4);
+
+		expect(bodies[0]).toMatchObject({ nodeId: NODE_ID, leaseTtlSec: 30, leaseGeneration: 4 });
+		expect(bodies[1]).toMatchObject({ nodeId: NODE_ID, success: true, leaseGeneration: 4 });
+	});
+
+	it('omits the field entirely when the lease carried none (an older API would 400 an unknown field)', async () => {
+		const { fetchFn, bodies } = capturing(200, { ok: true, job: job('2026-08-23T00:30:45.123Z') });
+		const client = new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn,
+			timeoutMs: 0
+		});
+
+		await client.heartbeat('job-1', 30);
+		await client.complete('job-1', { success: false, error: 'exit 1' });
+
+		expect(bodies[0]).not.toHaveProperty('leaseGeneration');
+		expect(bodies[1]).not.toHaveProperty('leaseGeneration');
+	});
+
+	it('THROWS stale-lease on a 409 from heartbeat rather than collapsing it to null', async () => {
+		const client = new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn: response(409, { statusCode: 409, reason: 'stale-lease', message: 'private detail' }),
+			timeoutMs: 0
+		});
+
+		const error: unknown = await client.heartbeat('job-1', 30, 1).catch((e: unknown) => e);
+		expect(error).toMatchObject({ name: 'FleetClientError', kind: 'stale-lease', status: 409 });
+		// The posture holds: nothing the server wrote reaches the message.
+		expect((error as Error).message).not.toContain('private detail');
+	});
+
+	it('THROWS stale-lease on a 409 from complete', async () => {
+		const client = new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn: response(409, { statusCode: 409, reason: 'stale-lease', message: 'private detail' }),
+			timeoutMs: 0
+		});
+
+		await expect(client.complete('job-1', { success: true }, 1)).rejects.toMatchObject({
+			kind: 'stale-lease',
+			status: 409
+		});
+	});
+
+	it('still maps every other 4xx to invalid-request', async () => {
+		const client = new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn: response(400, { message: ['leaseGeneration must be an integer'] }),
+			timeoutMs: 0
+		});
+
+		await expect(client.heartbeat('job-1', 30, 1)).rejects.toMatchObject({ kind: 'invalid-request', status: 400 });
+	});
+});
+
 describe('FleetJobClient lease cancellation', () => {
 	it('composes the worker AbortSignal with the request timeout for a real lease fetch', async () => {
 		let observedSignal: AbortSignal | undefined;

--- a/apps/node/src/core/job-client.ts
+++ b/apps/node/src/core/job-client.ts
@@ -22,6 +22,13 @@ import { MAX_CREDENTIAL_LENGTH, MIN_CREDENTIAL_LENGTH } from './types';
  * echoes a server body into an error message, so nothing about which
  * check failed can leak into a node's logs.
  *
+ * The one differentiated answer is `409` (suspend-safe leases): the
+ * `leaseGeneration` the node echoes on heartbeat/complete is no longer
+ * the job's current one, so the claim it holds is void. It is mapped to
+ * `FleetClientError('stale-lease')` from the STATUS alone — the body is
+ * never read — and it is thrown rather than collapsed to null, because
+ * the worker needs the reason to abort the run without reporting.
+ *
  * Wire shapes come from `@ever-works/contracts`, not a local mirror:
  * this is the one part of the node↔platform contract that carries
  * executable work, and a silent drift here would mean a node running
@@ -111,10 +118,18 @@ export class FleetJobClient {
 	 * revoked credential). A lost lease is a protocol outcome rather than a
 	 * transport exception; the worker aborts the shared task signal before the
 	 * platform can offer that job elsewhere.
+	 *
+	 * `leaseGeneration` is the claim identity the lease came with. Sent
+	 * only when the lease carried one (an older API neither issues nor
+	 * accepts the field), and a `409` answer — the platform re-issued the
+	 * claim while this run kept going — THROWS `stale-lease` rather than
+	 * returning null, so the worker can tell "abort, and do not report"
+	 * from "abort, and report".
 	 */
-	async heartbeat(jobId: string, leaseTtlSec?: number): Promise<FleetJobView | null> {
+	async heartbeat(jobId: string, leaseTtlSec?: number, leaseGeneration?: number): Promise<FleetJobView | null> {
 		const body: Record<string, unknown> = { nodeId: this.nodeId, secret: this.secret };
 		if (leaseTtlSec !== undefined) body.leaseTtlSec = leaseTtlSec;
+		if (leaseGeneration !== undefined) body.leaseGeneration = leaseGeneration;
 		try {
 			const payload = (await this.post(
 				`api/fleet/jobs/${encodeURIComponent(jobId)}/heartbeat`,
@@ -133,10 +148,15 @@ export class FleetJobClient {
 		}
 	}
 
-	/** Report the terminal outcome of a job. */
+	/**
+	 * Report the terminal outcome of a job. `leaseGeneration` as for
+	 * {@link heartbeat}; a `409` throws `stale-lease` — the platform wrote
+	 * nothing, and the worker must not retry with a failure report either.
+	 */
 	async complete(
 		jobId: string,
-		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null }
+		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null },
+		leaseGeneration?: number
 	): Promise<boolean> {
 		const body: Record<string, unknown> = {
 			nodeId: this.nodeId,
@@ -145,6 +165,7 @@ export class FleetJobClient {
 		};
 		if (outcome.success && outcome.result) body.result = outcome.result;
 		if (!outcome.success && outcome.error) body.error = outcome.error;
+		if (leaseGeneration !== undefined) body.leaseGeneration = leaseGeneration;
 
 		const payload = (await this.post(
 			`api/fleet/jobs/${encodeURIComponent(jobId)}/complete`,
@@ -228,6 +249,16 @@ export function errorForJobStatus(status: number, operation: string): FleetClien
 	}
 	if (status === 429) {
 		return new FleetClientError('rate-limited', 'Rate limited by the API — backing off', status);
+	}
+	if (status === 409) {
+		// Keyed on the status, never on the body: the reason token in the
+		// 409 is stable by contract (`FLEET_JOB_STALE_LEASE_REASON`) but the
+		// posture of this client is to surface nothing the server wrote.
+		return new FleetClientError(
+			'stale-lease',
+			'The platform holds a newer lease on this job (stale-lease); the claim this node is renewing or finalizing is void',
+			status
+		);
 	}
 	if (status >= 400 && status < 500) {
 		return new FleetClientError('invalid-request', `Request rejected by the API (HTTP ${status})`, status);

--- a/apps/node/src/core/worker-loop.spec.ts
+++ b/apps/node/src/core/worker-loop.spec.ts
@@ -5,11 +5,14 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FleetJobView } from '@ever-works/contracts';
+import { FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON, FLEET_JOB_STALE_LEASE_REASON } from '@ever-works/contracts';
 import { execFileWithVerifiedCancellation } from '@ever-works/local-workspace-plugin';
 import {
+	isSuspendGap,
 	LEASE_TERMINATION_SAFETY_MS,
 	nextBackoffMs,
 	PUBLISH_FENCE_MARGIN_MS,
+	SUSPEND_GAP_THRESHOLD_MS,
 	WorkerLoop,
 	type JobLeaseCapableClient,
 	type JobLeaseHandle
@@ -35,9 +38,11 @@ import { terminateNodeProcessTree } from './executors/acceptance-checks';
 function controllableScheduler(): Scheduler & {
 	delays: number[];
 	runNext(): void;
+	/** Fire the oldest pending timer that was armed with exactly `ms`; false when there is none. */
+	runDelay(ms: number): boolean;
 	pending: number;
 } {
-	const queue: Array<{ id: number; callback: () => void }> = [];
+	const queue: Array<{ id: number; ms: number; callback: () => void }> = [];
 	const delays: number[] = [];
 	let nextId = 1;
 
@@ -49,7 +54,7 @@ function controllableScheduler(): Scheduler & {
 		setTimeout(callback: () => void, ms: number): unknown {
 			delays.push(ms);
 			const id = nextId++;
-			queue.push({ id, callback });
+			queue.push({ id, ms, callback });
 			return id;
 		},
 		clearTimeout(handle: unknown): void {
@@ -59,6 +64,13 @@ function controllableScheduler(): Scheduler & {
 		runNext(): void {
 			const entry = queue.shift();
 			entry?.callback();
+		},
+		runDelay(ms: number): boolean {
+			const index = queue.findIndex((entry) => entry.ms === ms);
+			if (index < 0) return false;
+			const [entry] = queue.splice(index, 1);
+			entry!.callback();
+			return true;
 		}
 	};
 }
@@ -1245,5 +1257,530 @@ describe('WorkerLoop', () => {
 		const loop = new WorkerLoop({ client, scheduler: controllableScheduler() });
 		loop.register('acceptance-checks', async () => undefined);
 		expect(loop.registeredKinds).toEqual(['acceptance-checks']);
+	});
+});
+
+describe('isSuspendGap', () => {
+	it('reads a wall clock that ran far ahead of the monotonic clock as a suspend', () => {
+		// CLOCK_MONOTONIC on Linux/macOS stops through S3/S4: the machine
+		// slept an hour and the monotonic clock saw only the awake seconds.
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: 3_600_000, monotonicElapsedMs: 5_000 })).toBe(true);
+	});
+
+	it('reads a timer that fired far later than armed as a suspend even when both clocks advanced', () => {
+		// Windows QPC advances across a suspend, so the difference says
+		// nothing; the lateness against the armed delay still does.
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: 3_600_000, monotonicElapsedMs: 3_600_000 })).toBe(true);
+	});
+
+	it('does not read ordinary jitter or a gap under the threshold as a suspend', () => {
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: 5_040, monotonicElapsedMs: 5_040 })).toBe(false);
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: 20_000, monotonicElapsedMs: 5_000 })).toBe(false);
+		expect(
+			isSuspendGap({
+				armedForMs: 5_000,
+				wallElapsedMs: 5_000 + SUSPEND_GAP_THRESHOLD_MS,
+				monotonicElapsedMs: 5_000
+			})
+		).toBe(false);
+	});
+
+	it('degrades to "no resume noticed" on a broken wall clock, and still uses lateness when only the monotonic one is broken', () => {
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: Number.NaN, monotonicElapsedMs: 0 })).toBe(false);
+		expect(isSuspendGap({ armedForMs: 5_000, wallElapsedMs: 3_600_000, monotonicElapsedMs: Number.NaN })).toBe(
+			true
+		);
+	});
+});
+
+describe('WorkerLoop — suspend-safe leases', () => {
+	const staleLease = () =>
+		Object.assign(new Error('Request rejected by the API (HTTP 409)'), { kind: 'stale-lease', status: 409 });
+
+	/**
+	 * A running job with a deferred executor, two injectable clocks and the
+	 * controllable scheduler. After `start()` the queue holds the keep-alive
+	 * beat, the keep-alive deadline and the loop's own zero-delay re-arm (a
+	 * full batch was leased); the loop timer is the one that fires first on a
+	 * real wake-up, because the beat is still counting down AWAKE seconds.
+	 */
+	async function runningJob(options: { leaseMs: number; leaseTtlSec?: number; leaseGeneration?: number }) {
+		const startedAt = Date.parse('2026-09-05T08:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const clocks = { wall: startedAt, monotonic: 0 };
+		const leasedJob = job({
+			leaseExpiresAt: new Date(startedAt + options.leaseMs).toISOString(),
+			...(options.leaseGeneration !== undefined ? { leaseGeneration: options.leaseGeneration } : {})
+		});
+		const client = scriptedClient([[leasedJob], []]);
+		const executor = deferred<Record<string, unknown>>();
+		let jobSignal: AbortSignal | undefined;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			...(options.leaseTtlSec !== undefined ? { leaseTtlSec: options.leaseTtlSec } : {}),
+			idlePollMs: 60_000,
+			now: () => clocks.wall,
+			monotonicNow: () => clocks.monotonic
+		});
+		loop.register('acceptance-checks', (_job, signal) => {
+			jobSignal = signal;
+			return executor.promise;
+		});
+		await loop.start();
+		await vi.waitFor(() => expect(jobSignal).toBeDefined());
+		return { startedAt, scheduler, clocks, client, executor, loop, signal: () => jobSignal! };
+	}
+
+	it('aborts a job whose lease lapsed while the machine slept the moment the loop timer fires on resume', async () => {
+		const { startedAt, scheduler, clocks, client, executor, loop, signal } = await runningJob({
+			leaseMs: 30_000,
+			leaseTtlSec: 30,
+			leaseGeneration: 3
+		});
+		expect(client.heartbeat).not.toHaveBeenCalled();
+
+		// The lid closes for an hour. The wall clock jumps; the monotonic one
+		// saw five awake seconds. The keep-alive beat (armed for +10s) has
+		// not fired — it is still counting awake milliseconds — so without
+		// the loop-level detector the model would keep running for most of a
+		// keep-alive interval after wake.
+		clocks.wall = startedAt + 3_600_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+
+		expect(signal().aborted).toBe(true);
+		expect((signal().reason as Error).message).toBe(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON);
+		// Nothing was asked of the platform: the deadline had passed on this
+		// node's own clock, and the claim is treated as gone.
+		expect(client.heartbeat).not.toHaveBeenCalled();
+
+		executor.resolve({ pushed: 'nothing, the abort landed first' });
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(client.complete).toHaveBeenCalledTimes(1);
+		expect(client.complete).toHaveBeenCalledWith(
+			'job-1',
+			{ success: false, error: FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON },
+			3
+		);
+		expect(loop.getState().completed).toBe(0);
+		expect(loop.getState().lastError).toBe(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON);
+		await loop.stop();
+	});
+
+	it('does not read a short gap as a suspend', async () => {
+		const { startedAt, scheduler, clocks, client, executor, loop, signal } = await runningJob({
+			leaseMs: 300_000,
+			leaseGeneration: 3
+		});
+
+		// Twenty wall seconds against five awake ones: a busy scheduler, a
+		// GC pause, a brief lid-close — under the threshold, not a resume.
+		clocks.wall = startedAt + 20_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+
+		expect(signal().aborted).toBe(false);
+		expect(client.heartbeat).not.toHaveBeenCalled();
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().completed).toBe(1));
+		expect(client.complete).toHaveBeenCalledWith('job-1', { success: true, result: { ok: true } }, 3);
+		expect(loop.getState().failed).toBe(0);
+		await loop.stop();
+	});
+
+	it('re-confirms the claim with one immediate heartbeat when the machine resumes inside the lease', async () => {
+		const { startedAt, scheduler, clocks, client, executor, loop, signal } = await runningJob({
+			leaseMs: 300_000,
+			leaseGeneration: 3
+		});
+		client.heartbeat.mockResolvedValue(
+			job({
+				status: 'running',
+				leaseExpiresAt: new Date(startedAt + 120_000 + 300_000).toISOString(),
+				leaseGeneration: 3
+			})
+		);
+
+		// Two minutes asleep, three minutes of claim left on paper. The local
+		// deadline saw nothing; the platform may still have moved on. Ask.
+		clocks.wall = startedAt + 120_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+
+		await vi.waitFor(() => expect(client.heartbeat).toHaveBeenCalledTimes(1));
+		expect(client.heartbeat).toHaveBeenCalledWith('job-1', 300, 3);
+		expect(signal().aborted).toBe(false);
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().completed).toBe(1));
+		expect(loop.getState().failed).toBe(0);
+		await loop.stop();
+	});
+
+	it('aborts without reporting when the resume-time re-confirmation is answered stale-lease', async () => {
+		const { startedAt, scheduler, clocks, client, executor, loop, signal } = await runningJob({
+			leaseMs: 300_000,
+			leaseGeneration: 3
+		});
+		client.heartbeat.mockRejectedValue(staleLease());
+
+		clocks.wall = startedAt + 120_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+
+		await vi.waitFor(() => expect(client.heartbeat).toHaveBeenCalledTimes(1));
+		await vi.waitFor(() => expect(signal().aborted).toBe(true));
+		expect((signal().reason as Error).message).toBe(FLEET_JOB_STALE_LEASE_REASON);
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		// The platform holds a newer claim; a failure report would only be
+		// refused again. Nothing is sent.
+		expect(client.complete).not.toHaveBeenCalled();
+		expect(loop.getState().completed).toBe(0);
+		expect(loop.getState().lastError).toBe(FLEET_JOB_STALE_LEASE_REASON);
+		await loop.stop();
+	});
+
+	it('aborts at once when a scheduled heartbeat is answered stale-lease, and sends no report', async () => {
+		const client = scriptedClient([[job({ leaseGeneration: 2 })], []]);
+		client.heartbeat.mockRejectedValue(staleLease());
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler, leaseTtlSec: 30 });
+		const executor = deferred<Record<string, unknown>>();
+		let jobSignal: AbortSignal | undefined;
+		loop.register('acceptance-checks', (_job, signal) => {
+			jobSignal = signal;
+			return executor.promise;
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(jobSignal).toBeDefined());
+		scheduler.runNext();
+		await vi.waitFor(() => expect(client.heartbeat).toHaveBeenCalledWith('job-1', 30, 2));
+		await vi.waitFor(() => expect(jobSignal?.aborted).toBe(true));
+		expect((jobSignal?.reason as Error).message).toBe(FLEET_JOB_STALE_LEASE_REASON);
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(client.complete).not.toHaveBeenCalled();
+		expect(loop.getState().completed).toBe(0);
+		await loop.stop();
+	});
+
+	it('collapses the claim and aborts when the publish-time confirmation is answered stale-lease', async () => {
+		const startedAt = Date.parse('2026-09-05T09:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const leasedJob = job({ leaseExpiresAt: new Date(startedAt + 300_000).toISOString(), leaseGeneration: 4 });
+		const client = scriptedClient([[leasedJob], []]);
+		client.heartbeat.mockRejectedValue(staleLease());
+		let confirmed: number | undefined;
+		let jobSignal: AbortSignal | undefined;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			idlePollMs: 60_000,
+			now: () => startedAt,
+			monotonicNow: () => startedAt
+		});
+		loop.register('acceptance-checks', async (_job, signal, handle) => {
+			jobSignal = signal;
+			confirmed = await handle?.confirmDeadline();
+			return { ok: true };
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(confirmed).toBeDefined());
+
+		// Five minutes on paper; the platform says the claim was re-issued.
+		// The fence must be told NOW, so nothing is pushed against it.
+		expect(client.heartbeat).toHaveBeenCalledWith('job-1', 300, 4);
+		expect(confirmed).toBe(startedAt);
+		expect(jobSignal?.aborted).toBe(true);
+		expect((jobSignal?.reason as Error).message).toBe(FLEET_JOB_STALE_LEASE_REASON);
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(client.complete).not.toHaveBeenCalled();
+		await loop.stop();
+	});
+
+	it('does not follow a stale-lease refusal of its success report with a failure report', async () => {
+		const client = scriptedClient([[job({ leaseGeneration: 5 })], []]);
+		client.complete.mockRejectedValue(staleLease());
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler });
+		loop.register('acceptance-checks', async () => ({ gateStatus: 'green' }));
+
+		await loop.start();
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+
+		expect(client.complete).toHaveBeenCalledTimes(1);
+		expect(client.complete).toHaveBeenCalledWith('job-1', { success: true, result: { gateStatus: 'green' } }, 5);
+		expect(loop.getState().completed).toBe(0);
+		expect(loop.getState().lastError).toContain(FLEET_JOB_STALE_LEASE_REASON);
+		await loop.stop();
+	});
+
+	it('calls heartbeat and complete with their original arity when the lease carried no generation', async () => {
+		const client = scriptedClient([[job()], []]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({ client, scheduler, leaseTtlSec: 30 });
+		const executor = deferred<Record<string, unknown>>();
+		loop.register('acceptance-checks', () => executor.promise);
+
+		await loop.start();
+		scheduler.runNext();
+		await vi.waitFor(() => expect(client.heartbeat).toHaveBeenCalledTimes(1));
+		expect(client.heartbeat.mock.calls[0]).toEqual(['job-1', 30]);
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().completed).toBe(1));
+		expect(client.complete.mock.calls[0]).toEqual(['job-1', { success: true, result: { ok: true } }]);
+		await loop.stop();
+	});
+
+	it('kills a production agent-task command on resume when the lease lapsed during the suspend', async () => {
+		const startedAt = Date.parse('2026-09-05T10:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const clocks = { wall: startedAt, monotonic: 0 };
+		const workspacePath = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';
+		const leasedJob = job({
+			kind: 'agent-task',
+			leaseExpiresAt: new Date(startedAt + 30_000).toISOString(),
+			leaseGeneration: 3,
+			payload: {
+				taskId: 'task-suspend',
+				workspacePath,
+				steps: [{ id: 'blocking', command: 'blocking' }]
+			}
+		});
+		const client = scriptedClient([[leasedJob], []]);
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			leaseTtlSec: 30,
+			idlePollMs: 60_000,
+			now: () => clocks.wall,
+			monotonicNow: () => clocks.monotonic
+		});
+		let spawned = false;
+		const terminateProcessTree = vi.fn(async (child: ChildProcess) => {
+			child.kill('SIGKILL');
+		});
+		const spawnFn = (() => {
+			spawned = true;
+			const handlers = new Map<string, (arg?: unknown) => void>();
+			return {
+				pid: 4747,
+				stdout: { on: () => undefined, destroy: () => undefined },
+				stderr: { on: () => undefined, destroy: () => undefined },
+				on: (event: string, handler: (arg?: unknown) => void) => handlers.set(event, handler),
+				kill: () => {
+					queueMicrotask(() => {
+						handlers.get('exit')?.(null);
+						handlers.get('close')?.(null);
+					});
+				}
+			};
+		}) as never;
+		loop.register('agent-task', (leased, signal) =>
+			runAgentTaskJob(leased, { directoryExists: () => true, spawnFn, terminateProcessTree }, signal)
+		);
+
+		await loop.start();
+		await vi.waitFor(() => expect(spawned).toBe(true));
+
+		clocks.wall = startedAt + 3_600_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(terminateProcessTree).toHaveBeenCalledOnce();
+		expect(client.heartbeat).not.toHaveBeenCalled();
+		expect(client.complete).toHaveBeenCalledTimes(1);
+		expect(client.complete).toHaveBeenCalledWith(
+			'job-1',
+			expect.objectContaining({
+				success: false,
+				error: expect.stringContaining(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON)
+			}),
+			3
+		);
+		expect(loop.getState().completed).toBe(0);
+		expect(loop.cancelJob('job-1')).toBe(false);
+		await loop.stop();
+	});
+
+	it('notices a suspend that lands while a lease request is in flight, once that request settles', async () => {
+		// The loop timer is not pending while `lease()` is out, so the
+		// detector in `scheduleNext` cannot see a suspend that starts here.
+		// The poll reads its own span instead: the request settles after
+		// wake, the gap is an hour, and the lapsed job is stopped at once
+		// rather than when its keep-alive beat happens to fire.
+		const startedAt = Date.parse('2026-09-05T12:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const clocks = { wall: startedAt, monotonic: 0 };
+		const leasedJob = job({ leaseExpiresAt: new Date(startedAt + 30_000).toISOString(), leaseGeneration: 3 });
+		const secondLease = deferred<FleetJobView[]>();
+		let leaseCalls = 0;
+		const complete = vi.fn(async () => true);
+		const heartbeat = vi.fn(async () => job({ status: 'running' }));
+		const client: JobLeaseCapableClient = {
+			complete,
+			heartbeat,
+			lease: async () => {
+				leaseCalls += 1;
+				return leaseCalls === 1 ? [leasedJob] : secondLease.promise;
+			}
+		};
+		const executor = deferred<Record<string, unknown>>();
+		let jobSignal: AbortSignal | undefined;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			concurrency: 2,
+			leaseTtlSec: 30,
+			idlePollMs: 60_000,
+			now: () => clocks.wall,
+			monotonicNow: () => clocks.monotonic
+		});
+		loop.register('acceptance-checks', (_job, signal) => {
+			jobSignal = signal;
+			return executor.promise;
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(jobSignal).toBeDefined());
+		// Headroom for a second job, so the immediate re-poll actually asks
+		// the platform — and is still waiting on the answer when the lid
+		// closes. Nothing has moved on either clock yet: not a resume.
+		expect(scheduler.runDelay(0)).toBe(true);
+		await vi.waitFor(() => expect(leaseCalls).toBe(2));
+		expect(jobSignal!.aborted).toBe(false);
+
+		clocks.wall = startedAt + 3_600_000;
+		clocks.monotonic = 5_000;
+		secondLease.resolve([]);
+
+		await vi.waitFor(() => expect(jobSignal!.aborted).toBe(true));
+		expect((jobSignal!.reason as Error).message).toBe(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON);
+		expect(heartbeat).not.toHaveBeenCalled();
+
+		executor.resolve({});
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(complete).toHaveBeenCalledWith(
+			'job-1',
+			{ success: false, error: FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON },
+			3
+		);
+		await loop.stop();
+	});
+
+	it('keeps a same-job re-lease alive while the lapsed run it replaces is still tearing down', async () => {
+		// Reclaim runs inline on the node's OWN lease poll, so the first poll
+		// after a resume hands the job this node slept through straight back
+		// to it under the next generation — while the lapsed run is still
+		// killing its model process. With headroom for two jobs the same id
+		// is then in flight twice, and nothing the OLD run does on its way
+		// out (its refused report, its keep-alive noticing it lost the claim)
+		// may abort or silence the NEW claim.
+		const startedAt = Date.parse('2026-09-05T11:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const clocks = { wall: startedAt, monotonic: 0 };
+		const first = job({ leaseExpiresAt: new Date(startedAt + 30_000).toISOString(), leaseGeneration: 1 });
+		const second = job({
+			leaseExpiresAt: new Date(startedAt + 3_600_000 + 30_000).toISOString(),
+			leaseGeneration: 2
+		});
+		const client = scriptedClient([[first], [second], []]);
+		client.complete.mockImplementation(async (_jobId: string, _outcome: unknown, generation?: number) => {
+			if (generation === 1) throw staleLease();
+			return true;
+		});
+		const runs: Array<{ signal: AbortSignal; executor: ReturnType<typeof deferred<Record<string, unknown>>> }> = [];
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			concurrency: 2,
+			leaseTtlSec: 30,
+			idlePollMs: 60_000,
+			now: () => clocks.wall,
+			monotonicNow: () => clocks.monotonic
+		});
+		loop.register('acceptance-checks', (_job, signal) => {
+			const executor = deferred<Record<string, unknown>>();
+			runs.push({ signal, executor });
+			return executor.promise;
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(runs).toHaveLength(1));
+
+		// Resume after an hour: the loop timer aborts the lapsed run and the
+		// poll it triggers re-leases the same job under generation 2.
+		clocks.wall = startedAt + 3_600_000;
+		clocks.monotonic = 5_000;
+		expect(scheduler.runDelay(0)).toBe(true);
+		expect(runs[0]!.signal.aborted).toBe(true);
+		await vi.waitFor(() => expect(client.leaseCalls).toBe(2));
+
+		// The old run's executor finally notices the abort and returns; its
+		// claim is void, so its report is not sent (the platform would only
+		// answer stale-lease) — and above all the fresh claim is untouched.
+		runs[0]!.executor.resolve({});
+		await vi.waitFor(() => expect(runs).toHaveLength(2));
+		expect(runs[1]!.signal.aborted).toBe(false);
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(client.complete).not.toHaveBeenCalledWith('job-1', expect.anything(), 1);
+		expect(runs[1]!.signal.aborted).toBe(false);
+		expect(loop.getState().activeJobIds).toEqual(['job-1']);
+
+		runs[1]!.executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().completed).toBe(1));
+		expect(client.complete).toHaveBeenCalledTimes(1);
+		expect(client.complete).toHaveBeenCalledWith('job-1', { success: true, result: { ok: true } }, 2);
+		expect(loop.getState().activeJobIds).toEqual([]);
+		await loop.stop();
+	});
+
+	it('collapses the local publish deadline the moment a run is aborted, even with minutes left on paper', async () => {
+		// A run voided by a same-node re-lease, or cancelled by an operator, is
+		// aborted straight through its controller — not through a refused
+		// beat, so nothing in the keep-alive has told the deadline anything.
+		// `confirmDeadline` deliberately stops re-asking the platform once the
+		// signal is aborted, so the fence must be told NOW rather than handed
+		// the five healthy minutes the wire still shows.
+		const startedAt = Date.parse('2026-09-05T13:00:00.000Z');
+		const scheduler = controllableScheduler();
+		const leasedJob = job({ leaseExpiresAt: new Date(startedAt + 300_000).toISOString(), leaseGeneration: 2 });
+		const client = scriptedClient([[leasedJob], []]);
+		const executor = deferred<Record<string, unknown>>();
+		let lease: JobLeaseHandle | undefined;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			idlePollMs: 60_000,
+			now: () => startedAt,
+			monotonicNow: () => 0
+		});
+		loop.register('acceptance-checks', (_job, _signal, handle) => {
+			lease = handle;
+			return executor.promise;
+		});
+
+		await loop.start();
+		await vi.waitFor(() => expect(lease).toBeDefined());
+		expect(lease!.deadlineAt()).toBe(startedAt + 300_000);
+
+		expect(loop.cancelJob('job-1', 'operator cancellation')).toBe(true);
+		expect(lease!.deadlineAt()).toBe(startedAt);
+		await expect(lease!.confirmDeadline()).resolves.toBe(startedAt);
+		expect(client.heartbeat).not.toHaveBeenCalled();
+
+		executor.resolve({ ok: true });
+		await vi.waitFor(() => expect(loop.getState().failed).toBe(1));
+		expect(client.complete).not.toHaveBeenCalledWith('job-1', expect.objectContaining({ success: true }), 2);
+		await loop.stop();
 	});
 });

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -1,6 +1,12 @@
 import { performance } from 'node:perf_hooks';
 import type { FleetJobKind, FleetJobView } from '@ever-works/contracts';
-import { clampLeaseTtlSec, FLEET_JOB_DEFAULT_LEASE_TTL_SEC, FLEET_JOB_MAX_LEASE_BATCH } from '@ever-works/contracts';
+import {
+	clampLeaseTtlSec,
+	FLEET_JOB_DEFAULT_LEASE_TTL_SEC,
+	FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON,
+	FLEET_JOB_MAX_LEASE_BATCH,
+	FLEET_JOB_STALE_LEASE_REASON
+} from '@ever-works/contracts';
 import type { Logger } from './logger';
 import type { Scheduler } from './heartbeat';
 import { systemScheduler } from './heartbeat';
@@ -50,6 +56,29 @@ import type { WorkerSafetyGate } from './worker-safety-store';
  *   Pausing is a state a running node is in, not a way to kill it.
  * - **Backoff is exponential with a ceiling**, so an API outage produces
  *   a slow retry rather than a hot loop against a dead endpoint.
+ * - **A machine that slept through its lease stops itself** (suspend-safe
+ *   leases, self-build finding R7). Desk PCs sleep; a suspended node
+ *   stops beating, its lease lapses and the platform re-issues the job —
+ *   while the model here keeps running and, without help, would push a
+ *   branch against a claim it no longer holds. Two defences, both keyed
+ *   on stable reasons from `@ever-works/contracts`:
+ *     1. every timer this loop arms records when it was armed on BOTH
+ *        clocks, and every lease poll records when it began; a tick that
+ *        fires far later than armed, or a poll whose span is far longer
+ *        than any awake request ({@link SUSPEND_GAP_THRESHOLD_MS}), is a
+ *        resume, and every in-flight lease is re-checked: lapsed on the
+ *        wall clock → the job is aborted (model process killed, nothing
+ *        pushed, reported as `lease-lapsed-while-suspended`); still inside
+ *        its claim → one immediate heartbeat re-confirms it with the
+ *        platform;
+ *     2. every heartbeat and report echoes the `leaseGeneration` the lease
+ *        came with, and a `409 stale-lease` answer aborts the run at once
+ *        and suppresses the follow-up report, which would only be refused
+ *        again.
+ *   Both are keyed on the RUN, not the job id: the first poll after a
+ *   resume reclaims and re-leases the very job this node slept through
+ *   (reclaim runs inline on the lease path), so the same id can be in
+ *   flight twice — see {@link JobRun}.
  *
  * Timers and the transport are injected so the whole state machine is
  * testable without waiting on wall time or opening a socket.
@@ -103,6 +132,57 @@ export const PUBLISH_FENCE_MARGIN_MS = 60_000;
 export const DEFAULT_LEASE_POLL_DRAIN_TIMEOUT_MS = 5_000;
 
 /**
+ * How much later than armed a timer may fire before the gap is read as a
+ * suspend/resume rather than scheduler jitter.
+ *
+ * Thirty seconds is far above anything an awake Node process produces —
+ * this process mostly awaits child processes and never blocks its event
+ * loop for more than milliseconds — and far below the 300 s default lease,
+ * so a resume is noticed with most of the claim still decidable. A false
+ * positive (a wall-clock step forward, a debugger pause) costs one extra
+ * heartbeat; it never aborts a job whose lease is still valid.
+ */
+export const SUSPEND_GAP_THRESHOLD_MS = 30_000;
+
+/** What a timer observed when it finally fired, on both clocks. */
+export interface TimerGap {
+	/** The delay the timer was armed with. */
+	armedForMs: number;
+	/** Wall-clock milliseconds between arming and firing. */
+	wallElapsedMs: number;
+	/** Monotonic milliseconds between arming and firing. */
+	monotonicElapsedMs: number;
+}
+
+/**
+ * Did the machine suspend between a timer being armed and it firing?
+ *
+ * Two clauses, because the two clocks disagree about a suspend in
+ * platform-specific ways and neither is trusted alone:
+ *
+ * - the wall clock advanced far more than the monotonic one — a monotonic
+ *   source that stops through S3/S4 (CLOCK_MONOTONIC on Linux, macOS) sees
+ *   the gap only in the difference;
+ * - the timer fired far later than it was armed for, on the wall clock —
+ *   covers a monotonic source that DOES advance across a suspend
+ *   (Windows QPC) and a wall clock stepped forward on wake, where both
+ *   elapsed values grow together and the difference says nothing.
+ *
+ * Non-finite inputs never detect: a broken clock must degrade to "no
+ * resume noticed", which is exactly the behaviour before this existed.
+ */
+export function isSuspendGap(gap: TimerGap): boolean {
+	if (!Number.isFinite(gap.wallElapsedMs) || !Number.isFinite(gap.armedForMs)) return false;
+	if (
+		Number.isFinite(gap.monotonicElapsedMs) &&
+		gap.wallElapsedMs - gap.monotonicElapsedMs > SUSPEND_GAP_THRESHOLD_MS
+	) {
+		return true;
+	}
+	return gap.wallElapsedMs - gap.armedForMs > SUSPEND_GAP_THRESHOLD_MS;
+}
+
+/**
  * Exponential backoff for `n` consecutive failures, capped.
  *
  * `nextBackoffMs(1)` is the base delay and each further failure doubles
@@ -118,16 +198,24 @@ export function nextBackoffMs(consecutiveFailures: number): number {
 	return Math.min(WORKER_BACKOFF_BASE_MS * 2 ** exponent, WORKER_BACKOFF_MAX_MS);
 }
 
-/** Just enough of {@link FleetJobClient} for the loop — keeps tests tiny. */
+/**
+ * Just enough of {@link FleetJobClient} for the loop — keeps tests tiny.
+ *
+ * `leaseGeneration` is passed to `heartbeat` / `complete` ONLY when the
+ * lease view carried one; a lease from an older API has none, and the
+ * call is then made with its original arity. A `409` from either call is
+ * expected to surface as an error whose `kind` is `'stale-lease'`.
+ */
 export interface JobLeaseCapableClient {
 	lease(
 		request: { max?: number; leaseTtlSec?: number; capabilities?: string[] },
 		signal?: AbortSignal
 	): Promise<FleetJobView[]>;
-	heartbeat(jobId: string, leaseTtlSec?: number): Promise<FleetJobView | null>;
+	heartbeat(jobId: string, leaseTtlSec?: number, leaseGeneration?: number): Promise<FleetJobView | null>;
 	complete(
 		jobId: string,
-		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null }
+		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null },
+		leaseGeneration?: number
 	): Promise<boolean>;
 }
 
@@ -151,9 +239,10 @@ export interface JobLeaseHandle {
 	 * value is additionally capped by an independent monotonic budget: a
 	 * node clock that runs slow, or that w32time steps backwards after a
 	 * wake-up, cannot hand a caller more claim than the platform granted.
-	 * The two clocks catch different faults and neither is trusted alone —
-	 * a monotonic clock does not tick through S3/S4, so only the wall clock
-	 * sees a suspend, and only the monotonic one survives an NTP step.
+	 * The two clocks catch different faults and neither is trusted alone:
+	 * only the monotonic one survives an NTP step, and a suspend shows up
+	 * as the two disagreeing (or as a timer firing far later than armed),
+	 * which is what {@link isSuspendGap} reads and the loop acts on.
 	 */
 	deadlineAt(): number;
 	/** How much of that claim a publish must have left before it may start. */
@@ -318,7 +407,10 @@ export interface WorkerLoopOptions {
 export class WorkerLoop {
 	private readonly executors = new Map<FleetJobKind, JobExecutor>();
 	private readonly inFlight = new Map<string, Promise<void>>();
-	private readonly jobControllers = new Map<string, AbortController>();
+	/** The run currently holding each in-flight job id — see {@link JobRun}. */
+	private readonly runs = new Map<string, JobRun>();
+	/** One per in-flight keep-alive: "the machine just woke up, re-check your claim". */
+	private readonly resumeHandlers = new Set<() => void>();
 	private readonly activePolls = new Set<Promise<void>>();
 	private readonly pollControllers = new Set<AbortController>();
 	private readonly listeners = new Set<(state: WorkerLoopState) => void>();
@@ -558,9 +650,9 @@ export class WorkerLoop {
 	 * model process. A settled or unknown job has no live controller.
 	 */
 	cancelJob(jobId: string, reason = 'Fleet job was cancelled'): boolean {
-		const controller = this.jobControllers.get(jobId);
-		if (!controller || controller.signal.aborted) return false;
-		controller.abort(new Error(reason));
+		const run = this.runs.get(jobId);
+		if (!run || run.controller.signal.aborted) return false;
+		run.controller.abort(new Error(reason));
 		return true;
 	}
 
@@ -601,12 +693,28 @@ export class WorkerLoop {
 			return;
 		}
 
+		// The loop timer is not pending from here until the lease call has
+		// settled, so a suspend that lands inside this poll would escape the
+		// detector in `scheduleNext` until a keep-alive beat happens to fire.
+		// Read the poll's own span for the gap as well: nothing awake in it
+		// takes thirty seconds (the lease request times out well before),
+		// so `armedForMs` is simply zero.
+		const pollBeganWall = this.now();
+		const pollBeganMonotonic = this.monotonicNow();
+		const noticeResumeDuringPoll = (): void =>
+			this.noticeResume({
+				armedForMs: 0,
+				wallElapsedMs: this.now() - pollBeganWall,
+				monotonicElapsedMs: this.monotonicNow() - pollBeganMonotonic
+			});
+
 		// Admission gate: CPU / memory ceilings. Evaluated BEFORE the lease
 		// call so an over-loaded machine never claims work it then has to
 		// run badly — the platform re-offers it to a node with headroom.
 		const admission = await this.checkResourceAdmission();
 		if (!this.running || this.stopping) return;
 		if (!admission.admit) {
+			noticeResumeDuringPoll();
 			this.patch({
 				state: this.inFlight.size > 0 ? 'working' : 'throttled',
 				throttleReason: admission.reason
@@ -632,20 +740,26 @@ export class WorkerLoop {
 			jobs = await this.options.client.lease(request, pollController.signal);
 		} catch (error) {
 			if (pollController.signal.aborted || this.stopping || !this.running) return;
+			noticeResumeDuringPoll();
 			this.onPollFailure(error);
 			this.scheduleNext(nextBackoffMs(this.state.consecutiveFailures));
 			return;
 		} finally {
 			this.pollControllers.delete(pollController);
 		}
+		noticeResumeDuringPoll();
 
 		if (!this.running || this.stopping) {
 			await Promise.allSettled(
 				jobs.map((job) =>
-					this.report(job.id, {
-						success: false,
-						error: 'Fleet worker stopped before execution; no command was started'
-					})
+					this.report(
+						job.id,
+						{
+							success: false,
+							error: 'Fleet worker stopped before execution; no command was started'
+						},
+						leaseGenerationOf(job)
+					)
 				)
 			);
 			return;
@@ -658,10 +772,14 @@ export class WorkerLoop {
 		if (this.unsafe) {
 			await Promise.allSettled(
 				jobs.map((job) =>
-					this.report(job.id, {
-						success: false,
-						error: 'Fleet worker quarantined before execution; no command was started'
-					})
+					this.report(
+						job.id,
+						{
+							success: false,
+							error: 'Fleet worker quarantined before execution; no command was started'
+						},
+						leaseGenerationOf(job)
+					)
 				)
 			);
 			this.patch({ state: 'unsafe' });
@@ -678,10 +796,14 @@ export class WorkerLoop {
 
 		for (const job of jobs) {
 			if (!this.running || this.stopping || this.unsafe) {
-				await this.report(job.id, {
-					success: false,
-					error: 'Fleet worker stopped or quarantined before execution; no command was started'
-				});
+				await this.report(
+					job.id,
+					{
+						success: false,
+						error: 'Fleet worker stopped or quarantined before execution; no command was started'
+					},
+					leaseGenerationOf(job)
+				);
 				continue;
 			}
 			this.startJob(job);
@@ -693,13 +815,52 @@ export class WorkerLoop {
 	}
 
 	private startJob(job: FleetJobView): void {
-		const controller = new AbortController();
-		this.jobControllers.set(job.id, controller);
-		const task = this.executeJob(job, controller.signal).finally(() => {
-			this.inFlight.delete(job.id);
-			if (this.jobControllers.get(job.id) === controller) {
-				this.jobControllers.delete(job.id);
+		const run: JobRun = {
+			job,
+			generation: leaseGenerationOf(job),
+			controller: new AbortController(),
+			stale: false
+		};
+		// The same job id can already be in flight here: reclaim runs inline
+		// on this node's OWN lease poll, so the first poll after a resume
+		// hands the job it slept through straight back — while the lapsed
+		// run is still killing its model process. Being handed the job again
+		// proves the claim behind that run is void (reclaimed, or drained),
+		// so it is voided as stale — its report would only be refused — and
+		// the fresh claim starts once it has torn down, never beside it in
+		// the same workspace.
+		const previous = this.runs.get(job.id);
+		const previousTask = this.inFlight.get(job.id);
+		if (previous) {
+			this.options.logger?.warn(
+				`Fleet job ${job.id} was leased again while an earlier claim was still running here — that run is void (${FLEET_JOB_STALE_LEASE_REASON}); the new claim starts once it has stopped`
+			);
+			voidRun(previous);
+		}
+		this.runs.set(job.id, run);
+		const execute = async (): Promise<void> => {
+			// A claim that waited behind an earlier run gets the same answer a
+			// freshly leased one gets from `pollOnce` if the loop stopped or
+			// quarantined itself in the meantime: fail it without starting.
+			if (previousTask && (!this.running || this.stopping || this.unsafe)) {
+				await this.report(
+					job.id,
+					{
+						success: false,
+						error: 'Fleet worker stopped or quarantined before execution; no command was started'
+					},
+					run.generation,
+					run
+				);
+				return;
 			}
+			await this.executeJob(run);
+		};
+		const task: Promise<void> = (previousTask ? previousTask.then(execute, execute) : execute()).finally(() => {
+			// Identity-guarded: a later run of the same id may have replaced
+			// these entries while this one was tearing down.
+			if (this.inFlight.get(job.id) === task) this.inFlight.delete(job.id);
+			if (this.runs.get(job.id) === run) this.runs.delete(job.id);
 			this.patch({
 				activeJobIds: [...this.inFlight.keys()],
 				state: this.nextIdleState()
@@ -790,32 +951,50 @@ export class WorkerLoop {
 	 * blows up is reported as a job failure, because a job whose node
 	 * silently swallowed the error is indistinguishable from a hung one.
 	 */
-	private async executeJob(job: FleetJobView, signal: AbortSignal): Promise<void> {
+	private async executeJob(run: JobRun): Promise<void> {
+		const { job, generation, controller } = run;
+		const signal = controller.signal;
 		const executor = this.executors.get(job.kind);
 		if (!executor) {
 			this.options.logger?.warn(
 				`Leased job ${job.id} of kind '${job.kind}' has no executor on this node — reporting failure`
 			);
-			await this.report(job.id, {
-				success: false,
-				error: `No executor registered for fleet job kind '${job.kind}' on this node`
-			});
+			await this.report(
+				job.id,
+				{
+					success: false,
+					error: `No executor registered for fleet job kind '${job.kind}' on this node`
+				},
+				generation,
+				run
+			);
 			return;
 		}
 
-		const keepAlive = this.startKeepAlive(job);
+		const keepAlive = this.startKeepAlive(run);
 		let successAccepted = false;
 		try {
-			this.options.logger?.info(`Executing fleet job ${job.id} (${job.kind})`);
+			this.options.logger?.info(
+				`Executing fleet job ${job.id} (${job.kind}${generation === undefined ? '' : `, lease #${generation}`})`
+			);
 			const result = await executor(job, signal, keepAlive.handle);
 			throwIfJobAborted(signal);
 			if (this.settleDeferred(job.id, keepAlive.deferral())) return;
-			const accepted = await this.report(job.id, {
-				success: true,
-				result: (result as Record<string, unknown> | undefined) ?? null
-			});
+			const accepted = await this.report(
+				job.id,
+				{
+					success: true,
+					result: (result as Record<string, unknown> | undefined) ?? null
+				},
+				generation,
+				run
+			);
 			if (!accepted) {
-				throw new Error('Fleet job success settlement was rejected; the lease may no longer be owned');
+				throw new Error(
+					run.stale
+						? `Fleet job success settlement was refused: ${FLEET_JOB_STALE_LEASE_REASON} — the platform holds a newer lease on this job`
+						: 'Fleet job success settlement was rejected; the lease may no longer be owned'
+				);
 			}
 			// The server's accepted terminal transition is authoritative. Stop
 			// heartbeat delivery before any late response can abort/count failure.
@@ -835,7 +1014,7 @@ export class WorkerLoop {
 			// abort recorded as a terminal `failed`, which would retire a job
 			// nobody has run to a result.
 			if (this.settleDeferred(job.id, keepAlive.deferral())) return;
-			await this.report(job.id, { success: false, error: message });
+			await this.report(job.id, { success: false, error: message }, generation, run);
 			this.patch({ failed: this.state.failed + 1, lastError: message });
 			this.options.logger?.warn(`Fleet job ${job.id} failed: ${message}`);
 		} finally {
@@ -922,7 +1101,12 @@ export class WorkerLoop {
 	 * platform at the moment of the write; `defer` hands the job back
 	 * unsettled when the executor declined to finish it.
 	 */
-	private startKeepAlive(job: FleetJobView): JobKeepAlive {
+	private startKeepAlive(run: JobRun): JobKeepAlive {
+		// Bound to THIS run's controller, never looked up by job id: after a
+		// resume the same id can be re-leased to this node while the lapsed
+		// run is still tearing down, and this keep-alive must only ever
+		// stop the run it belongs to.
+		const { job, generation, controller } = run;
 		const jobId = job.id;
 		const ttlMs = this.leaseTtlSec * 1000;
 		const everyMs = Math.max(Math.floor(ttlMs / 3), MIN_KEEPALIVE_MS);
@@ -930,6 +1114,8 @@ export class WorkerLoop {
 		let confirmedUntil = Number.isFinite(wireExpiry) ? wireExpiry : this.now() + ttlMs;
 		let monotonicUntil = 0;
 		let beatTimer: unknown = null;
+		/** When the pending beat was armed, so its firing can be read for a suspend. */
+		let beatArmed: { wall: number; monotonic: number; forMs: number } | null = null;
 		let deadlineTimer: unknown = null;
 		let stopped = false;
 		let inFlightBeat: Promise<void> | null = null;
@@ -955,6 +1141,22 @@ export class WorkerLoop {
 			const now = this.now();
 			return now + Math.min(confirmedUntil - now, monotonicUntil - this.monotonicNow());
 		};
+		/**
+		 * Any abort of this run ends the claim's usefulness, whichever way it
+		 * arrived — a refused beat, a lapse, an operator cancel, or `startJob`
+		 * voiding it because the platform handed this node the same job back
+		 * under a newer generation. Only the first of those reaches
+		 * `confirm()` on its own; the rest abort straight through the
+		 * controller while the local deadline may still read minutes ahead.
+		 * `confirmDeadline` deliberately stops re-asking the platform once the
+		 * signal is aborted, so without this collapse it would answer a
+		 * publish fence with that healthy-looking figure. Fail closed instead:
+		 * from the abort on, `deadlineAt` says the claim is spent.
+		 */
+		const onAbort = (): void => {
+			if (stopped) return;
+			confirm(this.now());
+		};
 
 		/**
 		 * `stopped`, not `inFlight`, is what says this keep-alive is finished.
@@ -970,20 +1172,24 @@ export class WorkerLoop {
 		const stop = (): void => {
 			if (stopped) return;
 			stopped = true;
+			this.resumeHandlers.delete(onResume);
+			controller.signal.removeEventListener('abort', onAbort);
 			if (beatTimer !== null) this.scheduler.clearTimeout(beatTimer);
 			if (deadlineTimer !== null) this.scheduler.clearTimeout(deadlineTimer);
 			beatTimer = null;
 			deadlineTimer = null;
 		};
-		const abortForLapsedLease = (): void => {
+		const abortForLapsedLease = (reason = 'Fleet job lease confirmation expired'): void => {
 			this.options.logger?.warn(
-				`Fleet job ${jobId} reached its last confirmed lease deadline — aborting before server reclaim`
+				`Fleet job ${jobId} reached its last confirmed lease deadline — aborting before server reclaim (${reason})`
 			);
-			this.cancelJob(jobId, 'Fleet job lease confirmation expired');
+			abortRun(run, reason);
 		};
 		/**
 		 * Stop the job when this node's own WALL clock says the claim is
-		 * spent, and report whether it did.
+		 * spent, and report whether it did. `reason` is what the abort — and
+		 * so the failure report — carries; a caller that KNOWS the lapse
+		 * happened across a suspend passes the stable suspend reason.
 		 *
 		 * Asked on the wall clock rather than left to `deadlineTimer` because
 		 * a timer's base clock does not advance while a machine is suspended:
@@ -991,11 +1197,42 @@ export class WorkerLoop {
 		 * and the timer still counting down awake seconds. Six PCs that get
 		 * shut mid-run is the ordinary case on this fleet, not the exotic one.
 		 */
-		const expireIfLapsed = (): boolean => {
+		const expireIfLapsed = (reason?: string): boolean => {
 			if (stopped) return false;
 			if (this.now() < confirmedUntil - LEASE_TERMINATION_SAFETY_MS) return false;
-			abortForLapsedLease();
+			abortForLapsedLease(reason);
 			return true;
+		};
+		/**
+		 * The claim is void: the platform answered `stale-lease`, meaning it
+		 * re-issued this job after our lease lapsed. Collapse the local
+		 * deadline so nothing asking "may I still publish?" is told yes, abort
+		 * the run, and make sure no report follows — the platform would only
+		 * refuse it again, and the row now belongs to another claim.
+		 */
+		const voidClaim = (): void => {
+			if (stopped) return;
+			this.options.logger?.warn(
+				`Fleet job ${jobId}: the platform holds a newer lease (${FLEET_JOB_STALE_LEASE_REASON}) — aborting; nothing will be published or reported`
+			);
+			confirm(this.now());
+			voidRun(run);
+		};
+		/**
+		 * The loop noticed the machine resume from a suspend. The pending
+		 * beat timer is still counting down AWAKE milliseconds and may not
+		 * fire for most of a keep-alive interval, so decide now: lapsed on the
+		 * wall clock → abort with the suspend reason; otherwise the platform
+		 * may still have re-issued the claim during the sleep, so re-confirm
+		 * at once rather than trusting a local deadline that saw nothing.
+		 */
+		const onResume = (): void => {
+			if (stopped || controller.signal.aborted) return;
+			if (expireIfLapsed(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON)) return;
+			this.options.logger?.warn(
+				`Fleet job ${jobId}: machine resumed inside the lease — re-confirming the claim with the platform now`
+			);
+			void runBeat();
 		};
 		const scheduleDeadline = (): void => {
 			if (deadlineTimer !== null) this.scheduler.clearTimeout(deadlineTimer);
@@ -1024,7 +1261,9 @@ export class WorkerLoop {
 			// faster than the keep-alive floor, which no lease can undercut.
 			if (expireIfLapsed()) return;
 			const remaining = Math.max(0, confirmedUntil - LEASE_TERMINATION_SAFETY_MS - this.now());
-			beatTimer = this.scheduler.setTimeout(beat, Math.max(MIN_KEEPALIVE_MS, Math.min(everyMs, remaining)));
+			const forMs = Math.max(MIN_KEEPALIVE_MS, Math.min(everyMs, remaining));
+			beatArmed = { wall: this.now(), monotonic: this.monotonicNow(), forMs };
+			beatTimer = this.scheduler.setTimeout(beat, forMs);
 		};
 		const applyRenewal = (renewed: FleetJobView | null): void => {
 			if (stopped) return;
@@ -1036,17 +1275,25 @@ export class WorkerLoop {
 				// collapse it so anything asking "may I still publish?" is
 				// told the truth even if it never observes the abort.
 				confirm(this.now());
-				this.cancelJob(jobId, 'Fleet job lease was lost');
+				abortRun(run, 'Fleet job lease was lost');
 				return;
 			}
-			if (this.jobControllers.get(jobId)?.signal.aborted) return;
+			if (controller.signal.aborted) return;
 			const renewedExpiry = renewed.leaseExpiresAt ? Date.parse(renewed.leaseExpiresAt) : Number.NaN;
 			if (
 				renewed.id !== jobId ||
 				!Number.isFinite(renewedExpiry) ||
 				renewedExpiry <= this.now() + LEASE_TERMINATION_SAFETY_MS
 			) {
-				this.cancelJob(jobId, 'Fleet job heartbeat returned an invalid lease expiry');
+				abortRun(run, 'Fleet job heartbeat returned an invalid lease expiry');
+				return;
+			}
+			// Belt and braces on the generation: an accepted renewal is by
+			// construction for OUR claim, so a view naming another one is a
+			// protocol fault and the safe reading is "not ours".
+			const renewedGeneration = leaseGenerationOf(renewed);
+			if (generation !== undefined && renewedGeneration !== undefined && renewedGeneration !== generation) {
+				abortRun(run, 'Fleet job heartbeat returned a different lease generation');
 				return;
 			}
 			confirm(renewedExpiry);
@@ -1056,13 +1303,24 @@ export class WorkerLoop {
 		 * One beat, at most one in flight. A publish that asks for a fresh
 		 * confirmation while the scheduled beat is already out joins that
 		 * request rather than doubling it.
+		 *
+		 * A `stale-lease` answer is the one transport error that IS a
+		 * protocol outcome: it proves the claim is void, so it aborts here
+		 * rather than being logged and retried like a network fault.
 		 */
 		const runBeat = (): Promise<void> => {
 			if (inFlightBeat) return inFlightBeat;
-			const attempt = this.options.client
-				.heartbeat(jobId, this.leaseTtlSec)
+			const renewal =
+				generation === undefined
+					? this.options.client.heartbeat(jobId, this.leaseTtlSec)
+					: this.options.client.heartbeat(jobId, this.leaseTtlSec, generation);
+			const attempt = renewal
 				.then(applyRenewal)
 				.catch((error: unknown) => {
+					if (isStaleLeaseError(error)) {
+						voidClaim();
+						return;
+					}
 					const raw = error instanceof Error ? error.message : String(error);
 					this.options.logger?.warn(
 						`Job heartbeat failed for ${jobId}: ${this.options.logger?.redact(raw) ?? raw}`
@@ -1076,20 +1334,37 @@ export class WorkerLoop {
 		};
 		const beat = (): void => {
 			beatTimer = null;
-			if (stopped || this.jobControllers.get(jobId)?.signal.aborted) return;
-			if (expireIfLapsed()) return;
+			if (stopped || controller.signal.aborted) return;
+			// Read the firing against the arming on both clocks: a beat that
+			// arrives long after it was due is the machine waking up, and a
+			// lapse found then is reported as such rather than as a bare
+			// expiry, so the run's error says what actually happened.
+			const suspended =
+				beatArmed !== null &&
+				isSuspendGap({
+					armedForMs: beatArmed.forMs,
+					wallElapsedMs: this.now() - beatArmed.wall,
+					monotonicElapsedMs: this.monotonicNow() - beatArmed.monotonic
+				});
+			beatArmed = null;
+			if (expireIfLapsed(suspended ? FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON : undefined)) return;
 			void runBeat().finally(() => {
-				if (!this.jobControllers.get(jobId)?.signal.aborted) scheduleBeat();
+				if (!controller.signal.aborted) scheduleBeat();
 			});
 		};
 		const confirmDeadline = async (): Promise<number> => {
-			if (!stopped && !this.jobControllers.get(jobId)?.signal.aborted) {
+			if (!stopped && !controller.signal.aborted) {
 				await runBeat();
 			}
 			return deadlineAt();
 		};
 		scheduleBeat();
 		scheduleDeadline();
+		this.resumeHandlers.add(onResume);
+		// A run voided while it waited behind an earlier claim on the same
+		// job arrives here already aborted; the listener would never fire.
+		if (controller.signal.aborted) onAbort();
+		else controller.signal.addEventListener('abort', onAbort, { once: true });
 		return {
 			stop,
 			deferral: () => deferral,
@@ -1106,13 +1381,53 @@ export class WorkerLoop {
 		};
 	}
 
+	/**
+	 * The loop's own timer fired far later than it was armed for: the
+	 * machine was suspended in between. Hand every in-flight keep-alive the
+	 * chance to abort (lease lapsed while asleep) or to re-confirm (still
+	 * inside the claim, but the platform may have moved on regardless).
+	 */
+	private noticeResume(gap: TimerGap): void {
+		if (this.resumeHandlers.size === 0 || !isSuspendGap(gap)) return;
+		this.options.logger?.warn(
+			`Fleet worker resumed after a ${Math.round(gap.wallElapsedMs / 1000)}s gap (timer armed for ${Math.round(
+				gap.armedForMs / 1000
+			)}s) — re-checking ${this.resumeHandlers.size} in-flight lease(s)`
+		);
+		for (const handler of [...this.resumeHandlers]) handler();
+	}
+
+	/**
+	 * `run` is the claim this report belongs to, when there is one (a job
+	 * refused before any executor started has none). A run the platform
+	 * has already answered `stale-lease` for — or that this node re-leased
+	 * over — reports nothing: the platform has moved on to the claim that
+	 * superseded it and would only refuse again.
+	 */
 	private async report(
 		jobId: string,
-		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null }
+		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null },
+		leaseGeneration?: number,
+		run?: JobRun
 	): Promise<boolean> {
+		if (run?.stale) {
+			this.options.logger?.warn(
+				`Not reporting fleet job ${jobId}: this node's lease is stale (${FLEET_JOB_STALE_LEASE_REASON})`
+			);
+			return false;
+		}
 		try {
-			return await this.options.client.complete(jobId, outcome);
+			return await (leaseGeneration === undefined
+				? this.options.client.complete(jobId, outcome)
+				: this.options.client.complete(jobId, outcome, leaseGeneration));
 		} catch (error) {
+			if (isStaleLeaseError(error)) {
+				this.options.logger?.warn(
+					`Fleet job ${jobId}: report refused — the platform holds a newer lease (${FLEET_JOB_STALE_LEASE_REASON}); aborting and not retrying`
+				);
+				if (run) voidRun(run);
+				return false;
+			}
 			// The lease will expire and the job will be reclaimed — the
 			// protocol survives an unreportable result by construction.
 			const raw = error instanceof Error ? error.message : String(error);
@@ -1159,8 +1474,19 @@ export class WorkerLoop {
 
 	private scheduleNext(delayMs: number): void {
 		if (!this.running || this.stopping) return;
+		// Record the arming on both clocks: the loop timer is the one timer
+		// guaranteed to be pending whenever the loop is running (busy, idle,
+		// paused or backing off), which makes it the resume detector. A
+		// suspend shows up as this callback firing far later than `delayMs`.
+		const armedWall = this.now();
+		const armedMonotonic = this.monotonicNow();
 		this.timer = this.scheduler.setTimeout(() => {
 			this.timer = null;
+			this.noticeResume({
+				armedForMs: delayMs,
+				wallElapsedMs: this.now() - armedWall,
+				monotonicElapsedMs: this.monotonicNow() - armedMonotonic
+			});
 			void this.tick();
 		}, delayMs);
 	}
@@ -1191,6 +1517,63 @@ function throwIfJobAborted(signal: AbortSignal): void {
 
 function isProcessTreeTerminationError(error: unknown): boolean {
 	return error instanceof Error && error.name === 'ProcessTreeTerminationError';
+}
+
+/**
+ * Duck-typed like the `unauthorized` check in `onPollFailure`: the client
+ * is injected, and a test double that answers a 409 should not have to
+ * construct the real error class to be believed.
+ */
+function isStaleLeaseError(error: unknown): boolean {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		(error as { kind?: unknown }).kind === FLEET_JOB_STALE_LEASE_REASON
+	);
+}
+
+/**
+ * One claim being executed on this node. Everything a keep-alive or a
+ * report decides is keyed on the RUN, never on the job id alone: after a
+ * suspend the node's own poll reclaims and re-leases the job it slept
+ * through, so the same id can be in flight twice — the lapsed run tearing
+ * down and the fresh claim starting — and nothing the old one does on its
+ * way out may abort or silence the new one.
+ */
+interface JobRun {
+	readonly job: FleetJobView;
+	/** The claim identity the lease carried, or undefined from an older platform. */
+	readonly generation: number | undefined;
+	/** Shared by workspace provisioning, the model process and the keep-alive. */
+	readonly controller: AbortController;
+	/**
+	 * Set once this claim is known to be void — the platform answered
+	 * `stale-lease` for it, or re-issued the job to this node while it was
+	 * still running. No report is sent for a stale run.
+	 */
+	stale: boolean;
+}
+
+/** Abort one run with a stable reason; a no-op once it has already been aborted. */
+function abortRun(run: JobRun, reason: string): void {
+	if (run.controller.signal.aborted) return;
+	run.controller.abort(new Error(reason));
+}
+
+/** The platform holds a newer claim than this run: abort it and never report it. */
+function voidRun(run: JobRun): void {
+	run.stale = true;
+	abortRun(run, FLEET_JOB_STALE_LEASE_REASON);
+}
+
+/**
+ * The claim identity a lease view carries, or undefined when the platform
+ * that issued it predates lease generations (the call is then made with
+ * its original arity, which is also what that platform accepts).
+ */
+function leaseGenerationOf(job: FleetJobView): number | undefined {
+	const value = job.leaseGeneration;
+	return typeof value === 'number' && Number.isInteger(value) && value >= 1 ? value : undefined;
 }
 
 function errorDetail(error: unknown): string {

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -168,6 +168,24 @@ When the node reports, the platform reconciles the result the same way a cloud r
 
 Routing preferences (**Settings → Fleet → Execution routing**) decide what happens when no runner is free: wait for one (`local-wait`), fall back to the cloud with a notice (`local-fallback`), or always use the cloud. An Agent can be pinned to one specific node (`PUT /api/fleet/agents/:agentId/node-affinity`); a pinned Agent never runs elsewhere.
 
+### Suspend safety (lease generations)
+
+Desk PCs sleep. A node that is suspended mid-run stops heart-beating, its lease (300 s by default) lapses, and the platform re-offers the job — possibly to the same machine once it wakes and polls again — while the first model run (up to 1200 s by default) is still going and, on its own, would only learn it lost the claim on its next heartbeat. Left alone that produces two runs against the same Task branch, and either the loser's push is rejected after full model spend or it lands first and the winner's is.
+
+What the platform does:
+
+- Every successful lease, including a re-lease after a lapse, increments the job's `leaseGeneration` and returns it with the lease.
+- Every heartbeat and every completion report must carry that generation. A call whose generation is not the job's current one is refused with `409 { "reason": "stale-lease" }`, before anything is written and before any lifecycle event fires — a stale holder can never flip the status, land a result, or cause a pull request to be opened for its branch. The repository guards pin the generation next to the node id in the same conditional `UPDATE`, so the guarantee holds against the same node re-leasing its own lapsed job, which a node-id check alone cannot see.
+- The `409` is the one differentiated answer in the node work channel, and it is reachable only by the node that is the recorded holder of an active job; every other refusal stays the undifferentiated `401`.
+
+What the node does:
+
+- It watches for a resume. The worker's own timers record when they were armed on both the wall clock and a monotonic clock, and each lease poll records when it began; a timer that fires far later than it was armed for (30 s beyond schedule, or the wall clock advancing 30 s more than the monotonic one), or a poll whose span is that long, is a suspend/resume. On resume every in-flight job is re-checked at once: if its lease deadline passed while the machine slept, the job is aborted — the model process is killed, nothing is committed or pushed, the in-memory workspace serialisation releases as the abort propagates — and the failure is reported with the reason `lease-lapsed-while-suspended`; if the lease is still valid, one immediate heartbeat re-confirms it with the platform instead of trusting a local deadline that saw nothing.
+- It aborts immediately on `stale-lease`, whether the answer comes from a heartbeat, from the publish-time confirmation that precedes every push, or from the final report. No follow-up failure report is sent for that job: the platform has already moved on to the claim that superseded it.
+- It keeps the two claims apart when it is handed its own job back. Reclaim runs inline on the node's own lease poll, so the first poll after a resume can re-lease the very job the node slept through while the lapsed run is still killing its model process. The old run is treated as void (nothing is reported for it), the fresh claim starts only once it has stopped — never beside it in the same workspace — and nothing the old run does on its way out can abort or silence the new one.
+
+Compatibility: a node built before this release sends no generation and is refused on heartbeat and complete (`400` at the edge); rows that were leased when the platform was upgraded carry generation 0, which is never accepted, so their in-flight runs abort at the node's next lapse and the jobs are re-offered under generation 1. Upgrade the node apps together with the platform.
+
 ### Tasks that span several repositories
 
 A Task keeps one primary Work and branch. When the run agent has **repository attachments** (Agent →

--- a/packages/agent/src/entities/fleet-job.entity.ts
+++ b/packages/agent/src/entities/fleet-job.entity.ts
@@ -31,6 +31,11 @@ import type { FleetJobKind, FleetJobStatus } from '@ever-works/contracts';
  *      maxAttempts`, otherwise `failed`. Reclaim runs inline on every
  *      lease poll AND on the `fleet-job-lease-sweeper` cron, so a fleet
  *      that stops polling still converges.
+ *   6. Every claim (step 2, including a re-lease after step 5) increments
+ *      `leaseGeneration`; heartbeat and complete carry it and are refused
+ *      (`409 stale-lease`) when it is not the current one, so a node that
+ *      slept through its lease can never overwrite the current holder —
+ *      not even when that holder is the same node on a later claim.
  *
  * Auth: every node-facing transition authenticates with the SAME node
  * secret minted at enrollment (constant-time compare against the
@@ -108,6 +113,21 @@ export class FleetJob {
 
     @Column({ type: 'int', default: 3 })
     maxAttempts: number;
+
+    /**
+     * Monotonic identity of the CLAIM (suspend-safe leases, self-build
+     * finding R7). 0 until the first lease; every successful claim —
+     * including a re-lease after a lapse — writes `previous + 1`, and the
+     * node is handed the new value with the lease. `extendLease` and
+     * `complete` pin it in their WHERE clause next to `nodeId`, which is
+     * what closes the hole `nodeId` alone cannot: the same machine
+     * re-leasing the job it slept through, whose old in-flight run would
+     * otherwise renew and finalize the NEW claim. No index — the row is
+     * always addressed by primary key and this is an equality predicate
+     * on that one row.
+     */
+    @Column({ type: 'int', default: 0 })
+    leaseGeneration: number;
 
     /**
      * Stable identity across retries (`JobEnqueueOptions.idempotencyKey`).

--- a/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.cancel-and-events.spec.ts
@@ -49,6 +49,7 @@ function makeJob(over: Partial<FleetJob> = {}): FleetJob {
         leaseExpiresAt: null,
         attempts: 0,
         maxAttempts: 3,
+        leaseGeneration: 0,
         idempotencyKey: null,
         result: null,
         error: null,
@@ -145,6 +146,9 @@ describe('FleetJobService — cancel + lifecycle events', () => {
         expect(event.job.status).toBe('leased');
         expect(event.nodeId).toBe(NODE);
         expect(event.userId).toBe(USER);
+        // The claim identity rides on the event as it rides on the wire.
+        expect(view.leaseGeneration).toBe(1);
+        expect(event.job.leaseGeneration).toBe(1);
     });
 
     it('emits fleet.job.completed with the node report on complete', async () => {
@@ -156,6 +160,7 @@ describe('FleetJobService — cancel + lifecycle events', () => {
             jobId: JOB,
             success: true,
             result: { status: 'succeeded', taskId: 'task-1' },
+            leaseGeneration: job.leaseGeneration,
         });
         expect(done?.status).toBe('done');
         expect(emitter.emit).toHaveBeenCalledTimes(1);
@@ -166,6 +171,7 @@ describe('FleetJobService — cancel + lifecycle events', () => {
         expect(event.nodeId).toBe(NODE);
         expect(event.succeeded).toBe(true);
         expect(event.result).toEqual({ status: 'succeeded', taskId: 'task-1' });
+        expect(event.job.leaseGeneration).toBe(1);
     });
 
     it('emits fleet.job.completed (lease-exhausted) when the reclaim sweep fails a job', async () => {
@@ -257,7 +263,7 @@ describe('FleetJobService — cancel + lifecycle events', () => {
             // No completion yet — the node has not reported.
             expect(emitter.emit).not.toHaveBeenCalled();
 
-            const beat = await service.heartbeatJob(NODE, secret, JOB, 300);
+            const beat = await service.heartbeatJob(NODE, secret, JOB, 300, job.leaseGeneration);
             expect(beat).toBeNull();
             expect(jobs.extendLease).not.toHaveBeenCalled();
 
@@ -268,6 +274,7 @@ describe('FleetJobService — cancel + lifecycle events', () => {
                 jobId: JOB,
                 success: false,
                 error: 'Fleet job lease was lost',
+                leaseGeneration: job.leaseGeneration,
             });
             expect(reported?.status).toBe('failed');
             expect(emitter.emit.mock.calls[0][1].source).toBe('node-report');

--- a/packages/agent/src/fleet/__tests__/fleet-job.kill-switch.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.kill-switch.spec.ts
@@ -58,6 +58,10 @@ function makeJob(over: Partial<FleetJob> = {}): FleetJob {
         completedAt: null,
         createdAt: new Date('2026-09-05T10:00:00Z'),
         updatedAt: new Date('2026-09-05T10:00:00Z'),
+        // Suspend-safe leases (EW-792): a claim carries a generation and the
+        // platform refuses 0. The literal is cast, so leaving this out would
+        // read as undefined and every settle below would be a stale lease.
+        leaseGeneration: 1,
         ...over,
     } as FleetJob;
 }
@@ -179,7 +183,7 @@ describe('FleetJobService — global stop flag on the lease path', () => {
     it('keeps accepting job heartbeats while stopped', async () => {
         killSwitch.isStopped.mockResolvedValue(true);
         job = makeJob({ nodeId: NODE, status: 'leased', leaseExpiresAt: new Date() });
-        const beat = await build(killSwitch).heartbeatJob(NODE, secret, JOB, 60);
+        const beat = await build(killSwitch).heartbeatJob(NODE, secret, JOB, 60, 1);
         expect(beat?.status).toBe('running');
         expect(jobs.extendLease).toHaveBeenCalledTimes(1);
     });
@@ -193,6 +197,7 @@ describe('FleetJobService — global stop flag on the lease path', () => {
             jobId: JOB,
             success: true,
             result: { ok: true },
+            leaseGeneration: 1,
         });
         expect(done?.status).toBe('done');
         expect(jobs.complete).toHaveBeenCalledTimes(1);

--- a/packages/agent/src/fleet/__tests__/fleet-job.lease-generation.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.lease-generation.spec.ts
@@ -1,0 +1,490 @@
+import { ConflictException } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import { FLEET_JOB_STALE_LEASE_REASON } from '@ever-works/contracts';
+import { FleetJobCompletedEvent, FleetJobLeasedEvent } from '../../events/fleet-job.events';
+import { FleetJob } from '../../entities/fleet-job.entity';
+import { FleetJobService, FleetJobStaleLeaseError } from '../fleet-job.service';
+
+/**
+ * Suspend-safe leases (self-build program note §6, finding R7).
+ *
+ * The defect: a desk PC sleeps mid-run, its lease lapses, the job is
+ * reclaimed and leased AGAIN — to another machine, or to the same one
+ * once it wakes and polls — while the first model run is still going.
+ * Before generations, that first run's heartbeat and completion matched
+ * the row on `nodeId` alone, so on the same-node re-lease it could renew
+ * and finalize a claim it never held: status, result, branch, PR.
+ *
+ * What is pinned here is the CLAIM identity: every lease mints one, every
+ * renew/complete must echo the current one, and a stale echo is refused
+ * with the ONE differentiated error in this channel — without touching
+ * the row and without emitting an event. The store below honours the
+ * generation in the same conditional way the real WHERE clauses do,
+ * because that predicate IS the guarantee.
+ */
+
+const NODE_A = '11111111-1111-4111-8111-111111111111';
+const NODE_B = '22222222-2222-4222-8222-222222222222';
+const USER = 'owner-1';
+const sha256Hex = (value: string): string =>
+    createHash('sha256').update(value, 'utf8').digest('hex');
+
+type Row = FleetJob & { leaseGeneration: number };
+
+function activeMatch(row: Row, id: string, nodeId: string, generation: number): boolean {
+    return (
+        row.id === id &&
+        row.nodeId === nodeId &&
+        row.leaseGeneration === generation &&
+        (row.status === 'leased' || row.status === 'running')
+    );
+}
+
+describe('FleetJobService — lease generations', () => {
+    const secretA = randomBytes(24).toString('base64url');
+    const secretB = randomBytes(24).toString('base64url');
+    let rows: Row[];
+    let jobs: Record<string, jest.Mock>;
+    let emitter: { emit: jest.Mock };
+    let service: FleetJobService;
+
+    const node = (id: string, secret: string) => ({
+        id,
+        userId: USER,
+        status: 'online',
+        enrollmentTokenHash: sha256Hex(secret),
+        capabilities: [],
+    });
+
+    beforeEach(() => {
+        rows = [];
+        jobs = {
+            create: jest.fn(async (data: Record<string, unknown>) => {
+                const row = {
+                    id: `job-${rows.length + 1}`,
+                    status: 'queued',
+                    nodeId: null,
+                    attempts: 0,
+                    maxAttempts: 3,
+                    leaseGeneration: 0,
+                    requiredCapabilities: [],
+                    result: null,
+                    error: null,
+                    leaseExpiresAt: null,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    ...data,
+                } as unknown as Row;
+                rows.push(row);
+                return row;
+            }),
+            findById: jest.fn(async (id: string) => rows.find((r) => r.id === id) ?? null),
+            findByIdempotencyKey: jest.fn(async () => null),
+            findQueuedForNode: jest.fn(async (userId: string, nodeId: string) =>
+                rows.filter(
+                    (r) =>
+                        r.userId === userId &&
+                        r.status === 'queued' &&
+                        (!r.targetNodeId || r.targetNodeId === nodeId),
+                ),
+            ),
+            claim: jest.fn(async (id: string, patch: Record<string, unknown>) => {
+                const row = rows.find(
+                    (r) =>
+                        r.id === id &&
+                        r.status === 'queued' &&
+                        !r.cancelRequestedAt &&
+                        r.leaseGeneration === (patch.leaseGeneration as number) - 1,
+                );
+                if (!row) return false;
+                Object.assign(row, patch);
+                return true;
+            }),
+            extendLease: jest.fn(
+                async (
+                    id: string,
+                    nodeId: string,
+                    leaseExpiresAt: Date,
+                    startedAt: Date | undefined,
+                    leaseGeneration: number,
+                ) => {
+                    const row = rows.find((r) => activeMatch(r, id, nodeId, leaseGeneration));
+                    if (!row) return false;
+                    row.status = 'running';
+                    row.leaseExpiresAt = leaseExpiresAt;
+                    if (startedAt) row.startedAt = startedAt;
+                    return true;
+                },
+            ),
+            complete: jest.fn(
+                async (
+                    id: string,
+                    nodeId: string,
+                    patch: Record<string, unknown>,
+                    leaseGeneration: number,
+                ) => {
+                    const row = rows.find((r) => activeMatch(r, id, nodeId, leaseGeneration));
+                    if (!row) return false;
+                    Object.assign(row, patch, { leaseExpiresAt: null });
+                    return true;
+                },
+            ),
+            findExpiredLeases: jest.fn(async (cutoff: Date, _limit: number, userId?: string) =>
+                rows.filter(
+                    (r) =>
+                        (!userId || r.userId === userId) &&
+                        (r.status === 'leased' || r.status === 'running') &&
+                        r.leaseExpiresAt instanceof Date &&
+                        r.leaseExpiresAt.getTime() < cutoff.getTime(),
+                ),
+            ),
+            reclaim: jest.fn(
+                async (
+                    id: string,
+                    observed: {
+                        status: string;
+                        nodeId: string;
+                        leaseExpiresAt: Date;
+                        leaseGeneration: number;
+                    },
+                ) => {
+                    const row = rows.find(
+                        (r) =>
+                            r.id === id &&
+                            r.status === observed.status &&
+                            r.nodeId === observed.nodeId &&
+                            r.leaseGeneration === observed.leaseGeneration &&
+                            r.leaseExpiresAt?.getTime() === observed.leaseExpiresAt.getTime(),
+                    );
+                    if (!row) return false;
+                    Object.assign(row, { status: 'queued', nodeId: null, leaseExpiresAt: null });
+                    return true;
+                },
+            ),
+            failExhausted: jest.fn(async () => false),
+        };
+        emitter = { emit: jest.fn() };
+        service = new FleetJobService(
+            jobs as never,
+            {
+                findById: jest.fn(async (id: string) =>
+                    id === NODE_A
+                        ? node(NODE_A, secretA)
+                        : id === NODE_B
+                          ? node(NODE_B, secretB)
+                          : null,
+                ),
+            } as never,
+            { findForOwnedAgent: jest.fn(async () => null) } as never,
+            emitter as never,
+        );
+    });
+
+    const enqueue = () => service.enqueue({ userId: USER, kind: 'acceptance-checks' });
+    const leaseAs = async (nodeId: string, secret: string) => {
+        const leased = await service.lease({ nodeId, secret, max: 1 });
+        expect(leased).not.toBeNull();
+        return leased!;
+    };
+    const lapse = (row: Row) => {
+        row.leaseExpiresAt = new Date(Date.now() - 1_000);
+    };
+    const completedEvents = () =>
+        emitter.emit.mock.calls.filter(([name]) => name === FleetJobCompletedEvent.EVENT_NAME);
+
+    describe('minting', () => {
+        it('starts every job at generation 0 and mints 1 on the first lease', async () => {
+            const queued = await enqueue();
+            expect(queued.leaseGeneration).toBe(0);
+            const [leased] = await leaseAs(NODE_A, secretA);
+            expect(leased.leaseGeneration).toBe(1);
+            expect(rows[0].leaseGeneration).toBe(1);
+            expect(jobs.claim).toHaveBeenCalledWith(
+                queued.id,
+                expect.objectContaining({ leaseGeneration: 1 }),
+            );
+        });
+
+        it('carries the generation on the leased event', async () => {
+            await enqueue();
+            await leaseAs(NODE_A, secretA);
+            const [name, event] = emitter.emit.mock.calls[0];
+            expect(name).toBe(FleetJobLeasedEvent.EVENT_NAME);
+            expect(event.job.leaseGeneration).toBe(1);
+        });
+
+        it('mints a NEW generation when another node re-leases a lapsed claim', async () => {
+            await enqueue();
+            await leaseAs(NODE_A, secretA);
+            lapse(rows[0]);
+            const [relaesed] = await leaseAs(NODE_B, secretB);
+            expect(relaesed.nodeId).toBe(NODE_B);
+            expect(relaesed.leaseGeneration).toBe(2);
+        });
+
+        it('mints a NEW generation when the SAME node re-leases the job it slept through', async () => {
+            // The case a nodeId guard cannot see: the holder and the
+            // re-leaser are one machine.
+            await enqueue();
+            const [first] = await leaseAs(NODE_A, secretA);
+            lapse(rows[0]);
+            const [second] = await leaseAs(NODE_A, secretA);
+            expect(second.id).toBe(first.id);
+            expect(second.nodeId).toBe(NODE_A);
+            expect(first.leaseGeneration).toBe(1);
+            expect(second.leaseGeneration).toBe(2);
+        });
+
+        it('refuses to mint a generation the platform already issued (CAS on the observed value)', async () => {
+            await enqueue();
+            // Between the candidate read and the CAS, the row was leased and
+            // lost by someone else: it is queued again but at generation 1.
+            jobs.findQueuedForNode.mockImplementationOnce(async () => [
+                { ...rows[0], leaseGeneration: 0 },
+            ]);
+            rows[0].leaseGeneration = 1;
+            await expect(service.lease({ nodeId: NODE_A, secret: secretA })).resolves.toEqual([]);
+            expect(rows[0].status).toBe('queued');
+            expect(rows[0].leaseGeneration).toBe(1);
+        });
+    });
+
+    describe('a stale holder on the SAME node (slept through its lease, re-leased it on wake)', () => {
+        let jobId: string;
+        let staleGeneration: number;
+        let currentExpiry: Date;
+
+        beforeEach(async () => {
+            await enqueue();
+            const [first] = await leaseAs(NODE_A, secretA);
+            jobId = first.id;
+            staleGeneration = first.leaseGeneration!;
+            lapse(rows[0]);
+            await leaseAs(NODE_A, secretA);
+            currentExpiry = rows[0].leaseExpiresAt!;
+            emitter.emit.mockClear();
+        });
+
+        it('cannot renew: heartbeat throws stale-lease and the row is untouched', async () => {
+            await expect(
+                service.heartbeatJob(NODE_A, secretA, jobId, 300, staleGeneration),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+            expect(jobs.extendLease).not.toHaveBeenCalled();
+            expect(rows[0]).toMatchObject({
+                status: 'leased',
+                nodeId: NODE_A,
+                leaseGeneration: 2,
+                leaseExpiresAt: currentExpiry,
+            });
+            expect(emitter.emit).not.toHaveBeenCalled();
+        });
+
+        it('cannot flip the status or land a result: complete throws stale-lease before any write', async () => {
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_A,
+                    secret: secretA,
+                    jobId,
+                    success: true,
+                    result: { branch: 'task/from-the-run-that-slept' },
+                    leaseGeneration: staleGeneration,
+                }),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+            expect(jobs.complete).not.toHaveBeenCalled();
+            expect(rows[0]).toMatchObject({
+                status: 'leased',
+                result: null,
+                error: null,
+                leaseGeneration: 2,
+                leaseExpiresAt: currentExpiry,
+            });
+            // No completion event → the reconciler never opens a PR for it.
+            expect(completedEvents()).toEqual([]);
+        });
+
+        it('cannot record a failure over the current claim either', async () => {
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_A,
+                    secret: secretA,
+                    jobId,
+                    success: false,
+                    error: 'lease-lapsed-while-suspended',
+                    leaseGeneration: staleGeneration,
+                }),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+            expect(rows[0].status).toBe('leased');
+            expect(rows[0].error).toBeNull();
+        });
+
+        it('while the CURRENT claim on the same node renews and completes normally', async () => {
+            const beat = await service.heartbeatJob(NODE_A, secretA, jobId, 300, 2);
+            expect(beat?.status).toBe('running');
+            expect(beat?.leaseGeneration).toBe(2);
+            const done = await service.completeJob({
+                nodeId: NODE_A,
+                secret: secretA,
+                jobId,
+                success: true,
+                result: { branch: 'task/from-the-current-run' },
+                leaseGeneration: 2,
+            });
+            expect(done?.status).toBe('done');
+            expect(rows[0].result).toEqual({ branch: 'task/from-the-current-run' });
+            const [, event] = completedEvents()[0];
+            expect(event.job.leaseGeneration).toBe(2);
+        });
+
+        it('surfaces as a 409 with the stable machine-readable reason', async () => {
+            const error = await service
+                .heartbeatJob(NODE_A, secretA, jobId, 300, staleGeneration)
+                .catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getStatus()).toBe(409);
+            expect((error as ConflictException).getResponse()).toMatchObject({
+                statusCode: 409,
+                reason: FLEET_JOB_STALE_LEASE_REASON,
+                message: expect.any(String),
+            });
+        });
+    });
+
+    describe('a stale holder on ANOTHER node (job re-leased elsewhere)', () => {
+        it('is refused on the undifferentiated 401 path, and the new holder is never disturbed', async () => {
+            await enqueue();
+            const [first] = await leaseAs(NODE_A, secretA);
+            lapse(rows[0]);
+            await leaseAs(NODE_B, secretB);
+            emitter.emit.mockClear();
+
+            await expect(
+                service.heartbeatJob(NODE_A, secretA, first.id, 300, first.leaseGeneration),
+            ).resolves.toBeNull();
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_A,
+                    secret: secretA,
+                    jobId: first.id,
+                    success: true,
+                    result: { pushed: true },
+                    leaseGeneration: first.leaseGeneration,
+                }),
+            ).resolves.toBeNull();
+            expect(rows[0]).toMatchObject({
+                status: 'leased',
+                nodeId: NODE_B,
+                leaseGeneration: 2,
+                result: null,
+            });
+            expect(emitter.emit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('fail-closed generation shapes', () => {
+        let jobId: string;
+
+        beforeEach(async () => {
+            await enqueue();
+            const [leased] = await leaseAs(NODE_A, secretA);
+            jobId = leased.id;
+            emitter.emit.mockClear();
+        });
+
+        it.each([
+            ['missing (a node built before generations)', undefined],
+            ['null', null],
+            ['zero (the migration backfill / a pre-protocol lease)', 0],
+            ['a negative number', -1],
+            ['a non-integer', 1.5],
+            ['a numeric string', '1'],
+            ['a future generation', 2],
+            ['NaN', Number.NaN],
+        ])('refuses heartbeat and complete when the generation is %s', async (_label, value) => {
+            await expect(
+                service.heartbeatJob(NODE_A, secretA, jobId, 300, value),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_A,
+                    secret: secretA,
+                    jobId,
+                    success: true,
+                    leaseGeneration: value,
+                }),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+            expect(jobs.extendLease).not.toHaveBeenCalled();
+            expect(jobs.complete).not.toHaveBeenCalled();
+            expect(rows[0].status).toBe('leased');
+            expect(emitter.emit).not.toHaveBeenCalled();
+        });
+
+        it('keeps the status check ahead of the generation check (a terminal job is a 401, not a 409)', async () => {
+            await service.completeJob({
+                nodeId: NODE_A,
+                secret: secretA,
+                jobId,
+                success: true,
+                leaseGeneration: 1,
+            });
+            // Replay with a nonsense generation: the row is terminal, so
+            // the answer is the undifferentiated null, revealing nothing.
+            await expect(service.heartbeatJob(NODE_A, secretA, jobId, 300, 99)).resolves.toBeNull();
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_A,
+                    secret: secretA,
+                    jobId,
+                    success: false,
+                    leaseGeneration: 99,
+                }),
+            ).resolves.toBeNull();
+        });
+
+        it('keeps the holder check ahead of the generation check (a foreign node is a 401, not a 409)', async () => {
+            await expect(
+                service.heartbeatJob(NODE_B, secretB, jobId, 300, 999),
+            ).resolves.toBeNull();
+            await expect(
+                service.completeJob({
+                    nodeId: NODE_B,
+                    secret: secretB,
+                    jobId,
+                    success: true,
+                    leaseGeneration: 999,
+                }),
+            ).resolves.toBeNull();
+        });
+    });
+
+    describe('reclaim', () => {
+        it('pins the observed generation so a claim re-issued between scan and write is left alone', async () => {
+            await enqueue();
+            await leaseAs(NODE_A, secretA);
+            lapse(rows[0]);
+
+            const summary = await service.reclaimExpired(USER);
+            expect(summary).toMatchObject({ requeued: 1, failed: 0 });
+            expect(jobs.reclaim).toHaveBeenCalledWith(
+                rows[0].id,
+                expect.objectContaining({ nodeId: NODE_A, leaseGeneration: 1 }),
+            );
+            // The generation is NOT reset by reclaim: the next claim
+            // advances it, which is what voids the lapsed run.
+            expect(rows[0]).toMatchObject({ status: 'queued', nodeId: null, leaseGeneration: 1 });
+
+            // A scan snapshot from before a re-lease matches nothing.
+            const [again] = await leaseAs(NODE_A, secretA);
+            expect(again.leaseGeneration).toBe(2);
+            jobs.findExpiredLeases.mockResolvedValueOnce([
+                {
+                    ...rows[0],
+                    leaseGeneration: 1,
+                    leaseExpiresAt: new Date(Date.now() - 5_000),
+                },
+            ]);
+            const stale = await service.reclaimExpired(USER);
+            expect(stale).toMatchObject({ requeued: 0, failed: 0 });
+            expect(rows[0]).toMatchObject({ status: 'leased', nodeId: NODE_A, leaseGeneration: 2 });
+        });
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet-job.queue-expiry.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.queue-expiry.spec.ts
@@ -588,7 +588,12 @@ describe('FleetJobRepository — queue SLA writes', () => {
     });
 
     it('re-stamps queuedAt when reclaim and drain return a row to the pool', async () => {
-        const observed = { status: 'running' as const, nodeId: NODE_A, leaseExpiresAt: new Date() };
+        const observed = {
+            status: 'running' as const,
+            nodeId: NODE_A,
+            leaseExpiresAt: new Date(),
+            leaseGeneration: 1,
+        };
         await repository.reclaim('job-1', observed);
         expect(typeorm.update.mock.calls[0][1]).toMatchObject({
             status: 'queued',

--- a/packages/agent/src/fleet/__tests__/fleet-job.repository.integration.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.repository.integration.spec.ts
@@ -1,0 +1,278 @@
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '../../database/_entities-inventory';
+import { FleetJob } from '../../entities/fleet-job.entity';
+import { FleetJobRepository } from '../fleet-job.repository';
+
+/**
+ * The REAL predicates behind lease generations, against a real
+ * (better-sqlite3, synchronize) schema.
+ *
+ * The service specs drive the repository through in-memory doubles that
+ * re-implement the WHERE clause, so they cannot notice the one failure
+ * that matters here: a `leaseGeneration` that silently drops out of a
+ * conditional UPDATE and turns "pinned to this claim" back into "pinned
+ * to this node". Every write a node can trigger is exercised with the
+ * current generation (lands) and a stale one (matches zero rows and
+ * leaves the row byte-for-byte as it was).
+ */
+describe('fleet job lease generation — repository integration (better-sqlite3)', () => {
+    const OWNER = '44444444-4444-4444-8444-444444444444';
+    const NODE_A = '11111111-1111-4111-8111-111111111111';
+    const NODE_B = '22222222-2222-4222-8222-222222222222';
+
+    let dataSource: DataSource;
+    let jobs: FleetJobRepository;
+    let rows: Repository<FleetJob>;
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+        rows = dataSource.getRepository(FleetJob);
+        jobs = new FleetJobRepository(rows);
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    afterEach(async () => {
+        await rows.clear();
+    });
+
+    const expiry = (offsetMs: number) => new Date(Date.now() + offsetMs);
+    const read = (id: string) => rows.findOneByOrFail({ id });
+
+    /** Enqueue and lease once as `nodeId`, returning the row at generation 1. */
+    async function leasedJob(nodeId = NODE_A): Promise<FleetJob> {
+        const created = await jobs.create({ userId: OWNER, kind: 'acceptance-checks' });
+        expect(created.leaseGeneration).toBe(0);
+        const won = await jobs.claim(created.id, {
+            nodeId,
+            status: 'leased',
+            leaseExpiresAt: expiry(60_000),
+            attempts: 1,
+            queuedReason: null,
+            leaseGeneration: 1,
+        });
+        expect(won).toBe(true);
+        return read(created.id);
+    }
+
+    describe('claim', () => {
+        it('mints previous + 1 and refuses to mint a value the row has moved past', async () => {
+            const job = await leasedJob();
+            expect(job.leaseGeneration).toBe(1);
+
+            // Back to the pool WITHOUT resetting the generation.
+            expect(
+                await jobs.reclaim(job.id, {
+                    status: 'leased',
+                    nodeId: NODE_A,
+                    leaseExpiresAt: job.leaseExpiresAt!,
+                    leaseGeneration: 1,
+                }),
+            ).toBe(true);
+            expect(await read(job.id)).toMatchObject({
+                status: 'queued',
+                nodeId: null,
+                leaseGeneration: 1,
+            });
+
+            // A claim computed from a stale read (observed 0 → mint 1) must
+            // not land: the platform already issued generation 1 once.
+            expect(
+                await jobs.claim(job.id, {
+                    nodeId: NODE_B,
+                    status: 'leased',
+                    leaseExpiresAt: expiry(60_000),
+                    attempts: 2,
+                    queuedReason: null,
+                    leaseGeneration: 1,
+                }),
+            ).toBe(false);
+            expect(await read(job.id)).toMatchObject({ status: 'queued', leaseGeneration: 1 });
+
+            // The claim computed from the current row (observed 1 → mint 2) does.
+            expect(
+                await jobs.claim(job.id, {
+                    nodeId: NODE_B,
+                    status: 'leased',
+                    leaseExpiresAt: expiry(60_000),
+                    attempts: 2,
+                    queuedReason: null,
+                    leaseGeneration: 2,
+                }),
+            ).toBe(true);
+            expect(await read(job.id)).toMatchObject({
+                status: 'leased',
+                nodeId: NODE_B,
+                leaseGeneration: 2,
+            });
+        });
+    });
+
+    describe('extendLease', () => {
+        it('lands only for the current generation and leaves the row untouched otherwise', async () => {
+            const job = await leasedJob();
+            const before = await read(job.id);
+
+            expect(await jobs.extendLease(job.id, NODE_A, expiry(120_000), new Date(), 0)).toBe(
+                false,
+            );
+            expect(await jobs.extendLease(job.id, NODE_A, expiry(120_000), new Date(), 2)).toBe(
+                false,
+            );
+            expect(await read(job.id)).toEqual(before);
+
+            expect(await jobs.extendLease(job.id, NODE_A, expiry(120_000), new Date(), 1)).toBe(
+                true,
+            );
+            expect(await read(job.id)).toMatchObject({ status: 'running', leaseGeneration: 1 });
+        });
+
+        it('refuses the previous generation on the SAME node after a re-lease', async () => {
+            const job = await leasedJob();
+            // Lapse → reclaim → the same node claims again at generation 2.
+            await jobs.reclaim(job.id, {
+                status: 'leased',
+                nodeId: NODE_A,
+                leaseExpiresAt: job.leaseExpiresAt!,
+                leaseGeneration: 1,
+            });
+            await jobs.claim(job.id, {
+                nodeId: NODE_A,
+                status: 'leased',
+                leaseExpiresAt: expiry(60_000),
+                attempts: 2,
+                queuedReason: null,
+                leaseGeneration: 2,
+            });
+            const current = await read(job.id);
+
+            // The run that slept: same node, generation 1.
+            expect(await jobs.extendLease(job.id, NODE_A, expiry(600_000), new Date(), 1)).toBe(
+                false,
+            );
+            expect(await read(job.id)).toEqual(current);
+        });
+    });
+
+    describe('complete', () => {
+        it('never lets a stale generation write status, result or error over the current claim', async () => {
+            const job = await leasedJob();
+            await jobs.reclaim(job.id, {
+                status: 'leased',
+                nodeId: NODE_A,
+                leaseExpiresAt: job.leaseExpiresAt!,
+                leaseGeneration: 1,
+            });
+            await jobs.claim(job.id, {
+                nodeId: NODE_A,
+                status: 'leased',
+                leaseExpiresAt: expiry(60_000),
+                attempts: 2,
+                queuedReason: null,
+                leaseGeneration: 2,
+            });
+            const current = await read(job.id);
+
+            for (const stale of [0, 1, 3]) {
+                expect(
+                    await jobs.complete(
+                        job.id,
+                        NODE_A,
+                        {
+                            status: 'done',
+                            result: { branch: 'task/from-the-run-that-slept' },
+                            completedAt: new Date(),
+                        },
+                        stale,
+                    ),
+                ).toBe(false);
+                expect(
+                    await jobs.complete(
+                        job.id,
+                        NODE_A,
+                        { status: 'failed', error: 'stale verdict', completedAt: new Date() },
+                        stale,
+                    ),
+                ).toBe(false);
+            }
+            expect(await read(job.id)).toEqual(current);
+
+            expect(
+                await jobs.complete(
+                    job.id,
+                    NODE_A,
+                    {
+                        status: 'done',
+                        result: { branch: 'task/from-the-current-run' },
+                        completedAt: new Date(),
+                    },
+                    2,
+                ),
+            ).toBe(true);
+            expect(await read(job.id)).toMatchObject({
+                status: 'done',
+                result: { branch: 'task/from-the-current-run' },
+                leaseExpiresAt: null,
+                leaseGeneration: 2,
+            });
+        });
+    });
+
+    describe('reclaim / failExhausted', () => {
+        it('pin the observed generation and leave it intact on the row', async () => {
+            const job = await leasedJob();
+            const observed = {
+                status: 'leased' as const,
+                nodeId: NODE_A,
+                leaseExpiresAt: job.leaseExpiresAt!,
+            };
+
+            expect(await jobs.reclaim(job.id, { ...observed, leaseGeneration: 2 })).toBe(false);
+            expect(
+                await jobs.failExhausted(
+                    job.id,
+                    { ...observed, leaseGeneration: 2 },
+                    'budget exhausted',
+                    new Date(),
+                ),
+            ).toBe(false);
+            expect(await read(job.id)).toMatchObject({ status: 'leased', leaseGeneration: 1 });
+
+            expect(
+                await jobs.failExhausted(
+                    job.id,
+                    { ...observed, leaseGeneration: 1 },
+                    'budget exhausted',
+                    new Date(),
+                ),
+            ).toBe(true);
+            expect(await read(job.id)).toMatchObject({
+                status: 'failed',
+                error: 'budget exhausted',
+                leaseGeneration: 1,
+            });
+        });
+    });
+
+    describe('releaseClaimsForNode (drain)', () => {
+        it('requeues without advancing the generation — the next claim does that', async () => {
+            const job = await leasedJob();
+            expect(await jobs.releaseClaimsForNode(OWNER, NODE_A)).toBe(1);
+            expect(await read(job.id)).toMatchObject({
+                status: 'queued',
+                nodeId: null,
+                leaseExpiresAt: null,
+                leaseGeneration: 1,
+            });
+        });
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
@@ -75,6 +75,7 @@ function makeRepos(stores: Stores): {
                 status: 'queued',
                 attempts: 0,
                 maxAttempts: 3,
+                leaseGeneration: 0,
                 requiredCapabilities: [],
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -103,17 +104,33 @@ function makeRepos(stores: Stores): {
                 .slice(0, limit),
         ),
         claim: jest.fn(async (id: string, patch: Record<string, unknown>) => {
-            // The real guarantee: the row must STILL be queued.
+            // The real guarantee: the row must STILL be queued, and still
+            // carry the generation this claim advances from.
             return (
-                applyUpdate(stores.jobs, { id, status: 'queued' } as never, patch as never) === 1
+                applyUpdate(
+                    stores.jobs,
+                    {
+                        id,
+                        status: 'queued',
+                        leaseGeneration: (patch.leaseGeneration as number) - 1,
+                    } as never,
+                    patch as never,
+                ) === 1
             );
         }),
         extendLease: jest.fn(
-            async (id: string, nodeId: string, leaseExpiresAt: Date, startedAt?: Date) => {
+            async (
+                id: string,
+                nodeId: string,
+                leaseExpiresAt: Date,
+                startedAt: Date | undefined,
+                leaseGeneration: number,
+            ) => {
                 const row = stores.jobs.find(
                     (j) =>
                         j.id === id &&
                         j.nodeId === nodeId &&
+                        j.leaseGeneration === leaseGeneration &&
                         (j.status === 'leased' || j.status === 'running'),
                 );
                 if (!row) return false;
@@ -123,17 +140,25 @@ function makeRepos(stores: Stores): {
                 return true;
             },
         ),
-        complete: jest.fn(async (id: string, nodeId: string, patch: Record<string, unknown>) => {
-            const row = stores.jobs.find(
-                (j) =>
-                    j.id === id &&
-                    j.nodeId === nodeId &&
-                    (j.status === 'leased' || j.status === 'running'),
-            );
-            if (!row) return false;
-            Object.assign(row, patch, { leaseExpiresAt: null });
-            return true;
-        }),
+        complete: jest.fn(
+            async (
+                id: string,
+                nodeId: string,
+                patch: Record<string, unknown>,
+                leaseGeneration: number,
+            ) => {
+                const row = stores.jobs.find(
+                    (j) =>
+                        j.id === id &&
+                        j.nodeId === nodeId &&
+                        j.leaseGeneration === leaseGeneration &&
+                        (j.status === 'leased' || j.status === 'running'),
+                );
+                if (!row) return false;
+                Object.assign(row, patch, { leaseExpiresAt: null });
+                return true;
+            },
+        ),
         findExpiredLeases: jest.fn(async (cutoff: Date, limit: number, userId?: string) =>
             stores.jobs
                 .filter(
@@ -149,13 +174,19 @@ function makeRepos(stores: Stores): {
         reclaim: jest.fn(
             async (
                 id: string,
-                observed: { status: string; nodeId: string; leaseExpiresAt: Date },
+                observed: {
+                    status: string;
+                    nodeId: string;
+                    leaseExpiresAt: Date;
+                    leaseGeneration: number;
+                },
             ) => {
                 const row = stores.jobs.find(
                     (j) =>
                         j.id === id &&
                         j.status === observed.status &&
                         j.nodeId === observed.nodeId &&
+                        j.leaseGeneration === observed.leaseGeneration &&
                         j.leaseExpiresAt?.getTime() === observed.leaseExpiresAt.getTime(),
                 );
                 if (!row) return false;
@@ -170,7 +201,12 @@ function makeRepos(stores: Stores): {
         failExhausted: jest.fn(
             async (
                 id: string,
-                observed: { status: string; nodeId: string; leaseExpiresAt: Date },
+                observed: {
+                    status: string;
+                    nodeId: string;
+                    leaseExpiresAt: Date;
+                    leaseGeneration: number;
+                },
                 error: string,
                 completedAt: Date,
             ) => {
@@ -179,6 +215,7 @@ function makeRepos(stores: Stores): {
                         j.id === id &&
                         j.status === observed.status &&
                         j.nodeId === observed.nodeId &&
+                        j.leaseGeneration === observed.leaseGeneration &&
                         j.leaseExpiresAt?.getTime() === observed.leaseExpiresAt.getTime(),
                 );
                 if (!row) return false;
@@ -684,7 +721,13 @@ describe('FleetJobService', () => {
             // Push the stored expiry back so any extension is unambiguous.
             stores.jobs[0].leaseExpiresAt = new Date(before - 60_000);
 
-            const beat = await service.heartbeatJob(NODE_A, secretA, leased![0].id);
+            const beat = await service.heartbeatJob(
+                NODE_A,
+                secretA,
+                leased![0].id,
+                undefined,
+                leased![0].leaseGeneration,
+            );
             expect(beat?.status).toBe('running');
             expect(new Date(beat!.leaseExpiresAt!).getTime()).toBeGreaterThan(before - 60_000);
             expect(beat?.startedAt).not.toBeNull();
@@ -693,7 +736,15 @@ describe('FleetJobService', () => {
         it("refuses to extend another node's claim", async () => {
             await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
             const leased = await service.lease({ nodeId: NODE_A, secret: secretA });
-            await expect(service.heartbeatJob(NODE_B, secretB, leased![0].id)).resolves.toBeNull();
+            await expect(
+                service.heartbeatJob(
+                    NODE_B,
+                    secretB,
+                    leased![0].id,
+                    undefined,
+                    leased![0].leaseGeneration,
+                ),
+            ).resolves.toBeNull();
         });
 
         it('refuses to extend a job that is still queued', async () => {
@@ -701,7 +752,9 @@ describe('FleetJobService', () => {
                 userId: 'owner-1',
                 kind: 'acceptance-checks',
             });
-            await expect(service.heartbeatJob(NODE_A, secretA, queued.id)).resolves.toBeNull();
+            await expect(
+                service.heartbeatJob(NODE_A, secretA, queued.id, undefined, 1),
+            ).resolves.toBeNull();
         });
     });
 
@@ -720,6 +773,7 @@ describe('FleetJobService', () => {
                 jobId: leased![0].id,
                 success: true,
                 result: { gateStatus: 'green' },
+                leaseGeneration: leased![0].leaseGeneration,
             });
 
             expect(done?.status).toBe('done');
@@ -737,6 +791,7 @@ describe('FleetJobService', () => {
                 jobId: leased![0].id,
                 success: false,
                 error: 'check `pnpm build` exited 1',
+                leaseGeneration: leased![0].leaseGeneration,
             });
 
             expect(failed?.status).toBe('failed');
@@ -755,6 +810,7 @@ describe('FleetJobService', () => {
                 secret: secretA,
                 jobId: leased![0].id,
                 success: true,
+                leaseGeneration: leased![0].leaseGeneration,
             };
             await expect(service.completeJob(input)).resolves.not.toBeNull();
             await expect(service.completeJob(input)).resolves.toBeNull();
@@ -769,6 +825,7 @@ describe('FleetJobService', () => {
                     secret: secretB,
                     jobId: leased![0].id,
                     success: true,
+                    leaseGeneration: leased![0].leaseGeneration,
                 }),
             ).resolves.toBeNull();
         });
@@ -870,10 +927,12 @@ describe('FleetJobService', () => {
                             status: string;
                             nodeId: string;
                             leaseExpiresAt: Date;
+                            leaseGeneration: number;
                         };
                         if (
                             row.status !== observed.status ||
                             row.nodeId !== observed.nodeId ||
+                            row.leaseGeneration !== observed.leaseGeneration ||
                             row.leaseExpiresAt.getTime() !== observed.leaseExpiresAt.getTime()
                         ) {
                             return false;

--- a/packages/agent/src/fleet/fleet-job.repository.ts
+++ b/packages/agent/src/fleet/fleet-job.repository.ts
@@ -35,6 +35,14 @@ export interface ClaimJobPatch {
      * stale.
      */
     queuedReason: null;
+    /**
+     * The generation being MINTED by this claim — always the value the
+     * service observed on the candidate plus one. `claim()` pins the
+     * observed value (`leaseGeneration - 1`) in its WHERE clause, so a
+     * read-then-claim that straddles another node's lease-and-lapse of
+     * the same row matches zero rows instead of minting a duplicate.
+     */
+    leaseGeneration: number;
 }
 
 /** Exact claim snapshot observed by an expiry scan. */
@@ -42,6 +50,8 @@ export interface ObservedFleetJobLease {
     status: FleetJobStatus;
     nodeId: string;
     leaseExpiresAt: Date;
+    /** Generation of the claim being reclaimed; a newer claim is never touched. */
+    leaseGeneration: number;
 }
 
 /**
@@ -126,41 +136,63 @@ export class FleetJobRepository {
      * instead of requeuing them, but this is the invariant itself rather
      * than one caller remembering it — any future path that queues a
      * flagged row is refused here.
+     *
+     * `leaseGeneration` is pinned to the value this claim advances FROM
+     * (suspend-safe leases): the service reads the candidate, computes
+     * `previous + 1`, and this CAS refuses to mint that value unless the
+     * row still carries `previous`. Without it, a candidate read before
+     * another node leased and lost the same row would stamp a generation
+     * the platform had already issued once.
      */
     async claim(id: string, patch: ClaimJobPatch): Promise<boolean> {
         const result = await this.repository.update(
-            { id, status: 'queued', cancelRequestedAt: IsNull() },
+            {
+                id,
+                status: 'queued',
+                cancelRequestedAt: IsNull(),
+                leaseGeneration: patch.leaseGeneration - 1,
+            },
             patch,
         );
         return (result.affected ?? 0) === 1;
     }
 
     /**
-     * Extend the lease of a job this node still holds. The WHERE clause
-     * pins both the node id and the active statuses, so a node cannot
-     * extend someone else's claim or resurrect a terminal job.
+     * Extend the lease of a job this node still holds UNDER THIS CLAIM.
+     * The WHERE clause pins the node id, the active statuses AND the
+     * lease generation: it identifies the claim, not merely the holder.
+     * A node cannot extend someone else's claim, resurrect a terminal
+     * job, or — the suspend case — renew a NEWER claim on the same job
+     * from an older run that never learned it lost the first one.
+     *
+     * `leaseGeneration` is required, positioned last so every earlier
+     * positional caller stays readable; there is no fail-open form.
      */
     async extendLease(
         id: string,
         nodeId: string,
         leaseExpiresAt: Date,
-        startedAt?: Date,
+        startedAt: Date | undefined,
+        leaseGeneration: number,
     ): Promise<boolean> {
         const patch: Partial<FleetJob> = { leaseExpiresAt, status: 'running' };
         if (startedAt) {
             patch.startedAt = startedAt;
         }
         const result = await this.repository.update(
-            { id, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]) },
+            { id, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]), leaseGeneration },
             patch,
         );
         return (result.affected ?? 0) === 1;
     }
 
     /**
-     * Terminal transition for a job this node still holds. Same pinned
-     * WHERE clause as `extendLease` — completing a job twice, or
-     * completing another node's job, matches zero rows.
+     * Terminal transition for a job this node still holds UNDER THIS
+     * CLAIM. Same pinned WHERE clause as `extendLease` — completing a job
+     * twice, completing another node's job, or completing a claim that
+     * has since been re-issued (even to this node) matches zero rows, so
+     * a stale holder can never write a status, result or error over the
+     * current holder's.
      */
     async complete(
         id: string,
@@ -171,9 +203,10 @@ export class FleetJobRepository {
             error?: string | null;
             completedAt: Date;
         },
+        leaseGeneration: number,
     ): Promise<boolean> {
         const updated = await this.repository.update(
-            { id, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]) },
+            { id, nodeId, status: In([...FLEET_JOB_ACTIVE_STATUSES]), leaseGeneration },
             { ...patch, leaseExpiresAt: null },
         );
         return (updated.affected ?? 0) === 1;
@@ -337,7 +370,10 @@ export class FleetJobRepository {
     /**
      * Return one lapsed claim to the pool. Pins the previous status so a
      * job that completed between the scan and the write is never
-     * resurrected.
+     * resurrected, and the observed generation so a claim re-issued
+     * between the scan and the write is never requeued underneath its
+     * new holder. The generation itself is left as it is: the NEXT claim
+     * advances it, which is what invalidates the lapsed run.
      */
     async reclaim(id: string, observed: ObservedFleetJobLease): Promise<boolean> {
         const result = await this.repository.update(
@@ -346,6 +382,7 @@ export class FleetJobRepository {
                 status: observed.status,
                 nodeId: observed.nodeId,
                 leaseExpiresAt: observed.leaseExpiresAt,
+                leaseGeneration: observed.leaseGeneration,
             },
             // Reclaim returns the row to the pool as an ORDINARY queued
             // job: the reason it originally waited (no free runner) is
@@ -364,7 +401,7 @@ export class FleetJobRepository {
         return (result.affected ?? 0) === 1;
     }
 
-    /** Fail a lapsed claim that has exhausted its attempt budget. */
+    /** Fail a lapsed claim that has exhausted its attempt budget (same pinned tuple as `reclaim`). */
     async failExhausted(
         id: string,
         observed: ObservedFleetJobLease,
@@ -377,6 +414,7 @@ export class FleetJobRepository {
                 status: observed.status,
                 nodeId: observed.nodeId,
                 leaseExpiresAt: observed.leaseExpiresAt,
+                leaseGeneration: observed.leaseGeneration,
             },
             { status: 'failed', leaseExpiresAt: null, error, completedAt },
         );
@@ -439,6 +477,11 @@ export class FleetJobRepository {
      * the node re-asking (`heartbeat` → 401 → abort) immediately before
      * any irreversible write, which is why `apps/node` confirms the claim
      * at the moment it publishes rather than trusting its own deadline.
+     *
+     * `leaseGeneration` is deliberately NOT advanced here: a drain is not
+     * a claim. The next `claim()` advances it, and that is the moment the
+     * drained node's in-flight run — should it ever report — is refused
+     * even if the same node is re-enabled and re-leases the job itself.
      */
     async releaseClaimsForNode(userId: string, nodeId: string): Promise<number> {
         const result = await this.repository.update(

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    Logger,
+    Optional,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { isUUID } from 'class-validator';
 import type {
@@ -17,6 +23,7 @@ import {
     FLEET_JOB_MAX_REQUIRED_CAPABILITIES,
     FLEET_JOB_MAX_RESULT_BYTES,
     FLEET_JOB_QUEUE_EXPIRED_REASON,
+    FLEET_JOB_STALE_LEASE_REASON,
     isFleetJobKind,
     nodeSatisfiesCapabilities,
 } from '@ever-works/contracts';
@@ -67,6 +74,12 @@ export interface CompleteFleetJobInput {
     success: boolean;
     result?: Record<string, unknown> | null;
     error?: string | null;
+    /**
+     * The `leaseGeneration` the node was handed with the lease. Typed
+     * `unknown` like the credential: the service validates the shape and
+     * refuses anything that is not exactly the job's current generation.
+     */
+    leaseGeneration?: unknown;
 }
 
 export interface ReclaimSummary {
@@ -109,6 +122,31 @@ export interface CancelFleetJobOutcome {
 }
 
 /**
+ * Suspend-safe leases (self-build finding R7) — the ONE differentiated
+ * refusal in the node work channel.
+ *
+ * Thrown by `heartbeatJob` / `completeJob` when the caller IS the
+ * recorded holder of an active job but the generation it echoes is not
+ * the job's current one: its claim lapsed and was re-issued (to another
+ * node, or to this same node on a later poll) while its run kept going.
+ * Surfaces at the edge as `409 { statusCode, reason: 'stale-lease',
+ * message }`, which the node keys its abort on.
+ *
+ * Deliberately reachable ONLY after the credential, `nodeId` and status
+ * checks have passed, so it reveals nothing to a node that is not the
+ * recorded holder: every other refusal stays the undifferentiated 401.
+ */
+export class FleetJobStaleLeaseError extends ConflictException {
+    constructor() {
+        super({
+            statusCode: 409,
+            reason: FLEET_JOB_STALE_LEASE_REASON,
+            message: 'The lease this node holds on the job is no longer current',
+        });
+    }
+}
+
+/**
  * Fleet job runtime (Desktop PRD §6.2 / M4) — the lease protocol.
  *
  * This is the server half of `job-runtime-node`: the provider's "queue"
@@ -120,6 +158,11 @@ export interface CancelFleetJobOutcome {
  *     (`FleetJobRepository.claim` pins `status:'queued'`);
  *   - a node can only heartbeat/complete a job it still holds
  *     (both pin `nodeId` AND the active statuses);
+ *   - a node can only heartbeat/complete the CLAIM it was handed: every
+ *     lease mints a `leaseGeneration`, both calls carry it, and a stale
+ *     one is refused with `409 stale-lease` and never touches the row —
+ *     so a machine that slept through its lease cannot overwrite the
+ *     current holder, even when that is itself on a later claim;
  *   - a lapsed claim is reclaimable without the node's cooperation
  *     (the lease is a deadline, never a lock).
  *
@@ -315,6 +358,10 @@ export class FleetJobService {
             }
             const leaseExpiresAt = new Date(Date.now() + ttlSec * 1000);
             const attempts = (candidate.attempts ?? 0) + 1;
+            // Every claim — a first lease or a re-lease after a lapse —
+            // mints a new generation. The CAS pins the one observed here,
+            // so this value is issued at most once for this job.
+            const leaseGeneration = (candidate.leaseGeneration ?? 0) + 1;
             const won = await this.jobs.claim(candidate.id, {
                 nodeId: node.id,
                 status: 'leased',
@@ -323,6 +370,7 @@ export class FleetJobService {
                 // The claim IS the moment "waiting for a runner" stops
                 // being true, so it is the claim that clears the token.
                 queuedReason: null,
+                leaseGeneration,
             });
             if (!won) {
                 // Another node won the race. Not an error — just skip it.
@@ -335,6 +383,7 @@ export class FleetJobService {
                 leaseExpiresAt,
                 attempts,
                 queuedReason: null,
+                leaseGeneration,
             } as FleetJob);
             leased.push(view);
             this.emit(
@@ -449,12 +498,19 @@ export class FleetJobService {
      * first beat `leased` → `running` (the node acknowledged the work).
      * Null on any invalid path — bad credential, foreign job, terminal
      * job — so the edge cannot leak which.
+     *
+     * `leaseGeneration` (suspend-safe leases) must be exactly the value
+     * the node was handed with the lease. Checked AFTER the holder and
+     * status checks, so only the recorded holder of an active job can
+     * ever see the differentiated {@link FleetJobStaleLeaseError}; a
+     * missing, malformed, older or newer generation all fail closed.
      */
     async heartbeatJob(
         nodeId: unknown,
         secret: unknown,
         jobId: string,
         leaseTtlSec?: number,
+        leaseGeneration?: unknown,
     ): Promise<FleetJobView | null> {
         // 'report': a draining (paused/disabled) node must keep the
         // claim on work it is already running.
@@ -464,6 +520,12 @@ export class FleetJobService {
         const job = await this.jobs.findById(jobId);
         if (!job || job.nodeId !== node.id) return null;
         if (job.status !== 'leased' && job.status !== 'running') return null;
+        if (!isCurrentLeaseGeneration(job, leaseGeneration)) {
+            this.logger.log(
+                `Fleet job ${job.id}: heartbeat refused — stale lease generation from node ${node.id}`,
+            );
+            throw new FleetJobStaleLeaseError();
+        }
         // Agent execution v2 (slice B) — an operator cancel is delivered
         // as a REFUSED heartbeat: the node reads it as "lease lost" and
         // aborts the job, exactly as it would for a dead server. Its
@@ -477,7 +539,13 @@ export class FleetJobService {
         const ttlSec = clampLeaseTtlSec(leaseTtlSec);
         const leaseExpiresAt = new Date(Date.now() + ttlSec * 1000);
         const startedAt = job.startedAt ?? new Date();
-        const extended = await this.jobs.extendLease(job.id, node.id, leaseExpiresAt, startedAt);
+        const extended = await this.jobs.extendLease(
+            job.id,
+            node.id,
+            leaseExpiresAt,
+            startedAt,
+            job.leaseGeneration,
+        );
         if (!extended) return null;
 
         return toJobView({
@@ -494,6 +562,13 @@ export class FleetJobService {
      * node reported a real verdict, and silently re-running a check that
      * legitimately went red would be worse than surfacing it. Only
      * LAPSED claims (no verdict at all) are retried, by the reclaim path.
+     *
+     * A report carrying a stale `leaseGeneration` is refused with
+     * {@link FleetJobStaleLeaseError} BEFORE anything is written and
+     * BEFORE any completion event is emitted, so a holder that lost its
+     * claim during a suspend can neither flip the status, nor land a
+     * result/error, nor cause the reconciler to open a pull request for
+     * a branch it was never entitled to push.
      */
     async completeJob(input: CompleteFleetJobInput): Promise<FleetJobView | null> {
         // 'report': the whole point of a drain is that in-flight work
@@ -504,6 +579,12 @@ export class FleetJobService {
         const job = await this.jobs.findById(input.jobId);
         if (!job || job.nodeId !== node.id) return null;
         if (job.status !== 'leased' && job.status !== 'running') return null;
+        if (!isCurrentLeaseGeneration(job, input.leaseGeneration)) {
+            this.logger.log(
+                `Fleet job ${job.id}: completion refused — stale lease generation from node ${node.id}`,
+            );
+            throw new FleetJobStaleLeaseError();
+        }
 
         const completedAt = new Date();
         const status: Extract<FleetJobStatus, 'done' | 'failed'> = input.success
@@ -514,12 +595,17 @@ export class FleetJobService {
             : null;
         const error = input.success ? null : truncate(input.error, FLEET_JOB_MAX_ERROR_LENGTH);
 
-        const applied = await this.jobs.complete(job.id, node.id, {
-            status,
-            result,
-            error,
-            completedAt,
-        });
+        const applied = await this.jobs.complete(
+            job.id,
+            node.id,
+            {
+                status,
+                result,
+                error,
+                completedAt,
+            },
+            job.leaseGeneration,
+        );
         if (!applied) return null;
 
         const view = toJobView({
@@ -556,6 +642,7 @@ export class FleetJobService {
                     status: job.status,
                     nodeId: job.nodeId,
                     leaseExpiresAt: job.leaseExpiresAt,
+                    leaseGeneration: job.leaseGeneration ?? 0,
                 };
                 // A cancelled job must never go back in the pool.
                 //
@@ -948,6 +1035,7 @@ export function toJobView(job: FleetJob): FleetJobView {
         queuedAt: job.queuedAt ? toIso(job.queuedAt) : null,
         queuedReason: job.queuedReason ?? null,
         cancelRequestedAt: job.cancelRequestedAt ? toIso(job.cancelRequestedAt) : null,
+        leaseGeneration: job.leaseGeneration ?? 0,
     };
 }
 
@@ -974,6 +1062,26 @@ function formatDuration(seconds: number): string {
     if (seconds % 3600 === 0) return `${seconds / 3600}h`;
     if (seconds % 60 === 0) return `${seconds / 60}m`;
     return `${seconds}s`;
+}
+
+/**
+ * Is `supplied` exactly the generation of the claim `job` currently
+ * carries? Fail-closed on every other shape: missing (a node built before
+ * generations existed), non-integer, older (a run that slept through its
+ * lease), newer (cannot legitimately happen), and — deliberately — 0.
+ *
+ * 0 is what every row backfilled by the migration carries, and what a
+ * row still holds if it was leased before this protocol shipped. Never
+ * accepting it means such an in-flight job is refused on its next beat,
+ * aborts on the node, and is re-offered by reclaim under generation 1:
+ * one lost attempt, in exchange for never having a claim the protocol
+ * cannot tell apart from its successor.
+ */
+function isCurrentLeaseGeneration(job: FleetJob, supplied: unknown): boolean {
+    if (typeof supplied !== 'number' || !Number.isInteger(supplied) || supplied < 1) {
+        return false;
+    }
+    return supplied === (job.leaseGeneration ?? 0);
 }
 
 /**

--- a/packages/contracts/src/fleet/__tests__/fleet-jobs.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-jobs.spec.ts
@@ -18,6 +18,7 @@ import {
 	FLEET_JOB_DEFAULT_MAX_ATTEMPTS,
 	FLEET_JOB_DEFAULT_QUEUED_MAX_AGE_SEC,
 	FLEET_JOB_KINDS,
+	FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON,
 	FLEET_JOB_MAX_ATTEMPTS_CEILING,
 	FLEET_JOB_MAX_ERROR_LENGTH,
 	FLEET_JOB_MAX_LEASE_BATCH,
@@ -29,6 +30,7 @@ import {
 	FLEET_JOB_MIN_LEASE_TTL_SEC,
 	FLEET_JOB_MIN_QUEUED_MAX_AGE_SEC,
 	FLEET_JOB_QUEUE_EXPIRED_REASON,
+	FLEET_JOB_STALE_LEASE_REASON,
 	FLEET_JOB_STATUSES,
 	FLEET_JOB_TERMINAL_STATUSES,
 	isFleetJobActive,
@@ -260,6 +262,26 @@ describe('capability tag constants', () => {
 
 	it('keeps the two tags distinct', () => {
 		expect(FLEET_BROWSER_CAPABILITY).not.toBe(FLEET_GPU_CAPABILITY);
+	});
+});
+
+describe('suspend-safe lease reasons', () => {
+	// Both tokens are keyed on by code, not read by people: the node aborts
+	// on the 409 `reason`, and the run's error carries the suspend reason
+	// verbatim. The literal IS the contract.
+	it('pins the stale-lease reason the 409 body carries', () => {
+		expect(FLEET_JOB_STALE_LEASE_REASON).toBe('stale-lease');
+	});
+
+	it('pins the reason a node reports for a lease that lapsed during a suspend', () => {
+		expect(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON).toBe('lease-lapsed-while-suspended');
+	});
+
+	it('keeps the two reasons distinct short machine tokens', () => {
+		expect(FLEET_JOB_STALE_LEASE_REASON).not.toBe(FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON);
+		for (const token of [FLEET_JOB_STALE_LEASE_REASON, FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON]) {
+			expect(token).toMatch(/^[a-z][a-z-]{1,63}$/);
+		}
 	});
 });
 

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -66,7 +66,10 @@ const JOB_EXPORTS = [
 	'FLEET_JOB_MAX_QUEUED_MAX_AGE_SEC',
 	'clampQueuedMaxAgeSec',
 	'FLEET_JOB_QUEUE_EXPIRED_REASON',
-	'isQueueExpiredError'
+	'isQueueExpiredError',
+	// Suspend-safe leases (self-build finding R7).
+	'FLEET_JOB_STALE_LEASE_REASON',
+	'FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON'
 ] as const;
 
 const NODE_EXPORTS = [
@@ -219,14 +222,14 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 112 runtime symbols', () => {
+	it('exposes exactly these 114 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
 		// 92 → 98 with fleet cost accounting (EW-777): two node bounds and
 		// four cost-accounting helpers, each pinned in its own spec.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(112);
+		expect(Object.keys(fleet)).toHaveLength(114);
 	});
 
 	it.each([

--- a/packages/contracts/src/fleet/fleet-jobs.types.ts
+++ b/packages/contracts/src/fleet/fleet-jobs.types.ts
@@ -293,6 +293,45 @@ export interface FleetJobView {
 	 * reports; the row then settles `failed`. Null / absent otherwise.
 	 */
 	cancelRequestedAt?: string | null;
+	/**
+	 * Identity of the CLAIM this view was minted under (suspend-safe
+	 * leases, self-build finding R7). Every successful lease — including a
+	 * re-lease after the previous claim lapsed — increments it, and the
+	 * node echoes it on every call that mutates the job (heartbeat,
+	 * complete). A call carrying any other value is refused with
+	 * `409 { reason: "stale-lease" }`, so a machine that slept through
+	 * its lease can never overwrite the state of whoever holds the job
+	 * now — even when that is the same machine on a later claim.
+	 *
+	 * Optional on the wire so an older API build that does not send it
+	 * still satisfies this type on a newer client; a node that receives
+	 * no generation simply omits it, and an API that requires one then
+	 * refuses that node — the safe direction.
+	 */
+	leaseGeneration?: number;
+}
+
+/**
+ * Machine-readable reason carried by the `409` a node receives when the
+ * generation it echoes is no longer the job's current one. Stable: the
+ * node keys its abort on this token (and on the status), never on the
+ * message text.
+ */
+export const FLEET_JOB_STALE_LEASE_REASON = 'stale-lease';
+
+/**
+ * Stable failure reason a node reports when it detects, on resume from a
+ * suspend, that its lease deadline passed while the machine slept. The
+ * job is aborted locally (model process killed, nothing pushed) and this
+ * token is what the report and the run's error carry.
+ */
+export const FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON = 'lease-lapsed-while-suspended';
+
+/** Body of the `409` returned for a stale lease generation. */
+export interface FleetJobStaleLeaseResponse {
+	statusCode: 409;
+	reason: typeof FLEET_JOB_STALE_LEASE_REASON;
+	message: string;
 }
 
 /** Owner-safe view of one active-Organization Agent-to-node binding. */
@@ -1111,6 +1150,12 @@ export interface FleetJobHeartbeatRequest {
 	secret: string;
 	/** Requested lease extension; clamped server-side. */
 	leaseTtlSec?: number;
+	/**
+	 * The `leaseGeneration` returned with the lease. Required: a beat whose
+	 * generation is not the job's current one is refused with
+	 * `409 { reason: "stale-lease" }` and the node must abort the run.
+	 */
+	leaseGeneration: number;
 }
 
 /** Response body for `POST /api/fleet/jobs/:id/heartbeat`. */
@@ -1129,6 +1174,12 @@ export interface FleetJobCompleteRequest {
 	result?: Record<string, unknown> | null;
 	/** Failure detail. Capped server-side. */
 	error?: string | null;
+	/**
+	 * The `leaseGeneration` returned with the lease. Required: a report
+	 * whose generation is not the job's current one is refused with
+	 * `409 { reason: "stale-lease" }` and never touches the row.
+	 */
+	leaseGeneration: number;
 }
 
 /** Response body for `POST /api/fleet/jobs/:id/complete`. */


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AN** (program note §6, finding R7). Refs **EW-792**. No slice dependencies.

Desk PCs sleep. A suspended node stops heart-beating, its 300 s lease expires, another machine leases the same job and a second model run starts on the same Task branch while the first PC's model is still running (default execution timeout 1200 s inside a 300 s lease). The first node only learned it had lost the claim on its next beat, and because the keep-alive timer counts *awake* milliseconds the wall-clock lapse check lagged up to 100 s after a resume. Whoever pushed second lost a full model run to a non-fast-forward rejection.

### What changes

**Platform**
- `fleet_jobs.lease_generation` (int, NOT NULL, default 0) — migration `1788400000000-AddFleetJobLeaseGeneration` (guarded, idempotent up, down leaves rows) with spec.
- `lease()` mints `generation + 1` **inside the same CAS UPDATE** that flips the row to leased (`WHERE id, status = 'queued', cancel_requested_at IS NULL, lease_generation = minted - 1`). The view returned to the node (and `fleet.job.leased`) carries it.
- heartbeat and complete **require** `leaseGeneration` (`@IsInt @Min(1)`, 400 at the edge). The service refuses missing / older / newer with `FleetJobStaleLeaseError` → 409 `{ statusCode: 409, reason: 'stale-lease' }`. `extendLease` / `complete` pin the generation in the UPDATE `WHERE` next to `nodeId`; reclaim / failExhausted pin the observed generation; drain deliberately does not bump — the next claim does, which is what voids a drained node's in-flight run.
- A stale holder on another node is refused earlier by the nodeId check (401); a stale holder on the **same** node (re-lease after a lapse) gets the 409. Both fail closed. The reconciler only consumes events emitted after the CAS and never writes `fleet_jobs` by nodeId/jobId.

**Node**
- Two-clock suspend detector in the worker loop: wall-minus-monotonic drift (Linux/macOS, where `CLOCK_MONOTONIC` stops in S3) **and** "timer fired far later than armed" (Windows QPC advances across sleep), 30 s threshold. A run whose lease deadline passed while suspended is aborted with the stable reason `lease-lapsed-while-suspended`; the abort reaches `terminateProcessTree` (`taskkill /T /F` on win32, job-object containment when active), nothing is pushed, the failure is reported.
- A renew answered 409 `stale-lease` aborts immediately. A same-job re-lease is chained behind the old run's teardown with identity guards on the in-flight maps.
- The node sends the generation it was given and omits the field when an older API issued none.

**Contracts**: `FleetJobView.leaseGeneration?`, required `leaseGeneration` on `FleetJobHeartbeatRequest` / `FleetJobCompleteRequest`, `FLEET_JOB_STALE_LEASE_REASON`, `FLEET_JOB_LEASE_LAPSED_WHILE_SUSPENDED_REASON`, `FleetJobStaleLeaseResponse`.

### Deliberate hard cut (please read)

Nodes older than this change are refused (400) on heartbeat and complete once the API is deployed, and jobs leased before the migration (generation 0) abort on the node and are re-offered under generation 1. Documented in `docs/features/fleet.md`, the DTO and the migration. **Upgrade the six nodes together with the API deploy.** The alternative (accepting a missing generation) would silently keep the exact double-run this slice exists to stop.

### Adversarial review (fixed before this PR)

- `confirmDeadline()` skipped the platform re-check once the run's signal was aborted and returned the un-collapsed local deadline, so a run voided by a same-node re-lease, or cancelled by an operator, could still be told by the publish fence that minutes of claim remained. The keep-alive now collapses the local deadline on **any** abort (spec added).
- Reviewed and holding: no node-facing mutator escapes the generation check (grep of every `@Post/@Put/@Patch` under `apps/api/src/fleet` and every `api/` URL in `apps/node/src`); CAS atomicity via single UPDATEs (proven on better-sqlite3 in a new repository integration spec); re-lease increments before the new node can act; detector false positives cost one heartbeat at most.

### Verified locally

- Specs, all green: `apps/api` controller + DTO 30/30 and the whole `src/migrations` tree 34 suites / 144 (incl. the directory contract); `packages/agent` fleet + events 12 suites / 178 (incl. the new `fleet-job.lease-generation.spec.ts` and the sqlite `fleet-job.repository.integration.spec.ts`); `apps/node` full vitest 699 passed (2 pre-existing environment failures: the unbuilt Rust job-launcher helper, and a mounts spec against a stale `local-workspace` dist — neither in this diff); `packages/contracts` full vitest 1523/1523.
- `prettier --check` on all 22 changed/new files: clean.
- `tsc`: `worker-loop.ts`, `job-client.ts`, `fleet-client.ts` clean under strict; the four api fleet files type-check with 0 errors against the real `@ever-works/agent` source via a scratch path mapping. Remaining local tsc noise is the pre-existing unbuilt-workspace family (`@ever-works/agent-plugins`, stale `@ever-works/plugin` dist).

### Not verified locally

- Three `apps/api` suites (planner, reconciler, dispatch) cannot load in this worktree (`@ever-works/agent-plugins` unbuilt); none touches the changed signatures. CI has the built package.
- A real suspend/resume cycle on a PC; e2e (stage-only gate); the migration on a real Postgres.
- ESLint (no lint config in apps/node / packages; CI lints `apps/web` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added suspend-safe fleet job leases using generation tokens to prevent outdated claims from updating jobs.
  - Workers now detect suspend/resume gaps, re-confirm active leases, and safely stop runs when leases lapse.
  - Heartbeat and completion requests now include lease generations and clearly report stale leases with a `409` response.

- **Bug Fixes**
  - Prevented stale workers from submitting outdated heartbeats, completions, or reports after a job is re-leased.

- **Documentation**
  - Documented lease-generation behavior, suspend handling, and stale-lease responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->