### PR TITLE
feat(goals): delivery Goal kind + Goal cold start (EW-795)

### DIFF
--- a/apps/api/src/goals/dto/goal.dto.spec.ts
+++ b/apps/api/src/goals/dto/goal.dto.spec.ts
@@ -1,0 +1,301 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+// `goal.dto.ts` (and the `goal-orchestration.dto.ts` it imports for the DoD
+// criterion) read their bounds + unions from the `@ever-works/agent/goals`
+// barrel, which transitively pulls in GoalOrchestratorService -> tasks-domain
+// -> database.module -> `@src/config` (unmapped in the api jest scope). Stub
+// the barrel with the literal values read at module-eval time — the same
+// pattern `goal-orchestration.dto.spec.ts` and `mission.dto.spec.ts` use.
+// The kind vocabulary itself comes from `@ever-works/contracts`, which IS
+// source-mapped, so `GOAL_KINDS` / `isGoalKind` below are the real ones.
+jest.mock('@ever-works/agent/goals', () => ({
+    GOAL_CONSTRAINT_CATEGORIES: ['time', 'cost', 'safety', 'scope', 'quality'],
+    MAX_GOAL_CRITERIA: 20,
+    MAX_GOAL_CONSTRAINTS: 20,
+    GOAL_DOD_STATUSES: ['open', 'done', 'waived'],
+    GOAL_DOD_SOURCES: ['operator', 'planner'],
+    GOAL_EXECUTION_TARGETS: ['cloud', 'local-runner'],
+    MAX_DOD_EVIDENCE_CHARS: 1000,
+    MAX_DOD_ID_CHARS: 64,
+    MAX_DOD_NOTE_CHARS: 500,
+    MAX_DOD_TEXT_CHARS: 500,
+    MAX_GOAL_DOD_CRITERIA: 50,
+    MAX_GRACE_PERIOD_MINUTES: 1440,
+    MAX_MODEL_HINT_CHARS: 120,
+    MAX_NUDGE_CHARS: 2000,
+    MAX_SESSION_BUDGET_MINUTES: 1440,
+    MAX_SPEND_CAP_CENTS: 100_000_000,
+    MAX_STUCK_THRESHOLD_ITERATIONS: 1000,
+    MAX_WALL_CLOCK_LIMIT_HOURS: 8760,
+}));
+
+import { CreateGoalDto, UpdateGoalDto } from './goal.dto';
+
+/** The global pipe's exact posture (apps/api/src/main.ts). */
+const PIPE_OPTIONS = { whitelist: true, forbidNonWhitelisted: true } as const;
+
+/** Flatten nested (`metricSource` -> property) validation errors. */
+function flatten(
+    errors: Array<{
+        property: string;
+        constraints?: Record<string, string>;
+        children?: unknown[];
+    }>,
+    prefix = '',
+): string[] {
+    return errors.flatMap((error) => {
+        const path = prefix ? `${prefix}.${error.property}` : error.property;
+        const own = Object.keys(error.constraints ?? {}).map(
+            (constraint) => `${path}:${constraint}`,
+        );
+        const children = flatten((error.children ?? []) as Parameters<typeof flatten>[0], path);
+        return [...own, ...children];
+    });
+}
+
+async function validateCreate(body: unknown): Promise<string[]> {
+    return flatten(await validate(plainToInstance(CreateGoalDto, body), PIPE_OPTIONS));
+}
+
+async function validateUpdate(body: unknown): Promise<string[]> {
+    return flatten(await validate(plainToInstance(UpdateGoalDto, body), PIPE_OPTIONS));
+}
+
+const METRIC_BODY = {
+    title: 'Income >= $1000/month',
+    metricSource: { pluginId: 'stripe', metricId: 'income' },
+    comparator: 'gte',
+    targetValue: 1000,
+    unit: 'usd',
+    window: 'month',
+};
+
+const DELIVERY_BODY = {
+    title: 'Ship feature X across three repos',
+    goalKind: 'delivery',
+    dodCriteria: [
+        { id: 'api', text: 'API endpoint merged', status: 'open' },
+        { id: 'web', text: 'Web form merged', status: 'open' },
+    ],
+};
+
+/**
+ * `CreateGoalDto` — Goal kinds (self-build slice AG, EW-795).
+ *
+ * The trap this suite exists for: `@IsOptional()` skips EVERY validator on a
+ * property when it is undefined, so a cross-field rule hung on `goalKind`
+ * with `@IsOptional()` would never run for the default (metric) body — and
+ * two `@ValidateIf` conditions on one property AND together. A wrong
+ * combination silently admits a metric Goal without a target, the exact
+ * vacuous-Goal defect EW-044 fixed on the web side. Every branch of the
+ * fail-closed rule is therefore pinned here.
+ */
+describe('CreateGoalDto — metric kind (the default)', () => {
+    it('accepts the classic metric body with no goalKind at all', async () => {
+        expect(await validateCreate(METRIC_BODY)).toEqual([]);
+    });
+
+    it('accepts an explicit metric kind', async () => {
+        expect(await validateCreate({ ...METRIC_BODY, goalKind: 'metric' })).toEqual([]);
+    });
+
+    it('still requires targetValue — a missing target is not a target of 0', async () => {
+        const { targetValue: _omit, ...body } = METRIC_BODY;
+        expect(await validateCreate(body)).toEqual(['targetValue:isNumber']);
+        expect(await validateCreate({ ...METRIC_BODY, targetValue: '1000' })).toEqual([
+            'targetValue:isNumber',
+        ]);
+        expect(await validateCreate({ ...METRIC_BODY, targetValue: null })).toEqual([
+            'targetValue:isNumber',
+        ]);
+    });
+
+    it('still requires comparator, unit and window with their own per-field messages', async () => {
+        const { comparator: _c, ...noComparator } = METRIC_BODY;
+        expect(await validateCreate(noComparator)).toEqual(['comparator:isIn']);
+
+        const { unit: _u, ...noUnit } = METRIC_BODY;
+        expect(await validateCreate(noUnit)).toEqual(
+            expect.arrayContaining(['unit:isString', 'unit:minLength']),
+        );
+
+        const { window: _w, ...noWindow } = METRIC_BODY;
+        expect(await validateCreate(noWindow)).toEqual(['window:isIn']);
+    });
+
+    it('lets a MISSING metricSource through to the service, which owns that message', async () => {
+        // Pinned by the e2e validation matrix: `metricSource` undefined → 400
+        // "metricSource must be an object." from `GoalsService.create`, not a
+        // DTO message. `@ValidateNested` is a no-op on undefined, and the
+        // kind change must not start intercepting it.
+        const { metricSource: _m, ...body } = METRIC_BODY;
+        expect(await validateCreate(body)).toEqual([]);
+    });
+
+    it('still validates a present metricSource nested shape', async () => {
+        expect(
+            await validateCreate({ ...METRIC_BODY, metricSource: { pluginId: 'stripe' } }),
+        ).toEqual(expect.arrayContaining(['metricSource.metricId:isString']));
+        expect(await validateCreate({ ...METRIC_BODY, metricSource: 'stripe' })).toEqual([
+            'metricSource:nestedValidation',
+        ]);
+    });
+
+    it('accepts an optional seed checklist on a metric Goal', async () => {
+        expect(
+            await validateCreate({
+                ...METRIC_BODY,
+                dodCriteria: [{ id: 'docs', text: 'Write the docs', status: 'open' }],
+            }),
+        ).toEqual([]);
+    });
+
+    it('refuses an empty seed checklist', async () => {
+        expect(await validateCreate({ ...METRIC_BODY, dodCriteria: [] })).toEqual([
+            'dodCriteria:arrayMinSize',
+        ]);
+    });
+});
+
+describe('CreateGoalDto — delivery kind', () => {
+    it('accepts a delivery body that carries no metric key at all', async () => {
+        expect(await validateCreate(DELIVERY_BODY)).toEqual([]);
+    });
+
+    it('accepts explicit nulls for the metric fields (absent-or-null is the wire contract)', async () => {
+        expect(
+            await validateCreate({
+                ...DELIVERY_BODY,
+                metricSource: null,
+                comparator: null,
+                targetValue: null,
+                unit: null,
+                window: null,
+                baselineValue: null,
+            }),
+        ).toEqual([]);
+    });
+
+    it.each([
+        ['metricSource', { pluginId: 'stripe', metricId: 'income' }],
+        ['comparator', 'gte'],
+        ['targetValue', 1000],
+        ['unit', 'usd'],
+        ['window', 'month'],
+        ['baselineValue', 5],
+        ['criteria', []],
+        ['constraints', []],
+    ])('refuses a delivery body that sets the metric-only field %s', async (field, value) => {
+        const errors = await validateCreate({ ...DELIVERY_BODY, [field]: value });
+        expect(errors).toContain('goalKind:goalKindShape');
+    });
+
+    it('refuses a delivery body without a Definition of Done', async () => {
+        const { dodCriteria: _omit, ...body } = DELIVERY_BODY;
+        expect(await validateCreate(body)).toEqual(['goalKind:goalKindShape']);
+        expect(await validateCreate({ ...DELIVERY_BODY, dodCriteria: null })).toEqual([
+            'goalKind:goalKindShape',
+        ]);
+    });
+
+    it('refuses an empty Definition of Done on a delivery body', async () => {
+        const errors = await validateCreate({ ...DELIVERY_BODY, dodCriteria: [] });
+        expect(errors).toEqual(
+            expect.arrayContaining(['goalKind:goalKindShape', 'dodCriteria:arrayMinSize']),
+        );
+    });
+
+    it('refuses a delivery body whose criteria are all still proposed (no approved finish line)', async () => {
+        expect(
+            await validateCreate({
+                ...DELIVERY_BODY,
+                dodCriteria: [
+                    { id: 'a', text: 'Only a proposal', status: 'open', proposed: true },
+                    { id: 'b', text: 'Another proposal', status: 'open', proposed: true },
+                ],
+            }),
+        ).toEqual(['goalKind:goalKindShape']);
+    });
+
+    it('accepts a delivery body that mixes proposed and approved criteria', async () => {
+        expect(
+            await validateCreate({
+                ...DELIVERY_BODY,
+                dodCriteria: [
+                    { id: 'a', text: 'Approved', status: 'open' },
+                    { id: 'b', text: 'Proposal', status: 'open', proposed: true },
+                ],
+            }),
+        ).toEqual([]);
+    });
+
+    it('validates each criterion on the wire', async () => {
+        expect(
+            await validateCreate({
+                ...DELIVERY_BODY,
+                dodCriteria: [{ id: 'a', text: 'x', status: 'finished' }],
+            }),
+        ).toEqual(['dodCriteria.0.status:isIn']);
+        expect(
+            await validateCreate({
+                ...DELIVERY_BODY,
+                dodCriteria: [{ id: 'a', text: 'x', status: 'open', sneaky: 1 }],
+            }),
+        ).toEqual(['dodCriteria.0.sneaky:whitelistValidation']);
+    });
+
+    it('does not report missing METRIC fields for a delivery body', async () => {
+        // The per-field metric validators are gated on the kind; a delivery
+        // body must not be told that it is missing a target.
+        const errors = await validateCreate(DELIVERY_BODY);
+        expect(errors.some((e) => e.startsWith('targetValue'))).toBe(false);
+        expect(errors.some((e) => e.startsWith('comparator'))).toBe(false);
+    });
+
+    it('names every problem in the shape message', async () => {
+        const errors = await validate(
+            plainToInstance(CreateGoalDto, {
+                title: 'x',
+                goalKind: 'delivery',
+                targetValue: 5,
+                unit: 'usd',
+            }),
+            PIPE_OPTIONS,
+        );
+        const message = errors.find((e) => e.property === 'goalKind')?.constraints?.goalKindShape;
+        expect(message).toContain('targetValue must be omitted for a delivery Goal');
+        expect(message).toContain('unit must be omitted for a delivery Goal');
+        expect(message).toContain('at least one Definition-of-Done criterion');
+    });
+});
+
+describe('CreateGoalDto — neither kind (fail closed)', () => {
+    it.each(['bogus', 'Metric', '', 42, {}])('refuses goalKind %j', async (goalKind) => {
+        const errors = await validateCreate({ ...METRIC_BODY, goalKind });
+        expect(errors).toContain('goalKind:goalKindMember');
+    });
+
+    it('refuses an unknown property anywhere in the body', async () => {
+        expect(await validateCreate({ ...METRIC_BODY, sneaky: 'value' })).toContain(
+            'sneaky:whitelistValidation',
+        );
+        expect(await validateCreate({ ...DELIVERY_BODY, sneaky: 'value' })).toContain(
+            'sneaky:whitelistValidation',
+        );
+    });
+});
+
+describe('UpdateGoalDto', () => {
+    it('does not accept goalKind — the kind is immutable after create', async () => {
+        expect(await validateUpdate({ goalKind: 'delivery' })).toEqual([
+            'goalKind:whitelistValidation',
+        ]);
+    });
+
+    it('still accepts a metric-field patch (the service refuses it on a delivery Goal)', async () => {
+        expect(await validateUpdate({ targetValue: 2500 })).toEqual([]);
+        expect(await validateUpdate({})).toEqual([]);
+    });
+});

--- a/apps/api/src/goals/dto/goal.dto.ts
+++ b/apps/api/src/goals/dto/goal.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
     ArrayMaxSize,
+    ArrayMinSize,
     IsArray,
     IsBoolean,
     IsDateString,
