### PR TITLE
fix(ci): a failed artifact upload must not fail a green e2e shard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -474,6 +474,19 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
+        # A DIAGNOSTIC must never decide whether the shard passed. This step
+        # runs `if: always()`, so without this line anything that stops the
+        # upload — most cheaply the account's artifact storage quota, which
+        # is shared and recalculated only every 6-12 hours — fails the step
+        # and takes a fully green shard down with it.
+        #
+        # Observed on stage run 33962668128 (2026-09-05): shards 21 and 31
+        # reported `failure` with "Artifact storage quota has been hit" while
+        # their tests read `225 passed / 1 flaky` and `211 passed`. The
+        # promotion gate reads those conclusions, so a quota problem in one
+        # account presents as a broken product and invites an override label
+        # for a release that never needed one.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           # Per-shard artifact name so the 4 parallel uploads don't clobber.
@@ -486,6 +499,10 @@ jobs:
 
       - name: Upload server logs on failure
         if: failure()
+        # Same reasoning, and it compounds: once the report upload above has
+        # failed the job, THIS step's `if: failure()` becomes true, so a
+        # green shard uploads server logs it does not need and fails twice.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: server-logs-${{ steps.tag.outputs.tag }}-shard${{ matrix.shard }}-${{ github.run_attempt }}


### PR DESCRIPTION
## What happened

Stage run [33962668128](https://github.com/ever-works/ever-works/actions/runs/33962668128) reported shards 21 and 31 as `failure`. Their tests were green:

| Shard | Test result | Failing steps |
|---|---|---|
| 21 | `225 passed`, 1 flaky (passed on retry) | Upload Playwright report, Upload server logs on failure |
| 31 | `211 passed` | Upload Playwright report, Upload server logs on failure |

One annotation explains both:

```
Failed to CreateArtifact: Artifact storage quota has been hit.
Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
```

## Why it matters more than it looks

"Upload Playwright report" runs `if: always()` and had no `continue-on-error`, so a quota problem — **account-level, shared, and self-clearing only every 6-12 hours** — fails the step and takes the whole shard with it. It then compounds: once the job is failing, the `if: failure()` server-log upload runs too and fails identically.

That job conclusion is exactly what `promotion-gate.yml` reads at the `stage → main` gate. So an artifact quota problem in one account presents as **a broken product**, and the natural response is to reach for the `override-e2e-gate` label on a release that never needed one. That is the failure mode worth removing: a diagnostic deciding whether the shard passed.

## The change

`continue-on-error: true` on both uploads. A failed upload still surfaces as a warning annotation on the step; it no longer changes the verdict. One file, two lines, plus the reasoning in comments so the next person does not "tidy" them away.

## Deliberately not done here

The report upload runs `if: always()`, so **every** shard of **every** run uploads a report with 14-day retention — 33 shards per run is very likely what exhausted the quota in the first place. Narrowing that to `if: failure()`, or shortening retention, would cut usage sharply and keep the diagnostic where it is actually used.

I have not made that call: it removes the ability to inspect a green run's trace, which is a real capability someone may rely on. It is worth a decision, and the underlying quota still needs clearing on the account side either way — this PR only stops it from lying about the tests.