@@ -15,22 +16,116 @@ import {
     MaxLength,
     Min,
     MinLength,
+    Validate,
+    ValidateIf,
     ValidateNested,
+    ValidatorConstraint,
+    type ValidationArguments,
+    type ValidatorConstraintInterface,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+// The kind vocabulary comes from `@ever-works/contracts` rather than the
+// agent barrel so specs that stub the barrel (the house idiom for these
+// DTOs) keep the real list.
+import { GOAL_KINDS, isGoalKind, type GoalKind } from '@ever-works/contracts';
 import {
     GOAL_CONSTRAINT_CATEGORIES,
     MAX_GOAL_CONSTRAINTS,
     MAX_GOAL_CRITERIA,
+    MAX_GOAL_DOD_CRITERIA,
     type GoalComparator,
     type GoalConstraintCategory,
     type GoalOutcome,
     type GoalWindow,
 } from '@ever-works/agent/goals';
+import { GoalDoDCriterionDto } from './goal-orchestration.dto';
 
 const GOAL_COMPARATORS: GoalComparator[] = ['gte', 'lte'];
 const GOAL_WINDOWS: GoalWindow[] = ['day', 'week', 'month', 'total', 'point'];
 const GOAL_OUTCOMES: GoalOutcome[] = ['achieved', 'missed', 'abandoned'] as GoalOutcome[];
+
+/**
+ * Fields that only mean something on a metric Goal. Mirrors
+ * `GOAL_METRIC_ONLY_FIELDS` in `@ever-works/agent/goals` (goal-kind.ts);
+ * spelled out here because the DTO must not depend on the agent barrel's
+ * runtime for a rule the service re-checks anyway.
+ */
+const METRIC_ONLY_FIELDS = [
+    'metricSource',
+    'comparator',
+    'targetValue',
+    'unit',
+    'window',
+    'baselineValue',
+    'criteria',
+    'constraints',
+] as const;
+
+/** Omitted kind = metric — every client that predates kinds. */
+function isMetricKind(body: { goalKind?: unknown }): boolean {
+    return body.goalKind === undefined || body.goalKind === null || body.goalKind === 'metric';
+}
+
+/**
+ * Cross-field shape rule for `CreateGoalDto`, evaluated on `goalKind`
+ * WITHOUT `@IsOptional()` — that decorator would skip the whole property
+ * when the kind is omitted, which is exactly the (metric) case the
+ * per-field validators below must still cover.
+ *
+ * Returns the problems for a DELIVERY body; a metric body reports nothing
+ * here because its missing fields keep their own per-field messages
+ * (pinned by the e2e validation matrix), and an unknown kind is reported
+ * by {@link GoalKindMemberConstraint} instead.
+ */
+function goalKindShapeProblems(body: Record<string, unknown>): string[] {
+    const kind = body.goalKind === undefined || body.goalKind === null ? 'metric' : body.goalKind;
+    if (!isGoalKind(kind) || kind === 'metric') return [];
+    const problems = METRIC_ONLY_FIELDS.filter(
+        (field) => body[field] !== undefined && body[field] !== null,
+    ).map((field) => `${field} must be omitted for a delivery Goal`);
+    if (!Array.isArray(body.dodCriteria) || body.dodCriteria.length === 0) {
+        problems.push(
+            'a delivery Goal requires at least one Definition-of-Done criterion (dodCriteria)',
+        );
+    } else if (
+        body.dodCriteria.every(
+            (entry) =>
+                typeof entry === 'object' &&
+                entry !== null &&
+                (entry as { proposed?: unknown }).proposed === true,
+        )
+    ) {
+        // `summarizeDoD` excludes proposed criteria from the rollup, so a
+        // Goal born with nothing but proposals would have no finish line at
+        // all. Mirrors `validateDeliveryGoalInput` in the service.
+        problems.push(
+            'a delivery Goal cannot be created with only proposed (unapproved) criteria — at least one must be approved',
+        );
+    }
+    return problems;
+}
+
+@ValidatorConstraint({ name: 'goalKindMember' })
+class GoalKindMemberConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        return value === undefined || value === null || isGoalKind(value);
+    }
+
+    defaultMessage(): string {
+        return `goalKind must be one of the following values: ${GOAL_KINDS.join(', ')}`;
+    }
+}
+
+@ValidatorConstraint({ name: 'goalKindShape' })
+class GoalKindShapeConstraint implements ValidatorConstraintInterface {
+    validate(_value: unknown, args: ValidationArguments): boolean {
+        return goalKindShapeProblems(args.object as Record<string, unknown>).length === 0;
+    }
+
+    defaultMessage(args: ValidationArguments): string {
+        return goalKindShapeProblems(args.object as Record<string, unknown>).join('; ');
+    }
+}
 
 /**
  * Goals & Metrics — PR-8. Which metrics-provider plugin + metric a
@@ -174,8 +269,21 @@ export class GoalConstraintDto {
 /**
  * Request body for `POST /api/me/goals`. Semantic rules
  * (comparator/window membership, metricSource shape, the ≥15-minute
- * frequency clamp — spec FR-12) are re-validated in
+ * frequency clamp — spec FR-12, the per-kind shape) are re-validated in
  * `GoalsService.create`, the single source of truth PATCH reuses.
+ *
+ * Two KINDS share this body (self-build slice AG, EW-795):
+ *   - `metric` (default) — `metricSource`, `comparator`, `targetValue`,
+ *     `unit` and `window` are REQUIRED, exactly as before the kind
+ *     existed; each keeps its own validator and message.
+ *   - `delivery` — those fields must be omitted (or null) and `dodCriteria`
+ *     must carry at least one criterion; the cross-field rule lives on
+ *     `goalKind` so a body that satisfies neither kind is refused here,
+ *     before the service refuses it again.
+ *
+ * The MCP `create_goal` tool schema is derived from these `@ApiProperty`
+ * annotations, so the metric fields are declared optional on the wire and
+ * the per-kind requirement is documented in their descriptions.
  */
 export class CreateGoalDto {
     @ApiProperty({ minLength: 1, maxLength: 200 })
@@ -190,30 +298,70 @@ export class CreateGoalDto {
     @MaxLength(10000)
     description?: string | null;
 
-    @ApiProperty({ type: GoalMetricSourceDto })
+    @ApiProperty({
+        required: false,
+        enum: [...GOAL_KINDS],
+        default: 'metric',
+        description:
+            "'metric' (default) reads a metrics-provider plugin and completes when comparator/targetValue is satisfied — metricSource, comparator, targetValue, unit and window are required. 'delivery' has no metric: omit those fields, supply dodCriteria (at least one), and the Goal completes when every approved Definition-of-Done criterion is done or waived. Immutable after create.",
+    })
+    @Validate(GoalKindMemberConstraint)
+    @Validate(GoalKindShapeConstraint)
+    goalKind?: GoalKind;
+
+    @ApiProperty({
+        required: false,
+        type: GoalMetricSourceDto,
+        description:
+            'Metric Goals only — required when goalKind is metric, must be omitted for delivery.',
+    })
+    @ValidateIf(isMetricKind)
     @ValidateNested()
     @Type(() => GoalMetricSourceDto)
-    metricSource: GoalMetricSourceDto;
+    metricSource?: GoalMetricSourceDto;
 
-    @ApiProperty({ enum: GOAL_COMPARATORS, description: 'gte = grow-to-target, lte = shrink.' })
+    @ApiProperty({
+        required: false,
+        enum: GOAL_COMPARATORS,
+        description:
+            'Metric Goals only (required for metric, omit for delivery). gte = grow-to-target, lte = shrink.',
+    })
+    @ValidateIf(isMetricKind)
     @IsIn(GOAL_COMPARATORS)
-    comparator: GoalComparator;
+    comparator?: GoalComparator;
 
-    @ApiProperty()
+    @ApiProperty({
+        required: false,
+        description:
+            'Metric Goals only — required when goalKind is metric, must be omitted for delivery.',
+    })
+    @ValidateIf(isMetricKind)
     @IsNumber()
-    targetValue: number;
+    targetValue?: number;
 
-    @ApiProperty({ maxLength: 32, description: "Unit of targetValue (e.g. 'usd', 'count')." })
+    @ApiProperty({
+        required: false,
+        maxLength: 32,
+        description:
+            "Metric Goals only (required for metric, omit for delivery). Unit of targetValue (e.g. 'usd', 'count').",
+    })
+    @ValidateIf(isMetricKind)
     @IsString()
     @MinLength(1)
     @MaxLength(32)
-    unit: string;
+    unit?: string;
 
-    @ApiProperty({ enum: GOAL_WINDOWS })
+    @ApiProperty({
+        required: false,
+        enum: GOAL_WINDOWS,
+        description:
+            'Metric Goals only — required when goalKind is metric, must be omitted for delivery.',
+    })
+    @ValidateIf(isMetricKind)
     @IsIn(GOAL_WINDOWS)
-    window: GoalWindow;
+    window?: GoalWindow;
 
-    @ApiProperty({ required: false, nullable: true })
+    @ApiProperty({ required: false, nullable: true, description: 'Metric Goals only.' })
     @IsOptional()
     @IsNumber()
     baselineValue?: number | null;
@@ -254,7 +402,7 @@ export class CreateGoalDto {
         required: false,
         type: [GoalConstraintDto],
         description:
-            'Judgment layer G1 - constraints that must hold; a hard violation vetoes ACHIEVED.',
+            'Judgment layer G1 - constraints that must hold; a hard violation vetoes ACHIEVED. Metric Goals only.',
     })
     @IsOptional()
     @IsArray()
@@ -262,6 +410,22 @@ export class CreateGoalDto {
     @ValidateNested({ each: true })
     @Type(() => GoalConstraintDto)
     constraints?: GoalConstraintDto[];
+
+    @ApiProperty({
+        required: false,
+        type: [GoalDoDCriterionDto],
+        minItems: 1,
+        maxItems: MAX_GOAL_DOD_CRITERIA,
+        description:
+            'Definition of Done. REQUIRED for a delivery Goal (at least one approved criterion — it is the whole completion rule); an optional seed checklist for a metric Goal.',
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMinSize(1)
+    @ArrayMaxSize(MAX_GOAL_DOD_CRITERIA)
+    @ValidateNested({ each: true })
+    @Type(() => GoalDoDCriterionDto)
+    dodCriteria?: GoalDoDCriterionDto[];
 }
 
 /**
@@ -269,7 +433,9 @@ export class CreateGoalDto {
  * `null` clears nullable fields. `status` is NOT writable here (use
  * activate/pause) — but `outcome` IS: spec FR-13 makes auto-set
  * outcomes human-overridable, including `abandoned` and clearing
- * with `null`.
+ * with `null`. `goalKind` is deliberately absent: the kind is immutable
+ * after create, and the service refuses every metric field on a delivery
+ * Goal.
  */
 export class UpdateGoalDto {
     @ApiProperty({ required: false, minLength: 1, maxLength: 200 })
@@ -285,35 +451,58 @@ export class UpdateGoalDto {
     @MaxLength(10000)
     description?: string | null;
 
-    @ApiProperty({ required: false, type: GoalMetricSourceDto })
+    @ApiProperty({
+        required: false,
+        type: GoalMetricSourceDto,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @ValidateNested()
     @Type(() => GoalMetricSourceDto)
     metricSource?: GoalMetricSourceDto;
 
-    @ApiProperty({ required: false, enum: GOAL_COMPARATORS })
+    @ApiProperty({
+        required: false,
+        enum: GOAL_COMPARATORS,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @IsIn(GOAL_COMPARATORS)
     comparator?: GoalComparator;
 
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        required: false,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @IsNumber()
     targetValue?: number;
 
-    @ApiProperty({ required: false, maxLength: 32 })
+    @ApiProperty({
+        required: false,
+        maxLength: 32,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @IsString()
     @MinLength(1)
     @MaxLength(32)
     unit?: string;
 
-    @ApiProperty({ required: false, enum: GOAL_WINDOWS })
+    @ApiProperty({
+        required: false,
+        enum: GOAL_WINDOWS,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @IsIn(GOAL_WINDOWS)
     window?: GoalWindow;
 
-    @ApiProperty({ required: false, nullable: true })
+    @ApiProperty({
+        required: false,
+        nullable: true,
+        description: 'Metric Goals only — rejected (400) on a delivery Goal.',
+    })
     @IsOptional()
     @IsNumber()
     baselineValue?: number | null;

--- a/apps/api/src/goals/goals.controller.ts
+++ b/apps/api/src/goals/goals.controller.ts
@@ -119,7 +119,10 @@ export class GoalsController {
     }
 
     @Post()
-    @ApiOperation({ summary: 'Create a goal (status=draft; activate to start evaluation)' })
+    @ApiOperation({
+        summary:
+            "Create a goal (status=draft; activate to start evaluation). goalKind 'metric' (default) needs metricSource + comparator + targetValue + unit + window; 'delivery' needs dodCriteria instead and carries no metric.",
+    })
     @HttpCode(HttpStatus.CREATED)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async create(
@@ -131,6 +134,11 @@ export class GoalsController {
             {
                 title: body.title,
                 description: body.description ?? null,
+                // Omitted = metric; the service refuses anything unknown.
+                goalKind: body.goalKind,
+                // Metric fields pass through possibly-undefined: the service
+                // requires all of them for a metric Goal and refuses every one
+                // of them for a delivery Goal.
                 metricSource: body.metricSource,
                 comparator: body.comparator,
                 targetValue: body.targetValue,
@@ -143,6 +151,8 @@ export class GoalsController {
                 // the service persists as NULL: the single-metric Goal.
                 criteria: body.criteria,
                 constraints: body.constraints,
+                // Required for a delivery Goal, optional seed for a metric one.
+                dodCriteria: body.dodCriteria,
             },
             this.scopeContext?.getScope(),
         );
@@ -224,7 +234,7 @@ export class GoalsController {
     @Post(':id/activate')
     @ApiOperation({
         summary:
-            'Activate a goal ((draft|paused|completed) → active). Requires metricSource pluginId + metricId; reactivating a completed goal clears its outcome.',
+            'Activate a goal ((draft|paused|completed) → active). Metric goals require metricSource pluginId + metricId; delivery goals require at least one approved Definition-of-Done criterion. Reactivating a completed goal clears its outcome.',
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
@@ -249,7 +259,7 @@ export class GoalsController {
     @Post(':id/evaluate-now')
     @ApiOperation({
         summary:
-            'Evaluate immediately (manual tick). Bypasses the nextCheckAt schedule but NOT the plugin budget guard.',
+            'Evaluate immediately (manual tick). Bypasses the nextCheckAt schedule but NOT the plugin budget guard. Metric goals read the provider; delivery goals re-check the Definition of Done and the deadline without any plugin call.',
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 10, ttl: 60_000 } })

--- a/apps/api/src/migrations/1788700000000-AddGoalKind.ts
+++ b/apps/api/src/migrations/1788700000000-AddGoalKind.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Self-build slice AG (EW-795) — the `goals.goalKind` discriminator and
+ * the four metric columns going nullable.
+ *
+ * ## Why
+ *
+ * "Ship feature X across three repos" could not be represented: the only
+ * multi-iteration autonomous driver on the platform demanded a metrics
+ * plugin and a numeric target because `metricSource`, `comparator`,
+ * `targetValue` and `unit` were all NOT NULL. A **delivery** Goal has none
+ * of those — it completes on its approved Definition of Done alone — so
+ * the four columns become nullable and `goalKind` says which rule applies.
+ *
+ * ## What existing rows read as
+ *
+ * `goalKind` is added as `varchar(16) NOT NULL DEFAULT 'metric'`, so the
+ * DEFAULT backfills every existing row to `'metric'` inside the same
+ * `ALTER TABLE` on Postgres and better-sqlite3 alike (the same mechanism
+ * the `integer NOT NULL DEFAULT 0` counters in 1786900000000 rely on) —
+ * no UPDATE pass, and every pre-existing Goal keeps behaving exactly as
+ * the metric Goal it always was. Their four metric columns are still
+ * populated; only the CONSTRAINT relaxes.
+ *
+ * ## Portability
+ *
+ * The DROP NOT NULL uses TypeORM's `changeColumn` on a cloned column
+ * descriptor (precedent: 1781200000000-RelaxTenantJobRuntimeAuditTenantNullable):
+ * `ALTER COLUMN ... DROP NOT NULL` on Postgres, a table recreate on the
+ * sqlite test driver — with indexes and the other columns carried across.
+ * Every step is guarded by `findColumnByName` / `isNullable`, so re-running
+ * the migration is a no-op.
+ */
+export class AddGoalKind1788700000000 implements MigrationInterface {
+    name = 'AddGoalKind1788700000000';
+
+    /** The four columns a delivery Goal leaves NULL. */
+    private static readonly METRIC_COLUMNS = ['metricSource', 'comparator', 'targetValue', 'unit'];
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('goals');
+        if (!table) return;
+
+        if (!table.findColumnByName('goalKind')) {
+            await queryRunner.query(
+                `ALTER TABLE "goals" ADD COLUMN "goalKind" varchar(16) NOT NULL DEFAULT 'metric'`,
+            );
+        }
+
+        for (const name of AddGoalKind1788700000000.METRIC_COLUMNS) {
+            // Re-read on every step: on sqlite `changeColumn` recreates the
+            // table, so a descriptor captured before it is stale.
+            const refreshed = await queryRunner.getTable('goals');
+            const column = refreshed?.findColumnByName(name);
+            if (!column || column.isNullable) continue;
+            const updated = column.clone();
+            updated.isNullable = true;
+            await queryRunner.changeColumn('goals', column, updated);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('goals');
+        if (!table) return;
+
+        // Reverting REMOVES delivery Goals: they have no metric fields, so
+        // re-tightening NOT NULL below could not succeed while they exist.
+        // That is a real data loss, but it is confined to the feature this
+        // migration introduced — no delivery row can predate it — so an
+        // operator running the revert is choosing to remove the feature,
+        // the same posture 1786900000000's down() takes with the DoD text.
+        if (table.findColumnByName('goalKind')) {
+            await queryRunner.query(`DELETE FROM "goals" WHERE "goalKind" = 'delivery'`);
+        }
+
+        for (const name of AddGoalKind1788700000000.METRIC_COLUMNS) {
+            const refreshed = await queryRunner.getTable('goals');
+            const column = refreshed?.findColumnByName(name);
+            if (!column || !column.isNullable) continue;
+            const updated = column.clone();
+            updated.isNullable = false;
+            await queryRunner.changeColumn('goals', column, updated);
+        }
+
+        const refreshed = await queryRunner.getTable('goals');
+        if (refreshed?.findColumnByName('goalKind')) {
+            await queryRunner.query(`ALTER TABLE "goals" DROP COLUMN "goalKind"`);
+        }
+    }
+}

--- a/apps/api/src/migrations/1788700000000-AddGoalKind.ts
+++ b/apps/api/src/migrations/1788700000000-AddGoalKind.ts
@@ -83,9 +83,15 @@ export class AddGoalKind1788700000000 implements MigrationInterface {
             await queryRunner.changeColumn('goals', column, updated);
         }
 
+        // TypeORM's own primitive rather than a raw `ALTER TABLE ... DROP
+        // COLUMN`: sqlite only learned that statement in 3.35, and on sqlite
+        // TypeORM drops a column by recreating the table — which also keeps
+        // the query runner's table metadata in step with the physical schema
+        // for anything that runs after this migration in the same runner.
         const refreshed = await queryRunner.getTable('goals');
-        if (refreshed?.findColumnByName('goalKind')) {
-            await queryRunner.query(`ALTER TABLE "goals" DROP COLUMN "goalKind"`);
+        const goalKind = refreshed?.findColumnByName('goalKind');
+        if (goalKind) {
+            await queryRunner.dropColumn('goals', goalKind);
         }
     }
 }

--- a/apps/api/src/migrations/__tests__/AddGoalKind.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddGoalKind.spec.ts
@@ -1,0 +1,211 @@
+import { DataSource } from 'typeorm';
+import { AddGoalKind1788700000000 } from '../1788700000000-AddGoalKind';
+
+/**
+ * Migration test for the `goals.goalKind` discriminator + nullable metric
+ * columns (self-build slice AG, EW-795).
+ *
+ * Runs on the same in-memory better-sqlite3 harness as its siblings, and
+ * for the same reason: production is Postgres while CI and the e2e stack
+ * are sqlite, so DDL that only works on one of them would pass in prod
+ * and fail every CI run — or the reverse.
+ *
+ * What is pinned here beyond "the column exists":
+ *  - EXISTING rows read `goalKind = 'metric'` after up() with no UPDATE
+ *    pass, and a row inserted afterwards without the column defaults to it.
+ *  - After up() a delivery row with NULL metricSource/comparator/targetValue/unit
+ *    inserts cleanly — and the SAME insert throws NOT NULL before up().
+ *  - The relax step (a table recreate on sqlite) keeps the other columns AND
+ *    the indexes it was not asked to touch.
+ *  - down() is symmetric: NOT NULL is back on all four, `goalKind` is gone,
+ *    the metric row survives and the delivery row does not.
+ */
+describe('AddGoalKind1788700000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddGoalKind1788700000000();
+
+    const METRIC_COLUMNS = ['metricSource', 'comparator', 'targetValue', 'unit'];
+
+    /** A minimal stand-in for the pre-existing `goals` table (+ one of its indexes). */
+    const createGoalsTable = async () => {
+        await dataSource.query(`
+            CREATE TABLE "goals" (
+                "id" varchar PRIMARY KEY,
+                "userId" varchar NOT NULL,
+                "title" varchar NOT NULL,
+                "metricSource" text NOT NULL,
+                "comparator" varchar NOT NULL,
+                "targetValue" float NOT NULL,
+                "unit" varchar NOT NULL,
+                "window" varchar NOT NULL,
+                "checkFrequencyMinutes" integer NOT NULL DEFAULT 60,
+                "status" varchar NOT NULL DEFAULT 'draft',
+                "dodCriteria" text
+            )
+        `);
+        await dataSource.query(
+            `CREATE INDEX "idx_goals_user_status" ON "goals" ("userId", "status")`,
+        );
+    };
+
+    const insertMetricRow = (id: string) =>
+        dataSource.query(
+            `INSERT INTO "goals" ("id","userId","title","metricSource","comparator","targetValue","unit","window","status")
+             VALUES ('${id}','u1','Legacy metric goal','{"pluginId":"stripe","metricId":"income"}','gte',1000,'usd','month','active')`,
+        );
+
+    const insertDeliveryRow = (id: string) =>
+        dataSource.query(
+            `INSERT INTO "goals" ("id","userId","title","metricSource","comparator","targetValue","unit","window","status","goalKind","dodCriteria")
+             VALUES ('${id}','u1','Ship feature X',NULL,NULL,NULL,NULL,'total','draft','delivery','[{"id":"a","text":"ship","status":"open"}]')`,
+        );
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('adds goalKind and relaxes NOT NULL on the four metric columns', async () => {
+        await createGoalsTable();
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('goals');
+        expect(table?.findColumnByName('goalKind')).toBeDefined();
+        for (const name of METRIC_COLUMNS) {
+            expect(table?.findColumnByName(name)?.isNullable).toBe(true);
+        }
+        // `window` is not one of the four — a delivery Goal still stores 'total'.
+        expect(table?.findColumnByName('window')?.isNullable).toBe(false);
+
+        await runner.release();
+    });
+
+    it("backfills every EXISTING row to goalKind = 'metric' and defaults new rows to it", async () => {
+        await createGoalsTable();
+        await insertMetricRow('g-existing');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        // Inserted AFTER up() without naming the column at all.
+        await insertMetricRow('g-new');
+
+        const rows = await dataSource.query(
+            `SELECT "id","goalKind","targetValue","unit" FROM "goals" ORDER BY "id"`,
+        );
+        expect(rows).toEqual([
+            { id: 'g-existing', goalKind: 'metric', targetValue: 1000, unit: 'usd' },
+            { id: 'g-new', goalKind: 'metric', targetValue: 1000, unit: 'usd' },
+        ]);
+
+        await runner.release();
+    });
+
+    it('lets a delivery row insert with NULL metric fields only AFTER up()', async () => {
+        await createGoalsTable();
+        // Control: the pre-migration table refuses the delivery shape, which
+        // is exactly the defect this migration removes.
+        await expect(
+            dataSource.query(
+                `INSERT INTO "goals" ("id","userId","title","metricSource","comparator","targetValue","unit","window","status")
+                 VALUES ('g-before','u1','x',NULL,NULL,NULL,NULL,'total','draft')`,
+            ),
+        ).rejects.toThrow(/NOT NULL/i);
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        await expect(insertDeliveryRow('g-delivery')).resolves.not.toThrow();
+        const rows = await dataSource.query(
+            `SELECT "goalKind","metricSource","comparator","targetValue","unit","window" FROM "goals" WHERE "id" = 'g-delivery'`,
+        );
+        expect(rows[0]).toEqual({
+            goalKind: 'delivery',
+            metricSource: null,
+            comparator: null,
+            targetValue: null,
+            unit: null,
+            window: 'total',
+        });
+
+        await runner.release();
+    });
+
+    it('keeps the other columns and the existing indexes through the relax step', async () => {
+        await createGoalsTable();
+        await insertMetricRow('g1');
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('goals');
+        for (const name of ['status', 'window', 'checkFrequencyMinutes', 'dodCriteria']) {
+            expect(table?.findColumnByName(name)).toBeDefined();
+        }
+        expect((table?.indices ?? []).map((index) => index.name)).toEqual(
+            expect.arrayContaining(['idx_goals_user_status']),
+        );
+        // The pre-existing row's data survived the recreate.
+        const rows = await dataSource.query(
+            `SELECT "metricSource","status" FROM "goals" WHERE "id" = 'g1'`,
+        );
+        expect(rows[0]).toEqual({
+            metricSource: '{"pluginId":"stripe","metricId":"income"}',
+            status: 'active',
+        });
+
+        await runner.release();
+    });
+
+    it('is idempotent — a second up() does not throw and changes nothing', async () => {
+        await createGoalsTable();
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.not.toThrow();
+
+        const table = await runner.getTable('goals');
+        expect(table?.findColumnByName('goalKind')).toBeDefined();
+        for (const name of METRIC_COLUMNS) {
+            expect(table?.findColumnByName(name)?.isNullable).toBe(true);
+        }
+        await runner.release();
+    });
+
+    it('no-ops when the goals table does not exist yet', async () => {
+        const runner = dataSource.createQueryRunner();
+        await expect(migration.up(runner)).resolves.not.toThrow();
+        await expect(migration.down(runner)).resolves.not.toThrow();
+        await runner.release();
+    });
+
+    it('down() drops goalKind, restores NOT NULL, keeps metric rows and removes delivery rows', async () => {
+        await createGoalsTable();
+        await insertMetricRow('g-metric');
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await insertDeliveryRow('g-delivery');
+
+        await migration.down(runner);
+
+        const table = await runner.getTable('goals');
+        expect(table?.findColumnByName('goalKind')).toBeUndefined();
+        for (const name of METRIC_COLUMNS) {
+            expect(table?.findColumnByName(name)?.isNullable).toBe(false);
+        }
+        const rows = await dataSource.query(`SELECT "id" FROM "goals" ORDER BY "id"`);
+        expect(rows).toEqual([{ id: 'g-metric' }]);
+        // The NOT NULL really is back: the delivery shape is refused again.
+        await expect(insertDeliveryRow('g-again')).rejects.toThrow();
+
+        await runner.release();
+    });
+});

--- a/apps/api/src/migrations/__tests__/AddGoalKind.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddGoalKind.spec.ts
@@ -203,8 +203,29 @@ describe('AddGoalKind1788700000000', () => {
         }
         const rows = await dataSource.query(`SELECT "id" FROM "goals" ORDER BY "id"`);
         expect(rows).toEqual([{ id: 'g-metric' }]);
-        // The NOT NULL really is back: the delivery shape is refused again.
-        await expect(insertDeliveryRow('g-again')).rejects.toThrow();
+
+        // The column is gone from the PHYSICAL schema, not merely from the
+        // query runner's cached table metadata (which is what
+        // `findColumnByName` reads and can lag a sqlite table recreate).
+        const columns: Array<{ name: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("goals")`,
+        );
+        expect(columns.map((c) => c.name)).not.toContain('goalKind');
+        for (const name of METRIC_COLUMNS) {
+            expect(columns.find((c) => c.name === name)?.notnull).toBe(1);
+        }
+
+        // And the NOT NULL really is back: the delivery SHAPE — NULL in all
+        // four metric columns — is refused again. Asserted WITHOUT naming
+        // `goalKind`, so a passing test can only mean the constraint was
+        // restored; the previous form named the dropped column and would
+        // also have passed on "no such column".
+        await expect(
+            dataSource.query(
+                `INSERT INTO "goals" ("id","userId","title","metricSource","comparator","targetValue","unit","window","status")
+                 VALUES ('g-again','u1','Ship feature X',NULL,NULL,NULL,NULL,'total','draft')`,
+            ),
+        ).rejects.toThrow();
 
         await runner.release();
     });

--- a/apps/mcp/test/goal-kind-schema.spec.ts
+++ b/apps/mcp/test/goal-kind-schema.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { SchemaConverterService, type JsonSchema } from '../src/openapi-tools/schema-converter.service.js';
+
+/**
+ * `create_goal` tool schema — Goal kinds (self-build slice AG, EW-795).
+ *
+ * MCP tool input schemas are NOT hand-written: `SchemaConverterService`
+ * derives them at runtime from the API's Swagger document, i.e. from the
+ * `@ApiProperty` metadata on `CreateGoalDto`. This spec feeds the converter
+ * the request-body schema Nest emits for the kind-aware DTO and pins what
+ * an agent calling the tool can and cannot send:
+ *
+ *  - a classic metric payload still parses;
+ *  - a delivery payload (`goalKind: 'delivery'` + `dodCriteria`, no metric
+ *    keys at all) parses;
+ *  - an unknown kind, a non-numeric target and an unknown DoD status are
+ *    refused before the round trip;
+ *  - the four metric names are NO LONGER in `required` — they are required
+ *    for the metric kind only.
+ *
+ * The cross-field rule ("metric ⇒ all four, delivery ⇒ none of them + a
+ * DoD") cannot be expressed in this schema: the converter turns `oneOf`
+ * into `z.any()`, and JSON Schema `if/then` is not modelled at all. It is
+ * enforced by the API (`CreateGoalDto` + `GoalsService.create`), which is
+ * why the property descriptions carry it in prose.
+ */
+const DOD_CRITERION: JsonSchema = {
+	type: 'object',
+	properties: {
+		id: { type: 'string', minLength: 1, maxLength: 64 },
+		text: { type: 'string', minLength: 1, maxLength: 500 },
+		status: { enum: ['open', 'done', 'waived'] },
+		evidence: { type: 'string', nullable: true, maxLength: 1000 },
+		note: { type: 'string', nullable: true, maxLength: 500 },
+		source: { enum: ['operator', 'planner'] },
+		updatedAt: { type: 'string' }
+	},
+	required: ['id', 'text', 'status']
+};
+
+/** What Nest emits for `CreateGoalDto` after the kind change (metric fields optional). */
+const CREATE_GOAL_BODY: JsonSchema = {
+	type: 'object',
+	properties: {
+		title: { type: 'string', minLength: 1, maxLength: 200 },
+		description: { type: 'string', nullable: true, maxLength: 10000 },
+		goalKind: {
+			enum: ['metric', 'delivery'],
+			default: 'metric',
+			description:
+				"'metric' (default) reads a metrics-provider plugin … 'delivery' has no metric: omit those fields, supply dodCriteria."
+		},
+		metricSource: {
+			type: 'object',
+			properties: {
+				pluginId: { type: 'string', minLength: 1, maxLength: 100 },
+				metricId: { type: 'string', minLength: 1, maxLength: 200 },
+				params: { type: 'object' }
+			},
+			required: ['pluginId', 'metricId'],
+			description: 'Metric Goals only — required when goalKind is metric, must be omitted for delivery.'
+		},
+		comparator: { enum: ['gte', 'lte'], description: 'Metric Goals only.' },
+		targetValue: { type: 'number', description: 'Metric Goals only.' },
+		unit: { type: 'string', minLength: 1, maxLength: 32, description: 'Metric Goals only.' },
+		window: { enum: ['day', 'week', 'month', 'total', 'point'], description: 'Metric Goals only.' },
+		baselineValue: { type: 'number', nullable: true },
+		deadline: { type: 'string', nullable: true },
+		checkFrequencyMinutes: { type: 'integer', minimum: 1, default: 60 },
+		dodCriteria: {
+			type: 'array',
+			items: DOD_CRITERION,
+			minItems: 1,
+			maxItems: 50,
+			description: 'Definition of Done. REQUIRED for a delivery Goal; optional seed for a metric Goal.'
+		}
+	},
+	// `title` is the only field required for every kind.
+	required: ['title']
+};
+
+describe('create_goal tool schema — Goal kinds', () => {
+	const converter = new SchemaConverterService();
+	const schema = converter.buildToolParameters([], [], CREATE_GOAL_BODY);
+
+	const metricPayload = {
+		title: 'Income >= $1000/month',
+		metricSource: { pluginId: 'stripe', metricId: 'income' },
+		comparator: 'gte',
+		targetValue: 1000,
+		unit: 'usd',
+		window: 'month'
+	};
+
+	const deliveryPayload = {
+		title: 'Ship feature X across three repos',
+		goalKind: 'delivery',
+		dodCriteria: [
+			{ id: 'api', text: 'API endpoint merged', status: 'open' },
+			{ id: 'web', text: 'Web form merged', status: 'open' },
+			{ id: 'docs', text: 'Docs updated', status: 'open' }
+		]
+	};
+
+	it('accepts a classic metric payload with no goalKind at all', () => {
+		expect(schema.safeParse(metricPayload).success).toBe(true);
+	});
+
+	it('accepts an explicit metric kind', () => {
+		expect(schema.safeParse({ ...metricPayload, goalKind: 'metric' }).success).toBe(true);
+	});
+
+	it('accepts a delivery payload that carries no metric keys', () => {
+		const result = schema.safeParse(deliveryPayload);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			// The parsed object must not have grown metric keys on the way through.
+			for (const key of ['metricSource', 'comparator', 'targetValue', 'unit', 'window']) {
+				expect(key in result.data).toBe(false);
+			}
+		}
+	});
+
+	it('refuses an unknown goalKind', () => {
+		expect(schema.safeParse({ ...deliveryPayload, goalKind: 'bogus' }).success).toBe(false);
+	});
+
+	it('refuses a non-numeric targetValue', () => {
+		expect(schema.safeParse({ ...metricPayload, targetValue: 'abc' }).success).toBe(false);
+	});
+
+	it('refuses an unknown Definition-of-Done status and an empty checklist', () => {
+		expect(
+			schema.safeParse({
+				...deliveryPayload,
+				dodCriteria: [{ id: 'a', text: 'x', status: 'finished' }]
+			}).success
+		).toBe(false);
+		expect(schema.safeParse({ ...deliveryPayload, dodCriteria: [] }).success).toBe(false);
+	});
+
+	it('no longer lists the four metric names as required', () => {
+		// `title` is required for both kinds; every metric field is optional at
+		// the schema level because a delivery Goal never sends it.
+		expect(schema.safeParse({ title: 'x' }).success).toBe(true);
+		expect(CREATE_GOAL_BODY.required).toEqual(['title']);
+		for (const key of ['metricSource', 'comparator', 'targetValue', 'unit']) {
+			expect(CREATE_GOAL_BODY.required).not.toContain(key);
+		}
+	});
+
+	it('documents that the per-kind requirement is enforced by the API, not the schema', () => {
+		// A metric payload missing its target parses HERE (zod cannot express
+		// the cross-field rule) and is refused by the API with a 400 — the
+		// tool description is where an agent learns that.
+		expect(schema.safeParse({ title: 'x', goalKind: 'metric' }).success).toBe(true);
+		expect(CREATE_GOAL_BODY.properties?.metricSource?.description).toContain('required when goalKind is metric');
+		expect(CREATE_GOAL_BODY.properties?.goalKind?.description).toContain('supply dodCriteria');
+	});
+});

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -7118,6 +7118,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -7164,12 +7168,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -7177,6 +7182,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -7187,9 +7193,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -7207,6 +7224,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -7235,6 +7253,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -7249,6 +7268,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7397,7 +7417,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -6807,6 +6807,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6853,12 +6857,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6866,6 +6871,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6876,9 +6882,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6896,6 +6913,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6924,6 +6942,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6938,6 +6957,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7086,7 +7106,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -6740,6 +6740,10 @@
                 "missed": "Missed",
                 "abandoned": "Abandoned"
             },
+            "kinds": {
+                "metric": "Metric",
+                "delivery": "Delivery"
+            },
             "filterBar": {
                 "status": "Status",
                 "anyStatus": "Any status",
@@ -6786,12 +6790,13 @@
         },
         "goalNew": {
             "title": "New Goal",
-            "subtitle": "Define a measurable target and the metric that tracks it. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
+            "subtitle": "Define what done looks like: a measurable metric target, or a delivery checklist with no metric at all. New Goals start as a draft — activate from the detail page to begin scheduled evaluation.",
             "backToGoals": "Back to Goals",
             "created": "Goal created",
             "sections": {
                 "metricSource": "Metric source",
                 "target": "Target",
+                "definitionOfDone": "Definition of Done",
                 "cadence": "Evaluation cadence"
             },
             "fields": {
@@ -6799,6 +6804,7 @@
                 "titlePlaceholder": "e.g. Monthly Stripe income of $1,000",
                 "description": "Description",
                 "descriptionPlaceholder": "Optional context for this Goal",
+                "goalKind": "Goal kind",
                 "pluginId": "Provider plugin ID",
                 "metricId": "Metric ID",
                 "params": "Parameters (JSON)",
@@ -6809,9 +6815,20 @@
                 "targetValue": "Target value",
                 "unit": "Unit",
                 "window": "Window",
+                "dodCriteria": "Criteria (one per line)",
+                "dodCriteriaPlaceholder": "API endpoint merged\nWeb form merged\nDocs updated",
+                "dodCriteriaHint": "Each line becomes one approved criterion. At least one is required; refine the list on the Goal page after creation.",
                 "deadline": "Deadline (optional)",
                 "checkFrequency": "Check frequency (minutes)",
                 "checkFrequencyHint": "Minimum {min} minutes; lower values are clamped."
+            },
+            "kinds": {
+                "metric": "Metric target",
+                "delivery": "Delivery"
+            },
+            "kindHints": {
+                "metric": "Reads a number from a metrics provider on a schedule and completes when the target is reached.",
+                "delivery": "No metric. Completes when every approved Definition-of-Done criterion is done or waived — for outcomes like \"ship feature X across three repos\"."
             },
             "comparators": {
                 "gte": "At least (grow to target)",
@@ -6829,6 +6846,7 @@
                 "metricSourceRequired": "Provider plugin ID and metric ID are required.",
                 "targetInvalid": "Target value must be a number.",
                 "unitRequired": "Unit is required.",
+                "dodRequired": "A delivery Goal needs at least one Definition-of-Done criterion.",
                 "deadlineInvalid": "Deadline is not a valid date.",
                 "createFailed": "Couldn't create the Goal. Please try again."
             },
@@ -6857,6 +6875,7 @@
                 "current": "Current",
                 "target": "Target",
                 "noSamples": "No observations yet. Activate the Goal or run an evaluation to start collecting samples.",
+                "deliveryHint": "This is a delivery Goal — there is no metric to chart. Progress is the Definition of Done: the Goal completes when every approved criterion is done or waived.",
                 "sampleCount": "{count} observations"
             },
             "comparator": {
@@ -6871,6 +6890,7 @@
                 "point": "Point-in-time"
             },
             "details": {
+                "kind": "Kind",
                 "plugin": "Provider",
                 "metric": "Metric",
                 "window": "Window",
@@ -7019,7 +7039,7 @@
                     "workerModelHelp": "Free text; passed through to iteration runs.",
                     "assignedAgent": "Pinned agent",
                     "assignedAgentNone": "No pin (round-robin)",
-                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — so a brand-new Goal needs one before the loop can start work."
+                    "assignedAgentHelp": "Routing always picks this agent. Without a pin the router round-robins over the agents that have already worked this Goal — and, for a brand-new Goal, over the eligible agents in its scope — so the loop can start without one."
                 },
                 "executionTargets": {
                     "cloud": "Cloud",

--- a/apps/web/src/app/[locale]/(dashboard)/goals/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/goals/[id]/page.tsx
@@ -36,12 +36,13 @@ export default async function GoalDetailPage({ params }: { params: Params }) {
     // the orchestrator log and the session list are supporting evidence,
     // and losing one of them must not take the whole Goal page down.
     //
-    // The Agent list is what makes the loop reachable at all: the router
-    // only ever considers the Goal's pinned agent plus the agents that have
-    // already worked one of its iterations, so a Goal created in the UI has
-    // an EMPTY candidate pool and every advance answers `no-candidate-agent`
-    // until an operator pins one. `assignedAgentId` is the field that does
-    // that, and the Adjust-limits dialog is where it is set.
+    // The Agent list feeds the Adjust-limits dialog's routing pin
+    // (`assignedAgentId`). A pin is optional: without one the router
+    // round-robins over the agents that have already worked this Goal and,
+    // for a brand-new Goal, over the eligible agents in the Goal's own
+    // Organization / tenant scope (self-build slice AG, finding R1) — so a
+    // Goal created in the UI can start its loop as soon as the scope has
+    // an agent, and `no-candidate-agent` now means the scope has none.
     const [samples, events, sessions, agents]: [
         GoalMetricSample[],
         GoalEvent[],

--- a/apps/web/src/components/goals/GoalCard.tsx
+++ b/apps/web/src/components/goals/GoalCard.tsx
@@ -6,17 +6,30 @@ import { Link } from '@/i18n/navigation';
 import { cn } from '@/lib/utils/cn';
 import { StatusPill } from '@/components/work-agent';
 import type { Goal } from '@/lib/api/goals';
-import { COMPARATOR_GLYPH, OutcomeBadge, formatMetricValue, formatDateTime } from './goal-ui';
+import {
+    COMPARATOR_GLYPH,
+    GoalKindBadge,
+    OutcomeBadge,
+    formatMetricValue,
+    formatDateTime,
+} from './goal-ui';
+import { DodProgressBar, DodRollup } from './goal-loop-ui';
 
 /**
  * Goals & Metrics — PR-8. Read-only summary card for a single Goal in
  * the `/goals` list grid. Whole card links to the Goal detail page.
- * Surfaces the current-vs-target progress with a comparator glyph
- * (≥/≤), the lifecycle status pill, the terminal outcome badge when
- * set, and the next scheduled check for active Goals.
+ *
+ * A METRIC Goal surfaces the current-vs-target progress with a comparator
+ * glyph (≥/≤) and its aggregation window; a DELIVERY Goal (self-build
+ * slice AG) has no metric, so the same slot carries the Definition-of-Done
+ * rollup instead and the window line is dropped. Both show the lifecycle
+ * status pill, the kind badge, the terminal outcome badge when set, and
+ * the next scheduled check for active Goals.
  */
 export function GoalCard({ goal }: { goal: Goal }) {
     const t = useTranslations('dashboard.goalsPage.card');
+    const isDelivery = goal.goalKind === 'delivery';
+    const unit = goal.unit ?? undefined;
 
     return (
         <Link
@@ -47,25 +60,36 @@ export function GoalCard({ goal }: { goal: Goal }) {
                 <ChevronRight className="w-4 h-4 text-text-muted dark:text-text-muted-dark shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
 
-            {/* Current vs target with comparator glyph */}
-            <div className="mb-3 flex items-center gap-2 rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 px-3 py-2">
-                <span className="text-sm font-semibold text-text dark:text-text-dark tabular-nums truncate">
-                    {formatMetricValue(goal.currentValue, goal.unit)}
-                </span>
-                <span
-                    className="text-sm font-semibold text-info shrink-0"
-                    aria-label={t(`comparator.${goal.comparator}`)}
-                    title={t(`comparator.${goal.comparator}`)}
-                >
-                    {COMPARATOR_GLYPH[goal.comparator]}
-                </span>
-                <span className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark tabular-nums truncate">
-                    {formatMetricValue(goal.targetValue, goal.unit)}
-                </span>
-            </div>
+            {isDelivery ? (
+                /* Delivery: the Definition of Done IS the progress. */
+                <div className="mb-3 space-y-2 rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 px-3 py-2">
+                    <DodRollup summary={goal.dodSummary} />
+                    <DodProgressBar summary={goal.dodSummary} />
+                </div>
+            ) : (
+                /* Metric: current vs target with comparator glyph. */
+                <div className="mb-3 flex items-center gap-2 rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 px-3 py-2">
+                    <span className="text-sm font-semibold text-text dark:text-text-dark tabular-nums truncate">
+                        {formatMetricValue(goal.currentValue, unit)}
+                    </span>
+                    <span
+                        className="text-sm font-semibold text-info shrink-0"
+                        aria-label={
+                            goal.comparator ? t(`comparator.${goal.comparator}`) : undefined
+                        }
+                        title={goal.comparator ? t(`comparator.${goal.comparator}`) : undefined}
+                    >
+                        {goal.comparator ? COMPARATOR_GLYPH[goal.comparator] : '—'}
+                    </span>
+                    <span className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark tabular-nums truncate">
+                        {formatMetricValue(goal.targetValue, unit)}
+                    </span>
+                </div>
+            )}
 
             <div className="mb-3 flex flex-wrap items-center gap-2">
                 <StatusPill status={goal.status} />
+                <GoalKindBadge kind={goal.goalKind} />
                 {goal.outcome ? <OutcomeBadge outcome={goal.outcome} /> : null}
             </div>
 
@@ -80,14 +104,14 @@ export function GoalCard({ goal }: { goal: Goal }) {
                             {formatDateTime(goal.nextCheckAt)}
                         </time>
                     </div>
-                ) : (
+                ) : !isDelivery ? (
                     <div>
                         <span className="font-medium text-text-secondary dark:text-text-secondary-dark">
                             {t('windowPrefix')}
                         </span>{' '}
                         {t(`window.${goal.window}`)}
                     </div>
-                )}
+                ) : null}
             </div>
         </Link>
     );

--- a/apps/web/src/components/goals/GoalDetailClient.tsx
+++ b/apps/web/src/components/goals/GoalDetailClient.tsx
@@ -33,8 +33,14 @@ import {
     type GoalOutcome,
     type GoalSession,
 } from '@/lib/api/goals';
-import { COMPARATOR_GLYPH, OutcomeBadge, formatDateTime, formatMetricValue } from './goal-ui';
-import { DodRollup, LoopStatusBadge, formatCents } from './goal-loop-ui';
+import {
+    COMPARATOR_GLYPH,
+    GoalKindBadge,
+    OutcomeBadge,
+    formatDateTime,
+    formatMetricValue,
+} from './goal-ui';
+import { DodProgressBar, DodRollup, LoopStatusBadge, formatCents } from './goal-loop-ui';
 import { Sparkline } from './Sparkline';
 import { GoalDodPanel } from './GoalDodPanel';
 import { GoalLimitsDialog, type GoalAgentOption } from './GoalLimitsDialog';
@@ -61,9 +67,11 @@ export interface GoalDetailClientProps {
     events: GoalEvent[];
     sessions: GoalSession[];
     /**
-     * Agents the routing pin may choose between. Server-fetched, because
-     * without a pin a Goal created in the UI has an empty candidate pool and
-     * the loop can only ever answer `no-candidate-agent`.
+     * Agents the routing pin may choose between. Server-fetched so the
+     * Adjust-limits dialog can offer a pin; without one the router
+     * round-robins over the agents that have worked this Goal and, for a
+     * brand-new Goal, over the eligible agents in its scope (self-build
+     * slice AG), so an empty pool now means the scope really has no agent.
      */
     agents?: GoalAgentOption[];
 }
@@ -149,7 +157,11 @@ export function GoalDetailClient({
 
     const canActivate = goal.status !== 'active';
     const canPause = goal.status === 'active';
+    // Kept for both kinds: on a delivery Goal "evaluate now" re-checks the
+    // Definition of Done and the deadline without any plugin call.
     const canEvaluate = goal.status === 'active';
+    const isDelivery = goal.goalKind === 'delivery';
+    const unit = goal.unit ?? undefined;
     const loopRunning = goal.loopStatus === 'running';
     const loopStartable = !loopRunning && goal.loopStatus !== 'cancelled' && !goal.archivedAt;
 
@@ -265,6 +277,7 @@ export function GoalDetailClient({
                             </h1>
                             <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 <StatusPill status={goal.status} />
+                                <GoalKindBadge kind={goal.goalKind} />
                                 {goal.outcome ? <OutcomeBadge outcome={goal.outcome} /> : null}
                                 {goal.loopStatus ? (
                                     <LoopStatusBadge status={goal.loopStatus} />
@@ -523,45 +536,65 @@ export function GoalDetailClient({
                             </h2>
                         </div>
 
-                        <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
-                            <div>
-                                <p className="text-[11px] uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
-                                    {t('progress.current')}
-                                </p>
-                                <p className="text-2xl font-semibold text-text dark:text-text-dark tabular-nums">
-                                    {formatMetricValue(goal.currentValue, goal.unit)}
-                                </p>
-                            </div>
-                            <span
-                                className="text-2xl font-semibold text-info pb-0.5"
-                                title={t(`comparator.${goal.comparator}`)}
-                            >
-                                {COMPARATOR_GLYPH[goal.comparator]}
-                            </span>
-                            <div>
-                                <p className="text-[11px] uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
-                                    {t('progress.target')}
-                                </p>
-                                <p className="text-2xl font-semibold text-text-secondary dark:text-text-secondary-dark tabular-nums">
-                                    {formatMetricValue(goal.targetValue, goal.unit)}
+                        {isDelivery ? (
+                            /* Delivery Goal: nothing is measured — the approved
+                               Definition of Done is the whole progress story. */
+                            <div className="space-y-3" data-testid="goal-delivery-progress">
+                                <DodRollup summary={goal.dodSummary} className="text-sm" />
+                                <DodProgressBar summary={goal.dodSummary} />
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t('progress.deliveryHint')}
                                 </p>
                             </div>
-                        </div>
+                        ) : (
+                            <>
+                                <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
+                                    <div>
+                                        <p className="text-[11px] uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+                                            {t('progress.current')}
+                                        </p>
+                                        <p className="text-2xl font-semibold text-text dark:text-text-dark tabular-nums">
+                                            {formatMetricValue(goal.currentValue, unit)}
+                                        </p>
+                                    </div>
+                                    <span
+                                        className="text-2xl font-semibold text-info pb-0.5"
+                                        title={
+                                            goal.comparator
+                                                ? t(`comparator.${goal.comparator}`)
+                                                : undefined
+                                        }
+                                    >
+                                        {goal.comparator ? COMPARATOR_GLYPH[goal.comparator] : '—'}
+                                    </span>
+                                    <div>
+                                        <p className="text-[11px] uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+                                            {t('progress.target')}
+                                        </p>
+                                        <p className="text-2xl font-semibold text-text-secondary dark:text-text-secondary-dark tabular-nums">
+                                            {formatMetricValue(goal.targetValue, unit)}
+                                        </p>
+                                    </div>
+                                </div>
 
-                        <div className="mt-4">
-                            {sparkValues.length > 0 ? (
-                                <Sparkline values={sparkValues} target={goal.targetValue} />
-                            ) : (
-                                <p className="text-xs text-text-muted dark:text-text-muted-dark py-6 text-center">
-                                    {t('progress.noSamples')}
-                                </p>
-                            )}
-                            {sparkValues.length > 0 ? (
-                                <p className="mt-1 text-[11px] text-text-muted dark:text-text-muted-dark">
-                                    {t('progress.sampleCount', { count: sparkValues.length })}
-                                </p>
-                            ) : null}
-                        </div>
+                                <div className="mt-4">
+                                    {sparkValues.length > 0 ? (
+                                        <Sparkline values={sparkValues} target={goal.targetValue} />
+                                    ) : (
+                                        <p className="text-xs text-text-muted dark:text-text-muted-dark py-6 text-center">
+                                            {t('progress.noSamples')}
+                                        </p>
+                                    )}
+                                    {sparkValues.length > 0 ? (
+                                        <p className="mt-1 text-[11px] text-text-muted dark:text-text-muted-dark">
+                                            {t('progress.sampleCount', {
+                                                count: sparkValues.length,
+                                            })}
+                                        </p>
+                                    ) : null}
+                                </div>
+                            </>
+                        )}
                     </section>
 
                     <div className="grid gap-5 @3xl/main:grid-cols-2">
@@ -570,18 +603,27 @@ export function GoalDetailClient({
                                 {t('sections.details')}
                             </h2>
                             <div className="divide-y divide-border/50 dark:divide-border-dark/50">
-                                <DetailRow label={t('details.plugin')}>
-                                    {goal.metricSource.pluginId}
+                                <DetailRow label={t('details.kind')}>
+                                    <GoalKindBadge kind={goal.goalKind} />
                                 </DetailRow>
-                                <DetailRow label={t('details.metric')}>
-                                    {goal.metricSource.metricId}
-                                </DetailRow>
-                                <DetailRow label={t('details.window')}>
-                                    {t(`window.${goal.window}`)}
-                                </DetailRow>
-                                <DetailRow label={t('details.baseline')}>
-                                    {formatMetricValue(goal.baselineValue, goal.unit)}
-                                </DetailRow>
+                                {/* Provider / metric / window / baseline only mean
+                                    something on a metric Goal. */}
+                                {!isDelivery ? (
+                                    <>
+                                        <DetailRow label={t('details.plugin')}>
+                                            {goal.metricSource?.pluginId ?? '—'}
+                                        </DetailRow>
+                                        <DetailRow label={t('details.metric')}>
+                                            {goal.metricSource?.metricId ?? '—'}
+                                        </DetailRow>
+                                        <DetailRow label={t('details.window')}>
+                                            {t(`window.${goal.window}`)}
+                                        </DetailRow>
+                                        <DetailRow label={t('details.baseline')}>
+                                            {formatMetricValue(goal.baselineValue, unit)}
+                                        </DetailRow>
+                                    </>
+                                ) : null}
                                 <DetailRow label={t('details.checkFrequency')}>
                                     {t('details.minutes', { count: goal.checkFrequencyMinutes })}
                                 </DetailRow>

--- a/apps/web/src/components/goals/GoalForm.tsx
+++ b/apps/web/src/components/goals/GoalForm.tsx
@@ -13,10 +13,13 @@ import { cn } from '@/lib/utils/cn';
 import {
     MIN_CHECK_FREQUENCY_MINUTES,
     DEFAULT_CHECK_FREQUENCY_MINUTES,
+    GOAL_KINDS,
     type GoalComparator,
+    type GoalKind,
     type GoalWindow,
 } from '@/lib/api/goals.shared';
 import { createGoalAction } from './actions';
+import { buildCreateGoalPayload, validateGoalFormFields } from './goal-form-payload';
 
 const COMPARATORS: GoalComparator[] = ['gte', 'lte'];
 const WINDOWS: GoalWindow[] = ['day', 'week', 'month', 'total', 'point'];
@@ -26,19 +29,41 @@ const sectionCard =
 
 const fieldLabel = 'block text-xs font-medium text-text dark:text-text-dark mb-2';
 
+const fieldHint = 'mt-1.5 text-xs text-text-muted dark:text-text-muted-dark';
+
+const dateInput = cn(
+    'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
+    'bg-card dark:bg-card-primary-dark',
+    'border border-card-border dark:border-white/9',
+    'text-text dark:text-text-dark',
+    'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
+);
+
 /**
  * Goals & Metrics — PR-8. Create-Goal form backing `/goals/new`.
- * Collects the metric source (pluginId + metricId + optional
- * params-JSON), the target comparator/value/unit/window, an optional
- * deadline, and the evaluation cadence (clamped server-side to
+ *
+ * Two KINDS share the form (self-build slice AG, EW-795), chosen by the
+ * selector in the Basics card:
+ *
+ *   - **Metric** (the default) — the original Goal: metric source
+ *     (pluginId + metricId + optional params-JSON), target
+ *     comparator/value/unit/window. Those sections render, and their
+ *     fields are sent, ONLY for this kind.
+ *   - **Delivery** — "ship feature X across three repos": no metric at
+ *     all. A Definition of Done (one criterion per line, at least one) is
+ *     collected instead, and the payload carries no metric key.
+ *
+ * Deadline and evaluation cadence apply to both (clamped server-side to
  * ≥15 min — surfaced here as a hint). New Goals land in `draft`;
- * activation happens from the detail page.
+ * activation happens from the detail page. The accept/reject decision and
+ * the exact payload live in `goal-form-payload.ts`.
  */
 export function GoalForm() {
     const t = useTranslations('dashboard.goalNew');
     const router = useRouter();
     const [pending, startSubmit] = useTransition();
 
+    const [kind, setKind] = useState<GoalKind>('metric');
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
     const [pluginId, setPluginId] = useState('');
@@ -49,10 +74,13 @@ export function GoalForm() {
     const [targetValue, setTargetValue] = useState('');
     const [unit, setUnit] = useState('');
     const [metricWindow, setMetricWindow] = useState<GoalWindow>('month');
+    const [dodText, setDodText] = useState('');
     const [deadline, setDeadline] = useState('');
     const [checkFrequencyMinutes, setCheckFrequencyMinutes] = useState(
         String(DEFAULT_CHECK_FREQUENCY_MINUTES),
     );
+
+    const isMetric = kind === 'metric';
 
     const parseParams = (): { ok: true; value?: Record<string, unknown> } | { ok: false } => {
         const raw = paramsText.trim();
@@ -75,39 +103,37 @@ export function GoalForm() {
     };
 
     const submit = () => {
-        const trimmedTitle = title.trim();
-        if (trimmedTitle.length < 1) {
-            toast.error(t('errors.titleRequired'));
+        const fields = {
+            title,
+            description,
+            pluginId,
+            metricId,
+            comparator,
+            targetValue,
+            unit,
+            window: metricWindow,
+            dodText,
+            deadline: null as string | null,
+            checkFrequencyMinutes: DEFAULT_CHECK_FREQUENCY_MINUTES,
+        };
+
+        // Kind-aware: a metric Goal keeps the legacy checks in the legacy
+        // order (title → source → target → unit, EW-044's empty-target guard
+        // included); a delivery Goal needs a title and at least one criterion.
+        const problem = validateGoalFormFields(kind, fields);
+        if (problem) {
+            toast.error(t(problem));
             return;
         }
-        if (!pluginId.trim() || !metricId.trim()) {
-            toast.error(t('errors.metricSourceRequired'));
-            return;
-        }
-        // `Number('')` is 0, NOT NaN — so checking only `Number.isFinite` let an
-        // EMPTY Target value through as a real target of 0. Combined with the
-        // default comparator `gte`, that creates a Goal meaning "reach at least
-        // 0", which every possible metric value already satisfies: the Goal is
-        // vacuous and reports success on its first evaluation. Verified on
-        // production — submitting the form with Target value blank produced
-        // `targetValue = 0, comparator = gte` with no error shown.
-        //
-        // The empty case must be rejected explicitly, before the conversion.
-        // `Number(' ')` is 0 too, hence the trim.
-        const rawTarget = targetValue.trim();
-        const target = Number(rawTarget);
-        if (rawTarget.length === 0 || !Number.isFinite(target)) {
-            toast.error(t('errors.targetInvalid'));
-            return;
-        }
-        if (!unit.trim()) {
-            toast.error(t('errors.unitRequired'));
-            return;
-        }
-        const params = parseParams();
-        if (!params.ok) {
-            toast.error(t('fields.paramsInvalid'));
-            return;
+
+        let params: Record<string, unknown> | undefined;
+        if (isMetric) {
+            const parsed = parseParams();
+            if (!parsed.ok) {
+                toast.error(t('fields.paramsInvalid'));
+                return;
+            }
+            params = parsed.value;
         }
 
         let deadlineIso: string | null = null;
@@ -124,23 +150,16 @@ export function GoalForm() {
         const checkFreq =
             Number.isFinite(freq) && freq > 0 ? Math.round(freq) : DEFAULT_CHECK_FREQUENCY_MINUTES;
 
+        const payload = buildCreateGoalPayload(kind, {
+            ...fields,
+            params,
+            deadline: deadlineIso,
+            checkFrequencyMinutes: checkFreq,
+        });
+
         startSubmit(async () => {
             try {
-                const goal = await createGoalAction({
-                    title: trimmedTitle,
-                    description: description.trim() || null,
-                    metricSource: {
-                        pluginId: pluginId.trim(),
-                        metricId: metricId.trim(),
-                        ...(params.value ? { params: params.value } : {}),
-                    },
-                    comparator,
-                    targetValue: target,
-                    unit: unit.trim(),
-                    window: metricWindow,
-                    deadline: deadlineIso,
-                    checkFrequencyMinutes: checkFreq,
-                });
+                const goal = await createGoalAction(payload);
                 toast.success(t('created'));
                 router.push(`/goals/${goal.id}`);
             } catch (err) {
@@ -193,82 +212,100 @@ export function GoalForm() {
                         placeholder={t('fields.descriptionPlaceholder')}
                     />
                 </div>
-            </section>
-
-            {/* Metric source */}
-            <section className={sectionCard}>
-                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                    {t('sections.metricSource')}
-                </h2>
-                <div className="grid gap-4 @lg/main:grid-cols-2">
-                    <Input
-                        label={t('fields.pluginId')}
-                        value={pluginId}
-                        onChange={(e) => setPluginId(e.target.value)}
-                        maxLength={100}
-                        placeholder="stripe"
-                    />
-                    <Input
-                        label={t('fields.metricId')}
-                        value={metricId}
-                        onChange={(e) => setMetricId(e.target.value)}
-                        maxLength={200}
-                        placeholder="income"
-                    />
-                </div>
                 <div>
-                    <label className={fieldLabel}>{t('fields.params')}</label>
-                    <Textarea
-                        value={paramsText}
-                        onChange={(e) => setParamsText(e.target.value)}
-                        onBlur={parseParams}
-                        rows={4}
-                        placeholder={'{\n  "currency": "usd"\n}'}
-                        className="font-mono text-xs"
-                        error={paramsError ?? undefined}
-                    />
-                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t('fields.paramsHint')}
-                    </p>
+                    <label className={fieldLabel} htmlFor="goal-kind">
+                        {t('fields.goalKind')}
+                    </label>
+                    <Select
+                        id="goal-kind"
+                        value={kind}
+                        onValueChange={(v) => setKind(v as GoalKind)}
+                        data-testid="goal-kind-select"
+                    >
+                        {GOAL_KINDS.map((k) => (
+                            <option key={k} value={k}>
+                                {t(`kinds.${k}`)}
+                            </option>
+                        ))}
+                    </Select>
+                    <p className={fieldHint}>{t(`kindHints.${kind}`)}</p>
                 </div>
             </section>
 
-            {/* Target */}
-            <section className={sectionCard}>
-                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                    {t('sections.target')}
-                </h2>
-                <div className="grid gap-4 @lg/main:grid-cols-3">
-                    <div>
-                        <label className={fieldLabel}>{t('fields.comparator')}</label>
-                        <Select
-                            value={comparator}
-                            onValueChange={(v) => setComparator(v as GoalComparator)}
-                        >
-                            {COMPARATORS.map((c) => (
-                                <option key={c} value={c}>
-                                    {t(`comparators.${c}`)}
-                                </option>
-                            ))}
-                        </Select>
+            {/* Metric source — metric Goals only */}
+            {isMetric ? (
+                <section className={sectionCard}>
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.metricSource')}
+                    </h2>
+                    <div className="grid gap-4 @lg/main:grid-cols-2">
+                        <Input
+                            label={t('fields.pluginId')}
+                            value={pluginId}
+                            onChange={(e) => setPluginId(e.target.value)}
+                            maxLength={100}
+                            placeholder="stripe"
+                        />
+                        <Input
+                            label={t('fields.metricId')}
+                            value={metricId}
+                            onChange={(e) => setMetricId(e.target.value)}
+                            maxLength={200}
+                            placeholder="income"
+                        />
                     </div>
-                    <Input
-                        type="number"
-                        label={t('fields.targetValue')}
-                        value={targetValue}
-                        onChange={(e) => setTargetValue(e.target.value)}
-                        step="any"
-                        placeholder="1000"
-                    />
-                    <Input
-                        label={t('fields.unit')}
-                        value={unit}
-                        onChange={(e) => setUnit(e.target.value)}
-                        maxLength={32}
-                        placeholder="usd"
-                    />
-                </div>
-                <div className="grid gap-4 @lg/main:grid-cols-2">
+                    <div>
+                        <label className={fieldLabel}>{t('fields.params')}</label>
+                        <Textarea
+                            value={paramsText}
+                            onChange={(e) => setParamsText(e.target.value)}
+                            onBlur={parseParams}
+                            rows={4}
+                            placeholder={'{\n  "currency": "usd"\n}'}
+                            className="font-mono text-xs"
+                            error={paramsError ?? undefined}
+                        />
+                        <p className={fieldHint}>{t('fields.paramsHint')}</p>
+                    </div>
+                </section>
+            ) : null}
+
+            {/* Target — metric Goals only */}
+            {isMetric ? (
+                <section className={sectionCard}>
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.target')}
+                    </h2>
+                    <div className="grid gap-4 @lg/main:grid-cols-3">
+                        <div>
+                            <label className={fieldLabel}>{t('fields.comparator')}</label>
+                            <Select
+                                value={comparator}
+                                onValueChange={(v) => setComparator(v as GoalComparator)}
+                            >
+                                {COMPARATORS.map((c) => (
+                                    <option key={c} value={c}>
+                                        {t(`comparators.${c}`)}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+                        <Input
+                            type="number"
+                            label={t('fields.targetValue')}
+                            value={targetValue}
+                            onChange={(e) => setTargetValue(e.target.value)}
+                            step="any"
+                            placeholder="1000"
+                        />
+                        <Input
+                            label={t('fields.unit')}
+                            value={unit}
+                            onChange={(e) => setUnit(e.target.value)}
+                            maxLength={32}
+                            placeholder="usd"
+                        />
+                    </div>
                     <div>
                         <label className={fieldLabel}>{t('fields.window')}</label>
                         <Select
@@ -282,40 +319,54 @@ export function GoalForm() {
                             ))}
                         </Select>
                     </div>
+                </section>
+            ) : null}
+
+            {/* Definition of Done — delivery Goals only */}
+            {!isMetric ? (
+                <section className={sectionCard}>
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('sections.definitionOfDone')}
+                    </h2>
+                    <Textarea
+                        label={t('fields.dodCriteria')}
+                        value={dodText}
+                        onChange={(e) => setDodText(e.target.value)}
+                        rows={5}
+                        placeholder={t('fields.dodCriteriaPlaceholder')}
+                        helperText={t('fields.dodCriteriaHint')}
+                        data-testid="goal-dod-text"
+                    />
+                </section>
+            ) : null}
+
+            {/* Cadence + deadline — both kinds */}
+            <section className={sectionCard}>
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('sections.cadence')}
+                </h2>
+                <div className="grid gap-4 @lg/main:grid-cols-2">
+                    <Input
+                        type="number"
+                        label={t('fields.checkFrequency')}
+                        value={checkFrequencyMinutes}
+                        min={MIN_CHECK_FREQUENCY_MINUTES}
+                        step={1}
+                        onChange={(e) => setCheckFrequencyMinutes(e.target.value)}
+                        helperText={t('fields.checkFrequencyHint', {
+                            min: MIN_CHECK_FREQUENCY_MINUTES,
+                        })}
+                    />
                     <div>
                         <label className={fieldLabel}>{t('fields.deadline')}</label>
                         <input
                             type="datetime-local"
                             value={deadline}
                             onChange={(e) => setDeadline(e.target.value)}
-                            className={cn(
-                                'w-full text-sm rounded-lg transition-colors outline-none px-4 py-2',
-                                'bg-card dark:bg-card-primary-dark',
-                                'border border-card-border dark:border-white/9',
-                                'text-text dark:text-text-dark',
-                                'focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20',
-                            )}
+                            className={dateInput}
                         />
                     </div>
                 </div>
-            </section>
-
-            {/* Cadence */}
-            <section className={sectionCard}>
-                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
-                    {t('sections.cadence')}
-                </h2>
-                <Input
-                    type="number"
-                    label={t('fields.checkFrequency')}
-                    value={checkFrequencyMinutes}
-                    min={MIN_CHECK_FREQUENCY_MINUTES}
-                    step={1}
-                    onChange={(e) => setCheckFrequencyMinutes(e.target.value)}
-                    helperText={t('fields.checkFrequencyHint', {
-                        min: MIN_CHECK_FREQUENCY_MINUTES,
-                    })}
-                />
             </section>
 
             <div className="flex items-center gap-2">

--- a/apps/web/src/components/goals/GoalForm.unit.spec.tsx
+++ b/apps/web/src/components/goals/GoalForm.unit.spec.tsx
@@ -1,0 +1,359 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+        vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+    toast: {
+        success: (...args: unknown[]) => toastSuccess(...args),
+        error: (...args: unknown[]) => toastError(...args),
+    },
+}));
+
+const push = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push, refresh: vi.fn() }),
+    Link: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+const createGoalAction = vi.fn();
+vi.mock('./actions', () => ({
+    createGoalAction: (...args: unknown[]) => createGoalAction(...args),
+}));
+
+// Stub the `Select` primitive with a native <select> — the real one is a
+// portal-rendered custom listbox, and this spec is about the form's kind
+// switch and payload, not the picker's internals (same convention as
+// MissionGoalsPanel.unit.spec.tsx).
+vi.mock('@/components/ui/select', () => ({
+    Select: ({
+        value,
+        children,
+        onValueChange,
+        ...rest
+    }: {
+        value: string;
+        children: React.ReactNode;
+        onValueChange: (v: string) => void;
+    } & Record<string, unknown>) => (
+        <select
+            data-testid={rest['data-testid'] as string | undefined}
+            id={rest.id as string | undefined}
+            value={value}
+            onChange={(e) => onValueChange(e.currentTarget.value)}
+        >
+            {children}
+        </select>
+    ),
+}));
+
+import { GoalForm } from './GoalForm';
+import {
+    buildCreateGoalPayload,
+    parseDodLines,
+    targetValueIsAcceptable,
+    validateGoalFormFields,
+    type GoalFormFields,
+} from './goal-form-payload';
+
+const METRIC_KEYS = ['metricSource', 'comparator', 'targetValue', 'unit', 'window'] as const;
+
+function setField(label: string, value: string) {
+    fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+function switchKind(kind: 'metric' | 'delivery') {
+    fireEvent.change(screen.getByTestId('goal-kind-select'), { target: { value: kind } });
+}
+
+function clickCreate() {
+    fireEvent.click(screen.getByRole('button', { name: 'actions.create' }));
+}
+
+/**
+ * Self-build slice AG (EW-795) — the create form's kind switch.
+ *
+ * What is pinned: the form defaults to a METRIC Goal (so the pinned e2e
+ * journey that looks for the "Target value" field on `/goals/new` keeps
+ * finding it), switching to DELIVERY hides every metric field and shows the
+ * Definition of Done, and — the part a rendered form is the only honest
+ * witness for — the payload handed to the server action for a delivery
+ * Goal carries NO metric key, while the metric payload is unchanged.
+ */
+describe('GoalForm — kind switch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createGoalAction.mockResolvedValue({ id: 'g-new' });
+    });
+
+    it('defaults to a metric Goal: metric source + target visible, no Definition of Done', () => {
+        render(<GoalForm />);
+        expect(screen.getByTestId('goal-kind-select')).toHaveValue('metric');
+        expect(screen.getByLabelText('fields.pluginId')).toBeInTheDocument();
+        expect(screen.getByLabelText('fields.metricId')).toBeInTheDocument();
+        expect(screen.getByLabelText('fields.targetValue')).toBeInTheDocument();
+        expect(screen.getByLabelText('fields.unit')).toBeInTheDocument();
+        expect(screen.getByText('sections.target')).toBeInTheDocument();
+        expect(screen.getByText('kindHints.metric')).toBeInTheDocument();
+        expect(screen.queryByLabelText('fields.dodCriteria')).toBeNull();
+        expect(screen.queryByText('sections.definitionOfDone')).toBeNull();
+    });
+
+    it('switching to delivery hides every metric field and shows the Definition of Done', () => {
+        render(<GoalForm />);
+        switchKind('delivery');
+
+        expect(screen.getByTestId('goal-kind-select')).toHaveValue('delivery');
+        expect(screen.queryByLabelText('fields.pluginId')).toBeNull();
+        expect(screen.queryByLabelText('fields.metricId')).toBeNull();
+        expect(screen.queryByLabelText('fields.targetValue')).toBeNull();
+        expect(screen.queryByLabelText('fields.unit')).toBeNull();
+        expect(screen.queryByText('sections.metricSource')).toBeNull();
+        expect(screen.queryByText('sections.target')).toBeNull();
+        expect(screen.getByLabelText('fields.dodCriteria')).toBeInTheDocument();
+        expect(screen.getByText('kindHints.delivery')).toBeInTheDocument();
+        // Deadline + cadence apply to both kinds and stay.
+        expect(screen.getByLabelText('fields.checkFrequency')).toBeInTheDocument();
+        expect(screen.getByText('fields.deadline')).toBeInTheDocument();
+    });
+
+    it('switching back to metric restores the metric fields', () => {
+        render(<GoalForm />);
+        switchKind('delivery');
+        switchKind('metric');
+        expect(screen.getByLabelText('fields.targetValue')).toBeInTheDocument();
+        expect(screen.queryByLabelText('fields.dodCriteria')).toBeNull();
+    });
+
+    it('a delivery submit sends goalKind + dodCriteria and NO metric key at all', async () => {
+        render(<GoalForm />);
+        switchKind('delivery');
+        setField('fields.title', 'Ship feature X across three repos');
+        setField('fields.dodCriteria', 'API endpoint merged\n\n  Web form merged  \nDocs updated');
+
+        clickCreate();
+
+        await waitFor(() => expect(createGoalAction).toHaveBeenCalledTimes(1));
+        const payload = createGoalAction.mock.calls[0][0] as Record<string, unknown>;
+        expect(payload).toEqual({
+            title: 'Ship feature X across three repos',
+            description: null,
+            goalKind: 'delivery',
+            dodCriteria: [
+                { id: 'dod-1', text: 'API endpoint merged', status: 'open', source: 'operator' },
+                { id: 'dod-2', text: 'Web form merged', status: 'open', source: 'operator' },
+                { id: 'dod-3', text: 'Docs updated', status: 'open', source: 'operator' },
+            ],
+            deadline: null,
+            checkFrequencyMinutes: 60,
+        });
+        // Absent, not undefined: the object must not pretend to have a target.
+        for (const key of METRIC_KEYS) {
+            expect(key in payload).toBe(false);
+        }
+        expect(toastError).not.toHaveBeenCalled();
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/goals/g-new'));
+    });
+
+    it('a delivery submit with an empty checklist is refused before any request', () => {
+        render(<GoalForm />);
+        switchKind('delivery');
+        setField('fields.title', 'Ship it');
+        setField('fields.dodCriteria', '  \n\n   ');
+
+        clickCreate();
+
+        expect(toastError).toHaveBeenCalledWith('errors.dodRequired');
+        expect(createGoalAction).not.toHaveBeenCalled();
+    });
+
+    it('a delivery submit never trips the metric validators for fields it does not show', async () => {
+        render(<GoalForm />);
+        switchKind('delivery');
+        setField('fields.title', 'Ship it');
+        setField('fields.dodCriteria', 'One criterion');
+
+        clickCreate();
+
+        await waitFor(() => expect(createGoalAction).toHaveBeenCalledTimes(1));
+        expect(toastError).not.toHaveBeenCalledWith('errors.metricSourceRequired');
+        expect(toastError).not.toHaveBeenCalledWith('errors.targetInvalid');
+    });
+
+    it('a metric submit payload is unchanged: no goalKind, no dodCriteria', async () => {
+        render(<GoalForm />);
+        setField('fields.title', 'Income >= $1000/month');
+        setField('fields.pluginId', 'stripe');
+        setField('fields.metricId', 'income');
+        setField('fields.targetValue', '1000');
+        setField('fields.unit', 'usd');
+
+        clickCreate();
+
+        await waitFor(() => expect(createGoalAction).toHaveBeenCalledTimes(1));
+        const payload = createGoalAction.mock.calls[0][0] as Record<string, unknown>;
+        expect(payload).toEqual({
+            title: 'Income >= $1000/month',
+            description: null,
+            metricSource: { pluginId: 'stripe', metricId: 'income' },
+            comparator: 'gte',
+            targetValue: 1000,
+            unit: 'usd',
+            window: 'month',
+            deadline: null,
+            checkFrequencyMinutes: 60,
+        });
+        expect('goalKind' in payload).toBe(false);
+        expect('dodCriteria' in payload).toBe(false);
+    });
+
+    it('a metric submit still refuses a blank target (EW-044) and sends nothing', () => {
+        render(<GoalForm />);
+        setField('fields.title', 'Income');
+        setField('fields.pluginId', 'stripe');
+        setField('fields.metricId', 'income');
+        setField('fields.unit', 'usd');
+
+        clickCreate();
+
+        expect(toastError).toHaveBeenCalledWith('errors.targetInvalid');
+        expect(createGoalAction).not.toHaveBeenCalled();
+    });
+
+    it('a delivery Goal with text typed into the (hidden) metric fields earlier still sends none of them', async () => {
+        render(<GoalForm />);
+        // Fill the metric fields first, THEN switch kinds — the stale values
+        // must not leak into the delivery payload.
+        setField('fields.title', 'Ship it');
+        setField('fields.pluginId', 'stripe');
+        setField('fields.metricId', 'income');
+        setField('fields.targetValue', '1000');
+        setField('fields.unit', 'usd');
+        switchKind('delivery');
+        setField('fields.dodCriteria', 'Done when merged');
+
+        clickCreate();
+
+        await waitFor(() => expect(createGoalAction).toHaveBeenCalledTimes(1));
+        const payload = createGoalAction.mock.calls[0][0] as Record<string, unknown>;
+        for (const key of METRIC_KEYS) {
+            expect(key in payload).toBe(false);
+        }
+        expect(payload.goalKind).toBe('delivery');
+    });
+});
+
+describe('goal-form-payload helpers', () => {
+    const fields = (overrides: Partial<GoalFormFields> = {}): GoalFormFields => ({
+        title: 'x',
+        description: '',
+        pluginId: 'stripe',
+        metricId: 'income',
+        comparator: 'gte',
+        targetValue: '1000',
+        unit: 'usd',
+        window: 'month',
+        dodText: 'Ship it',
+        deadline: null,
+        checkFrequencyMinutes: 60,
+        ...overrides,
+    });
+
+    it('parseDodLines: trims, drops blank lines, numbers ids, caps at the server bound', () => {
+        expect(parseDodLines('\n a \r\n\n b \n')).toEqual([
+            { id: 'dod-1', text: 'a', status: 'open', source: 'operator' },
+            { id: 'dod-2', text: 'b', status: 'open', source: 'operator' },
+        ]);
+        expect(parseDodLines('')).toEqual([]);
+        expect(parseDodLines('   \n  ')).toEqual([]);
+        const many = Array.from({ length: 60 }, (_, i) => `criterion ${i}`).join('\n');
+        expect(parseDodLines(many)).toHaveLength(50);
+        expect(parseDodLines('x'.repeat(600))[0].text).toHaveLength(500);
+    });
+
+    it('targetValueIsAcceptable: the EW-044 guard is unchanged', () => {
+        expect(targetValueIsAcceptable('')).toBe(false);
+        expect(targetValueIsAcceptable('   ')).toBe(false);
+        expect(targetValueIsAcceptable('abc')).toBe(false);
+        expect(targetValueIsAcceptable('Infinity')).toBe(false);
+        expect(targetValueIsAcceptable('0')).toBe(true);
+        expect(targetValueIsAcceptable(' 12.5 ')).toBe(true);
+        expect(targetValueIsAcceptable('-3')).toBe(true);
+    });
+
+    it('validateGoalFormFields: metric keeps the legacy order, delivery needs a title and a checklist', () => {
+        expect(validateGoalFormFields('metric', fields())).toBeNull();
+        expect(validateGoalFormFields('metric', fields({ title: ' ' }))).toBe(
+            'errors.titleRequired',
+        );
+        expect(validateGoalFormFields('metric', fields({ pluginId: '' }))).toBe(
+            'errors.metricSourceRequired',
+        );
+        expect(validateGoalFormFields('metric', fields({ metricId: ' ' }))).toBe(
+            'errors.metricSourceRequired',
+        );
+        expect(validateGoalFormFields('metric', fields({ targetValue: '' }))).toBe(
+            'errors.targetInvalid',
+        );
+        expect(validateGoalFormFields('metric', fields({ unit: '' }))).toBe('errors.unitRequired');
+
+        expect(validateGoalFormFields('delivery', fields())).toBeNull();
+        expect(validateGoalFormFields('delivery', fields({ title: '' }))).toBe(
+            'errors.titleRequired',
+        );
+        expect(validateGoalFormFields('delivery', fields({ dodText: '\n \n' }))).toBe(
+            'errors.dodRequired',
+        );
+        // A delivery Goal ignores the metric fields entirely.
+        expect(
+            validateGoalFormFields('delivery', fields({ pluginId: '', targetValue: '', unit: '' })),
+        ).toBeNull();
+    });
+
+    it('buildCreateGoalPayload: delivery carries no metric key; metric carries no kind', () => {
+        const delivery = buildCreateGoalPayload('delivery', fields({ dodText: 'a\nb' }));
+        expect(delivery).toEqual({
+            title: 'x',
+            description: null,
+            deadline: null,
+            checkFrequencyMinutes: 60,
+            goalKind: 'delivery',
+            dodCriteria: [
+                { id: 'dod-1', text: 'a', status: 'open', source: 'operator' },
+                { id: 'dod-2', text: 'b', status: 'open', source: 'operator' },
+            ],
+        });
+        for (const key of METRIC_KEYS) {
+            expect(key in delivery).toBe(false);
+        }
+
+        const metric = buildCreateGoalPayload(
+            'metric',
+            fields({ params: { currency: 'usd' }, description: '  ctx  ' }),
+        );
+        expect(metric).toEqual({
+            title: 'x',
+            description: 'ctx',
+            deadline: null,
+            checkFrequencyMinutes: 60,
+            metricSource: { pluginId: 'stripe', metricId: 'income', params: { currency: 'usd' } },
+            comparator: 'gte',
+            targetValue: 1000,
+            unit: 'usd',
+            window: 'month',
+        });
+        expect('goalKind' in metric).toBe(false);
+        expect('dodCriteria' in metric).toBe(false);
+        // No params → no params key (not `params: undefined`).
+        expect('params' in (buildCreateGoalPayload('metric', fields()).metricSource ?? {})).toBe(
+            false,
+        );
+    });
+});

--- a/apps/web/src/components/goals/goal-form-payload.ts
+++ b/apps/web/src/components/goals/goal-form-payload.ts
@@ -1,0 +1,133 @@
+import {
+    MAX_DOD_TEXT_CHARS,
+    MAX_GOAL_DOD_CRITERIA,
+    type GoalComparator,
+    type GoalKind,
+    type GoalWindow,
+} from '@/lib/api/goals.shared';
+import type { CreateGoalInput, GoalDoDCriterion } from '@/lib/api/goals';
+
+/**
+ * Goals & Metrics — the pure half of `GoalForm` (self-build slice AG,
+ * EW-795). Free of React and of the `server-only` module so the
+ * accept/reject decision and the EXACT wire payload for each Goal kind can
+ * be unit-tested without rendering the form — the same reasoning as
+ * `goal-target-validation.unit.spec.ts`, whose guard now lives here.
+ */
+
+export type GoalFormErrorKey =
+    | 'errors.titleRequired'
+    | 'errors.metricSourceRequired'
+    | 'errors.targetInvalid'
+    | 'errors.unitRequired'
+    | 'errors.dodRequired';
+
+export interface GoalFormFields {
+    title: string;
+    description: string;
+    /** Metric kind only. */
+    pluginId: string;
+    metricId: string;
+    params?: Record<string, unknown>;
+    comparator: GoalComparator;
+    /** Raw text from the number input — validated here, never coerced first. */
+    targetValue: string;
+    unit: string;
+    window: GoalWindow;
+    /** Delivery kind only: one Definition-of-Done criterion per line. */
+    dodText: string;
+    /** Both kinds. */
+    deadline: string | null;
+    checkFrequencyMinutes: number;
+}
+
+/**
+ * EW-044: `Number('')` is 0, NOT NaN, so an EMPTY target used to sail
+ * through as a real target of 0 — with the default comparator `gte` that
+ * is a Goal every value satisfies. The empty case is rejected explicitly,
+ * before the conversion; `Number(' ')` is 0 too, hence the trim.
+ */
+export function targetValueIsAcceptable(raw: string): boolean {
+    const trimmed = raw.trim();
+    return trimmed.length > 0 && Number.isFinite(Number(trimmed));
+}
+
+/**
+ * One approved criterion per non-blank line. Ids are positional
+ * (`dod-1`, `dod-2`, …): unique within the submitted list, which is all
+ * the server requires, and renameable from the Goal page. Capped at the
+ * server bounds so the form refuses locally what the API would refuse.
+ */
+export function parseDodLines(text: string): GoalDoDCriterion[] {
+    return text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .slice(0, MAX_GOAL_DOD_CRITERIA)
+        .map((line, index) => ({
+            id: `dod-${index + 1}`,
+            text: line.slice(0, MAX_DOD_TEXT_CHARS),
+            status: 'open' as const,
+            source: 'operator' as const,
+        }));
+}
+
+/**
+ * The accept/reject decision, as the i18n key of the FIRST problem. The
+ * metric checks run in the same order as before the kind existed, so the
+ * error a user sees for a given form state is unchanged.
+ */
+export function validateGoalFormFields(
+    kind: GoalKind,
+    fields: GoalFormFields,
+): GoalFormErrorKey | null {
+    if (fields.title.trim().length < 1) return 'errors.titleRequired';
+    if (kind === 'delivery') {
+        return parseDodLines(fields.dodText).length === 0 ? 'errors.dodRequired' : null;
+    }
+    if (!fields.pluginId.trim() || !fields.metricId.trim()) return 'errors.metricSourceRequired';
+    if (!targetValueIsAcceptable(fields.targetValue)) return 'errors.targetInvalid';
+    if (!fields.unit.trim()) return 'errors.unitRequired';
+    return null;
+}
+
+/**
+ * The exact `POST /me/goals` body for the chosen kind.
+ *
+ * A DELIVERY payload carries NO metric key at all — not `undefined`, not
+ * `null`. `JSON.stringify` would drop `undefined` anyway, but the object
+ * itself must not pretend to have a target: the API refuses a delivery
+ * Goal with any metric field present, and a spec that only inspected the
+ * serialised form could not tell "absent" from "undefined".
+ *
+ * A METRIC payload is what the form always sent — no `goalKind` key (the
+ * API defaults an omitted kind to `metric`), so every existing client and
+ * pinned e2e contract is untouched.
+ */
+export function buildCreateGoalPayload(kind: GoalKind, fields: GoalFormFields): CreateGoalInput {
+    const base = {
+        title: fields.title.trim(),
+        description: fields.description.trim() || null,
+        deadline: fields.deadline,
+        checkFrequencyMinutes: fields.checkFrequencyMinutes,
+    };
+    if (kind === 'delivery') {
+        return {
+            ...base,
+            goalKind: 'delivery',
+            dodCriteria: parseDodLines(fields.dodText),
+        };
+    }
+    return {
+        ...base,
+        metricSource: {
+            pluginId: fields.pluginId.trim(),
+            metricId: fields.metricId.trim(),
+            ...(fields.params ? { params: fields.params } : {}),
+        },
+        comparator: fields.comparator,
+        targetValue: Number(fields.targetValue.trim()),
+        unit: fields.unit.trim(),
+        window: fields.window,
+    };
+}

--- a/apps/web/src/components/goals/goal-ui.tsx
+++ b/apps/web/src/components/goals/goal-ui.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
-import type { GoalComparator, GoalOutcome } from '@/lib/api/goals';
+import type { GoalComparator, GoalKind, GoalOutcome } from '@/lib/api/goals';
 
 /**
  * Goals & Metrics — PR-8. Shared presentational helpers for the Goals
@@ -70,6 +70,29 @@ export function OutcomeBadge({ outcome, className }: { outcome: GoalOutcome; cla
             )}
         >
             {t(`outcomes.${outcome}`)}
+        </span>
+    );
+}
+
+/**
+ * Goal KIND badge (self-build slice AG, EW-795) — `metric` vs `delivery`.
+ * Neutral by design: the kind is a fact about the Goal, not a state, so
+ * the colour budget stays with the status pill and the outcome badge.
+ * Labels come from `dashboard.goalsPage.kinds` so the list card, the
+ * detail header and the Mission panel agree on the wording.
+ */
+export function GoalKindBadge({ kind, className }: { kind: GoalKind; className?: string }) {
+    const t = useTranslations('dashboard.goalsPage');
+    return (
+        <span
+            data-testid="goal-kind-badge"
+            className={cn(
+                'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                'border-border/70 dark:border-border-dark/70 bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark',
+                className,
+            )}
+        >
+            {t(`kinds.${kind}`)}
         </span>
     );
 }

--- a/apps/web/src/components/goals/index.ts
+++ b/apps/web/src/components/goals/index.ts
@@ -6,7 +6,19 @@ export { GoalCard } from './GoalCard';
 export { GoalForm } from './GoalForm';
 export { GoalDetailClient } from './GoalDetailClient';
 export { Sparkline } from './Sparkline';
-export { OutcomeBadge, COMPARATOR_GLYPH, formatMetricValue, formatDateTime } from './goal-ui';
+export {
+    OutcomeBadge,
+    GoalKindBadge,
+    COMPARATOR_GLYPH,
+    formatMetricValue,
+    formatDateTime,
+} from './goal-ui';
+export {
+    buildCreateGoalPayload,
+    parseDodLines,
+    validateGoalFormFields,
+    type GoalFormFields,
+} from './goal-form-payload';
 // Autonomy layer — Definition of Done, limits, orchestrator log, sessions.
 export { GoalDodPanel } from './GoalDodPanel';
 export { GoalLimitsDialog, type GoalAgentOption } from './GoalLimitsDialog';

--- a/apps/web/src/components/missions/MissionGoalsPanel.tsx
+++ b/apps/web/src/components/missions/MissionGoalsPanel.tsx
@@ -22,6 +22,7 @@ import { StatusPill } from '@/components/work-agent';
 // Direct module path (not the `@/components/goals` barrel) so this
 // client panel pulls in only the presentational helpers.
 import { COMPARATOR_GLYPH, formatMetricValue } from '@/components/goals/goal-ui';
+import { DodRollup } from '@/components/goals/goal-loop-ui';
 import {
     linkGoalToMissionAction,
     unlinkGoalFromMissionAction,
@@ -218,14 +219,30 @@ export function MissionGoalsPanel({
                                         Goal it is the whole point of the row,
                                         so it now sits under the title where it
                                         survives narrow widths. */}
-                                    {l.goal && (
+                                    {l.goal && l.goal.goalKind === 'delivery' ? (
+                                        /* A delivery Goal has no metric — its
+                                           progress is the Definition of Done
+                                           rollup (self-build slice AG). */
+                                        <DodRollup
+                                            summary={l.goal.dodSummary}
+                                            className="block truncate text-[11px] tabular-nums"
+                                        />
+                                    ) : l.goal ? (
                                         <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark tabular-nums">
-                                            {formatMetricValue(l.goal.currentValue, l.goal.unit)}
+                                            {formatMetricValue(
+                                                l.goal.currentValue,
+                                                l.goal.unit ?? undefined,
+                                            )}
                                             {' / '}
-                                            {COMPARATOR_GLYPH[l.goal.comparator]}{' '}
-                                            {formatMetricValue(l.goal.targetValue, l.goal.unit)}
+                                            {l.goal.comparator
+                                                ? COMPARATOR_GLYPH[l.goal.comparator]
+                                                : '—'}{' '}
+                                            {formatMetricValue(
+                                                l.goal.targetValue,
+                                                l.goal.unit ?? undefined,
+                                            )}
                                         </span>
-                                    )}
+                                    ) : null}
                                 </span>
                             </Link>
                             {l.isPrimary && (

--- a/apps/web/src/components/missions/MissionGoalsPanel.unit.spec.tsx
+++ b/apps/web/src/components/missions/MissionGoalsPanel.unit.spec.tsx
@@ -71,6 +71,9 @@ function mkGoal(overrides: Partial<Goal> = {}): Goal {
         id: 'g1',
         title: 'Reach 1k signups',
         description: null,
+        // Self-build slice AG: `Goal.goalKind` is required on the wire type;
+        // every Goal in this spec is the metric kind it always was.
+        goalKind: 'metric',
         metricSource: { pluginId: 'p', metricId: 'm' },
         comparator: 'gte',
         targetValue: 1000,
@@ -145,6 +148,47 @@ describe('MissionGoalsPanel', () => {
         // No Goals to attach either — the select is replaced by a hint.
         expect(screen.getByText('noGoalsToAttach')).toBeInTheDocument();
         expect(screen.queryByTestId('mission-attach-goal-select')).toBeNull();
+    });
+
+    it('shows the current/target readout for a metric Goal', () => {
+        render(<MissionGoalsPanel missionId="m1" initialLinks={[mkLink()]} attachableGoals={[]} />);
+        const row = screen.getByTestId('mission-goals-row-g1');
+        expect(row.textContent).toContain('≥');
+        expect(row.textContent).toContain('1,000 signups');
+        expect(screen.queryByText('rollup')).toBeNull();
+    });
+
+    it('shows the Definition-of-Done rollup instead of a metric readout for a delivery Goal', () => {
+        // Self-build slice AG: a delivery Goal has no metric fields at all.
+        const delivery = mkGoal({
+            goalKind: 'delivery',
+            metricSource: null,
+            comparator: null,
+            targetValue: null,
+            unit: null,
+            currentValue: null,
+            dodSummary: {
+                total: 3,
+                done: 1,
+                waived: 0,
+                open: 2,
+                proposed: 0,
+                closed: 1,
+                complete: false,
+            },
+        });
+        render(
+            <MissionGoalsPanel
+                missionId="m1"
+                initialLinks={[mkLink({ goal: delivery })]}
+                attachableGoals={[]}
+            />,
+        );
+        const row = screen.getByTestId('mission-goals-row-g1');
+        // The mocked `t` echoes the key — the rollup rendered, the glyph did not.
+        expect(screen.getByText('rollup')).toBeInTheDocument();
+        expect(row.textContent).not.toContain('≥');
+        expect(row.textContent).not.toContain('≤');
     });
 
     it('tags each picker option with a status-keyed Goal icon', () => {

--- a/apps/web/src/lib/api/goals.shared.ts
+++ b/apps/web/src/lib/api/goals.shared.ts
@@ -16,6 +16,15 @@ export type GoalComparator = 'gte' | 'lte';
 export type GoalWindow = 'day' | 'week' | 'month' | 'total' | 'point';
 
 /**
+ * Goal KIND (self-build slice AG, EW-795). `metric` is the original Goal —
+ * a metrics-provider number measured against a target; `delivery` has no
+ * metric at all and completes on its approved Definition of Done alone.
+ * Mirrors `GOAL_KINDS` in `@ever-works/contracts`.
+ */
+export type GoalKind = 'metric' | 'delivery';
+export const GOAL_KINDS: GoalKind[] = ['metric', 'delivery'];
+
+/**
  * Spec FR-12: per-Goal evaluation frequency is clamped server-side to
  * a minimum of 15 minutes regardless of what the form submits. Mirror
  * of `MIN_CHECK_FREQUENCY_MINUTES` from the agent package so the form

--- a/apps/web/src/lib/api/goals.ts
+++ b/apps/web/src/lib/api/goals.ts
@@ -24,6 +24,7 @@ export {
     GOAL_DOD_STATUSES,
     GOAL_LOOP_STATUSES,
     GOAL_EXECUTION_TARGETS,
+    GOAL_KINDS,
     MAX_GOAL_DOD_CRITERIA,
     MAX_DOD_TEXT_CHARS,
     MAX_DOD_EVIDENCE_CHARS,
@@ -32,6 +33,7 @@ export {
     type GoalStatus,
     type GoalOutcome,
     type GoalComparator,
+    type GoalKind,
     type GoalWindow,
     type GoalDoDStatus,
     type GoalDoDSource,
@@ -43,6 +45,7 @@ import type {
     GoalStatus,
     GoalOutcome,
     GoalComparator,
+    GoalKind,
     GoalWindow,
     GoalDoDStatus,
     GoalDoDSource,
@@ -85,10 +88,17 @@ export interface Goal {
     id: string;
     title: string;
     description: string | null;
-    metricSource: GoalMetricSource;
-    comparator: GoalComparator;
-    targetValue: number;
-    unit: string;
+    /**
+     * `metric` (the default, every pre-existing Goal) | `delivery`. Decides
+     * which completion rule applies and whether the four metric fields
+     * below are set (metric) or `null` (delivery — nothing is measured, the
+     * approved Definition of Done is the whole finish line).
+     */
+    goalKind: GoalKind;
+    metricSource: GoalMetricSource | null;
+    comparator: GoalComparator | null;
+    targetValue: number | null;
+    unit: string | null;
     window: GoalWindow;
     baselineValue: number | null;
     currentValue: number | null;
@@ -210,17 +220,27 @@ export interface EvaluateGoalNowResult {
     goal: Goal;
 }
 
+/**
+ * `POST /me/goals` body. Omitted `goalKind` = `metric`, for which every
+ * metric field is REQUIRED by the API exactly as before kinds existed. A
+ * `delivery` body must carry NONE of the metric fields and at least one
+ * `dodCriteria` entry — `buildCreateGoalPayload` (components/goals) is the
+ * one place that assembles either shape.
+ */
 export interface CreateGoalInput {
     title: string;
     description?: string | null;
-    metricSource: GoalMetricSource;
-    comparator: GoalComparator;
-    targetValue: number;
-    unit: string;
-    window: GoalWindow;
+    goalKind?: GoalKind;
+    metricSource?: GoalMetricSource;
+    comparator?: GoalComparator;
+    targetValue?: number;
+    unit?: string;
+    window?: GoalWindow;
     baselineValue?: number | null;
     deadline?: string | null;
     checkFrequencyMinutes?: number;
+    /** Required for a delivery Goal; an optional seed checklist for a metric one. */
+    dodCriteria?: GoalDoDCriterion[];
 }
 
 export interface UpdateGoalInput {

--- a/docs/features/goals.md
+++ b/docs/features/goals.md
@@ -6,32 +6,45 @@ sidebar_label: Goals
 
 # Goals
 
-A **Goal** is a number you want to move, checked on a schedule. Where a [Mission](./missions.md) keeps
-producing work on a topic, a Goal watches a single metric and tells you whether it is heading the right
-way.
+A **Goal** is something you want to be true, checked on a schedule. Where a [Mission](./missions.md)
+keeps producing work on a topic, a Goal watches one finish line and tells you whether you are there.
 
-A Goal does not build anything by itself. It reads a metric from a provider plugin, records what it
-saw, and reports progress toward a target.
+Goals come in two **kinds**:
+
+- A **metric Goal** — the original kind, and what every Goal created before kinds existed is — watches
+  a single number and tells you whether it is heading the right way. It reads a metric from a provider
+  plugin, records what it saw, and reports progress toward a target.
+- A **delivery Goal** has no metric at all. "Ship feature X across three repos" is a delivery Goal: it
+  completes when every approved item of its Definition of Done is done or waived. See
+  [Delivery goals](#delivery-goals).
+
+A Goal does not build anything by itself. Its execution loop (the orchestrator) hands iterations to
+agents; the Goal is the finish line they work toward.
 
 ## When to use a Goal
 
-| You want to…                                                    | Use a…      |
-| --------------------------------------------------------------- | ----------- |
-| Keep producing new Works and Ideas on a theme                   | **Mission** |
-| Track "monthly revenue reaches $1,000" and know when it happens | **Goal**    |
-| Track "support tickets stay below 20 a week"                    | **Goal**    |
-| Build one site from one prompt                                  | **Work**    |
+| You want to…                                                    | Use a…              |
+| --------------------------------------------------------------- | ------------------- |
+| Keep producing new Works and Ideas on a theme                   | **Mission**         |
+| Track "monthly revenue reaches $1,000" and know when it happens | **Goal** (metric)   |
+| Track "support tickets stay below 20 a week"                    | **Goal** (metric)   |
+| Drive "ship feature X across three repos" to done               | **Goal** (delivery) |
+| Build one site from one prompt                                  | **Work**            |
 
 Goals and Missions are independent — you can run either without the other.
 
 ## Creating a Goal
 
-From `/goals`, choose **New Goal**. The form at `/goals/new` collects:
+From `/goals`, choose **New Goal**. The form at `/goals/new` starts as a **metric** Goal; the
+**Goal kind** selector in the first card switches it to a delivery Goal, which hides the metric source
+and target fields and shows a Definition of Done instead (see [Delivery goals](#delivery-goals)). For a
+metric Goal the form collects:
 
 | Field                  | Required | Notes                                                                            |
 | ---------------------- | -------- | -------------------------------------------------------------------------------- |
 | **Title**              | yes      | Up to 200 characters. Shown on the catalog and the detail page.                  |
 | **Description**        | no       | Free context for whoever reads the Goal later.                                   |
+| **Goal kind**          | yes      | _Metric target_ (default) or _Delivery_. Fixed once the Goal exists.             |
 | **Provider plugin ID** | yes      | The metrics plugin that supplies the number — see below.                         |
 | **Metric ID**          | yes      | Which metric to read from that plugin.                                           |
 | **Parameters (JSON)**  | no       | Passed to the provider, e.g. `{ "currency": "usd" }`. Must be a JSON **object**. |
@@ -51,6 +64,45 @@ An **explicit** `0` is still perfectly valid. "Keep failures at most 0" is a rea
 :::
 
 New Goals are created in **draft**. Nothing is evaluated until you activate them.
+
+## Delivery goals
+
+A **delivery Goal** is for outcomes that are not a number — "ship feature X across three repos",
+"migrate the docs site", "close out the launch checklist". Choose **Delivery** under **Goal kind** on
+`/goals/new`.
+
+What changes compared with a metric Goal:
+
+- **No provider, no metric, no target.** The Provider plugin ID, Metric ID, Direction, Target value,
+  Unit and Window fields disappear, and the API refuses a delivery Goal that carries any of them. There
+  is nothing to read on a schedule and no comparator to satisfy.
+- **The Definition of Done is required.** The form takes one criterion per line and needs at least one.
+  Every criterion you enter is already approved (a delivery Goal cannot be born with only proposed
+  criteria), and the checklist can never be emptied later — a delivery Goal with no finish line would be
+  unfinishable, not open-ended. Refine, add, waive and mark criteria done on the Goal page's
+  **Definition of Done** tab as usual.
+- **Completion is the approved checklist alone.** The Goal completes with outcome **achieved** the
+  moment every _approved_ criterion is done or waived — whether the execution loop notices first or the
+  scheduled check does. Criteria a planning run _proposed_ never count until you approve them, so an
+  agent cannot finish a Goal by proposing that it is finished.
+- **Deadline and cadence still apply.** Activating a delivery Goal schedules the same checks as a metric
+  Goal; each check re-reads the Definition of Done and the deadline without calling any plugin, so a
+  passed deadline still ends the Goal as **missed**. **Evaluate now** does the same on demand.
+- **The execution loop, budgets and limits are unchanged.** Spend cap, wall-clock limit, stuck
+  threshold, pinning and nudging work exactly as for a metric Goal; the routed agent's brief says
+  explicitly that the checklist is the whole definition of done.
+
+Metric Goals behave exactly as before. Existing Goals are metric Goals; the kind is shown as a badge on
+the catalog card and the detail header.
+
+### Who runs a brand-new Goal
+
+The loop routes each iteration to the Goal's **pinned agent** if one is set, otherwise round-robin over
+the agents that have already worked the Goal. A brand-new Goal has neither — so, when no agent is
+pinned and none has worked it yet, the router falls back to the **eligible agents in the Goal's own
+scope** (the same Organization / tenant ownership rule the rest of the platform applies) and
+round-robins over them, oldest first. It never picks an agent outside the Goal's scope, and a scope
+with no agent still leaves the loop **stuck** with `no-candidate-agent` until you create or assign one.
 
 ## The metric source
 
@@ -94,9 +146,11 @@ you will see the failure.
 ## What a Goal does not do
 
 - It does **not** create Works or Ideas. That is a [Mission](./missions.md).
-- It does **not** change anything in your account when a target is hit — it records the outcome.
-- It cannot be edited after creation. Title, metric source, target, unit, window and cadence are fixed
-  once the Goal exists; to change any of them, create a new Goal.
+- It does **not** change anything in your account when a target is hit or a checklist is completed — it
+  records the outcome.
+- Its **kind** cannot change after creation, and a metric Goal's metric source, target, unit and window
+  cannot be given to a delivery Goal (the API refuses them). To change the kind, create a new Goal.
+- A delivery Goal cannot lose its Definition of Done: the checklist can be edited but never emptied.
 
 ## Related
 

--- a/packages/agent/src/campaigns/campaign-activation.service.ts
+++ b/packages/agent/src/campaigns/campaign-activation.service.ts
@@ -198,7 +198,9 @@ export class CampaignActivationService {
                     id: goal.id,
                     title: goal.title,
                     metricId,
-                    targetValue: goal.targetValue,
+                    // A campaign Goal is always a metric Goal, so the value is
+                    // set; the fallback only satisfies the now-nullable DTO.
+                    targetValue: goal.targetValue ?? targetValue,
                 },
                 agents,
                 tasks,

--- a/packages/agent/src/digest/digest.service.ts
+++ b/packages/agent/src/digest/digest.service.ts
@@ -1023,6 +1023,14 @@ export class DigestService {
         if (input.goals.length > 0) {
             lines.push('', '## Goal progress', '');
             for (const goal of input.goals.slice(0, MAX_ITEMS_PER_SECTION)) {
+                if (goal.goalKind === 'delivery') {
+                    // A delivery Goal has no metric; its progress IS the
+                    // Definition-of-Done rollup.
+                    lines.push(
+                        `- ${this.cap(goal.title)}: ${goal.dodSummary.closed} / ${goal.dodSummary.total} criteria done`,
+                    );
+                    continue;
+                }
                 const current = goal.currentValue ?? '—';
                 lines.push(
                     `- ${this.cap(goal.title)}: ${current} / ${goal.targetValue} ${goal.unit}`,

--- a/packages/agent/src/entities/goal.entity.ts
+++ b/packages/agent/src/entities/goal.entity.ts
@@ -8,8 +8,14 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { GOAL_KINDS, type GoalKind } from '@ever-works/contracts';
 import { User } from './user.entity';
 import { PortableDateColumn } from './_types';
+
+// The kind vocabulary lives in `@ever-works/contracts` (like `WorkKind`)
+// because the web app must render it without depending on this package.
+// Re-exported so the goals barrel keeps its single-import idiom.
+export { GOAL_KINDS, type GoalKind };
 
 /**
  * Goal lifecycle states (Goals & Metrics spec §3.2, PR-8).
@@ -276,21 +282,36 @@ export type GoalExecutionTarget = 'cloud' | 'local-runner';
 export const GOAL_EXECUTION_TARGETS: readonly GoalExecutionTarget[] = ['cloud', 'local-runner'];
 
 /**
- * A measurable target — "income >= $1000/month via Stripe" — evaluated
- * automatically against real business metrics (Goals & Metrics spec
- * FR-9..FR-14; domain-model review §23.4).
+ * A Goal comes in two KINDS (`goalKind`, self-build slice AG / EW-795):
+ *
+ *   - **metric** (the default, and every row that predates the column) —
+ *     a measurable target, "income >= $1000/month via Stripe", evaluated
+ *     automatically against real business metrics (Goals & Metrics spec
+ *     FR-9..FR-14; domain-model review §23.4). `metricSource`,
+ *     `comparator`, `targetValue` and `unit` are all REQUIRED (enforced
+ *     by the DTO and the service; the columns themselves are nullable
+ *     only so the delivery kind can share the table).
+ *   - **delivery** — "ship feature X across three repos". There is NO
+ *     metric: the four metric columns are NULL, no provider is ever read,
+ *     and the Goal completes on its approved Definition of Done alone
+ *     (`dodCriteria`, every approved criterion done or waived). A delivery
+ *     Goal is born with at least one approved criterion and can never be
+ *     emptied. Its iteration loop, budgets and deadline work exactly as
+ *     for a metric Goal.
  *
  * Goals are created standalone (owned by `userId`) and attached to
  * Missions via the `mission_goals` join table (spec §8 open-question
  * default: standalone-first). Evaluation:
  *   - the per-minute `goal-evaluate-dispatcher` cron claims due ACTIVE
- *     Goals (`nextCheckAt <= now`) with an atomic CAS update, reads the
- *     metric through `MetricsFacadeService.getMetricValue` (budget-
- *     guarded + metered), appends a `goal_metric_samples` row and
- *     updates `currentValue`.
- *   - when the comparator is satisfied → status COMPLETED + outcome
- *     ACHIEVED; when `deadline` passes unmet → COMPLETED + MISSED.
- *     Both auto-outcomes are human-overridable (FR-13).
+ *     Goals (`nextCheckAt <= now`) with an atomic CAS update. For a
+ *     metric Goal it reads the metric through
+ *     `MetricsFacadeService.getMetricValue` (budget-guarded + metered),
+ *     appends a `goal_metric_samples` row and updates `currentValue`; for
+ *     a delivery Goal it only re-checks the DoD rollup and the deadline.
+ *   - when the comparator is satisfied (metric) or the DoD is complete
+ *     (delivery) → status COMPLETED + outcome ACHIEVED; when `deadline`
+ *     passes unmet → COMPLETED + MISSED. Both auto-outcomes are
+ *     human-overridable (FR-13).
  *
  * **Invariant I-4 (FR-14): Goal evaluation NEVER touches Missions.**
  * A Mission is completed only by an explicit human action, even when
@@ -321,24 +342,43 @@ export class Goal {
     description?: string | null;
 
     /**
+     * `'metric'` (default — every pre-existing row) | `'delivery'`. Decides
+     * which completion rule applies and whether the four metric columns
+     * below are required (metric) or must be NULL (delivery). Immutable
+     * after create. Vocabulary: {@link GOAL_KINDS} in `@ever-works/contracts`.
+     */
+    @Column({ type: 'varchar', length: 16, default: 'metric' })
+    goalKind: GoalKind;
+
+    // ── Metric fields — REQUIRED on a metric Goal, NULL on a delivery Goal.
+    // Nullable at the column level only so both kinds share one table;
+    // the DTO and `GoalsService` refuse a metric Goal that lacks any of
+    // them, so a metric row with a NULL here is a corrupted row, not a
+    // valid state (evaluation fails closed on it).
+
+    /**
      * Which provider + metric to read. Stored as `simple-json` to
      * match how sibling entities persist small structured shapes
      * (`Mission.guardrailsOverride`).
      */
-    @Column('simple-json')
-    metricSource: GoalMetricSource;
+    @Column({ type: 'simple-json', nullable: true })
+    metricSource?: GoalMetricSource | null;
 
-    @Column({ type: 'varchar', length: 8 })
-    comparator: GoalComparator;
+    @Column({ type: 'varchar', length: 8, nullable: true })
+    comparator?: GoalComparator | null;
 
-    @Column({ type: 'float' })
-    targetValue: number;
+    @Column({ type: 'float', nullable: true })
+    targetValue?: number | null;
 
     /** Unit of `targetValue` / samples (e.g. `'usd'`, `'count'`). */
-    @Column({ type: 'varchar', length: 32 })
-    unit: string;
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    unit?: string | null;
 
-    /** Aggregation window the metric is read over on every evaluation. */
+    /**
+     * Aggregation window the metric is read over on every evaluation.
+     * Not one of the four metric fields — stays NOT NULL; a delivery Goal
+     * stores `'total'` and never reads it.
+     */
     @Column({ type: 'varchar', length: 16 })
     window: GoalWindow;
 

--- a/packages/agent/src/goals/__tests__/goal-evaluation.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-evaluation.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import type { Repository } from 'typeorm';
 import { Goal, GoalOutcome, GoalStatus } from '../../entities/goal.entity';
 import type { GoalMetricSample } from '../../entities/goal-metric-sample.entity';
@@ -23,6 +24,7 @@ function makeGoal(overrides: Partial<Goal> = {}): Goal {
         userId: 'u1',
         title: 'Income >= 1000/month',
         description: null,
+        goalKind: 'metric',
         metricSource: { pluginId: 'stripe', metricId: 'income' },
         comparator: 'gte',
         targetValue: 1000,
@@ -280,6 +282,195 @@ describe('GoalEvaluationService', () => {
             } finally {
                 jest.useRealTimers();
             }
+        });
+    });
+
+    // ── Self-build slice AG (EW-795): the delivery kind ────────────────
+
+    /** A delivery Goal row: no metric at all, the DoD is the completion rule. */
+    function deliveryGoal(overrides: Partial<Goal> = {}): Goal {
+        return makeGoal({
+            goalKind: 'delivery',
+            metricSource: null,
+            comparator: null,
+            targetValue: null,
+            unit: null,
+            window: 'total',
+            ...overrides,
+        });
+    }
+
+    describe('evaluateOne — delivery kind', () => {
+        it('completes on the approved Definition of Done alone — no provider read, no sample', async () => {
+            const { service, samples, metricsFacade, goals } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [
+                    { id: 'api', text: 'API merged', status: 'done' },
+                    { id: 'docs', text: 'Docs', status: 'waived' },
+                ],
+                nextCheckAt: new Date('2026-07-19T00:00:00.000Z'),
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry).toEqual({ goalId: 'g1', outcome: 'achieved' });
+            expect('value' in entry).toBe(false);
+            expect(goal.status).toBe(GoalStatus.COMPLETED);
+            expect(goal.outcome).toBe(GoalOutcome.ACHIEVED);
+            expect(goal.nextCheckAt).toBeNull();
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+            expect(samples.insert).not.toHaveBeenCalled();
+            // Only the Goal row is written (invariant I-4 holds).
+            expect(goals.save).toHaveBeenCalledTimes(1);
+            expect(goals.save).toHaveBeenCalledWith(goal);
+        });
+
+        it('keeps iterating (outcome "evaluated", stays ACTIVE) while a criterion is open', async () => {
+            const { service, samples, metricsFacade, goals } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [
+                    { id: 'api', text: 'API merged', status: 'done' },
+                    { id: 'web', text: 'Web form', status: 'open' },
+                ],
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry).toEqual({ goalId: 'g1', outcome: 'evaluated' });
+            expect(goal.status).toBe(GoalStatus.ACTIVE);
+            expect(goal.outcome).toBeNull();
+            expect(goal.currentValue).toBeNull();
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+            expect(samples.insert).not.toHaveBeenCalled();
+            expect(goals.save).toHaveBeenCalledWith(goal);
+        });
+
+        it('does not complete on proposed (unapproved) criteria, even when they are all done', async () => {
+            const { service } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [
+                    { id: 'p', text: 'Planner says done', status: 'done', proposed: true },
+                ],
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry.outcome).toBe('evaluated');
+            expect(goal.status).toBe(GoalStatus.ACTIVE);
+        });
+
+        it('ignores pending proposals once the approved criteria are complete', async () => {
+            const { service } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [
+                    { id: 'a', text: 'Approved and done', status: 'done' },
+                    { id: 'p', text: 'Also add a FAQ', status: 'open', proposed: true },
+                ],
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry.outcome).toBe('achieved');
+            expect(goal.status).toBe(GoalStatus.COMPLETED);
+        });
+
+        it('deadline passed with an open criterion → COMPLETED + MISSED, still no provider call', async () => {
+            const { service, metricsFacade } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [{ id: 'a', text: 'x', status: 'open' }],
+                deadline: new Date(Date.now() - 60_000),
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry.outcome).toBe('missed');
+            expect(goal.status).toBe(GoalStatus.COMPLETED);
+            expect(goal.outcome).toBe(GoalOutcome.MISSED);
+            expect(goal.nextCheckAt).toBeNull();
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+        });
+
+        it('a complete DoD beats a passed deadline', async () => {
+            const { service } = makeMocks();
+            const goal = deliveryGoal({
+                dodCriteria: [{ id: 'a', text: 'x', status: 'done' }],
+                deadline: new Date(Date.now() - 60_000),
+            });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry.outcome).toBe('achieved');
+            expect(goal.outcome).toBe(GoalOutcome.ACHIEVED);
+        });
+
+        it('fails closed on a metric row that lost one of its metric fields', async () => {
+            const { service, samples, metricsFacade, goals } = makeMocks();
+            const goal = makeGoal({ comparator: null });
+
+            await expect(service.evaluateOne(goal)).rejects.toBeInstanceOf(BadRequestException);
+
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+            expect(samples.insert).not.toHaveBeenCalled();
+            expect(goals.save).not.toHaveBeenCalled();
+            expect(goal.status).toBe(GoalStatus.ACTIVE);
+        });
+
+        it('a pre-migration row with no goalKind evaluates as the metric Goal it is', async () => {
+            const { service, metricsFacade, samples } = makeMocks();
+            metricsFacade.getMetricValue.mockResolvedValue({
+                value: 1500,
+                unit: 'usd',
+                at: '2026-07-19T00:00:00.000Z',
+            });
+            const goal = makeGoal({ goalKind: undefined });
+
+            const entry = await service.evaluateOne(goal);
+
+            expect(entry).toEqual({ goalId: 'g1', outcome: 'achieved', value: 1500 });
+            expect(metricsFacade.getMetricValue).toHaveBeenCalledTimes(1);
+            expect(samples.insert).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('evaluateDue — delivery kind', () => {
+        it('claims and completes a due delivery Goal without touching the provider', async () => {
+            const { service, goals, samples, metricsFacade } = makeMocks();
+            const token = new Date('2026-07-19T00:00:00.000Z');
+            const goal = deliveryGoal({
+                nextCheckAt: token,
+                dodCriteria: [{ id: 'a', text: 'x', status: 'done' }],
+            });
+            goals.find.mockResolvedValue([goal]);
+            goals.update.mockResolvedValue({ affected: 1 });
+
+            const summary = await service.evaluateDue();
+
+            expect(summary.evaluated).toBe(1);
+            expect(summary.failed).toBe(0);
+            expect(summary.entries[0]).toEqual({ goalId: 'g1', outcome: 'achieved' });
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+            expect(samples.insert).not.toHaveBeenCalled();
+            expect(goal.status).toBe(GoalStatus.COMPLETED);
+        });
+
+        it('counts a corrupt metric row as failed and moves on (no sample, schedule advanced)', async () => {
+            const { service, goals, samples, metricsFacade } = makeMocks();
+            const token = new Date('2026-07-19T00:00:00.000Z');
+            const goal = makeGoal({ nextCheckAt: token, targetValue: null });
+            goals.find.mockResolvedValue([goal]);
+            goals.update.mockResolvedValue({ affected: 1 });
+
+            const summary = await service.evaluateDue();
+
+            expect(summary.failed).toBe(1);
+            expect(summary.evaluated).toBe(0);
+            expect(summary.entries[0]).toEqual(
+                expect.objectContaining({ goalId: 'g1', outcome: 'failed' }),
+            );
+            expect(metricsFacade.getMetricValue).not.toHaveBeenCalled();
+            expect(samples.insert).not.toHaveBeenCalled();
+            expect(goal.nextCheckAt).not.toEqual(token);
+            expect(goal.status).toBe(GoalStatus.ACTIVE);
         });
     });
 });

--- a/packages/agent/src/goals/__tests__/goal-kind.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-kind.spec.ts
@@ -1,0 +1,234 @@
+import {
+    GOAL_METRIC_ONLY_FIELDS,
+    isDeliveryGoal,
+    isMetricGoal,
+    metricOnlyFieldsPresent,
+    resolveGoalKind,
+    validateDeliveryGoalInput,
+    validateGoalKindInput,
+    validateMetricGoalInput,
+    type GoalKindValidationError,
+} from '../goal-kind';
+
+/**
+ * Self-build slice AG (EW-795) — the per-kind shape rule, pinned once.
+ *
+ * `GoalsService.create`, the DTO and the evaluation service all lean on
+ * these helpers, so this suite is the specification of "what must a
+ * metric Goal carry, what must a delivery Goal NOT carry". Fail closed:
+ * a Goal that satisfies neither rule has no completion rule and is
+ * rejected, never coerced.
+ */
+
+const METRIC = {
+    metricSource: { pluginId: 'stripe', metricId: 'income' },
+    comparator: 'gte',
+    targetValue: 1000,
+    unit: 'usd',
+    window: 'month',
+};
+
+const DOD = [{ id: 'api', text: 'API endpoint merged', status: 'open' }];
+
+const fields = (errors: GoalKindValidationError[]) => errors.map((e) => e.field);
+
+describe('resolveGoalKind / isDeliveryGoal / isMetricGoal (read paths)', () => {
+    it('renders a row without the column, or with an unknown value, as the metric Goal it is', () => {
+        expect(resolveGoalKind({ goalKind: undefined as never })).toBe('metric');
+        expect(resolveGoalKind(null)).toBe('metric');
+        expect(resolveGoalKind(undefined)).toBe('metric');
+        expect(resolveGoalKind({ goalKind: 'outcome' as never })).toBe('metric');
+    });
+
+    it('recognises both kinds', () => {
+        expect(isMetricGoal({ goalKind: 'metric' })).toBe(true);
+        expect(isMetricGoal({ goalKind: 'delivery' })).toBe(false);
+        expect(isDeliveryGoal({ goalKind: 'delivery' })).toBe(true);
+        expect(isDeliveryGoal({ goalKind: 'metric' })).toBe(false);
+    });
+});
+
+describe('metricOnlyFieldsPresent', () => {
+    it('treats undefined AND null as absent by default (the create wire contract)', () => {
+        expect(metricOnlyFieldsPresent({ targetValue: undefined, unit: null })).toEqual([]);
+    });
+
+    it('treats null as a write when asked (update on a delivery Goal)', () => {
+        expect(
+            metricOnlyFieldsPresent({ baselineValue: null }, { treatNullAsPresent: true }),
+        ).toEqual(['baselineValue']);
+    });
+
+    it('reports every set field in the canonical order', () => {
+        expect(metricOnlyFieldsPresent({ unit: 'usd', metricSource: {}, criteria: [] })).toEqual([
+            'metricSource',
+            'unit',
+            'criteria',
+        ]);
+    });
+
+    it('covers exactly the metric-only vocabulary', () => {
+        expect([...GOAL_METRIC_ONLY_FIELDS]).toEqual([
+            'metricSource',
+            'comparator',
+            'targetValue',
+            'unit',
+            'window',
+            'baselineValue',
+            'criteria',
+            'constraints',
+        ]);
+    });
+});
+
+describe('validateGoalKindInput — metric (the default)', () => {
+    it('accepts the classic payload with no goalKind at all', () => {
+        expect(validateGoalKindInput(METRIC)).toEqual([]);
+    });
+
+    it('accepts an explicit metric kind and a null kind', () => {
+        expect(validateGoalKindInput({ ...METRIC, goalKind: 'metric' })).toEqual([]);
+        expect(validateGoalKindInput({ ...METRIC, goalKind: null })).toEqual([]);
+    });
+
+    it.each(['metricSource', 'comparator', 'targetValue', 'unit', 'window'])(
+        'still requires %s — exactly as before the kind existed',
+        (field) => {
+            expect(fields(validateGoalKindInput({ ...METRIC, [field]: undefined }))).toEqual([
+                field,
+            ]);
+            expect(fields(validateGoalKindInput({ ...METRIC, [field]: null }))).toEqual([field]);
+        },
+    );
+
+    it('rejects a non-finite target, an array metricSource, unknown members and a blank unit', () => {
+        expect(fields(validateMetricGoalInput({ ...METRIC, targetValue: Number.NaN }))).toEqual([
+            'targetValue',
+        ]);
+        expect(fields(validateMetricGoalInput({ ...METRIC, targetValue: '1000' }))).toEqual([
+            'targetValue',
+        ]);
+        expect(fields(validateMetricGoalInput({ ...METRIC, metricSource: [] }))).toEqual([
+            'metricSource',
+        ]);
+        expect(fields(validateMetricGoalInput({ ...METRIC, comparator: 'eq' }))).toEqual([
+            'comparator',
+        ]);
+        expect(fields(validateMetricGoalInput({ ...METRIC, window: 'year' }))).toEqual(['window']);
+        expect(fields(validateMetricGoalInput({ ...METRIC, unit: '   ' }))).toEqual(['unit']);
+    });
+
+    it('reports every missing field at once', () => {
+        expect(fields(validateGoalKindInput({}))).toEqual([
+            'metricSource',
+            'comparator',
+            'targetValue',
+            'unit',
+            'window',
+        ]);
+    });
+
+    it('tolerates a seed checklist on a metric Goal', () => {
+        expect(validateGoalKindInput({ ...METRIC, dodCriteria: DOD })).toEqual([]);
+    });
+});
+
+describe('validateGoalKindInput — delivery', () => {
+    const DELIVERY = { goalKind: 'delivery', dodCriteria: DOD };
+
+    it('accepts a clean delivery payload', () => {
+        expect(validateGoalKindInput(DELIVERY)).toEqual([]);
+    });
+
+    it('accepts explicit nulls for the metric fields (absent-or-null is the wire contract)', () => {
+        expect(
+            validateGoalKindInput({
+                ...DELIVERY,
+                metricSource: null,
+                comparator: null,
+                targetValue: null,
+                unit: null,
+                window: null,
+                baselineValue: null,
+                criteria: null,
+                constraints: null,
+            }),
+        ).toEqual([]);
+    });
+
+    it.each(GOAL_METRIC_ONLY_FIELDS)('rejects a delivery Goal that sets %s', (field) => {
+        const value =
+            field === 'criteria' || field === 'constraints'
+                ? []
+                : field === 'metricSource'
+                  ? { pluginId: 'p', metricId: 'm' }
+                  : field === 'comparator'
+                    ? 'gte'
+                    : field === 'window'
+                      ? 'month'
+                      : field === 'unit'
+                        ? 'usd'
+                        : 1;
+        const errors = validateGoalKindInput({ ...DELIVERY, [field]: value });
+        expect(fields(errors)).toEqual([field]);
+        expect(errors[0].message).toContain('must be omitted for a delivery Goal');
+    });
+
+    it('requires at least one Definition-of-Done criterion', () => {
+        expect(fields(validateGoalKindInput({ goalKind: 'delivery' }))).toEqual(['dodCriteria']);
+        expect(fields(validateGoalKindInput({ goalKind: 'delivery', dodCriteria: [] }))).toEqual([
+            'dodCriteria',
+        ]);
+        expect(fields(validateGoalKindInput({ goalKind: 'delivery', dodCriteria: null }))).toEqual([
+            'dodCriteria',
+        ]);
+    });
+
+    it('passes a malformed checklist through the DoD validator', () => {
+        const errors = validateDeliveryGoalInput({
+            goalKind: 'delivery',
+            dodCriteria: [{ id: '', text: 'x', status: 'open' }],
+        });
+        expect(errors.length).toBeGreaterThan(0);
+        expect(errors.every((e) => e.field === 'dodCriteria')).toBe(true);
+    });
+
+    it('refuses proposed (unapproved) criteria at birth — a Goal needs an approved finish line', () => {
+        const errors = validateGoalKindInput({
+            goalKind: 'delivery',
+            dodCriteria: [{ id: 'a', text: 'x', status: 'open', proposed: true }],
+        });
+        expect(fields(errors)).toEqual(['dodCriteria']);
+        expect(errors[0].message).toContain('proposed');
+    });
+
+    it('accepts a mix as long as at least one criterion is approved', () => {
+        expect(
+            validateGoalKindInput({
+                goalKind: 'delivery',
+                dodCriteria: [
+                    { id: 'a', text: 'x', status: 'open' },
+                    { id: 'b', text: 'y', status: 'done' },
+                ],
+            }),
+        ).toEqual([]);
+    });
+
+    it('reports the offending metric fields AND the missing checklist together', () => {
+        expect(fields(validateGoalKindInput({ goalKind: 'delivery', targetValue: 5 }))).toEqual([
+            'targetValue',
+            'dodCriteria',
+        ]);
+    });
+});
+
+describe('validateGoalKindInput — unknown kind (fail closed)', () => {
+    it.each(['outcome', 'Metric', ' delivery ', '', 42, {}])(
+        'rejects %j without coercing it',
+        (kind) => {
+            const errors = validateGoalKindInput({ ...METRIC, goalKind: kind });
+            expect(fields(errors)).toEqual(['goalKind']);
+            expect(errors[0].message).toContain('metric, delivery');
+        },
+    );
+});

--- a/packages/agent/src/goals/__tests__/goal-orchestrator-rules.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator-rules.spec.ts
@@ -258,6 +258,88 @@ describe('decideGoalLoop — routing', () => {
     });
 });
 
+describe('decideGoalLoop — cold start (scope fallback, self-build slice AG)', () => {
+    const scoped = [
+        candidate({ agentId: 'a', name: 'Alpha', source: 'scope' }),
+        candidate({ agentId: 'b', name: 'Beta', source: 'scope' }),
+    ];
+
+    it('dispatches to an in-scope agent and says so in the reasoning', () => {
+        const decision = decideGoalLoop(input({ iteration: 0, candidates: scoped }));
+        expect(decision.action).toBe('dispatch');
+        expect(decision.reasonCode).toBe('routed-scope-fallback');
+        expect(decision.nextIteration).toBe(1);
+        // nextIteration = 1, 1 % 2 = 1 → Beta.
+        expect(decision.agentId).toBe('b');
+        expect(decision.reasoning).toContain('Beta');
+        expect(decision.reasoning).toContain('no agent has worked it yet');
+        expect(decision.reasoning).toContain("2 eligible agent(s) in the Goal's scope");
+    });
+
+    it('round-robins over the scope pool by the persisted iteration counter alone', () => {
+        expect(decideGoalLoop(input({ iteration: 1, candidates: scoped })).agentId).toBe('a');
+        expect(decideGoalLoop(input({ iteration: 2, candidates: scoped })).agentId).toBe('b');
+        expect(decideGoalLoop(input({ iteration: 3, candidates: scoped })).agentId).toBe('a');
+    });
+
+    it('keeps the history reasoning untouched when the pool came from history', () => {
+        const decision = decideGoalLoop(
+            input({ candidates: [candidate({ agentId: 'h', name: 'Hist', source: 'history' })] }),
+        );
+        expect(decision.reasonCode).toBe('routed-round-robin');
+        expect(decision.reasoning).not.toContain('scope');
+    });
+
+    it('a pin still beats scope candidates', () => {
+        const decision = decideGoalLoop(
+            input({
+                candidates: [...scoped, candidate({ agentId: 'pin', source: 'assigned' })],
+            }),
+        );
+        expect(decision.agentId).toBe('pin');
+        expect(decision.reasonCode).toBe('routed-assigned-agent');
+    });
+
+    it('an empty pool is still an honest stuck, and points the operator at the Goal scope', () => {
+        const decision = decideGoalLoop(input({ candidates: [] }));
+        expect(decision.action).toBe('stuck');
+        expect(decision.reasonCode).toBe('no-candidate-agent');
+        expect(decision.reasoning).toContain("in this Goal's scope");
+    });
+
+    it('limits still beat routing: a spend cap pauses before any scope candidate is used', () => {
+        const decision = decideGoalLoop(
+            input({ candidates: scoped, spendCapCents: 100, spentCents: 500 }),
+        );
+        expect(decision.action).toBe('pause');
+        expect(decision.agentId).toBeUndefined();
+    });
+});
+
+describe('decideGoalLoop — Definition of Done approval (kind-agnostic)', () => {
+    it('does not complete on proposed-only criteria — the loop keeps dispatching', () => {
+        const decision = decideGoalLoop(
+            input({
+                dod: summarizeDoD([{ id: 'a', text: 'x', status: 'done', proposed: true }]),
+            }),
+        );
+        expect(decision.action).toBe('dispatch');
+    });
+
+    it('completes once every APPROVED criterion is closed, even with proposals pending', () => {
+        const decision = decideGoalLoop(
+            input({
+                dod: summarizeDoD([
+                    { id: 'a', text: 'x', status: 'done' },
+                    { id: 'p', text: 'y', status: 'open', proposed: true },
+                ]),
+            }),
+        );
+        expect(decision.action).toBe('complete');
+        expect(decision.reasonCode).toBe('dod-complete');
+    });
+});
+
 describe('formatUsd', () => {
     it('renders cents as dollars', () => {
         expect(formatUsd(0)).toBe('$0.00');

--- a/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goal-orchestrator.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { Repository } from 'typeorm';
-import { Goal } from '../../entities/goal.entity';
+import { Goal, GoalOutcome, GoalStatus } from '../../entities/goal.entity';
 import type { GoalEvent } from '../../entities/goal-event.entity';
 import type { AgentRun } from '../../entities/agent-run.entity';
 import { Task } from '../../entities/task.entity';
@@ -87,6 +87,7 @@ function goalRow(overrides: Partial<Goal> = {}): AnyRow {
         userId: 'u1',
         title: 'Reach 1k signups',
         description: null,
+        goalKind: 'metric',
         metricSource: { pluginId: 'stripe', metricId: 'signups' },
         comparator: 'gte',
         targetValue: 1000,
@@ -134,6 +135,17 @@ function build(overrides: { goal?: Partial<Goal> } = {}) {
                 _userId?: string,
                 _scope?: { tenantId: string | null; organizationId: string | null },
             ) => ({ id, name: `Agent ${id}`, slug: id }),
+        ),
+        // Cold-start pool (self-build slice AG): EMPTY by default so every
+        // pre-existing expectation keeps its outcome (a fresh unpinned Goal
+        // still goes stuck when the scope has no agent); the scope-fallback
+        // suite below overrides it per test.
+        findByUserIdScoped: jest.fn(
+            async (
+                _userId: string,
+                _filter?: { limit?: number },
+                _scope?: { tenantId: string | null; organizationId: string | null },
+            ) => ({ rows: [] as Array<Record<string, unknown>>, total: 0 }),
         ),
     };
     const tasksService = {
@@ -1298,5 +1310,432 @@ describe('GoalOrchestratorService — archive + sessions', () => {
         );
         const log = await service.listEvents('u1', 'g1');
         expect(log.map((e) => e.message)).toEqual(['second', 'first']);
+    });
+});
+
+// ── Self-build slice AG (EW-795) ────────────────────────────────────────
+
+describe('GoalOrchestratorService — cold start (scope fallback)', () => {
+    const everScope = {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+    };
+    const yoScope = {
+        tenantId: everScope.tenantId,
+        organizationId: '33333333-3333-4333-8333-333333333333',
+    };
+    const agentRow = (id: string, createdAt: string, scope: Record<string, unknown> = {}) => ({
+        id,
+        userId: 'u1',
+        name: `Agent ${id}`,
+        slug: id,
+        status: 'draft',
+        createdAt: new Date(createdAt),
+        ...scope,
+    });
+
+    it('routes a fresh unpinned Goal to an agent in its scope instead of going stuck', async () => {
+        const { service, agents, tasksService, transitions, events, goals } = build({
+            goal: {
+                loopStatus: 'running',
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }],
+            },
+        });
+        agents.findByUserIdScoped.mockResolvedValue({
+            rows: [agentRow('agent-a', '2026-08-01T00:00:00.000Z')],
+            total: 1,
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('dispatch');
+        expect(result.reasonCode).toBe('routed-scope-fallback');
+        expect(result.agentId).toBe('agent-a');
+        expect(result.iteration).toBe(1);
+        // A legacy null/null Goal asks for the owner-wide pool (undefined
+        // scope), exactly as the pin path does for `findByIdAndUser`.
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ limit: expect.any(Number) }),
+            undefined,
+        );
+        expect(tasksService.create).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ goalId: 'g1', agentId: 'agent-a' }),
+            { tenantId: null, organizationId: null },
+        );
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'task-1' }),
+            'agent-a',
+            { dedupKey: 'goal:g1:1' },
+        );
+        expect(eventKinds(events)).toEqual(['route', 'dispatch']);
+        expect(eventMessages(events)[0]).toContain("in the Goal's scope");
+        expect(goals._rows[0].loopStatus).toBe('running');
+        expect(goals._rows[0].activeAgentId).toBe('agent-a');
+    });
+
+    it('asks the repository for the Goal exact Organization scope and routes to what it returns', async () => {
+        const { service, agents, tasksService, transitions } = build({
+            goal: { loopStatus: 'running', ...everScope },
+        });
+        const everAgent = agentRow('ever-agent', '2026-08-01T00:00:00.000Z', everScope);
+        // The repository applies the ownership predicate for the scope it is
+        // handed; mirror that so a wrong scope argument yields nothing.
+        agents.findByUserIdScoped.mockImplementation(async (_userId, _filter, scope) =>
+            scope?.organizationId === everScope.organizationId
+                ? { rows: [everAgent], total: 1 }
+                : { rows: [], total: 0 },
+        );
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith('u1', expect.anything(), everScope);
+        expect(result.action).toBe('dispatch');
+        expect(result.agentId).toBe('ever-agent');
+        expect(tasksService.create).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ agentId: 'ever-agent' }),
+            everScope,
+        );
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.objectContaining(everScope),
+            'ever-agent',
+            expect.anything(),
+        );
+    });
+
+    it('never routes to an agent that exists only in another Organization of the same user', async () => {
+        const { service, agents, transitions, goals } = build({
+            goal: { loopStatus: 'running', ...everScope },
+        });
+        const yoAgent = agentRow('yo-agent', '2026-08-01T00:00:00.000Z', yoScope);
+        agents.findByUserIdScoped.mockImplementation(async (_userId, _filter, scope) =>
+            scope?.organizationId === yoScope.organizationId
+                ? { rows: [yoAgent], total: 1 }
+                : { rows: [], total: 0 },
+        );
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith('u1', expect.anything(), everScope);
+        expect(result.action).toBe('stuck');
+        expect(result.reasonCode).toBe('no-candidate-agent');
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+        expect(goals._rows[0].loopStatus).toBe('stuck');
+    });
+
+    it('goes stuck with the existing reason when the scope has no agent at all', async () => {
+        const { service, goals, events, transitions } = build({
+            goal: { loopStatus: 'running' },
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('stuck');
+        expect(result.reasonCode).toBe('no-candidate-agent');
+        expect(goals._rows[0].loopStatus).toBe('stuck');
+        expect(eventKinds(events)).toEqual(['limit']);
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('prefers the Goal own history over the scope pool', async () => {
+        const { service, agents, tasks } = build({
+            goal: { loopStatus: 'running', iteration: 1 },
+        });
+        tasks._rows.push({
+            id: 'task-1',
+            goalId: 'g1',
+            agentId: 'agent-hist',
+            slug: 'T-1',
+            title: '[Goal] x — iteration 1',
+            status: 'done',
+            createdAt: new Date(1),
+        });
+        agents.findByUserIdScoped.mockResolvedValue({
+            rows: [agentRow('agent-scope', '2026-08-01T00:00:00.000Z')],
+            total: 1,
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.agentId).toBe('agent-hist');
+        expect(result.reasonCode).toBe('routed-round-robin');
+        expect(agents.findByUserIdScoped).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fall back to the scope when an explicit pin fails its scope check', async () => {
+        const { service, agents, transitions, goals } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                ...everScope,
+            },
+        });
+        agents.findByIdAndUser.mockResolvedValue(null as never);
+        agents.findByUserIdScoped.mockResolvedValue({
+            rows: [agentRow('ever-agent', '2026-08-01T00:00:00.000Z', everScope)],
+            total: 1,
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        // An unhonoured explicit pin is the operator's to fix, not something
+        // to route around silently.
+        expect(result.action).toBe('stuck');
+        expect(result.reasonCode).toBe('no-candidate-agent');
+        expect(agents.findByUserIdScoped).not.toHaveBeenCalled();
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+        expect(goals._rows[0].loopStatus).toBe('stuck');
+    });
+
+    it('orders the pool by createdAt so the round-robin is reproducible from the iteration counter', async () => {
+        const { service, agents } = build({ goal: { loopStatus: 'running', iteration: 1 } });
+        // The repository returns updatedAt DESC — newest first. Under that
+        // order nextIteration 2 % 2 = 0 would pick agent-b; sorted by
+        // createdAt it picks agent-a, and keeps picking it however often
+        // agent-b is edited.
+        agents.findByUserIdScoped.mockResolvedValue({
+            rows: [
+                agentRow('agent-b', '2026-08-02T00:00:00.000Z'),
+                agentRow('agent-a', '2026-08-01T00:00:00.000Z'),
+            ],
+            total: 2,
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.agentId).toBe('agent-a');
+        expect(result.reasoning).toContain("2 eligible agent(s) in the Goal's scope");
+    });
+
+    it('degrades to stuck on a slim install with no Agent repository wired', async () => {
+        const { goals, events, tasks, runs } = build({ goal: { loopStatus: 'running' } });
+        const slim = new GoalOrchestratorService(
+            goals as never,
+            events as never,
+            tasks as never,
+            runs as never,
+        );
+
+        const result = await slim.advance('u1', 'g1');
+
+        expect(result.action).toBe('stuck');
+        expect(result.reasonCode).toBe('no-candidate-agent');
+    });
+});
+
+describe('GoalOrchestratorService — delivery Goals', () => {
+    const deliveryRow = (overrides: Partial<Goal> = {}): Partial<Goal> => ({
+        goalKind: 'delivery',
+        metricSource: null,
+        comparator: null,
+        targetValue: null,
+        unit: null,
+        window: 'total',
+        ...overrides,
+    });
+
+    it('a finished loop completes the delivery Goal itself (COMPLETED + ACHIEVED, schedule cleared)', async () => {
+        const { service, goals, events, transitions } = build({
+            goal: deliveryRow({
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'done' }],
+                nextCheckAt: new Date('2026-08-15T00:00:00.000Z'),
+            }),
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('complete');
+        expect(goals._rows[0]).toMatchObject({
+            loopStatus: 'done',
+            activeAgentId: null,
+            status: 'completed',
+            outcome: 'achieved',
+            nextCheckAt: null,
+        });
+        expect(eventKinds(events)).toEqual(['complete']);
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('a finished loop leaves a METRIC Goal status untouched (loop done ≠ metric reached)', async () => {
+        const { service, goals } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'done' }],
+                nextCheckAt: new Date('2026-08-15T00:00:00.000Z'),
+            },
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('complete');
+        expect(goals._rows[0]).toMatchObject({
+            loopStatus: 'done',
+            status: 'active',
+            outcome: null,
+            nextCheckAt: new Date('2026-08-15T00:00:00.000Z'),
+        });
+    });
+
+    it('never overwrites a human outcome override on an already-completed delivery Goal (FR-13)', async () => {
+        // The operator abandoned the Goal while its loop was still running;
+        // an agent then closed the last criterion. The loop finishes, but the
+        // human decision on the Goal row stands.
+        const { service, goals } = build({
+            goal: deliveryRow({
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                status: GoalStatus.COMPLETED,
+                outcome: GoalOutcome.ABANDONED,
+                nextCheckAt: null,
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'done' }],
+            }),
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('complete');
+        expect(goals._rows[0]).toMatchObject({
+            loopStatus: 'done',
+            activeAgentId: null,
+            status: 'completed',
+            outcome: 'abandoned',
+        });
+    });
+
+    it('does not flip a deadline-missed delivery Goal to achieved when its loop finishes late', async () => {
+        // Metric parity: once the evaluation tick has recorded MISSED the Goal
+        // is COMPLETED and never re-evaluated; the loop landing the last
+        // criterion afterwards must not rewrite that history either.
+        const { service, goals } = build({
+            goal: deliveryRow({
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                status: GoalStatus.COMPLETED,
+                outcome: GoalOutcome.MISSED,
+                deadline: new Date('2026-01-01T00:00:00.000Z'),
+                nextCheckAt: null,
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'done' }],
+            }),
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('complete');
+        expect(goals._rows[0]).toMatchObject({
+            loopStatus: 'done',
+            status: 'completed',
+            outcome: 'missed',
+        });
+    });
+
+    it('keeps a not-yet-done delivery Goal iterating under the usual loop rules', async () => {
+        const { service, goals, transitions } = build({
+            goal: deliveryRow({
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                dodCriteria: [
+                    { id: 'a', text: 'Ship pricing', status: 'done' },
+                    { id: 'p', text: 'Proposed by a planner', status: 'done', proposed: true },
+                    { id: 'b', text: 'Write docs', status: 'open' },
+                ],
+            }),
+        });
+
+        const result = await service.advance('u1', 'g1');
+
+        expect(result.action).toBe('dispatch');
+        expect(transitions.dispatchAgentRun).toHaveBeenCalled();
+        expect(goals._rows[0]).toMatchObject({
+            status: 'active',
+            outcome: null,
+            loopStatus: 'running',
+        });
+    });
+
+    it('tells the routed agent that the checklist is the whole definition of done', async () => {
+        const { service, tasksService } = build({
+            goal: deliveryRow({
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }],
+            }),
+        });
+
+        await service.advance('u1', 'g1');
+
+        const brief = String(tasksService.create.mock.calls[0][1].description);
+        expect(brief).toContain('Delivery Goal — there is no metric');
+        expect(brief).toContain('Ship pricing');
+    });
+
+    it('a metric Goal brief carries no delivery banner', async () => {
+        const { service, tasksService } = build({
+            goal: {
+                loopStatus: 'running',
+                assignedAgentId: 'agent-7',
+                dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }],
+            },
+        });
+
+        await service.advance('u1', 'g1');
+
+        const brief = String(tasksService.create.mock.calls[0][1].description);
+        expect(brief).not.toContain('Delivery Goal');
+    });
+
+    it('refuses to clear, empty or de-approve the whole checklist of a delivery Goal', async () => {
+        const { service, goals } = build({
+            goal: deliveryRow({ dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }] }),
+        });
+
+        await expect(service.setDodCriteria('u1', 'g1', null)).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+        await expect(service.setDodCriteria('u1', 'g1', [])).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+        await expect(
+            service.setDodCriteria('u1', 'g1', [
+                { id: 'p', text: 'Only a proposal', status: 'open', proposed: true },
+            ]),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(goals._rows[0].dodCriteria).toHaveLength(1);
+
+        // Replacing it with another approved list is fine.
+        const dto = await service.setDodCriteria('u1', 'g1', [
+            { id: 'b', text: 'Write docs', status: 'open' },
+        ]);
+        expect(dto.dodSummary).toMatchObject({ total: 1, open: 1 });
+    });
+
+    it('still clears a metric Goal checklist with null', async () => {
+        const { service } = build({
+            goal: { dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }] },
+        });
+        const dto = await service.setDodCriteria('u1', 'g1', null);
+        expect(dto.dodCriteria).toBeNull();
+    });
+
+    it('refuses to start the loop on a delivery Goal with no approved criterion', async () => {
+        const { service, goals } = build({
+            goal: deliveryRow({
+                dodCriteria: [{ id: 'p', text: 'Only a proposal', status: 'open', proposed: true }],
+            }),
+        });
+        await expect(service.startLoop('u1', 'g1')).rejects.toBeInstanceOf(BadRequestException);
+        expect(goals._rows[0].loopStatus).toBeNull();
+    });
+
+    it('starts the loop on a delivery Goal with an approved criterion', async () => {
+        const { service, goals } = build({
+            goal: deliveryRow({ dodCriteria: [{ id: 'a', text: 'Ship pricing', status: 'open' }] }),
+        });
+        await service.startLoop('u1', 'g1');
+        expect(goals._rows[0].loopStatus).toBe('running');
     });
 });

--- a/packages/agent/src/goals/__tests__/goals.service.spec.ts
+++ b/packages/agent/src/goals/__tests__/goals.service.spec.ts
@@ -101,6 +101,7 @@ function makeGoalRow(overrides: Partial<Goal> = {}): AnyRow {
         userId: 'u1',
         title: 'seed goal',
         description: null,
+        goalKind: 'metric',
         metricSource: { pluginId: 'stripe', metricId: 'income' },
         comparator: 'gte',
         targetValue: 1000,
@@ -128,6 +129,21 @@ function validInput(overrides: Partial<CreateGoalInput> = {}): CreateGoalInput {
         targetValue: 1000,
         unit: 'usd',
         window: 'month',
+        ...overrides,
+    };
+}
+
+/** A delivery Goal (self-build slice AG): no metric, an approved DoD. */
+const DELIVERY_DOD = [
+    { id: 'api', text: 'API endpoint merged', status: 'open' as const },
+    { id: 'web', text: 'Web form merged', status: 'open' as const },
+];
+
+function deliveryInput(overrides: Partial<CreateGoalInput> = {}): CreateGoalInput {
+    return {
+        title: 'Ship feature X across three repos',
+        goalKind: 'delivery',
+        dodCriteria: DELIVERY_DOD,
         ...overrides,
     };
 }
@@ -520,6 +536,234 @@ describe('GoalsService', () => {
             expect(missionGoalsRepo._rows[0]).toMatchObject(everScope);
             expect(linked).toMatchObject(everScope);
             expect(linked.goal).toMatchObject(everScope);
+        });
+    });
+
+    // ── Self-build slice AG (EW-795): the delivery kind ────────────────
+
+    describe('create — delivery kind', () => {
+        it('persists a DRAFT delivery Goal with NULL metric fields, a total window and the normalized DoD', async () => {
+            const dto = await service.create('u1', deliveryInput());
+
+            expect(dto.goalKind).toBe('delivery');
+            expect(dto.status).toBe(GoalStatus.DRAFT);
+            expect(dto.nextCheckAt).toBeNull();
+            expect(dto.metricSource).toBeNull();
+            expect(dto.comparator).toBeNull();
+            expect(dto.targetValue).toBeNull();
+            expect(dto.unit).toBeNull();
+            expect(dto.window).toBe('total');
+            expect(dto.baselineValue).toBeNull();
+            expect(dto.dodCriteria).toHaveLength(2);
+            expect(dto.dodCriteria?.[0]).toMatchObject({
+                id: 'api',
+                text: 'API endpoint merged',
+                status: 'open',
+                source: 'operator',
+            });
+            expect(dto.dodSummary).toMatchObject({ total: 2, open: 2, complete: false });
+            // The row really carries NULLs (what the nullable columns store),
+            // not a missing key.
+            expect(goalsRepo._rows[0]).toMatchObject({
+                goalKind: 'delivery',
+                metricSource: null,
+                comparator: null,
+                targetValue: null,
+                unit: null,
+                criteria: null,
+                constraints: null,
+            });
+        });
+
+        it('accepts explicit nulls for the metric fields (absent-or-null is the wire contract)', async () => {
+            const dto = await service.create(
+                'u1',
+                deliveryInput({
+                    metricSource: null,
+                    comparator: null,
+                    targetValue: null,
+                    unit: null,
+                    window: null,
+                }),
+            );
+            expect(dto.goalKind).toBe('delivery');
+        });
+
+        it('rejects a delivery Goal without a Definition of Done', async () => {
+            for (const dodCriteria of [undefined, null, []]) {
+                await expect(
+                    service.create('u1', deliveryInput({ dodCriteria })),
+                ).rejects.toBeInstanceOf(BadRequestException);
+            }
+            expect(goalsRepo._rows).toHaveLength(0);
+        });
+
+        it.each([
+            ['targetValue', { targetValue: 1000 }],
+            ['metricSource', { metricSource: { pluginId: 'stripe', metricId: 'income' } }],
+            ['comparator', { comparator: 'gte' }],
+            ['unit', { unit: 'usd' }],
+            ['window', { window: 'month' }],
+            ['baselineValue', { baselineValue: 5 }],
+            ['criteria', { criteria: [] }],
+            ['constraints', { constraints: [] }],
+        ] as Array<[string, Partial<CreateGoalInput>]>)(
+            'rejects a delivery Goal that carries the metric-only field %s',
+            async (_field, extra) => {
+                await expect(service.create('u1', deliveryInput(extra))).rejects.toBeInstanceOf(
+                    BadRequestException,
+                );
+                expect(goalsRepo._rows).toHaveLength(0);
+            },
+        );
+
+        it('rejects a delivery Goal born with proposed (unapproved) criteria', async () => {
+            await expect(
+                service.create(
+                    'u1',
+                    deliveryInput({
+                        dodCriteria: [{ id: 'a', text: 'x', status: 'open', proposed: true }],
+                    }),
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('rejects a malformed Definition of Done', async () => {
+            await expect(
+                service.create(
+                    'u1',
+                    deliveryInput({
+                        dodCriteria: [{ id: '', text: 'x', status: 'open' }] as never,
+                    }),
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('rejects an unknown goalKind without coercing it', async () => {
+            await expect(
+                service.create('u1', validInput({ goalKind: 'outcome' as never })),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(goalsRepo._rows).toHaveLength(0);
+        });
+
+        it('still requires every metric field for an explicit metric kind', async () => {
+            await expect(
+                service.create('u1', validInput({ goalKind: 'metric', targetValue: undefined })),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                service.create('u1', validInput({ goalKind: 'metric', unit: undefined })),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                service.create('u1', validInput({ goalKind: 'metric', comparator: undefined })),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            // The e2e validation matrix pins this exact message for a missing source.
+            await expect(
+                service.create('u1', validInput({ goalKind: 'metric', metricSource: undefined })),
+            ).rejects.toThrow('metricSource must be an object.');
+        });
+
+        it('defaults an omitted goalKind to metric and keeps an optional seed checklist', async () => {
+            const bare = await service.create('u1', validInput());
+            expect(bare.goalKind).toBe('metric');
+            expect(bare.dodCriteria).toBeNull();
+
+            const seeded = await service.create(
+                'u1',
+                validInput({
+                    dodCriteria: [{ id: 'docs', text: 'Write the docs', status: 'open' }],
+                }),
+            );
+            expect(seeded.goalKind).toBe('metric');
+            expect(seeded.targetValue).toBe(1000);
+            expect(seeded.dodCriteria).toHaveLength(1);
+        });
+    });
+
+    describe('activate / update — delivery kind', () => {
+        it('activates a delivery Goal with no metric source at all and schedules the first check', async () => {
+            const created = await service.create('u1', deliveryInput());
+            const dto = await service.activate('u1', created.id);
+            expect(dto.status).toBe(GoalStatus.ACTIVE);
+            expect(dto.outcome).toBeNull();
+            // Scheduled like a metric Goal so deadline → MISSED still works
+            // without a plugin; the tick itself reads no provider.
+            expect(dto.nextCheckAt).not.toBeNull();
+        });
+
+        it('refuses to activate a delivery Goal whose criteria are all still proposed', async () => {
+            goalsRepo._rows.push(
+                makeGoalRow({
+                    id: 'gdel',
+                    goalKind: 'delivery',
+                    metricSource: null,
+                    comparator: null,
+                    targetValue: null,
+                    unit: null,
+                    window: 'total',
+                    dodCriteria: [{ id: 'a', text: 'x', status: 'open', proposed: true }],
+                }),
+            );
+            await expect(service.activate('u1', 'gdel')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+            expect(goalsRepo._rows[0].status).toBe(GoalStatus.DRAFT);
+        });
+
+        it('refuses to activate a delivery Goal with no Definition of Done at all', async () => {
+            goalsRepo._rows.push(
+                makeGoalRow({
+                    id: 'gdel',
+                    goalKind: 'delivery',
+                    metricSource: null,
+                    comparator: null,
+                    targetValue: null,
+                    unit: null,
+                    window: 'total',
+                    dodCriteria: null,
+                }),
+            );
+            await expect(service.activate('u1', 'gdel')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('refuses to give a delivery Goal a metric target — even as a null "clear"', async () => {
+            const created = await service.create('u1', deliveryInput());
+            await expect(
+                service.update('u1', created.id, { targetValue: 5 }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                service.update('u1', created.id, {
+                    metricSource: { pluginId: 'stripe', metricId: 'income' },
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                service.update('u1', created.id, { comparator: 'gte' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                service.update('u1', created.id, { baselineValue: null }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(goalsRepo._rows[0]).toMatchObject({ targetValue: null, metricSource: null });
+        });
+
+        it('still lets a delivery Goal change its title and take a human outcome override', async () => {
+            const created = await service.create('u1', deliveryInput());
+            const renamed = await service.update('u1', created.id, { title: '  Ship it  ' });
+            expect(renamed.title).toBe('Ship it');
+
+            await service.activate('u1', created.id);
+            const abandoned = await service.update('u1', created.id, {
+                outcome: GoalOutcome.ABANDONED,
+            });
+            expect(abandoned.outcome).toBe(GoalOutcome.ABANDONED);
+            expect(abandoned.status).toBe(GoalStatus.COMPLETED);
+            expect(abandoned.nextCheckAt).toBeNull();
+        });
+
+        it('metric Goals keep their metric-field updates', async () => {
+            const created = await service.create('u1', validInput());
+            const updated = await service.update('u1', created.id, { targetValue: 2500 });
+            expect(updated.targetValue).toBe(2500);
         });
     });
 });

--- a/packages/agent/src/goals/goal-criteria.ts
+++ b/packages/agent/src/goals/goal-criteria.ts
@@ -57,13 +57,18 @@ export function isHardConstraint(constraint: Pick<GoalConstraint, 'hard'>): bool
  * The metric a criterion/constraint reads: its own override, else the
  * Goal's. Inheritance is what keeps the common "same metric, several
  * thresholds" Goal free of repetition.
+ *
+ * `source` is `null` when neither the node nor the Goal names one — a
+ * delivery Goal has no `metricSource` (and refuses criteria/constraints on
+ * write), but the type must be honest so a caller cannot dereference a
+ * source that is not there.
  */
 export function resolveSourceFor(
     goal: Pick<Goal, 'metricSource' | 'window'>,
     node: { metricSource?: GoalMetricSource; window?: GoalWindow },
-): { source: GoalMetricSource; window: GoalWindow } {
+): { source: GoalMetricSource | null; window: GoalWindow } {
     return {
-        source: node.metricSource ?? goal.metricSource,
+        source: node.metricSource ?? goal.metricSource ?? null,
         window: node.window ?? goal.window,
     };
 }

--- a/packages/agent/src/goals/goal-evaluation.service.ts
+++ b/packages/agent/src/goals/goal-evaluation.service.ts
@@ -1,11 +1,13 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThanOrEqual, Repository } from 'typeorm';
 import {
     Goal,
     GoalOutcome,
     GoalStatus,
+    type GoalComparator,
     type GoalConstraint,
+    type GoalMetricSource,
     type GoalResolvedScore,
 } from '../entities/goal.entity';
 import { GoalMetricSample } from '../entities/goal-metric-sample.entity';
@@ -22,11 +24,20 @@ import {
     resolveSourceFor,
     type CriterionObservation,
 } from './goal-criteria';
+import { summarizeDoD } from './goal-dod';
+import { isDeliveryGoal } from './goal-kind';
 import {
     MIN_CHECK_FREQUENCY_MINUTES,
     type GoalEvaluationEntry,
     type GoalEvaluationSummary,
 } from './types';
+
+/** A metric Goal whose four metric fields are all present — the only shape this service will read. */
+type MetricGoal = Goal & {
+    metricSource: GoalMetricSource;
+    comparator: GoalComparator;
+    targetValue: number;
+};
 
 /**
  * Goals & Metrics — PR-8 evaluation engine (spec FR-12..FR-14).
@@ -125,10 +136,15 @@ export class GoalEvaluationService {
     }
 
     /**
-     * Evaluate one Goal now: read the metric through the facade
-     * (budget-guarded + metered per PR-7), append an (immutable)
-     * sample, refresh currentValue/baseline, and apply the
-     * auto-outcome rules:
+     * Evaluate one Goal now.
+     *
+     * **Delivery Goal** (self-build slice AG): no provider is read and no
+     * sample is written — the Goal completes on its approved Definition of
+     * Done alone. See {@link evaluateDelivery}.
+     *
+     * **Metric Goal**: read the metric through the facade (budget-guarded
+     * + metered per PR-7), append an (immutable) sample, refresh
+     * currentValue/baseline, and apply the auto-outcome rules:
      *
      *   - comparator satisfied            → COMPLETED + ACHIEVED
      *   - deadline passed AND unsatisfied → COMPLETED + MISSED
@@ -139,9 +155,17 @@ export class GoalEvaluationService {
      * deliberately leaves the schedule untouched.
      *
      * Throws the facade's typed errors on provider failure — no
-     * sample and no Goal mutation happens in that case.
+     * sample and no Goal mutation happens in that case. Also throws,
+     * fail-closed, on a metric row that lacks any of its metric fields:
+     * that row is corrupt, and guessing a target would be worse than
+     * reporting it (`evaluateDue` counts it `failed` and moves on).
      */
     async evaluateOne(goal: Goal): Promise<GoalEvaluationEntry> {
+        if (isDeliveryGoal(goal)) {
+            return this.evaluateDelivery(goal);
+        }
+        this.assertMetricGoalShape(goal);
+
         const source = goal.metricSource;
         const sample = await this.metricsFacade.getMetricValue(
             source.pluginId,
@@ -222,7 +246,65 @@ export class GoalEvaluationService {
         };
     }
 
+    /**
+     * Delivery-kind evaluation: the approved DoD IS the completion rule.
+     *
+     * No `MetricsFacadeService` call, no `goal_metric_samples` row, no
+     * comparator — a delivery Goal has none of those, and reading a
+     * provider for it would be reading nothing. `summarizeDoD` already
+     * excludes proposed (unapproved) criteria, so a planning run cannot
+     * complete a Goal by proposing that it is done. The deadline rule is
+     * the same as for a metric Goal, which is why `activate` schedules
+     * delivery Goals too: a missed deadline must surface without a plugin.
+     *
+     * Idempotent with the orchestrator's `applyTerminal`, which writes the
+     * same terminal state when the loop observes the complete DoD first.
+     * Invariant I-4 holds: only the Goal row is written.
+     */
+    private async evaluateDelivery(goal: Goal): Promise<GoalEvaluationEntry> {
+        const now = new Date();
+        const dod = summarizeDoD(goal.dodCriteria);
+        let outcome: GoalEvaluationEntry['outcome'] = 'evaluated';
+
+        if (dod.complete) {
+            goal.status = GoalStatus.COMPLETED;
+            goal.outcome = GoalOutcome.ACHIEVED;
+            goal.nextCheckAt = null;
+            outcome = 'achieved';
+        } else if (goal.deadline && goal.deadline.getTime() <= now.getTime()) {
+            goal.status = GoalStatus.COMPLETED;
+            goal.outcome = GoalOutcome.MISSED;
+            goal.nextCheckAt = null;
+            outcome = 'missed';
+        }
+
+        await this.goals.save(goal);
+        return { goalId: goal.id, outcome };
+    }
+
     // ─── internals ──────────────────────────────────────────────────
+
+    /**
+     * Fail closed on a metric row that lacks its metric fields. The
+     * columns are nullable only so the delivery kind can share the table;
+     * for a metric Goal a NULL there is corruption, never a valid state.
+     */
+    private assertMetricGoalShape(goal: Goal): asserts goal is MetricGoal {
+        const source = goal.metricSource;
+        const missing: string[] = [];
+        if (typeof source !== 'object' || source === null || Array.isArray(source)) {
+            missing.push('metricSource');
+        }
+        if (goal.comparator !== 'gte' && goal.comparator !== 'lte') missing.push('comparator');
+        if (typeof goal.targetValue !== 'number' || !Number.isFinite(goal.targetValue)) {
+            missing.push('targetValue');
+        }
+        if (missing.length > 0) {
+            throw new BadRequestException(
+                `Metric Goal ${goal.id} cannot be evaluated: missing ${missing.join(', ')}.`,
+            );
+        }
+    }
 
     /**
      * Atomic claim: advance `nextCheckAt` by the (re-clamped)
@@ -256,7 +338,7 @@ export class GoalEvaluationService {
         return true;
     }
 
-    private isSatisfied(goal: Goal, value: number): boolean {
+    private isSatisfied(goal: MetricGoal, value: number): boolean {
         return goal.comparator === 'gte' ? value >= goal.targetValue : value <= goal.targetValue;
     }
 
@@ -289,6 +371,12 @@ export class GoalEvaluationService {
         const observations: CriterionObservation[] = [];
         for (const criterion of goal.criteria) {
             const { source, window } = resolveSourceFor(goal, criterion);
+            if (!source) {
+                // Neither the criterion nor the Goal names a metric: unknown,
+                // not failed — the same containment as a provider outage.
+                observations.push({ criterion, value: null, error: 'no metric source' });
+                continue;
+            }
             try {
                 const sample = await this.metricsFacade.getMetricValue(
                     source.pluginId,
@@ -316,6 +404,13 @@ export class GoalEvaluationService {
             // platform does not claim to have checked what it cannot read.
             if (!isMeasurableConstraint(constraint)) continue;
             const { source, window } = resolveSourceFor(goal, constraint);
+            if (!source) {
+                // No metric to read → UNKNOWN, never violated (see below).
+                this.logger.warn(
+                    `Goal ${goal.id} constraint '${constraint.id}' has no metric source (treated as not violated)`,
+                );
+                continue;
+            }
             try {
                 const sample = await this.metricsFacade.getMetricValue(
                     source.pluginId,

--- a/packages/agent/src/goals/goal-kind.ts
+++ b/packages/agent/src/goals/goal-kind.ts
@@ -1,0 +1,197 @@
+import {
+    DEFAULT_GOAL_KIND,
+    GOAL_KINDS,
+    isGoalKind,
+    normalizeGoalKind,
+    type GoalKind,
+} from '@ever-works/contracts';
+import type { Goal, GoalComparator, GoalDoDCriterion, GoalWindow } from '../entities/goal.entity';
+import { validateDoDCriteria } from './goal-dod';
+
+/**
+ * Self-build slice AG (EW-795) — pure helpers for the Goal KIND
+ * discriminator.
+ *
+ * Side-effect free and taking plain row shapes, exactly like
+ * `goal-criteria.ts` / `goal-dod.ts`: the write-path validator, the
+ * evaluation service, the orchestrator and the specs all share ONE set of
+ * rules for "what must a metric Goal carry, what must a delivery Goal NOT
+ * carry" instead of four re-derivations that drift apart.
+ *
+ * The rule, stated once:
+ *   - **metric**   ⇒ `metricSource`, `comparator`, `targetValue`, `unit`
+ *                    and `window` are all REQUIRED (exactly as before the
+ *                    kind existed).
+ *   - **delivery** ⇒ every metric-only field must be absent or null, and a
+ *                    Definition of Done with at least one APPROVED
+ *                    criterion is required. A delivery Goal cannot be born
+ *                    with an unapproved finish line.
+ *   - anything else ⇒ rejected. A Goal that satisfies neither rule has no
+ *                    completion rule and must not exist.
+ */
+
+export const GOAL_COMPARATORS: readonly GoalComparator[] = ['gte', 'lte'];
+export const GOAL_WINDOWS: readonly GoalWindow[] = ['day', 'week', 'month', 'total', 'point'];
+
+/**
+ * Fields that only mean something on a metric Goal. `window` is included
+ * even though its column stays NOT NULL (a delivery row stores `'total'`
+ * and never reads it): accepting a window on a delivery Goal would let a
+ * client believe an aggregation is happening when nothing is measured.
+ */
+export type GoalMetricOnlyField =
+    | 'metricSource'
+    | 'comparator'
+    | 'targetValue'
+    | 'unit'
+    | 'window'
+    | 'baselineValue'
+    | 'criteria'
+    | 'constraints';
+
+export const GOAL_METRIC_ONLY_FIELDS: readonly GoalMetricOnlyField[] = [
+    'metricSource',
+    'comparator',
+    'targetValue',
+    'unit',
+    'window',
+    'baselineValue',
+    'criteria',
+    'constraints',
+];
+
+export interface GoalKindValidationError {
+    field: string;
+    message: string;
+}
+
+/** The loose input shape the kind rules inspect (create payloads and row-like objects). */
+export type GoalKindShapeInput = {
+    goalKind?: unknown;
+    dodCriteria?: unknown;
+} & Partial<Record<GoalMetricOnlyField, unknown>>;
+
+/** READ-path kind of a row: an unknown/missing value renders as `metric`. */
+export function resolveGoalKind(goal: Pick<Goal, 'goalKind'> | null | undefined): GoalKind {
+    return normalizeGoalKind(goal?.goalKind);
+}
+
+export function isDeliveryGoal(goal: Pick<Goal, 'goalKind'> | null | undefined): boolean {
+    return resolveGoalKind(goal) === 'delivery';
+}
+
+export function isMetricGoal(goal: Pick<Goal, 'goalKind'> | null | undefined): boolean {
+    return resolveGoalKind(goal) === 'metric';
+}
+
+/**
+ * Which metric-only fields the input actually SETS.
+ *
+ * `null` counts as absent by default — the wire contract says "absent or
+ * null" for a delivery Goal, and a client that serialises every optional
+ * field as `null` must not be rejected for it. `update` on a delivery Goal
+ * passes `treatNullAsPresent` because there `null` is a write ("clear the
+ * baseline") that has no meaning on a Goal without a metric.
+ */
+export function metricOnlyFieldsPresent(
+    input: Partial<Record<GoalMetricOnlyField, unknown>>,
+    opts: { treatNullAsPresent?: boolean } = {},
+): GoalMetricOnlyField[] {
+    return GOAL_METRIC_ONLY_FIELDS.filter((field) => {
+        const value = input[field];
+        if (value === undefined) return false;
+        if (value === null) return opts.treatNullAsPresent === true;
+        return true;
+    });
+}
+
+/**
+ * Validate a create payload against its kind, reporting EVERY problem at
+ * once. Returns a list rather than throwing so the calling service owns
+ * the exception type — the `validateGoalJudgment` / `validateDoDCriteria`
+ * idiom.
+ *
+ * For a metric Goal this is a presence check only; `GoalsService` still
+ * runs its per-field assertions (whose exact messages are pinned by the
+ * e2e validation matrix) BEFORE calling this, so the two never disagree
+ * and this layer is the fail-closed backstop.
+ */
+export function validateGoalKindInput(input: GoalKindShapeInput): GoalKindValidationError[] {
+    const kind =
+        input.goalKind === undefined || input.goalKind === null
+            ? DEFAULT_GOAL_KIND
+            : input.goalKind;
+    if (!isGoalKind(kind)) {
+        return [
+            {
+                field: 'goalKind',
+                message: `must be one of ${GOAL_KINDS.join(', ')}`,
+            },
+        ];
+    }
+    return kind === 'delivery' ? validateDeliveryGoalInput(input) : validateMetricGoalInput(input);
+}
+
+/** metric ⇒ all four metric fields + window required. */
+export function validateMetricGoalInput(
+    input: Partial<Record<GoalMetricOnlyField, unknown>>,
+): GoalKindValidationError[] {
+    const errors: GoalKindValidationError[] = [];
+    const source = input.metricSource;
+    if (typeof source !== 'object' || source === null || Array.isArray(source)) {
+        errors.push({ field: 'metricSource', message: 'is required for a metric Goal' });
+    }
+    if (!GOAL_COMPARATORS.includes(input.comparator as GoalComparator)) {
+        errors.push({
+            field: 'comparator',
+            message: `is required for a metric Goal (one of ${GOAL_COMPARATORS.join(', ')})`,
+        });
+    }
+    if (typeof input.targetValue !== 'number' || !Number.isFinite(input.targetValue)) {
+        errors.push({ field: 'targetValue', message: 'is required for a metric Goal' });
+    }
+    if (typeof input.unit !== 'string' || input.unit.trim().length === 0) {
+        errors.push({ field: 'unit', message: 'is required for a metric Goal' });
+    }
+    if (!GOAL_WINDOWS.includes(input.window as GoalWindow)) {
+        errors.push({
+            field: 'window',
+            message: `is required for a metric Goal (one of ${GOAL_WINDOWS.join(', ')})`,
+        });
+    }
+    return errors;
+}
+
+/**
+ * delivery ⇒ no metric-only field, and a Definition of Done with at least
+ * one approved criterion. Proposed (planner-authored, unapproved) entries
+ * are refused outright: `summarizeDoD` excludes them from the rollup, so a
+ * Goal born with nothing but proposals would have no finish line at all.
+ */
+export function validateDeliveryGoalInput(input: GoalKindShapeInput): GoalKindValidationError[] {
+    const errors: GoalKindValidationError[] = metricOnlyFieldsPresent(input).map((field) => ({
+        field,
+        message: 'must be omitted for a delivery Goal (delivery Goals carry no metric target)',
+    }));
+
+    const dod = input.dodCriteria;
+    if (!Array.isArray(dod) || dod.length === 0) {
+        errors.push({
+            field: 'dodCriteria',
+            message: 'a delivery Goal needs at least one Definition-of-Done criterion',
+        });
+        return errors;
+    }
+    const dodErrors = validateDoDCriteria(dod);
+    if (dodErrors.length > 0) {
+        return [...errors, ...dodErrors];
+    }
+    if ((dod as GoalDoDCriterion[]).some((entry) => entry.proposed === true)) {
+        errors.push({
+            field: 'dodCriteria',
+            message:
+                'a delivery Goal cannot be created with proposed (unapproved) criteria — every criterion must be approved',
+        });
+    }
+    return errors;
+}

--- a/packages/agent/src/goals/goal-orchestrator-rules.ts
+++ b/packages/agent/src/goals/goal-orchestrator-rules.ts
@@ -24,10 +24,13 @@ export interface GoalRoutingCandidate {
     /** Display name for the reasoning string; falls back to the id. */
     name?: string | null;
     /**
-     * Where the candidate came from — `assigned` (operator pin) or
-     * `history` (has already worked an iteration of this goal).
+     * Where the candidate came from — `assigned` (operator pin),
+     * `history` (has already worked an iteration of this goal), or
+     * `scope` (cold start: an eligible agent in the Goal's own
+     * Organization / tenant scope, offered only when there is no pin and
+     * no history — self-build slice AG, finding R1).
      */
-    source: 'assigned' | 'history';
+    source: 'assigned' | 'history' | 'scope';
 }
 
 export type GoalLoopAction =
@@ -55,7 +58,8 @@ export type GoalLoopReasonCode =
     | 'grace-period'
     | 'no-candidate-agent'
     | 'routed-assigned-agent'
-    | 'routed-round-robin';
+    | 'routed-round-robin'
+    | 'routed-scope-fallback';
 
 export interface GoalLoopDecision {
     action: GoalLoopAction;
@@ -110,7 +114,11 @@ const MS_PER_MINUTE = 60_000;
  *     the first one's workspace.
  *  7. **No candidate agent** → stuck. Honest degradation: a loop with
  *     nothing to route to is not "running", it is waiting on a human.
- *  8. Otherwise → dispatch, pinned agent first, else round-robin.
+ *     (The service already widened the pool to the Goal's scope for a
+ *     fresh Goal, so reaching here means the scope has no agent at all.)
+ *  8. Otherwise → dispatch, pinned agent first, else round-robin over
+ *     the history — or, for a fresh unpinned Goal, over the eligible
+ *     agents of its scope (`routed-scope-fallback`).
  *
  * `gracePeriodMinutes` extends the WALL-CLOCK limit only, and only while
  * an iteration is actually in flight: the point is to let a session that
@@ -219,8 +227,8 @@ export function decideGoalLoop(input: GoalLoopInput): GoalLoopDecision {
             action: 'stuck',
             reasonCode: 'no-candidate-agent',
             reasoning:
-                'No agent is available to run this Goal — assign an agent to the Goal (or run one ' +
-                'iteration manually) before the loop can route work.',
+                "No agent is available to run this Goal — create or assign an agent in this Goal's " +
+                'scope (or run one iteration manually) before the loop can route work.',
         };
     }
 
@@ -242,6 +250,23 @@ export function decideGoalLoop(input: GoalLoopInput): GoalLoopDecision {
     // iterations visit different agents and the sequence is reproducible
     // from the persisted counter alone (no hidden cursor to drift).
     const chosen = input.candidates[nextIteration % input.candidates.length];
+    if (chosen.source === 'scope') {
+        // Cold start: nobody has worked this Goal yet, so the service
+        // offered the eligible agents of the Goal's own scope. The log line
+        // says so explicitly — an operator must be able to tell "routed to
+        // the agent that already knows this Goal" from "routed to whoever
+        // is in the Organization".
+        return {
+            action: 'dispatch',
+            reasonCode: 'routed-scope-fallback',
+            agentId: chosen.agentId,
+            nextIteration,
+            reasoning:
+                `Routed iteration ${nextIteration} → ${label(chosen)}: the Goal pins no agent and no ` +
+                'agent has worked it yet, so the router round-robins over the ' +
+                `${input.candidates.length} eligible agent(s) in the Goal's scope.`,
+        };
+    }
     return {
         action: 'dispatch',
         reasonCode: 'routed-round-robin',

--- a/packages/agent/src/goals/goal-orchestrator.service.ts
+++ b/packages/agent/src/goals/goal-orchestrator.service.ts
@@ -11,6 +11,8 @@ import { In, IsNull, Repository } from 'typeorm';
 import {
     GOAL_EXECUTION_TARGETS,
     Goal,
+    GoalOutcome,
+    GoalStatus,
     type GoalDoDCriterion,
     type GoalExecutionTarget,
     type GoalLoopStatus,
@@ -37,10 +39,12 @@ import {
 } from '../database/ownership-scope';
 import {
     dodProgressSignature,
+    hasDefinitionOfDone,
     normalizeDoDCriteria,
     summarizeDoD,
     validateDoDCriteria,
 } from './goal-dod';
+import { isDeliveryGoal } from './goal-kind';
 import {
     decideGoalLoop,
     formatUsd,
@@ -75,6 +79,12 @@ export const MAX_NUDGE_CHARS = 2000;
 
 /** How many iteration Tasks one rollup will ever consider. */
 const MAX_GOAL_TASKS = 500;
+
+/**
+ * Cold-start pool bound: how many in-scope agents a fresh unpinned Goal
+ * round-robins over. Mirrors the default page `findByUserIdScoped` uses.
+ */
+const MAX_SCOPE_CANDIDATES = 50;
 
 const ACTIVE_RUN_STATUSES = ['queued', 'running'];
 
@@ -232,7 +242,13 @@ export class GoalOrchestratorService {
 
     // ─── Definition of Done ─────────────────────────────────────────
 
-    /** Replace the whole checklist (operator-authored, already approved). */
+    /**
+     * Replace the whole checklist (operator-authored, already approved).
+     *
+     * A DELIVERY Goal's checklist is its entire completion rule, so it can
+     * never be cleared or reduced to nothing approved — a delivery Goal
+     * with no finish line would be unfinishable, not "open-ended".
+     */
     async setDodCriteria(
         userId: string,
         goalId: string,
@@ -240,6 +256,14 @@ export class GoalOrchestratorService {
     ): Promise<GoalDto> {
         const goal = await this.findOrThrow(userId, goalId);
         this.assertDod(criteria);
+        if (
+            isDeliveryGoal(goal) &&
+            (criteria === null || !hasDefinitionOfDone({ dodCriteria: criteria }))
+        ) {
+            throw new BadRequestException(
+                'A delivery Goal must keep at least one approved Definition-of-Done criterion.',
+            );
+        }
         const beforeSignature = dodProgressSignature(goal.dodCriteria);
         goal.dodCriteria = criteria === null ? null : normalizeDoDCriteria(criteria);
         this.markProgressIfChanged(goal, beforeSignature);
@@ -408,6 +432,13 @@ export class GoalOrchestratorService {
         const goal = await this.findOrThrow(userId, goalId);
         if (goal.archivedAt) {
             throw new BadRequestException('Archived Goals cannot run an execution loop.');
+        }
+        if (isDeliveryGoal(goal) && !hasDefinitionOfDone(goal)) {
+            // Defensive: create + setDodCriteria already guarantee this, but a
+            // loop with no finish line would run until a budget stops it.
+            throw new BadRequestException(
+                'A delivery Goal needs at least one approved Definition-of-Done criterion before its loop can start.',
+            );
         }
         const resuming = goal.loopStatus === 'paused' || goal.loopStatus === 'stuck';
         goal.loopStatus = 'running';
@@ -884,7 +915,21 @@ export class GoalOrchestratorService {
         };
     }
 
-    /** Apply a terminal decision (done / paused / stuck) + log it. */
+    /**
+     * Apply a terminal decision (done / paused / stuck) + log it.
+     *
+     * For a DELIVERY Goal, `done` also completes the Goal itself
+     * (COMPLETED + ACHIEVED, schedule cleared): the approved DoD is its
+     * only completion rule, so whichever path observes it first — this
+     * loop or the evaluation tick — records the same terminal state, and
+     * both writes are idempotent on an already-completed row. A row that
+     * is ALREADY COMPLETED is left alone: a human outcome override
+     * (`abandoned`, FR-13) or a deadline `missed` recorded by the evaluation
+     * tick is never overwritten by the loop finishing late — the same way a
+     * metric Goal stops being evaluated once it is COMPLETED. A metric
+     * Goal's `status`/`outcome` stay untouched here: its loop finishing is
+     * not the same fact as its metric being reached.
+     */
     private async applyTerminal(
         goal: Goal,
         decision: GoalLoopDecision,
@@ -892,6 +937,11 @@ export class GoalOrchestratorService {
     ): Promise<GoalAdvanceResult> {
         goal.loopStatus = loopStatus;
         goal.activeAgentId = null;
+        if (loopStatus === 'done' && isDeliveryGoal(goal) && goal.status !== GoalStatus.COMPLETED) {
+            goal.status = GoalStatus.COMPLETED;
+            goal.outcome = GoalOutcome.ACHIEVED;
+            goal.nextCheckAt = null;
+        }
         const saved = await this.goals.save(goal);
 
         const kind: GoalEventKind = loopStatus === 'done' ? 'complete' : 'limit';
@@ -1037,6 +1087,20 @@ export class GoalOrchestratorService {
      * data alone. An agent that has been deleted (or belongs to someone
      * else) is dropped: routing must never offer what dispatch would
      * reject.
+     *
+     * **Cold start** (self-build slice AG, finding R1): a fresh unpinned
+     * Goal has no history, and until now that meant an EMPTY pool and
+     * `stuck / no-candidate-agent` on iteration 1 — the loop could only
+     * ever start after an operator pinned an agent. So when there is no
+     * pin and no history the pool falls back to the eligible agents of the
+     * Goal's own scope, through `AgentRepository.findByUserIdScoped` with
+     * `ownershipRelationScopeOf(goal)` — the same Organization / tenant
+     * rule `findByIdAndUser` applies to the pin and the dispatch path
+     * re-validates. An agent outside the Goal's scope is therefore never
+     * offered; an empty scope still yields `[]` and the honest `stuck`.
+     * The fallback is deliberately NOT taken when a pin exists but failed
+     * its scope check: an unhonoured explicit pin is the operator's to
+     * fix, not something to route around silently.
      */
     private async resolveCandidates(goal: Goal): Promise<GoalRoutingCandidate[]> {
         if (goal.assignedAgentId) {
@@ -1077,7 +1141,48 @@ export class GoalOrchestratorService {
                 source: 'history',
             });
         }
-        return [...out.values()];
+        if (out.size > 0 || goal.assignedAgentId || !this.agents) {
+            return [...out.values()];
+        }
+        return this.resolveScopeCandidates(goal);
+    }
+
+    /**
+     * The cold-start pool: every agent the Goal's owner may run inside the
+     * Goal's scope, oldest first.
+     *
+     * Ordered by `createdAt` then `id` IN MEMORY because the repository
+     * orders by `updatedAt DESC` — under which the iteration-keyed
+     * round-robin would pick a different agent every time any agent was
+     * edited, and the log line "round-robins over N agents" would stop
+     * being reproducible from the persisted counter. No status filter,
+     * matching `TasksService.listRunCandidates`: agents are created DRAFT
+     * and the whole point of this pool is that a freshly created agent
+     * can be picked. Archived agents are excluded by the repository.
+     */
+    private async resolveScopeCandidates(goal: Goal): Promise<GoalRoutingCandidate[]> {
+        if (!this.agents) return [];
+        // A repository failure PROPAGATES: `advanceDue` counts a throwing
+        // Goal as `failed` and retries it next tick, whereas swallowing it
+        // into `[]` would mark the loop `stuck` — a terminal state a human
+        // has to resume — over what was an infrastructure hiccup.
+        const { rows } = await this.agents.findByUserIdScoped(
+            goal.userId,
+            { limit: MAX_SCOPE_CANDIDATES },
+            ownershipRelationScopeOf(goal),
+        );
+        return [...rows]
+            .sort((a, b) => {
+                const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+                const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+                if (aTime !== bTime) return aTime - bTime;
+                return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+            })
+            .map((agent) => ({
+                agentId: agent.id,
+                name: agent.name ?? agent.slug ?? null,
+                source: 'scope' as const,
+            }));
     }
 
     /**
@@ -1096,6 +1201,12 @@ export class GoalOrchestratorService {
             `Iteration ${iteration} of the Goal "${goal.title}".`,
             '',
             goal.description ? `${goal.description}\n` : '',
+            ...(isDeliveryGoal(goal)
+                ? [
+                      'Delivery Goal — there is no metric; the checklist below is the whole definition of done.',
+                      '',
+                  ]
+                : []),
             `Definition of Done — ${summary.done} done, ${summary.waived} waived, ${summary.open} open:`,
             open.length > 0 ? open.join('\n') : '- (no open criteria recorded)',
             '',

--- a/packages/agent/src/goals/goals.service.ts
+++ b/packages/agent/src/goals/goals.service.ts
@@ -1,10 +1,12 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, Not, Repository, type FindOptionsWhere } from 'typeorm';
+import { DEFAULT_GOAL_KIND, GOAL_KINDS, isGoalKind, type GoalKind } from '@ever-works/contracts';
 import {
     Goal,
     GoalStatus,
     type GoalComparator,
+    type GoalDoDCriterion,
     type GoalMetricSource,
     type GoalOutcome,
     type GoalWindow,
@@ -14,6 +16,8 @@ import { MissionGoal } from '../entities/mission-goal.entity';
 import { Mission } from '../entities/mission.entity';
 import { GoalEvaluationService } from './goal-evaluation.service';
 import { validateGoalJudgment } from './goal-criteria';
+import { hasDefinitionOfDone, normalizeDoDCriteria, validateDoDCriteria } from './goal-dod';
+import { isDeliveryGoal, metricOnlyFieldsPresent, validateGoalKindInput } from './goal-kind';
 import {
     ownershipStamp,
     ownershipWhere,
@@ -149,14 +153,35 @@ export class GoalsService {
         return rows.map(toGoalMetricSampleDto);
     }
 
+    /**
+     * Create a Goal of either kind (self-build slice AG, EW-795).
+     *
+     * The kind decides the shape, and the check is FAIL-CLOSED both ways:
+     * a metric Goal (the default — every caller that never heard of kinds)
+     * still needs all four metric fields and is validated by exactly the
+     * per-field assertions it always was; a delivery Goal must carry none
+     * of them and at least one approved Definition-of-Done criterion; an
+     * unknown kind is refused. `validateGoalKindInput` then re-checks the
+     * chosen shape as one rule shared with the specs.
+     */
     async create(userId: string, input: CreateGoalInput, scope?: OwnershipScope): Promise<GoalDto> {
-        const metricSource = this.validateMetricSource(input.metricSource, {
-            requireProvider: false,
-        });
-        this.assertComparator(input.comparator);
-        this.assertWindow(input.window);
-        this.assertFiniteNumber(input.targetValue, 'targetValue');
-        this.assertJudgment({ criteria: input.criteria, constraints: input.constraints });
+        const goalKind = this.resolveWriteKind(input.goalKind);
+
+        let metricSource: GoalMetricSource | null = null;
+        if (goalKind === 'metric') {
+            // The legacy per-field assertions run FIRST and unchanged — their
+            // exact messages are pinned by the e2e validation matrix.
+            metricSource = this.validateMetricSource(input.metricSource, {
+                requireProvider: false,
+            });
+            this.assertComparator(input.comparator);
+            this.assertWindow(input.window);
+            this.assertFiniteNumber(input.targetValue, 'targetValue');
+            this.assertUnit(input.unit);
+            this.assertJudgment({ criteria: input.criteria, constraints: input.constraints });
+        }
+        this.assertGoalKindShape({ ...input, goalKind });
+        const dodCriteria = this.normalizeDodInput(input.dodCriteria);
 
         const saved = await this.goals.save(
             this.goals.create({
@@ -164,21 +189,40 @@ export class GoalsService {
                 ...ownershipStamp(scope),
                 title: input.title.trim().slice(0, 200),
                 description: input.description?.trim() || null,
-                metricSource,
-                comparator: input.comparator,
-                targetValue: input.targetValue,
-                unit: input.unit.trim().slice(0, 32),
-                window: input.window,
-                baselineValue: input.baselineValue ?? null,
+                goalKind,
+                ...(goalKind === 'metric'
+                    ? {
+                          metricSource,
+                          comparator: input.comparator,
+                          targetValue: input.targetValue,
+                          unit: (input.unit as string).trim().slice(0, 32),
+                          window: input.window as GoalWindow,
+                          baselineValue: input.baselineValue ?? null,
+                          // Judgment layer G1 - additive. Omitted stays NULL,
+                          // which IS the single-metric Goal this service
+                          // already created.
+                          criteria: input.criteria ?? null,
+                          constraints: input.constraints ?? null,
+                      }
+                    : {
+                          // A delivery Goal carries no metric at all. `window`
+                          // stays NOT NULL at the column level and is never
+                          // read for this kind.
+                          metricSource: null,
+                          comparator: null,
+                          targetValue: null,
+                          unit: null,
+                          window: 'total' as GoalWindow,
+                          baselineValue: null,
+                          criteria: null,
+                          constraints: null,
+                      }),
                 deadline: input.deadline ?? null,
                 checkFrequencyMinutes: this.clampFrequency(input.checkFrequencyMinutes),
                 nextCheckAt: null,
                 status: GoalStatus.DRAFT,
                 outcome: null,
-                // Judgment layer G1 - additive. Omitted stays NULL, which
-                // IS the single-metric Goal this service already created.
-                criteria: input.criteria ?? null,
-                constraints: input.constraints ?? null,
+                dodCriteria,
             }),
         );
         return toGoalDto(saved);
@@ -199,6 +243,18 @@ export class GoalsService {
         scope?: OwnershipScope,
     ): Promise<GoalDto> {
         const existing = await this.findOrThrow(userId, goalId, scope);
+
+        if (isDeliveryGoal(existing)) {
+            // The kind is immutable and a delivery Goal has no metric: any
+            // attempt to give it one (even `null`, which is a "clear" write
+            // on a metric Goal) is a client error, not a no-op.
+            const offending = metricOnlyFieldsPresent(input, { treatNullAsPresent: true });
+            if (offending.length > 0) {
+                throw new BadRequestException(
+                    `Delivery Goals carry no metric target; ${offending.join(', ')} cannot be set.`,
+                );
+            }
+        }
 
         if (input.title !== undefined) existing.title = input.title.trim().slice(0, 200);
         if (input.description !== undefined) {
@@ -284,12 +340,17 @@ export class GoalsService {
     // ─── lifecycle ──────────────────────────────────────────────────
 
     /**
-     * DRAFT | PAUSED | COMPLETED → ACTIVE. Requires an evaluable
-     * `metricSource` (explicit pluginId + metricId — spec FR-3:
-     * multiple providers may be enabled, so a Goal always names its
-     * provider). Re-activating a COMPLETED Goal clears its outcome.
-     * `nextCheckAt` is set to "now" so the next dispatcher tick
-     * evaluates immediately.
+     * DRAFT | PAUSED | COMPLETED → ACTIVE.
+     *
+     * A metric Goal requires an evaluable `metricSource` (explicit
+     * pluginId + metricId — spec FR-3: multiple providers may be enabled,
+     * so a Goal always names its provider). A delivery Goal requires at
+     * least one APPROVED Definition-of-Done criterion — without one it has
+     * no finish line to evaluate against. Re-activating a COMPLETED Goal
+     * clears its outcome. `nextCheckAt` is set to "now" for BOTH kinds so
+     * the next dispatcher tick evaluates immediately: for a delivery Goal
+     * that tick reads no provider, it only re-checks the DoD and the
+     * deadline (so deadline → MISSED still works without a plugin).
      */
     async activate(userId: string, goalId: string, scope?: OwnershipScope): Promise<GoalDto> {
         const existing = await this.findOrThrow(userId, goalId, scope);
@@ -298,7 +359,15 @@ export class GoalsService {
                 `Goal cannot be activated from status "${existing.status}". Allowed: ${ACTIVATABLE_STATUSES.join(', ')}.`,
             );
         }
-        this.validateMetricSource(existing.metricSource, { requireProvider: true });
+        if (isDeliveryGoal(existing)) {
+            if (!hasDefinitionOfDone(existing)) {
+                throw new BadRequestException(
+                    'Delivery Goals need at least one approved Definition-of-Done criterion before activation.',
+                );
+            }
+        } else {
+            this.validateMetricSource(existing.metricSource, { requireProvider: true });
+        }
         existing.status = GoalStatus.ACTIVE;
         existing.outcome = null;
         existing.nextCheckAt = new Date();
@@ -323,7 +392,8 @@ export class GoalsService {
      * `nextCheckAt` schedule but NOT the budget guard — the metric
      * read goes through the same `MetricsFacadeService.getMetricValue`
      * path as a scheduled evaluation. Only ACTIVE Goals can be
-     * evaluated (activation is what validates the metric source).
+     * evaluated (activation is what validates the metric source). For a
+     * delivery Goal the tick reads no provider; it re-checks the DoD.
      */
     async evaluateNow(
         userId: string,
@@ -519,7 +589,6 @@ export class GoalsService {
         return row;
     }
 
-    /** Spec FR-12 — clamp to ≥ 15 minutes; default 60. */
     /**
      * Judgment layer G1 - reject an invalid criteria/constraint payload
      * with EVERY problem at once. The helper returns a list rather than
@@ -533,6 +602,54 @@ export class GoalsService {
         }
     }
 
+    /**
+     * WRITE-path kind resolution: omitted means `metric` (every caller
+     * that predates kinds), anything not in the vocabulary is refused. No
+     * coercion here — that is `normalizeGoalKind`'s job on READ paths only.
+     */
+    private resolveWriteKind(value: GoalKind | undefined): GoalKind {
+        const kind = value === undefined || value === null ? DEFAULT_GOAL_KIND : value;
+        if (!isGoalKind(kind)) {
+            throw new BadRequestException(
+                `Invalid goalKind "${String(kind)}". Allowed: ${GOAL_KINDS.join(', ')}.`,
+            );
+        }
+        return kind;
+    }
+
+    /** The per-kind shape rule (`goal-kind.ts`), reported all at once. */
+    private assertGoalKindShape(input: Parameters<typeof validateGoalKindInput>[0]): void {
+        const errors = validateGoalKindInput(input);
+        if (errors.length > 0) {
+            throw new BadRequestException(errors.map((e) => `${e.field}: ${e.message}`).join('; '));
+        }
+    }
+
+    /**
+     * Validate + canonicalise a submitted Definition of Done for the
+     * create path. Absent → NULL (no checklist, which is the metric Goal
+     * this service always created). The delivery-kind requirement of at
+     * least one approved entry is enforced by `assertGoalKindShape`.
+     */
+    private normalizeDodInput(
+        criteria: GoalDoDCriterion[] | null | undefined,
+    ): GoalDoDCriterion[] | null {
+        if (criteria === undefined || criteria === null) return null;
+        const errors = validateDoDCriteria(criteria);
+        if (errors.length > 0) {
+            throw new BadRequestException(errors.map((e) => `${e.field}: ${e.message}`).join('; '));
+        }
+        return criteria.length === 0 ? null : normalizeDoDCriteria(criteria);
+    }
+
+    private assertUnit(value: unknown): void {
+        if (typeof value !== 'string' || value.trim().length === 0) {
+            throw new BadRequestException('unit must be a non-empty string.');
+        }
+    }
+
+    /** Spec FR-12 — clamp to ≥ 15 minutes; default 60. */
+
     private clampFrequency(minutes: number | undefined): number {
         if (minutes === undefined || minutes === null) return DEFAULT_CHECK_FREQUENCY_MINUTES;
         if (!Number.isInteger(minutes)) {
@@ -542,10 +659,11 @@ export class GoalsService {
     }
 
     /**
-     * Validate + normalize the metric source. `requireProvider`
-     * hardens the activation path: a DRAFT goal may be sketched with
-     * placeholder ids, but activation (and any edit while ACTIVE)
-     * demands a concrete pluginId + metricId.
+     * Validate + normalize the metric source — METRIC Goals only; a
+     * delivery Goal never reaches this (its `metricSource` is NULL by
+     * rule). `requireProvider` hardens the activation path: a DRAFT goal
+     * may be sketched with placeholder ids, but activation (and any edit
+     * while ACTIVE) demands a concrete pluginId + metricId.
      */
     private validateMetricSource(
         value: unknown,

--- a/packages/agent/src/goals/index.ts
+++ b/packages/agent/src/goals/index.ts
@@ -6,6 +6,7 @@ export * from './goal-evaluation.service';
 export * from './goal-orchestrator.service';
 export * from './goal-orchestrator-rules';
 export * from './goal-dod';
+export * from './goal-kind';
 export * from './goals.module';
 export * from './types';
 export * from './goal-criteria';
@@ -13,6 +14,8 @@ export {
     Goal,
     GoalStatus,
     GoalOutcome,
+    GOAL_KINDS,
+    type GoalKind,
     GOAL_CONSTRAINT_CATEGORIES,
     GOAL_DOD_STATUSES,
     GOAL_DOD_SOURCES,

--- a/packages/agent/src/goals/types.ts
+++ b/packages/agent/src/goals/types.ts
@@ -1,3 +1,4 @@
+import { normalizeGoalKind, type GoalKind } from '@ever-works/contracts';
 import type {
     Goal,
     GoalComparator,
@@ -39,10 +40,14 @@ export interface GoalDto {
     organizationId: string | null;
     title: string;
     description: string | null;
-    metricSource: GoalMetricSource;
-    comparator: GoalComparator;
-    targetValue: number;
-    unit: string;
+    /** `metric` (default) | `delivery` — see the entity docblock. */
+    goalKind: GoalKind;
+    // The four metric fields are `null` on a delivery Goal and always set
+    // on a metric Goal.
+    metricSource: GoalMetricSource | null;
+    comparator: GoalComparator | null;
+    targetValue: number | null;
+    unit: string | null;
     window: GoalWindow;
     baselineValue: number | null;
     currentValue: number | null;
@@ -91,10 +96,13 @@ export function toGoalDto(goal: Goal): GoalDto {
         organizationId: goal.organizationId ?? null,
         title: goal.title,
         description: goal.description ?? null,
-        metricSource: goal.metricSource,
-        comparator: goal.comparator,
-        targetValue: goal.targetValue,
-        unit: goal.unit,
+        // Read-path normalisation: a row from before the column (or one
+        // written by a newer server) renders as the metric Goal it is.
+        goalKind: normalizeGoalKind(goal.goalKind),
+        metricSource: goal.metricSource ?? null,
+        comparator: goal.comparator ?? null,
+        targetValue: goal.targetValue ?? null,
+        unit: goal.unit ?? null,
         window: goal.window,
         baselineValue: goal.baselineValue ?? null,
         currentValue: goal.currentValue ?? null,
@@ -179,17 +187,23 @@ export function toMissionGoalLinkDto(link: MissionGoal, goal?: Goal | null): Mis
  * Input shape for `GoalsService.create`. Validation of primitive
  * shapes lives at the DTO layer (`CreateGoalDto` in apps/api);
  * the service re-validates the semantic rules (comparator/window
- * membership, metricSource shape, ≥15-minute clamp) as the single
- * source of truth.
+ * membership, metricSource shape, ≥15-minute clamp, the per-kind
+ * shape in `goal-kind.ts`) as the single source of truth.
+ *
+ * The metric fields are optional at the TYPE level only because a
+ * delivery Goal omits them; a metric Goal (the default) is refused
+ * without every one of them, exactly as before the kind existed.
  */
 export interface CreateGoalInput {
     title: string;
     description?: string | null;
-    metricSource: GoalMetricSource;
-    comparator: GoalComparator;
-    targetValue: number;
-    unit: string;
-    window: GoalWindow;
+    /** Omitted = `metric`. Immutable after create. */
+    goalKind?: GoalKind;
+    metricSource?: GoalMetricSource | null;
+    comparator?: GoalComparator | null;
+    targetValue?: number | null;
+    unit?: string | null;
+    window?: GoalWindow | null;
     baselineValue?: number | null;
     deadline?: Date | null;
     checkFrequencyMinutes?: number;
@@ -197,6 +211,12 @@ export interface CreateGoalInput {
     criteria?: GoalCriterion[] | null;
     /** Judgment layer G1 - constraints that must hold. */
     constraints?: GoalConstraint[] | null;
+    /**
+     * Definition of Done. REQUIRED (≥ 1 approved criterion) for a delivery
+     * Goal — it is the whole completion rule; an optional seed checklist
+     * for a metric Goal.
+     */
+    dodCriteria?: GoalDoDCriterion[] | null;
 }
 
 /**
@@ -343,6 +363,7 @@ export interface GoalAdvanceSummary {
 export interface GoalEvaluationEntry {
     goalId: string;
     outcome: 'evaluated' | 'achieved' | 'missed' | 'skipped' | 'failed';
+    /** The observed metric value. Absent for a delivery Goal — nothing is read. */
     value?: number;
     message?: string;
     /**

--- a/packages/contracts/src/domain/__tests__/goal-kind.spec.ts
+++ b/packages/contracts/src/domain/__tests__/goal-kind.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_GOAL_KIND, GOAL_KINDS, isDeliveryGoalKind, isGoalKind, normalizeGoalKind } from '../index.js';
+
+/**
+ * Goal kind vocabulary (self-build slice AG, EW-795).
+ *
+ * The list is shared by the API DTO, the service, the MCP schema and the
+ * web form; pinning its members here means adding a kind is a deliberate
+ * multi-surface change rather than a silent widening.
+ */
+describe('GOAL_KINDS', () => {
+	it('exposes exactly the two kinds the platform completes differently', () => {
+		expect([...GOAL_KINDS]).toEqual(['metric', 'delivery']);
+	});
+
+	it('defaults to metric — what every pre-existing Goal row is', () => {
+		expect(DEFAULT_GOAL_KIND).toBe('metric');
+	});
+});
+
+describe('isGoalKind (write paths — fail closed)', () => {
+	it.each(['metric', 'delivery'])('accepts %s', (value) => {
+		expect(isGoalKind(value)).toBe(true);
+	});
+
+	it.each(['Metric', ' delivery ', 'outcome', '', null, undefined, 42, {}])(
+		'rejects %j without coercing',
+		(value) => {
+			expect(isGoalKind(value)).toBe(false);
+		}
+	);
+});
+
+describe('normalizeGoalKind (read paths — never throws)', () => {
+	it('returns the canonical kind for loose spellings', () => {
+		expect(normalizeGoalKind('delivery')).toBe('delivery');
+		expect(normalizeGoalKind(' Delivery ')).toBe('delivery');
+		expect(normalizeGoalKind('METRIC')).toBe('metric');
+	});
+
+	it('falls back to metric for unknown, empty or missing values', () => {
+		expect(normalizeGoalKind('outcome')).toBe('metric');
+		expect(normalizeGoalKind('')).toBe('metric');
+		expect(normalizeGoalKind(null)).toBe('metric');
+		expect(normalizeGoalKind(undefined)).toBe('metric');
+	});
+});
+
+describe('isDeliveryGoalKind', () => {
+	it('is true only for the delivery kind', () => {
+		expect(isDeliveryGoalKind('delivery')).toBe(true);
+		expect(isDeliveryGoalKind('metric')).toBe(false);
+		expect(isDeliveryGoalKind(undefined)).toBe(false);
+	});
+});

--- a/packages/contracts/src/domain/goal-kind.ts
+++ b/packages/contracts/src/domain/goal-kind.ts
@@ -1,0 +1,60 @@
+/**
+ * Goal "kind" vocabulary — the single source of truth shared by the API,
+ * the agent package, the MCP server and the web app.
+ *
+ * Lives in `@ever-works/contracts` for the same reason `work-kind.ts` does:
+ * `apps/web` deliberately does not depend on `@ever-works/agent`, and
+ * contracts is the only package every side imports. The Goal entity
+ * (`packages/agent/src/entities/goal.entity.ts`) re-exports from here so
+ * there is exactly one list to extend when a new kind ships.
+ *
+ *   - `metric`   — the original Goal: reads a number from a metrics-provider
+ *                  plugin on a schedule and completes when the comparator is
+ *                  satisfied against `targetValue`. Every row that predates
+ *                  the `goalKind` column is a metric Goal.
+ *   - `delivery` — "ship feature X across three repos": there is NO metric,
+ *                  no comparator and no target value. The Goal completes on
+ *                  its approved Definition of Done alone — every approved
+ *                  criterion done or waived — and is otherwise driven by the
+ *                  same iteration loop and budget rules as a metric Goal.
+ */
+export const GOAL_KINDS = ['metric', 'delivery'] as const;
+
+export type GoalKind = (typeof GOAL_KINDS)[number];
+
+/** The column default, and what every pre-existing Goal row reads as. */
+export const DEFAULT_GOAL_KIND: GoalKind = 'metric';
+
+const GOAL_KIND_SET: ReadonlySet<string> = new Set<string>(GOAL_KINDS);
+
+/**
+ * Type guard for WRITE paths. Fail closed: an unknown kind is rejected by
+ * the caller, never coerced — a Goal that is neither metric nor delivery
+ * has no completion rule and must not be persisted.
+ */
+export function isGoalKind(value: unknown): value is GoalKind {
+	return typeof value === 'string' && GOAL_KIND_SET.has(value);
+}
+
+/**
+ * Coerce an arbitrary value into a known `GoalKind` for READ paths only.
+ *
+ * `goals.goalKind` is `varchar(16)`, so a row written by a newer server (or
+ * by hand) may carry a value this build does not know. Rendering it as the
+ * generic `metric` behaviour is the safe default for a display surface; a
+ * write path must use {@link isGoalKind} instead.
+ *
+ * NEVER throws.
+ */
+export function normalizeGoalKind(value?: string | null): GoalKind {
+	if (typeof value !== 'string') {
+		return DEFAULT_GOAL_KIND;
+	}
+	const normalized = value.trim().toLowerCase();
+	return GOAL_KIND_SET.has(normalized) ? (normalized as GoalKind) : DEFAULT_GOAL_KIND;
+}
+
+/** True when `value` names the Delivery kind. Accepts loose input; never throws. */
+export function isDeliveryGoalKind(value?: string | null): boolean {
+	return normalizeGoalKind(value) === 'delivery';
+}

--- a/packages/contracts/src/domain/index.ts
+++ b/packages/contracts/src/domain/index.ts
@@ -1,4 +1,5 @@
 export * from './domain.types.js';
 export * from './work-kind.js';
+export * from './goal-kind.js';
 export * from './work-metrics.js';
 export * from './work-capabilities.js';


### PR DESCRIPTION
## Summary

Phase-2 slice **AG** (program note §6, finding R1). Refs **EW-795**. No slice dependencies.

"Ship feature X across three repos" could not be represented: `Goal` declared `metricSource`, `comparator`, `targetValue` and `unit` **NOT NULL**, so the only multi-iteration autonomous driver on the platform demanded a metrics plugin and a numeric target. And the cold start was broken — `resolveCandidates` only returned agents that already had an iteration Task, so a fresh unpinned Goal went straight to `stuck` / `no-candidate-agent` on iteration 1.

### What changes

- **`goalKind` discriminator** (`metric` | `delivery`) in contracts, with `isGoalKind` on write paths (fail closed, never coerce) and `normalizeGoalKind` on read paths. Entity: `goal_kind varchar(16) NOT NULL DEFAULT 'metric'`, the four metric columns nullable, `window` still NOT NULL (delivery rows store `'total'`).
- **Migration `1788700000000-AddGoalKind`**: `ADD COLUMN … DEFAULT 'metric'` backfills every existing row in the same ALTER; NOT NULL relaxed via a cloned descriptor (precedent `1781200000000`); guarded, idempotent, indexes survive; symmetric `down()`.
- **Per-kind validation, fail closed on both sides.** A metric Goal still requires all four metric fields — every pre-existing validator is kept behind `@ValidateIf(isMetricKind)`, so the e2e matrix's pinned messages are byte-identical (a missing `metricSource` still reaches the service's `metricSource must be an object.`). A delivery Goal is refused with any metric-only field, without a definition of done, or with a proposed-only DoD, at the DTO **and** the service.
- **Delivery completion is the approved DoD alone.** Both completion paths gate on `summarizeDoD(...).complete`, which counts approved criteria only and requires zero open, so a pending-only or empty DoD can never complete; no writer can empty the approved set (`setDodCriteria` refuses, `propose` only appends, `approve` only approves). Metric Goals are untouched; evaluation additionally fails closed on a metric row carrying a NULL metric field.
- **Cold start**: with no pin and no history, candidates fall back to the eligible agents of the Goal's own scope (`AgentRepository.findByUserIdScoped` + the platform ownership predicate, so never another user's or another Organization's agent), deterministic (sorted by `createdAt`,`id`; round-robin on the persisted iteration counter) and bounded at 50. An unhonoured pin still yields no candidate rather than silently widening. Repository errors propagate for the next tick instead of becoming a terminal stuck.
- **Surfaces**: API DTOs with per-kind Swagger rules, MCP goal schemas (OpenAPI pass-throughs to the same DTO), the Goals create form (kind selector; metric sections and DoD textarea switched by kind; **no metric key is emitted at all** for delivery, pinned by spec including stale input typed before switching kinds), goal detail / cards / mission panel branch on the kind, 14 new keys in all 21 locales. `docs/features/goals.md`.

### Adversarial review (fixed before this PR)

- `applyTerminal('done')` on a delivery Goal wrote COMPLETED/ACHIEVED unconditionally, so a loop finishing late could overwrite a human `abandoned` override or a deadline-recorded `missed` (a metric Goal never flips like that because evaluation stops at COMPLETED). Now guarded on the current status, with two specs.
- Also closed: a DTO/service asymmetry that let a delivery body with all-proposed criteria through the DTO; `undefined.trim()` on a missing unit turned from a 500 into a 400.
- Reviewed and holding: every metric-field consumer across agent, api, mcp and web branches or guards before dereferencing; cold-start scoping cannot cross a user or Organization.

### Please confirm

The migration's `down()` **deletes delivery rows** before re-tightening NOT NULL — documented feature-removal data loss, the same posture as `AddGoalOrchestration`. Every FK to `goals` is ON DELETE CASCADE, so the revert completes. No delivery row can predate the feature, so the reviewer's call is only whether a revert may drop them.

### Verified locally

| Check | Result |
| --- | --- |
| `packages/agent` goals + digest | 9 suites / 326 tests |
| `apps/api` goal DTOs + whole migrations tree | 36 suites / 186 tests |
| `packages/contracts` full vitest + typecheck | 32 files / 1533 tests, no type errors |
| `apps/web` goals + missions unit | 8 files / 96 tests |
| `apps/web` `tsc --noEmit` | exit 0 |
| `prettier --check` on all 59 files | clean |
| i18n | 14 new keys present in all 20 non-English locales, no dotted leaf names |

### Not verified locally

- `apps/api` `tsc` cannot type-check `goals.controller.ts` here because `packages/agent/dist` is stale (no `goalKind`) and cannot be rebuilt in this worktree; CI's `turbo ^build` does. Verified against the real source with a temporary path mapping: zero errors.
- `campaign-activation.service.spec.ts` fails to load on the pre-existing unbuilt `@ever-works/agent-plugins` (same family as the fleet planner/reconciler specs); the slice's change there is a one-line nullable fallback.
- e2e never runs locally; no `next build` (form and detail components changed, no route added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Delivery Goals alongside Metric Goals.
  * Create Delivery Goals with Definition-of-Done checklists instead of metric targets.
  * Added kind badges, checklist progress, and delivery-specific details across goal cards, details, missions, and agent summaries.
  * New goals without a pinned agent can route through eligible agents in scope.

* **Bug Fixes**
  * Improved validation for goal kinds, checklist requirements, and metric targets.
  * Preserved existing Metric Goal behavior and support for older goals.

* **Documentation**
  * Updated Goals documentation and localized interface text across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->