### PR TITLE
feat(fleet): worker state on the heartbeat, offline notices, honest drawer (EW-776)

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-node-history.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-node-history.spec.ts
@@ -1,0 +1,223 @@
+import { FLEET_JOB_MAX_ERROR_LENGTH } from '@ever-works/contracts';
+import type { FleetNodeJobHistoryEntry } from '@ever-works/contracts';
+import {
+    buildNodeJobHistory,
+    isFailedNodeHistoryEntry,
+    nodeHistoryRunIds,
+    type ReconcilableRun,
+} from '../fleet-node-history';
+
+/**
+ * The node drawer's history composition (fleet health signals, EW-776).
+ *
+ * Three defects are pinned here, and one of them is a disclosure risk
+ * rather than a display bug:
+ *
+ *  - a job whose RUN failed used to render as a calm "done", because the
+ *    drawer only ever saw the job status;
+ *  - a failed job showed a red badge and no reason, because the error
+ *    text never left the server;
+ *  - `payload` — executor input composed from user content, bounded only
+ *    by `FLEET_JOB_MAX_PAYLOAD_BYTES` — was on the wire of a settings
+ *    endpoint for no one to render. It is stripped here rather than
+ *    "just not rendered", so nothing downstream can start rendering it.
+ */
+
+const RUN_ID = '99999999-9999-4999-8999-999999999999';
+const TASK_ID = '88888888-8888-4888-8888-888888888888';
+const AGENT_ID = '77777777-7777-4777-8777-777777777777';
+
+const job = (over: Partial<FleetNodeJobHistoryEntry> = {}): FleetNodeJobHistoryEntry =>
+    ({
+        id: 'job-1',
+        kind: 'agent-task',
+        status: 'done',
+        nodeId: 'node-1',
+        targetNodeId: null,
+        requiredCapabilities: [],
+        payload: { runId: RUN_ID, taskId: TASK_ID, agentId: AGENT_ID },
+        leaseExpiresAt: null,
+        attempts: 1,
+        maxAttempts: 3,
+        createdAt: null,
+        startedAt: null,
+        completedAt: null,
+        leaseGeneration: 1,
+        ...over,
+    }) as FleetNodeJobHistoryEntry;
+
+const run = (over: Partial<ReconcilableRun> = {}): ReconcilableRun => ({
+    id: RUN_ID,
+    status: 'completed',
+    summary: 'Added the missing guard and a spec',
+    errorMessage: null,
+    ...over,
+});
+
+describe('buildNodeJobHistory', () => {
+    it('never lets the payload reach the wire', () => {
+        const secret = { runId: RUN_ID, taskId: TASK_ID, instructions: 'PAYLOAD-SENTINEL' };
+
+        const [entry] = buildNodeJobHistory([job({ payload: secret })]);
+
+        expect(entry.payload).toBeNull();
+        expect(JSON.stringify(entry)).not.toContain('PAYLOAD-SENTINEL');
+    });
+
+    it('replaces it with an IDS-ONLY summary an operator can follow', () => {
+        const [entry] = buildNodeJobHistory([job()]);
+
+        expect(entry.summary).toEqual({
+            kind: 'agent-task',
+            taskId: TASK_ID,
+            runId: RUN_ID,
+            agentId: AGENT_ID,
+        });
+    });
+
+    it('maps the reconciled run outcome onto the row', () => {
+        const [entry] = buildNodeJobHistory(
+            [job()],
+            new Map([[RUN_ID, run({ status: 'failed', errorMessage: 'model refused the plan' })]]),
+        );
+
+        expect(entry.reconciled).toEqual({
+            runId: RUN_ID,
+            status: 'failed',
+            summary: 'Added the missing guard and a spec',
+            error: 'model refused the plan',
+        });
+    });
+
+    it('surfaces a FAILED run behind a job the node called done', () => {
+        // The whole point: the job settled fine and the run did not, and
+        // the drawer used to show only the first half.
+        const [entry] = buildNodeJobHistory(
+            [job({ status: 'done' })],
+            new Map([[RUN_ID, run({ status: 'failed', summary: null, errorMessage: 'blew up' })]]),
+        );
+
+        expect(entry.status).toBe('done');
+        expect(entry.reconciled?.status).toBe('failed');
+        expect(entry.reconciled?.error).toBe('blew up');
+    });
+
+    it('reports reconciled: null when the run could not be read', () => {
+        // The run read is best-effort at the edge. "Not known" must never
+        // be dressed up as an outcome.
+        const [entry] = buildNodeJobHistory([job()], new Map());
+
+        expect(entry.reconciled).toBeNull();
+    });
+
+    it('reports reconciled: null for a job that carries no run at all', () => {
+        const [entry] = buildNodeJobHistory([
+            job({ kind: 'acceptance-checks', payload: { workId: 'w1' } }),
+        ]);
+
+        expect(entry.reconciled).toBeNull();
+        expect(entry.summary).toEqual({
+            kind: 'acceptance-checks',
+            taskId: null,
+            runId: null,
+            agentId: null,
+        });
+    });
+
+    it("passes the job's own error text through", () => {
+        const [entry] = buildNodeJobHistory([
+            job({ status: 'failed', error: 'pnpm install exploded' }),
+        ]);
+
+        expect(entry.error).toBe('pnpm install exploded');
+    });
+
+    it('caps both error texts at the contract bound', () => {
+        const long = 'x'.repeat(FLEET_JOB_MAX_ERROR_LENGTH + 500);
+
+        const [entry] = buildNodeJobHistory(
+            [job({ status: 'failed', error: long })],
+            new Map([[RUN_ID, run({ status: 'failed', errorMessage: long })]]),
+        );
+
+        expect(entry.error).toHaveLength(FLEET_JOB_MAX_ERROR_LENGTH);
+        expect(entry.reconciled?.error).toHaveLength(FLEET_JOB_MAX_ERROR_LENGTH);
+    });
+
+    it('normalises an unrecognised run status instead of leaking it', () => {
+        const [entry] = buildNodeJobHistory(
+            [job()],
+            new Map([[RUN_ID, run({ status: 'archived' as never })]]),
+        );
+
+        expect(entry.reconciled?.status).toBe('queued');
+    });
+
+    it('treats blank text as absent rather than rendering an empty reason', () => {
+        const [entry] = buildNodeJobHistory(
+            [job({ error: '   ' })],
+            new Map([[RUN_ID, run({ summary: '', errorMessage: '  ' })]]),
+        );
+
+        expect(entry.error).toBeNull();
+        expect(entry.reconciled?.summary).toBeNull();
+        expect(entry.reconciled?.error).toBeNull();
+    });
+
+    it('keeps every other job field untouched', () => {
+        const [entry] = buildNodeJobHistory([
+            job({ id: 'job-9', attempts: 3, queuedReason: 'waiting-for-runner' }),
+        ]);
+
+        expect(entry.id).toBe('job-9');
+        expect(entry.attempts).toBe(3);
+        expect(entry.queuedReason).toBe('waiting-for-runner');
+    });
+});
+
+describe('nodeHistoryRunIds', () => {
+    it('collects the run ids the page correlates to', () => {
+        expect(nodeHistoryRunIds([job()])).toEqual([RUN_ID]);
+    });
+
+    it('deduplicates — a retried Task appears as several jobs on one run', () => {
+        expect(nodeHistoryRunIds([job({ id: 'a' }), job({ id: 'b' })])).toEqual([RUN_ID]);
+    });
+
+    it('ignores jobs that carry no run', () => {
+        expect(nodeHistoryRunIds([job({ kind: 'acceptance-checks', payload: null })])).toEqual([]);
+    });
+});
+
+/**
+ * The failed SUBSET the drawer is handed alongside the full list. It has
+ * to be judged the same way the badge on each row is judged, or the
+ * endpoint ships the original defect one layer up: a row rendering a red
+ * "Failed" in the full list and missing from the failed one beside it.
+ */
+describe('isFailedNodeHistoryEntry', () => {
+    const withRun = (
+        jobStatus: FleetNodeJobHistoryEntry['status'],
+        runStatus: NonNullable<FleetNodeJobHistoryEntry['reconciled']>['status'],
+    ) =>
+        buildNodeJobHistory(
+            [job({ status: jobStatus })],
+            new Map<string, ReconcilableRun>([[RUN_ID, { id: RUN_ID, status: runStatus }]]),
+        )[0];
+
+    it('counts a job the node called done whose RUN failed', () => {
+        expect(isFailedNodeHistoryEntry(withRun('done', 'failed'))).toBe(true);
+    });
+
+    it('does NOT count a job the node called failed whose run the reconciler completed', () => {
+        expect(isFailedNodeHistoryEntry(withRun('failed', 'completed'))).toBe(false);
+    });
+
+    it('falls back to the job status when there is no reconciled outcome', () => {
+        const [failed] = buildNodeJobHistory([job({ status: 'failed', payload: null })]);
+        const [done] = buildNodeJobHistory([job({ status: 'done', payload: null })]);
+
+        expect(isFailedNodeHistoryEntry(failed)).toBe(true);
+        expect(isFailedNodeHistoryEntry(done)).toBe(false);
+    });
+});

--- a/apps/api/src/fleet/__tests__/fleet-runner-status.service.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-runner-status.service.spec.ts
@@ -99,6 +99,11 @@ describe('FleetRunnerStatusService', () => {
                 busy: true,
                 activeJobCount: 1,
                 currentJobKind: 'agent-task',
+                // Fleet health signals (EW-776): what the MACHINE says
+                // about itself, alongside what the platform infers. Null
+                // here because this fixture's daemon reports neither.
+                workerState: null,
+                workerStateReason: null,
             });
         });
 
@@ -357,6 +362,111 @@ describe('FleetRunnerStatusService', () => {
                 fleetTotal: 0,
                 pinnedNodeId: 'b',
             });
+        });
+    });
+
+    /**
+     * Fleet health signals (EW-776, finding OPS-02) — the defect this
+     * whole slice exists for, seen from the router's side.
+     *
+     * A self-quarantined machine keeps heartbeating (that is what makes
+     * the quarantine observable instead of a blackout), so it reads
+     * `online` with no live claim: idle, healthy, free. It was refusing
+     * every lease. The pill said "1 of 1 online", `local-fallback` runs
+     * were "placed" on it, and `local-wait` runs queued behind it forever.
+     */
+    describe('worker state', () => {
+        it('projects the worker state and its reason onto the pill row', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue([
+                node({
+                    id: 'a',
+                    workerState: 'quarantined',
+                    workerStateReason: 'process tree could not be proven terminated',
+                }),
+            ]);
+
+            const snapshot = await build().snapshot('user-1');
+
+            expect(snapshot.nodes[0].workerState).toBe('quarantined');
+            expect(snapshot.nodes[0].workerStateReason).toBe(
+                'process tree could not be proven terminated',
+            );
+        });
+
+        it('reports null for a daemon that has never said what it is doing', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue([node({ id: 'a' })]);
+
+            const snapshot = await build().snapshot('user-1');
+
+            expect(snapshot.nodes[0].workerState).toBeNull();
+            expect(snapshot.nodes[0].workerStateReason).toBeNull();
+        });
+
+        it.each([['quarantined'], ['throttled'], ['paused']] as const)(
+            'still counts a %s node as ONLINE but never as free',
+            async (workerState) => {
+                // Online is the truth — the machine is reachable and the
+                // operator must keep seeing it. Free is the lie.
+                fleet.listEnrolledForUser.mockResolvedValue([node({ id: 'a', workerState })]);
+
+                await expect(build().availability('user-1')).resolves.toEqual({
+                    total: 1,
+                    online: 1,
+                    free: 0,
+                });
+            },
+        );
+
+        it.each([['idle'], ['working']] as const)(
+            'leaves a %s node counted as free when it holds no claim',
+            async (workerState) => {
+                fleet.listEnrolledForUser.mockResolvedValue([node({ id: 'a', workerState })]);
+
+                await expect(build().availability('user-1')).resolves.toEqual({
+                    total: 1,
+                    online: 1,
+                    free: 1,
+                });
+            },
+        );
+
+        it('leaves a node that reports nothing counted as free', async () => {
+            // Unknown is not a refusal. Treating it as one would empty the
+            // fleet of every machine running a build older than this field.
+            fleet.listEnrolledForUser.mockResolvedValue([node({ id: 'a' })]);
+
+            await expect(build().availability('user-1')).resolves.toEqual({
+                total: 1,
+                online: 1,
+                free: 1,
+            });
+        });
+
+        it('leaves the free count intact when only ONE of two nodes is quarantined', async () => {
+            fleet.listEnrolledForUser.mockResolvedValue([
+                node({ id: 'a', workerState: 'quarantined' }),
+                node({ id: 'b', workerState: 'idle' }),
+            ]);
+
+            await expect(build().availability('user-1')).resolves.toEqual({
+                total: 2,
+                online: 2,
+                free: 1,
+            });
+        });
+
+        it('does not hide a quarantined node from the pill counts', async () => {
+            // Routing must not send work to it; the operator must still see
+            // it, and see WHY. Those are different questions.
+            fleet.listEnrolledForUser.mockResolvedValue([
+                node({ id: 'a', workerState: 'quarantined' }),
+            ]);
+
+            const snapshot = await build().snapshot('user-1');
+
+            expect(snapshot.total).toBe(1);
+            expect(snapshot.online).toBe(1);
+            expect(snapshot.offline).toBe(0);
         });
     });
 });

--- a/apps/api/src/fleet/dto/fleet-heartbeat-worker-state.dto.spec.ts
+++ b/apps/api/src/fleet/dto/fleet-heartbeat-worker-state.dto.spec.ts
@@ -1,0 +1,114 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+    FLEET_MAX_WORKER_STATE_REASON_LENGTH,
+    FLEET_NODE_WORKER_STATES,
+} from '@ever-works/contracts';
+import { FleetHeartbeatDto } from './fleet.dto';
+
+/**
+ * Fleet health signals (EW-776) — the heartbeat DTO's half of the
+ * compatibility contract.
+ *
+ * The global pipe runs `whitelist + forbidNonWhitelisted`, which makes
+ * this file load-bearing in a way most DTOs are not: a field the DTO does
+ * not accept is not dropped, it fails the whole request — and a failed
+ * heartbeat is a node that goes offline. So both directions are pinned
+ * here:
+ *
+ *   - a NEWER node reporting a worker state an OLDER API has never heard
+ *     of must still beat (hence `@IsString`, not `@IsIn`);
+ *   - an OLDER node that sends nothing must still beat (hence
+ *     `@IsOptional`).
+ *
+ * The node-side half — that a daemon keeps beating when a 400 says the
+ * API predates the field — lives in `apps/node/src/core/heartbeat.spec.ts`.
+ */
+
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const SECRET = 'a'.repeat(43);
+
+async function failingProperties(dto: object): Promise<string[]> {
+    const errors = await validate(dto);
+    return errors.map((error) => error.property).sort();
+}
+
+const beat = (extra: Record<string, unknown>) =>
+    plainToInstance(FleetHeartbeatDto, { nodeId: NODE_ID, secret: SECRET, ...extra });
+
+describe('FleetHeartbeatDto — worker state', () => {
+    it.each(FLEET_NODE_WORKER_STATES.map((state) => [state]))('accepts %s', async (state) => {
+        await expect(failingProperties(beat({ workerState: state }))).resolves.toEqual([]);
+    });
+
+    it('accepts a state with its reason', async () => {
+        const dto = beat({
+            workerState: 'quarantined',
+            workerStateReason: 'process tree for job 42 could not be proven terminated',
+        });
+        await expect(failingProperties(dto)).resolves.toEqual([]);
+    });
+
+    it('accepts a value a NEWER node invented, rather than failing the beat', async () => {
+        // This is the whole reason the field is bounded as a string. A 400
+        // here would take a live machine offline for reporting the truth
+        // about itself; the server records it as "unknown" instead.
+        await expect(failingProperties(beat({ workerState: 'hibernating' }))).resolves.toEqual([]);
+    });
+
+    it('accepts a beat that says nothing about the worker at all', async () => {
+        // Every daemon in the field today. Absent must stay valid, and the
+        // service reads it as "leave the stored value alone".
+        await expect(failingProperties(beat({}))).resolves.toEqual([]);
+    });
+
+    it('accepts the reason at exactly the contract bound', async () => {
+        const dto = beat({
+            workerState: 'throttled',
+            workerStateReason: 'x'.repeat(FLEET_MAX_WORKER_STATE_REASON_LENGTH),
+        });
+        await expect(failingProperties(dto)).resolves.toEqual([]);
+    });
+
+    it('rejects a reason past the bound', async () => {
+        // The reason is free text from an untrusted machine; without a cap
+        // a heartbeat field is unbounded storage.
+        const dto = beat({
+            workerState: 'throttled',
+            workerStateReason: 'x'.repeat(FLEET_MAX_WORKER_STATE_REASON_LENGTH + 1),
+        });
+        await expect(failingProperties(dto)).resolves.toEqual(['workerStateReason']);
+    });
+
+    it('rejects an absurdly long worker state', async () => {
+        await expect(failingProperties(beat({ workerState: 'x'.repeat(33) }))).resolves.toEqual([
+            'workerState',
+        ]);
+    });
+
+    it.each([
+        ['a number', 42],
+        ['an object', { state: 'idle' }],
+        ['an array', ['idle']],
+    ])('rejects %s as a worker state', async (_label, workerState) => {
+        await expect(failingProperties(beat({ workerState }))).resolves.toEqual(['workerState']);
+    });
+
+    it('treats an explicit null as "said nothing", like every other optional field', async () => {
+        // `@IsOptional()` skips null by design, and the service matches
+        // that: a client that serializes missing fields as null must not
+        // wipe a reading an older client would have preserved.
+        await expect(failingProperties(beat({ workerState: null }))).resolves.toEqual([]);
+    });
+
+    it('rejects a non-string reason', async () => {
+        await expect(
+            failingProperties(beat({ workerState: 'idle', workerStateReason: 7 })),
+        ).resolves.toEqual(['workerStateReason']);
+    });
+
+    it('still requires the credential — the new fields buy no authority', async () => {
+        const dto = plainToInstance(FleetHeartbeatDto, { workerState: 'idle' });
+        await expect(failingProperties(dto)).resolves.toEqual(['nodeId', 'secret']);
+    });
+});

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -26,7 +26,9 @@ import {
     FLEET_MAX_NODE_NAME_LENGTH,
     FLEET_MAX_PLATFORM_LENGTH,
     FLEET_MAX_VERSION_LENGTH,
+    FLEET_MAX_WORKER_STATE_REASON_LENGTH,
     FLEET_MIN_NODE_NAME_LENGTH,
+    FLEET_NODE_WORKER_STATES,
 } from '@ever-works/contracts';
 import type {
     FleetEnrollableNodeKind,
@@ -264,6 +266,48 @@ export class FleetNodeSelfDescriptionDto {
     @IsString()
     @MaxLength(FLEET_MAX_MODEL_IDENTITY_LENGTH)
     modelIdentity?: string;
+
+    /**
+     * Fleet health signals (EW-776) — what the node's WORKER is doing.
+     *
+     * Bounded as a plain `@IsString()` and NOT `@IsIn(FLEET_NODE_WORKER_STATES)`,
+     * deliberately. The global pipe runs `whitelist + forbidNonWhitelisted`,
+     * so a value this build rejects does not merely get dropped — it fails
+     * the whole request, and a failed heartbeat is a node that goes
+     * offline. A daemon newer than the API it is talking to must be able
+     * to report a state we have never heard of and still stay alive; the
+     * service normalizes it to "unknown" rather than trusting it. The
+     * `enum` on the Swagger property documents the vocabulary without
+     * enforcing it.
+     */
+    @ApiProperty({
+        required: false,
+        enum: FLEET_NODE_WORKER_STATES,
+        maxLength: 32,
+        description:
+            "What the node's worker is doing (idle | working | paused | quarantined | throttled). Any other value is recorded as unknown rather than rejected, so a newer node never loses its heartbeat to an older API.",
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(32)
+    workerState?: string;
+
+    /**
+     * Why the worker is in that state — the quarantine message, the
+     * resource ceiling. Sanitized and re-capped in `FleetService`, which
+     * is the source of truth; this bound just refuses an oversized body
+     * at the edge.
+     */
+    @ApiProperty({
+        required: false,
+        maxLength: FLEET_MAX_WORKER_STATE_REASON_LENGTH,
+        description:
+            'Why the worker is in that state (quarantine reason, resource ceiling). Never a credential — the server redacts and caps it anyway.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(FLEET_MAX_WORKER_STATE_REASON_LENGTH)
+    workerStateReason?: string;
 }
 
 /**

--- a/apps/api/src/fleet/fleet-node-history.ts
+++ b/apps/api/src/fleet/fleet-node-history.ts
@@ -1,0 +1,134 @@
+import { FLEET_JOB_MAX_ERROR_LENGTH } from '@ever-works/contracts';
+import type { FleetJobReconciledOutcome, FleetNodeJobHistoryEntry } from '@ever-works/contracts';
+import { correlateAgentTaskJob } from './fleet-agent-task.correlation';
+
+/**
+ * Node-drawer job history — the composition rule, as a pure function.
+ *
+ * Three truths that slices B and E left open, and one thing the endpoint
+ * must stop doing:
+ *
+ *  1. **The reconciled outcome.** The job row and the Agent run row settle
+ *     separately: the node reports a verdict on the JOB, then the api-side
+ *     reconciler decides what that meant for the RUN. The drawer showed
+ *     only the first, so a job whose run had failed rendered a calm green
+ *     "done" — the exact question an operator opens the drawer to answer.
+ *  2. **The error text.** `fleet_jobs.error` was on the server all along
+ *     and never left it: a red badge with no way to find out why, whose
+ *     honest next step was "open a database".
+ *  3. **A payload-free summary.** `FleetJobView.payload` is executor input
+ *     — instructions, mount grants, repo coordinates, composed from user
+ *     content and bounded only by `FLEET_JOB_MAX_PAYLOAD_BYTES`. It has no
+ *     business being rendered in a settings drawer, so this function
+ *     replaces it with `null` and hands the UI the IDENTITIES instead
+ *     (task, run, agent), which is what an operator actually follows.
+ *
+ * Pure and separate from the controller so all three are testable without
+ * a Nest module — and so the payload stripping is one line that a spec can
+ * pin, rather than a habit each renderer has to remember.
+ */
+
+/** The subset of an `agent_runs` row this composer reads. */
+export interface ReconcilableRun {
+    id: string;
+    status: string;
+    summary?: string | null;
+    errorMessage?: string | null;
+}
+
+/** A job as it comes off `FleetJobService.historyForNode`. */
+export type NodeHistorySourceJob = FleetNodeJobHistoryEntry;
+
+/** Run statuses the wire contract admits; anything else reads as unknown. */
+const RUN_STATUSES: readonly FleetJobReconciledOutcome['status'][] = [
+    'queued',
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+];
+
+/**
+ * The run ids a page of history correlates to — what the caller needs to
+ * fetch before it can call {@link buildNodeJobHistory}.
+ *
+ * Deduplicated, because a retried Task can appear as several jobs carrying
+ * the same run: one bulk read, not one per row.
+ */
+export function nodeHistoryRunIds(jobs: readonly NodeHistorySourceJob[]): string[] {
+    const ids = new Set<string>();
+    for (const job of jobs) {
+        const correlation = correlateAgentTaskJob(job);
+        if (correlation) ids.add(correlation.runId);
+    }
+    return [...ids];
+}
+
+/**
+ * Compose the drawer's history rows.
+ *
+ * `runs` may be empty or partial — the run read is best-effort at the
+ * edge, and a job whose run could not be read reports `reconciled: null`
+ * ("not known") rather than inventing an outcome.
+ */
+export function buildNodeJobHistory(
+    jobs: readonly NodeHistorySourceJob[],
+    runs: ReadonlyMap<string, ReconcilableRun> = new Map(),
+): FleetNodeJobHistoryEntry[] {
+    return jobs.map((job) => {
+        const correlation = correlateAgentTaskJob(job);
+        const run = correlation ? runs.get(correlation.runId) : undefined;
+        return {
+            ...job,
+            // Never rendered, never shipped. See the header.
+            payload: null,
+            error: truncate(job.error),
+            summary: {
+                kind: job.kind,
+                taskId: correlation?.taskId ?? null,
+                runId: correlation?.runId ?? null,
+                agentId: correlation?.agentId ?? null,
+            },
+            reconciled: run ? toReconciledOutcome(run) : null,
+        };
+    });
+}
+
+/**
+ * Did the work this row carried FAIL?
+ *
+ * The reconciled outcome wins outright, exactly as it does in the badge
+ * the drawer renders (`fleetJobOutcomeKey`). Keeping `failures` on the
+ * job status alone would have shipped the original defect in a new
+ * place: a row rendering a red "Failed" badge in the full list while
+ * being absent from the failed subset that sits right beside it.
+ */
+export function isFailedNodeHistoryEntry(entry: FleetNodeJobHistoryEntry): boolean {
+    if (entry.reconciled) return entry.reconciled.status === 'failed';
+    return entry.status === 'failed';
+}
+
+function toReconciledOutcome(run: ReconcilableRun): FleetJobReconciledOutcome {
+    return {
+        runId: run.id,
+        // A status the contract does not know is reported as `queued`
+        // rather than passed through: the field is a union on the wire, and
+        // the drawer's own fallback ("unknown") covers the display side.
+        status: RUN_STATUSES.includes(run.status as FleetJobReconciledOutcome['status'])
+            ? (run.status as FleetJobReconciledOutcome['status'])
+            : 'queued',
+        summary: truncate(run.summary),
+        // Capped like the job's own error, which is what
+        // `FLEET_JOB_MAX_ERROR_LENGTH` exists for: an unbounded model
+        // failure pasted into a settings drawer is a rendering hazard, not
+        // an explanation.
+        error: truncate(run.errorMessage),
+    };
+}
+
+function truncate(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.slice(0, FLEET_JOB_MAX_ERROR_LENGTH);
+}

--- a/apps/api/src/fleet/fleet-runner-status.service.ts
+++ b/apps/api/src/fleet/fleet-runner-status.service.ts
@@ -8,6 +8,7 @@ import {
 import type {
     FleetNodeLoadView,
     FleetNodeView,
+    FleetNodeWorkerState,
     FleetRunnerAvailability,
     FleetRunnerNodeView,
     FleetRunnerStatusView,
@@ -144,6 +145,7 @@ export class FleetRunnerStatusService {
                 : online.filter(
                       (node) =>
                           !FLEET_NODE_NON_LEASABLE_STATUSES.includes(node.status) &&
+                          !isRefusingWork(node) &&
                           (load[node.id]?.activeJobCount ?? 0) <= 0,
                   );
             const result: FleetRunnerAvailability = {
@@ -203,6 +205,41 @@ export class FleetRunnerStatusService {
     }
 }
 
+/**
+ * Worker states in which a node will REFUSE the next job, whatever its
+ * registry status says (fleet health signals, EW-776).
+ *
+ * This is the honest half of the availability question. A machine that
+ * has self-quarantined keeps heartbeating — that is what makes the
+ * quarantine observable rather than a blackout — so it reads `online`
+ * while its worker loop refuses every lease. Counting it as FREE is how a
+ * `local-fallback` run got "placed" on a machine that would never take
+ * it, and how a `local-wait` run sat queued forever behind one.
+ *
+ * `paused` and `throttled` join `quarantined` for the same reason: all
+ * three are the node saying "not right now". The registry-level
+ * {@link FLEET_NODE_NON_LEASABLE_STATUSES} check above stays — it answers
+ * the operator's intent, this answers the machine's own condition, and
+ * they can disagree.
+ */
+const REFUSING_WORKER_STATES: readonly FleetNodeWorkerState[] = [
+    'quarantined',
+    'throttled',
+    'paused',
+];
+
+/**
+ * True when the node's own worker says it will not take work.
+ *
+ * A node that has never reported a state (`null` / absent — an older
+ * daemon) is NOT treated as refusing: unknown is not a refusal, and
+ * assuming otherwise would empty the fleet of every machine running a
+ * build that predates this field.
+ */
+function isRefusingWork(node: FleetNodeView): boolean {
+    return node.workerState != null && REFUSING_WORKER_STATES.includes(node.workerState);
+}
+
 /** The lease scan's two skip conditions, as a predicate over the registry row. */
 function isEligible(node: FleetNodeView, eligibility: FleetRunnerEligibility): boolean {
     if (eligibility.targetNodeId && node.id !== eligibility.targetNodeId) {
@@ -232,5 +269,9 @@ function toRunnerView(node: FleetNodeView, load: FleetNodeLoadView | null): Flee
         busy: activeJobCount > 0,
         activeJobCount,
         currentJobKind: load?.currentJobKind ?? null,
+        // Fleet health signals (EW-776): what the machine says about
+        // itself, next to what the platform infers about it.
+        workerState: node.workerState ?? null,
+        workerStateReason: node.workerStateReason ?? null,
     };
 }

--- a/apps/api/src/fleet/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/fleet.controller.spec.ts
@@ -37,8 +37,14 @@ describe('FleetController', () => {
         deleteForUser: jest.Mock;
         enroll: jest.Mock;
         heartbeat: jest.Mock;
+        getForUser: jest.Mock;
     };
-    let jobs: { loadByNodeForUser: jest.Mock; promoteWaitingForNode: jest.Mock };
+    let jobs: {
+        loadByNodeForUser: jest.Mock;
+        promoteWaitingForNode: jest.Mock;
+        historyForNode: jest.Mock;
+    };
+    let runs: { findByIds: jest.Mock };
     let controller: FleetController;
 
     // Appended constructor deps (runner status + execution preferences).
@@ -81,11 +87,14 @@ describe('FleetController', () => {
             deleteForUser: jest.fn(async () => undefined),
             enroll: jest.fn(async () => null),
             heartbeat: jest.fn(async () => null),
+            getForUser: jest.fn(async () => nodeView),
         };
         jobs = {
             loadByNodeForUser: jest.fn(async () => ({})),
             promoteWaitingForNode: jest.fn(async () => 0),
+            historyForNode: jest.fn(async () => []),
         };
+        runs = { findByIds: jest.fn(async () => []) };
         ceilingStub.describeForUser.mockClear();
         ceilingStub.setFleetCeilingForUser.mockClear();
         controller = new FleetController(
@@ -97,6 +106,8 @@ describe('FleetController', () => {
             // EW-778 — the per-node drain now lives in FleetPanicService
             // (shared with drain-all); its own spec covers it.
             { drainNodeForUser: jest.fn(async () => null) } as never,
+            // EW-776 — the reconciled run outcome behind each history row.
+            runs as never,
         );
     });
 
@@ -233,6 +244,117 @@ describe('FleetController', () => {
         expect(service.deleteForUser).toHaveBeenCalledWith('user-1', nodeView.id);
     });
 
+    describe('detail — the node drawer payload (EW-776)', () => {
+        const RUN_ID = '99999999-9999-4999-8999-999999999999';
+        const TASK_ID = '88888888-8888-4888-8888-888888888888';
+
+        const historyJob = (over: Record<string, unknown> = {}) => ({
+            id: 'job-1',
+            kind: 'agent-task',
+            status: 'done',
+            nodeId: nodeView.id,
+            targetNodeId: null,
+            requiredCapabilities: [],
+            payload: { runId: RUN_ID, taskId: TASK_ID, secret: 'PAYLOAD-SENTINEL' },
+            leaseExpiresAt: null,
+            attempts: 1,
+            maxAttempts: 3,
+            createdAt: null,
+            startedAt: null,
+            completedAt: null,
+            leaseGeneration: 1,
+            error: null,
+            ...over,
+        });
+
+        it('never ships the job payload to the drawer', async () => {
+            jobs.historyForNode.mockResolvedValue([historyJob()]);
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(detail.recentJobs[0].payload).toBeNull();
+            expect(JSON.stringify(detail)).not.toContain('PAYLOAD-SENTINEL');
+        });
+
+        it('shows the RECONCILED run outcome behind a job the node called done', async () => {
+            jobs.historyForNode.mockResolvedValue([historyJob()]);
+            runs.findByIds.mockResolvedValue([
+                { id: RUN_ID, status: 'failed', summary: null, errorMessage: 'model gave up' },
+            ]);
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(runs.findByIds).toHaveBeenCalledWith([RUN_ID], 'user-1');
+            expect(detail.recentJobs[0].reconciled).toEqual({
+                runId: RUN_ID,
+                status: 'failed',
+                summary: null,
+                error: 'model gave up',
+            });
+        });
+
+        it('degrades to job outcomes only when the run read fails', async () => {
+            // "Not known" is honest; a fabricated outcome is not, and a
+            // drawer that 500s on a node whose runs are unreadable is worse
+            // than one that shows a little less.
+            jobs.historyForNode.mockResolvedValue([historyJob()]);
+            runs.findByIds.mockRejectedValue(new Error('agent_runs unreachable'));
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(detail.recentJobs[0].reconciled).toBeNull();
+            expect(detail.historyUnavailable).toBe(false);
+        });
+
+        it('does not read runs at all for a history with no agent-task jobs', async () => {
+            jobs.historyForNode.mockResolvedValue([
+                historyJob({ kind: 'acceptance-checks', payload: null }),
+            ]);
+
+            await controller.detail(auth, nodeView.id);
+
+            expect(runs.findByIds).not.toHaveBeenCalled();
+        });
+
+        it('still renders the node when the job history is unavailable', async () => {
+            jobs.historyForNode.mockRejectedValue(new Error('fleet_jobs unreachable'));
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(detail.node).toEqual(nodeView);
+            expect(detail.recentJobs).toEqual([]);
+            expect(detail.historyUnavailable).toBe(true);
+        });
+
+        it('keeps the failed subset in sync with the composed rows', async () => {
+            jobs.historyForNode.mockResolvedValue([
+                historyJob({ id: 'ok' }),
+                historyJob({ id: 'bad', status: 'failed', error: 'pnpm install exploded' }),
+            ]);
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(detail.failures).toHaveLength(1);
+            expect(detail.failures[0].id).toBe('bad');
+            expect(detail.failures[0].error).toBe('pnpm install exploded');
+            expect(detail.failures[0].payload).toBeNull();
+        });
+
+        it('judges the failed subset on the RECONCILED outcome too', async () => {
+            // Or the endpoint ships the original defect one layer up: a row
+            // rendering a red "Failed" badge in the full list and missing
+            // from the failed list sitting right beside it.
+            jobs.historyForNode.mockResolvedValue([historyJob({ id: 'done-run-failed' })]);
+            runs.findByIds.mockResolvedValue([
+                { id: RUN_ID, status: 'failed', summary: null, errorMessage: 'model gave up' },
+            ]);
+
+            const detail = await controller.detail(auth, nodeView.id);
+
+            expect(detail.failures.map((entry) => entry.id)).toEqual(['done-run-failed']);
+        });
+    });
+
     describe('public enroll/heartbeat (fail-closed)', () => {
         it('enroll maps every invalid path to one undifferentiated 401', async () => {
             await expect(
@@ -254,8 +376,52 @@ describe('FleetController', () => {
                 platform: 'linux/x64',
                 version: undefined,
                 capabilities: undefined,
+                cliVersion: undefined,
+                diskFreeBytes: undefined,
+                modelIdentity: undefined,
+                workerState: undefined,
+                workerStateReason: undefined,
             });
             expect(result.secret).toBe('node-secret');
+        });
+
+        it('forwards the worker state on BOTH enroll and heartbeat (EW-776)', async () => {
+            // The explicit body maps are the failure mode this suite exists
+            // for: a field added to the DTO and forgotten in the map is
+            // accepted at the edge and silently dropped before the service.
+            service.enroll.mockResolvedValue({
+                nodeId: nodeView.id,
+                secret: 'node-secret',
+                node: nodeView,
+            });
+            await controller.enroll({
+                token: 'x'.repeat(43),
+                workerState: 'quarantined',
+                workerStateReason: 'process tree unproven',
+            } as EnrollFleetNodeDto);
+            expect(service.enroll).toHaveBeenCalledWith(
+                'x'.repeat(43),
+                expect.objectContaining({
+                    workerState: 'quarantined',
+                    workerStateReason: 'process tree unproven',
+                }),
+            );
+
+            service.heartbeat.mockResolvedValue({ node: nodeView });
+            await controller.heartbeat({
+                nodeId: nodeView.id,
+                secret: 'x'.repeat(43),
+                workerState: 'throttled',
+                workerStateReason: 'cpu ceiling',
+            } as FleetHeartbeatDto);
+            expect(service.heartbeat).toHaveBeenCalledWith(
+                nodeView.id,
+                'x'.repeat(43),
+                expect.objectContaining({
+                    workerState: 'throttled',
+                    workerStateReason: 'cpu ceiling',
+                }),
+            );
         });
 
         it('heartbeat maps a rejected credential to 401 and success to ok', async () => {

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -7,6 +7,7 @@ import {
     HttpCode,
     HttpStatus,
     Logger,
+    Optional,
     Param,
     ParseUUIDPipe,
     Patch,
@@ -36,8 +37,14 @@ import type {
     FleetNodeView,
     FleetRunnerStatusView,
 } from '@ever-works/contracts';
+import { AgentRunRepository } from '@ever-works/agent/database';
 import { FleetPanicService } from './fleet-panic.service';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
+import {
+    buildNodeJobHistory,
+    isFailedNodeHistoryEntry,
+    nodeHistoryRunIds,
+} from './fleet-node-history';
 import { Public } from '../auth/decorators/public.decorator';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
@@ -130,6 +137,12 @@ export class FleetController {
         private readonly costCeiling: FleetCostCeilingService,
         // EW-778 — owns the per-node drain so that drain-all reuses it.
         private readonly panic: FleetPanicService,
+        // EW-776 — the reconciled run outcome behind each history row.
+        // Appended LAST and @Optional() so every positional construction
+        // (the controller spec's included) keeps working, and so a missing
+        // binding degrades to `reconciled: null` instead of a 500 on the
+        // node drawer.
+        @Optional() private readonly runs?: AgentRunRepository,
     ) {}
 
     @Get('cost-ceiling')
@@ -268,12 +281,53 @@ export class FleetController {
             historyUnavailable = true;
         }
 
+        // The RECONCILED outcome (EW-776): a fleet job and the Agent run it
+        // carried settle separately, so a job the node called `done` can
+        // sit in front of a run that failed. One bulk read, owner-scoped in
+        // the query, and strictly best-effort — a run-table hiccup leaves
+        // `reconciled: null` ("not known") rather than taking the drawer
+        // down or, worse, inventing an outcome.
+        const runs = await this.readReconciledRuns(auth.userId, recentJobs);
+        // `buildNodeJobHistory` also strips `payload` from every row. A
+        // node's job payload is executor input composed from user content;
+        // a settings endpoint has no reason to ship it.
+        const history = buildNodeJobHistory(recentJobs, runs);
+
         return {
             node,
-            recentJobs,
-            failures: recentJobs.filter((job) => job.status === 'failed'),
+            recentJobs: history,
+            // Reconciled-aware, so the subset agrees with the badge each
+            // row renders: a job the node called `done` whose run failed
+            // belongs here, and one it called `failed` whose run the
+            // reconciler settled `completed` does not.
+            failures: history.filter(isFailedNodeHistoryEntry),
             historyUnavailable,
         };
+    }
+
+    /** Runs behind a page of node history, by id. Never throws. */
+    private async readReconciledRuns(
+        userId: string,
+        jobs: Awaited<ReturnType<FleetJobService['historyForNode']>>,
+    ): Promise<
+        Map<
+            string,
+            { id: string; status: string; summary?: string | null; errorMessage?: string | null }
+        >
+    > {
+        const runIds = nodeHistoryRunIds(jobs);
+        if (!this.runs || runIds.length === 0) return new Map();
+        try {
+            const rows = await this.runs.findByIds(runIds, userId);
+            return new Map(rows.map((run) => [run.id, run]));
+        } catch (error) {
+            this.logger.debug(
+                `Node history degraded to job outcomes only: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return new Map();
+        }
     }
 
     @Get('enrollment-tokens')
@@ -440,6 +494,8 @@ export class FleetController {
             cliVersion: body.cliVersion,
             diskFreeBytes: body.diskFreeBytes,
             modelIdentity: body.modelIdentity,
+            workerState: body.workerState,
+            workerStateReason: body.workerStateReason,
         });
         if (!result) {
             // One undifferentiated message — never say WHICH check failed.
@@ -465,6 +521,8 @@ export class FleetController {
             cliVersion: body.cliVersion,
             diskFreeBytes: body.diskFreeBytes,
             modelIdentity: body.modelIdentity,
+            workerState: body.workerState,
+            workerStateReason: body.workerStateReason,
         });
         if (!result) {
             throw new UnauthorizedException('Invalid node credential');

--- a/apps/api/src/migrations/1788900000000-AddFleetNodeWorkerState.ts
+++ b/apps/api/src/migrations/1788900000000-AddFleetNodeWorkerState.ts
@@ -1,0 +1,153 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+/**
+ * Fleet health signals — worker state + notice bookkeeping (EW-776,
+ * self-build finding OPS-02).
+ *
+ * The defect this closes: a heartbeat carried no worker state, so a
+ * machine that had self-quarantined (the durable worker safety marker,
+ * clearable only at that keyboard) kept reporting `online` while refusing
+ * every job it was offered. `status` said healthy, the queue said nothing
+ * was running, and — under the runbook's recommended `local-wait`, where
+ * there is no cloud fallback — nothing anywhere told the owner. Nothing
+ * told them a PC had gone dark either.
+ *
+ * Six nullable columns on `fleet_nodes`, in two groups:
+ *
+ *  1. What the machine reports — `workerState` (`idle | working | paused |
+ *     quarantined | throttled`), `workerStateReason`, and
+ *     `workerStateChangedAt`, which moves only on a TRANSITION so
+ *     "quarantined since 03:14" survives the beats that follow.
+ *  2. Notice dedup markers — `offlineNoticedAt`, `offlineLongNoticedAt`,
+ *     `quarantineNoticedAt`. `InboxService.notice` files
+ *     unconditionally and has no dedup of its own, so "exactly one notice
+ *     per transition" has to be a CAS on a column somewhere; the node row
+ *     is the one thing both the heartbeat and the offline sweep already
+ *     touch. Each marker is cleared when the node recovers, which is what
+ *     re-arms the next outage.
+ *
+ * NO DEFAULTS on any of them, on purpose. NULL is the honest backfill:
+ * an existing row genuinely has never reported a worker state, and
+ * defaulting it to `'idle'` would state — in the schema — the exact
+ * fabrication this whole slice exists to end.
+ *
+ * Also adds `idx_fleet_nodes_status_heartbeat`. The health sweep reads
+ * `(userId, status, lastHeartbeatAt)` twice per owner-scoped list, and
+ * that list is polled by the runner pill from every dashboard page.
+ * `idx_fleet_nodes_user` already narrows by owner; this one covers the
+ * rest of the predicate.
+ *
+ * NOT included: a foreign key on `fleet_agent_node_affinities.nodeId`.
+ * That table deliberately has none (see
+ * `1787508800000-CreateFleetAgentNodeAffinity`), and adding one now would
+ * change documented semantics AND fail on any database that already holds
+ * a pin to a deleted node. The cascade ships as an explicit transactional
+ * delete in `FleetNodeRepository.delete` instead, covered by
+ * `fleet-node.repository.integration.spec.ts`.
+ *
+ * Portable DDL (`TableColumn` / `TableIndex`) because CI and the e2e stack
+ * run better-sqlite3 while production runs Postgres. Forward-only with a
+ * guard per step, so a partially-applied database converges rather than
+ * aborting; `down()` reverses all of it.
+ */
+export class AddFleetNodeWorkerState1788900000000 implements MigrationInterface {
+    name = 'AddFleetNodeWorkerState1788900000000';
+
+    /** Column name → its portable definition. Order is the order they are added. */
+    private static readonly COLUMNS: ReadonlyArray<{ name: string; column: () => TableColumn }> = [
+        {
+            name: 'workerState',
+            column: () =>
+                new TableColumn({
+                    name: 'workerState',
+                    type: 'varchar',
+                    length: '16',
+                    isNullable: true,
+                }),
+        },
+        {
+            name: 'workerStateReason',
+            column: () =>
+                new TableColumn({
+                    name: 'workerStateReason',
+                    type: 'varchar',
+                    length: '500',
+                    isNullable: true,
+                }),
+        },
+        {
+            name: 'workerStateChangedAt',
+            column: () =>
+                new TableColumn({
+                    name: 'workerStateChangedAt',
+                    type: 'timestamp',
+                    isNullable: true,
+                }),
+        },
+        {
+            name: 'offlineNoticedAt',
+            column: () =>
+                new TableColumn({ name: 'offlineNoticedAt', type: 'timestamp', isNullable: true }),
+        },
+        {
+            name: 'offlineLongNoticedAt',
+            column: () =>
+                new TableColumn({
+                    name: 'offlineLongNoticedAt',
+                    type: 'timestamp',
+                    isNullable: true,
+                }),
+        },
+        {
+            name: 'quarantineNoticedAt',
+            column: () =>
+                new TableColumn({
+                    name: 'quarantineNoticedAt',
+                    type: 'timestamp',
+                    isNullable: true,
+                }),
+        },
+    ];
+
+    private static readonly INDEX_NAME = 'idx_fleet_nodes_status_heartbeat';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const nodes = await queryRunner.getTable('fleet_nodes');
+        if (!nodes) return;
+
+        for (const { name, column } of AddFleetNodeWorkerState1788900000000.COLUMNS) {
+            if (!nodes.findColumnByName(name)) {
+                await queryRunner.addColumn('fleet_nodes', column());
+            }
+        }
+
+        const indexName = AddFleetNodeWorkerState1788900000000.INDEX_NAME;
+        const hasIndex = nodes.indices.some((index) => index.name === indexName);
+        if (
+            !hasIndex &&
+            nodes.findColumnByName('status') &&
+            nodes.findColumnByName('lastHeartbeatAt')
+        ) {
+            await queryRunner.createIndex(
+                'fleet_nodes',
+                new TableIndex({ name: indexName, columnNames: ['status', 'lastHeartbeatAt'] }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const nodes = await queryRunner.getTable('fleet_nodes');
+        if (!nodes) return;
+
+        const indexName = AddFleetNodeWorkerState1788900000000.INDEX_NAME;
+        if (nodes.indices.some((index) => index.name === indexName)) {
+            await queryRunner.dropIndex('fleet_nodes', indexName);
+        }
+
+        for (const { name } of [...AddFleetNodeWorkerState1788900000000.COLUMNS].reverse()) {
+            if (nodes.findColumnByName(name)) {
+                await queryRunner.dropColumn('fleet_nodes', name);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddFleetNodeWorkerState.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddFleetNodeWorkerState.spec.ts
@@ -1,0 +1,151 @@
+import { DataSource } from 'typeorm';
+import { AddFleetNodeWorkerState1788900000000 } from '../1788900000000-AddFleetNodeWorkerState';
+
+/**
+ * Migration test for the fleet health-signal schema (EW-776).
+ *
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ * What matters here is unglamorous and load-bearing:
+ *
+ *  - every new column lands NULLABLE and NULL on existing rows. `NULL`
+ *    is the honest backfill — an already-enrolled node genuinely has
+ *    never reported a worker state, and a `'idle'` default would state
+ *    in the schema the exact fabrication the slice exists to end;
+ *  - the notice dedup markers start unset, so the first outage after an
+ *    upgrade notifies rather than being silently pre-deduped;
+ *  - `up()` is idempotent, because the house pattern is forward-only
+ *    with per-step guards and a partially-applied database must converge;
+ *  - `down()` reverses all of it and leaves the row itself intact.
+ */
+describe('AddFleetNodeWorkerState1788900000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddFleetNodeWorkerState1788900000000();
+
+    const NEW_COLUMNS = [
+        'workerState',
+        'workerStateReason',
+        'workerStateChangedAt',
+        'offlineNoticedAt',
+        'offlineLongNoticedAt',
+        'quarantineNoticedAt',
+    ];
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        // The subset of `fleet_nodes` this migration touches.
+        await dataSource.query(`
+            CREATE TABLE "fleet_nodes" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "userId" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "kind" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "lastHeartbeatAt" datetime
+            )
+        `);
+        await dataSource.query(
+            `INSERT INTO "fleet_nodes" ("id", "userId", "name", "kind", "status", "lastHeartbeatAt")
+             VALUES ('n1', 'u1', 'Office PC', 'desktop-node', 'online', '2026-09-01 10:00:00')`,
+        );
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('adds every worker-state and notice-marker column as nullable', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('fleet_nodes');
+        for (const name of NEW_COLUMNS) {
+            expect(table?.findColumnByName(name)?.isNullable).toBe(true);
+        }
+    });
+
+    it('leaves existing rows NULL rather than inventing a state for them', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const rows = await dataSource.query(
+            `SELECT "workerState", "workerStateReason", "workerStateChangedAt",
+                    "offlineNoticedAt", "offlineLongNoticedAt", "quarantineNoticedAt",
+                    "status", "lastHeartbeatAt"
+             FROM "fleet_nodes"`,
+        );
+        expect(rows).toHaveLength(1);
+        // NULL, not 'idle': a machine we have never heard from about its
+        // worker is UNKNOWN, and the UI says so.
+        expect(rows[0].workerState).toBeNull();
+        expect(rows[0].workerStateReason).toBeNull();
+        expect(rows[0].workerStateChangedAt).toBeNull();
+        // The dedup markers start unset, so the first outage after the
+        // upgrade actually notifies.
+        expect(rows[0].offlineNoticedAt).toBeNull();
+        expect(rows[0].offlineLongNoticedAt).toBeNull();
+        expect(rows[0].quarantineNoticedAt).toBeNull();
+        // Existing registry facts are untouched.
+        expect(rows[0].status).toBe('online');
+        expect(rows[0].lastHeartbeatAt).toBe('2026-09-01 10:00:00');
+    });
+
+    it('creates the (status, lastHeartbeatAt) index the sweep reads', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const table = await runner.getTable('fleet_nodes');
+        const index = (table?.indices ?? []).find(
+            (candidate) => candidate.name === 'idx_fleet_nodes_status_heartbeat',
+        );
+        expect(index).toBeDefined();
+        expect(index?.columnNames).toEqual(['status', 'lastHeartbeatAt']);
+    });
+
+    it('is idempotent — re-running up() does not throw', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+    });
+
+    it('down() drops every column and the index, and keeps the row', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+
+        const table = await runner.getTable('fleet_nodes');
+        for (const name of NEW_COLUMNS) {
+            expect(table?.findColumnByName(name)).toBeUndefined();
+        }
+        expect(
+            (table?.indices ?? []).some(
+                (index) => index.name === 'idx_fleet_nodes_status_heartbeat',
+            ),
+        ).toBe(false);
+        const rows = await dataSource.query(`SELECT "id", "status" FROM "fleet_nodes"`);
+        expect(rows).toEqual([{ id: 'n1', status: 'online' }]);
+    });
+
+    it('down() is safe to re-run', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+    });
+
+    it('does not explode when fleet_nodes does not exist at all', async () => {
+        // A stripped-down or not-yet-created schema must converge, not abort
+        // — the API self-applies migrations on every boot.
+        await dataSource.query(`DROP TABLE "fleet_nodes"`);
+        const runner = dataSource.createQueryRunner();
+
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+    });
+});

--- a/apps/node/src/core/capabilities.spec.ts
+++ b/apps/node/src/core/capabilities.spec.ts
@@ -261,4 +261,62 @@ describe('describeSelf', () => {
 		const long = await describeSelf(runnerWith([]), environment(), 'v'.repeat(80));
 		expect(long.version).toHaveLength(32);
 	});
+
+	/**
+	 * Fleet health signals (EW-776) — the worker state joins the
+	 * description through the same optional-probe seam as the telemetry,
+	 * and inherits its whole contract: a probe that returns null or throws
+	 * is an ABSENT field, never a failed beat and never a `null` on the
+	 * wire (the server reads absent as "leave the stored value alone", so
+	 * a momentary probe failure must not wipe a quarantine an operator is
+	 * reading right now).
+	 */
+	describe('worker health', () => {
+		it('carries the worker state and its reason', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				workerHealth: () => ({ workerState: 'quarantined', workerStateReason: 'process tree unproven' })
+			});
+
+			expect(description.workerState).toBe('quarantined');
+			expect(description.workerStateReason).toBe('process tree unproven');
+		});
+
+		it('omits the reason when the state carries none', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				workerHealth: () => ({ workerState: 'idle' })
+			});
+
+			expect(description.workerState).toBe('idle');
+			expect('workerStateReason' in description).toBe(false);
+		});
+
+		it('omits BOTH fields when there is no worker at all', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				workerHealth: () => null
+			});
+
+			expect('workerState' in description).toBe(false);
+			expect('workerStateReason' in description).toBe(false);
+		});
+
+		it('omits them when the probe throws, rather than failing the beat', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				workerHealth: () => {
+					throw new Error('worker loop is mid-restart');
+				}
+			});
+
+			expect('workerState' in description).toBe(false);
+			// Everything else still lands — one broken probe never costs the
+			// node its whole description.
+			expect(description.platform).toBe('linux/x64');
+		});
+
+		it('omits them when no probe is supplied at all', async () => {
+			// Every existing caller, and every older build of this app.
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0');
+
+			expect('workerState' in description).toBe(false);
+		});
+	});
 });

--- a/apps/node/src/core/capabilities.ts
+++ b/apps/node/src/core/capabilities.ts
@@ -2,6 +2,7 @@ import { FLEET_BROWSER_CAPABILITY, FLEET_GPU_CAPABILITY } from '@ever-works/cont
 import type { BrowserProbeIo } from './browser-probe';
 import type { ModelCliPaths } from './executors/model-cli';
 import { detectGpu } from './gpu-probe';
+import type { WorkerHealth } from './worker-health';
 import {
 	MAX_CAPABILITY_TAG_LENGTH,
 	MAX_CAPABILITY_TAGS,
@@ -292,6 +293,17 @@ export interface SelfDescriptionTelemetry {
 	 * display label, never a credential.
 	 */
 	modelIdentity?: () => Promise<string | null> | string | null;
+	/**
+	 * What the worker loop is doing (fleet health signals, EW-776), via
+	 * `describeWorkerHealth(worker.getState())`.
+	 *
+	 * A probe like the others — absent on a visibility-only node that has
+	 * no worker at all, and a null return is an ABSENT field rather than a
+	 * reported "unknown". That matters: the server treats an absent field
+	 * as "leave the stored value alone", so a probe that momentarily fails
+	 * does not wipe the quarantine an operator is currently reading.
+	 */
+	workerHealth?: () => Promise<WorkerHealth | null> | WorkerHealth | null;
 }
 
 /**
@@ -332,6 +344,17 @@ export async function describeSelf(
 	const modelIdentity = await resolveTelemetry(telemetry.modelIdentity);
 	if (typeof modelIdentity === 'string' && modelIdentity) {
 		description.modelIdentity = modelIdentity;
+	}
+	// Fleet health signals (EW-776). Both halves land together or neither
+	// does: a reason without a state has nothing to caption, and a state
+	// the probe could not produce must stay ABSENT so the server keeps the
+	// last one it was told.
+	const workerHealth = await resolveTelemetry(telemetry.workerHealth);
+	if (workerHealth && typeof workerHealth.workerState === 'string') {
+		description.workerState = workerHealth.workerState;
+		if (workerHealth.workerStateReason) {
+			description.workerStateReason = workerHealth.workerStateReason;
+		}
 	}
 	return description;
 }

--- a/apps/node/src/core/fleet-client.spec.ts
+++ b/apps/node/src/core/fleet-client.spec.ts
@@ -274,6 +274,38 @@ describe('heartbeat', () => {
 		expect(JSON.parse(calls[1].init.body)).not.toHaveProperty('modelIdentity');
 	});
 
+	it('carries the worker state and reason, and omits both when absent', async () => {
+		// Fleet health signals (EW-776), same whitelist trap as above: a
+		// worker state the loop computes and the client never sends is a
+		// quarantined machine that still reads healthy in Fleet — the
+		// precise defect this slice exists to close.
+		const { fetchFn, calls } = fakeFetch(() => ({ status: 200, body: { ok: true, node: nodeView } }));
+
+		await client(fetchFn).heartbeat({
+			nodeId: NODE_ID,
+			secret: SECRET,
+			workerState: 'quarantined',
+			workerStateReason: 'process tree for job 42 could not be proven terminated'
+		});
+		const body = JSON.parse(calls[0].init.body);
+		expect(body.workerState).toBe('quarantined');
+		expect(body.workerStateReason).toBe('process tree for job 42 could not be proven terminated');
+
+		await client(fetchFn).heartbeat({ nodeId: NODE_ID, secret: SECRET });
+		expect(JSON.parse(calls[1].init.body)).not.toHaveProperty('workerState');
+		expect(JSON.parse(calls[1].init.body)).not.toHaveProperty('workerStateReason');
+	});
+
+	it('sends a state without a reason when there is nothing to explain', async () => {
+		const { fetchFn, calls } = fakeFetch(() => ({ status: 200, body: { ok: true, node: nodeView } }));
+
+		await client(fetchFn).heartbeat({ nodeId: NODE_ID, secret: SECRET, workerState: 'idle' });
+
+		const body = JSON.parse(calls[0].init.body);
+		expect(body.workerState).toBe('idle');
+		expect(body).not.toHaveProperty('workerStateReason');
+	});
+
 	it('reports a revoked/disabled node as unauthorized with an actionable message', async () => {
 		const { fetchFn } = fakeFetch(() => ({ status: 401 }));
 		const error = await client(fetchFn)

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -358,6 +358,15 @@ function selfDescription(source: NodeSelfDescription): NodeSelfDescription {
 	if (source.modelIdentity !== undefined) {
 		out.modelIdentity = source.modelIdentity;
 	}
+	// Fleet health signals (EW-776). Named here for exactly the reason the
+	// header above gives: a field this whitelist does not list is a field
+	// the machine computes, logs and then silently never sends.
+	if (source.workerState !== undefined) {
+		out.workerState = source.workerState;
+	}
+	if (source.workerStateReason !== undefined) {
+		out.workerStateReason = source.workerStateReason;
+	}
 	return out;
 }
 

--- a/apps/node/src/core/heartbeat.spec.ts
+++ b/apps/node/src/core/heartbeat.spec.ts
@@ -230,4 +230,138 @@ describe('HeartbeatLoop', () => {
 		expect(text).toContain(REDACTED);
 		expect(loop.getState().lastError).not.toContain(SECRET);
 	});
+
+	/**
+	 * Fleet health signals (EW-776) — the node's half of the additive-wire
+	 * contract.
+	 *
+	 * The API validates heartbeats with `whitelist + forbidNonWhitelisted`,
+	 * so a field an older platform does not know 400s the whole request.
+	 * That makes the OBVIOUS implementation of this feature — just add the
+	 * field — one whose failure mode is "every node in a mixed-version
+	 * fleet stops beating and sweeps to offline": the exact class of
+	 * silent outage the slice was written to end. So the loop drops the
+	 * fields and retries once, and only for a literal 400.
+	 */
+	describe('worker state against an older platform', () => {
+		const workerBeat = (responses: Array<HeartbeatResponse | Error>) => {
+			const scheduler = fakeScheduler();
+			const scripted = scriptedClient(responses);
+			const entries: LogEntry[] = [];
+			const loop = new HeartbeatLoop({
+				client: scripted.client,
+				nodeId: NODE_ID,
+				secret: SECRET,
+				describe: async () => ({
+					platform: 'linux/x64',
+					capabilities: ['os:linux'],
+					workerState: 'quarantined',
+					workerStateReason: 'process tree unproven'
+				}),
+				intervalMs: INTERVAL,
+				scheduler: scheduler.scheduler,
+				logger: createLogger({ sink: (entry) => entries.push(entry) })
+			});
+			return { loop, scheduler, scripted, entries };
+		};
+
+		const rejected = () => new FleetClientError('invalid-request', 'Request rejected by the API (HTTP 400)', 400);
+
+		it('sends the worker state to a platform that accepts it', async () => {
+			const { loop, scripted } = workerBeat([ok]);
+
+			await loop.start();
+
+			expect(scripted.requests[0]).toMatchObject({
+				workerState: 'quarantined',
+				workerStateReason: 'process tree unproven'
+			});
+			expect(scripted.sent()).toBe(1);
+		});
+
+		it('retries once WITHOUT the fields when the platform 400s them', async () => {
+			const { loop, scripted, entries } = workerBeat([rejected(), ok]);
+
+			await loop.start();
+
+			// Two requests, one beat: the first carried the fields, the
+			// second did not, and the beat SUCCEEDED.
+			expect(scripted.sent()).toBe(2);
+			expect(scripted.requests[0]).toHaveProperty('workerState');
+			expect(scripted.requests[1]).not.toHaveProperty('workerState');
+			expect(scripted.requests[1]).not.toHaveProperty('workerStateReason');
+			// Everything else still goes.
+			expect(scripted.requests[1]).toMatchObject({ nodeId: NODE_ID, secret: SECRET, platform: 'linux/x64' });
+			// And it is a SUCCESS: connected, no failure counted, no backoff.
+			expect(loop.getState().state).toBe('connected');
+			expect(loop.getState().consecutiveFailures).toBe(0);
+			expect(entries.some((entry) => entry.message.includes('predates them'))).toBe(true);
+		});
+
+		it('latches, so it costs one extra request per process and not per beat', async () => {
+			const { loop, scripted } = workerBeat([rejected(), ok]);
+
+			await loop.start();
+			await loop.tick();
+			await loop.tick();
+
+			// 2 for the first beat (probe + retry), then 1 each.
+			expect(scripted.sent()).toBe(4);
+			expect(scripted.requests[2]).not.toHaveProperty('workerState');
+			expect(scripted.requests[3]).not.toHaveProperty('workerState');
+			expect(loop.getState().state).toBe('connected');
+		});
+
+		it('does not retry a 400 on a beat that carried no worker state', async () => {
+			// Preserves the old behaviour exactly for a description with
+			// nothing droppable: a 400 is a failure, and it backs off.
+			const scheduler = fakeScheduler();
+			const scripted = scriptedClient([rejected(), ok]);
+			const loop = new HeartbeatLoop({
+				client: scripted.client,
+				nodeId: NODE_ID,
+				secret: SECRET,
+				describe: async () => ({ platform: 'linux/x64' }),
+				intervalMs: INTERVAL,
+				scheduler: scheduler.scheduler
+			});
+
+			await loop.start();
+
+			expect(scripted.sent()).toBe(1);
+			expect(loop.getState().state).toBe('retrying');
+			expect(loop.getState().consecutiveFailures).toBe(1);
+		});
+
+		it.each([
+			['a 401', new FleetClientError('unauthorized', 'Node credential was rejected', 401)],
+			['a 403', new FleetClientError('forbidden', 'Refused by the API edge', 403)],
+			['a 429', new FleetClientError('rate-limited', 'Rate limited', 429)],
+			['a 5xx', new FleetClientError('server', 'API error (HTTP 503)', 503)],
+			['a network error', new Error('ECONNREFUSED')]
+		])('does not strip or latch on %s', async (_label, error) => {
+			// Latching on a blip would silence this node's health reporting
+			// until it restarts, for a platform that supports it perfectly.
+			const { loop, scripted } = workerBeat([error, ok]);
+
+			await loop.start();
+			expect(scripted.sent()).toBe(1);
+			expect(loop.getState().state).not.toBe('connected');
+
+			await loop.tick();
+			expect(scripted.requests[1]).toHaveProperty('workerState');
+		});
+
+		it('keeps beating when even the stripped retry fails', async () => {
+			// Both attempts refused: this is a real failure, counted once
+			// and backed off like any other.
+			const { loop, scripted } = workerBeat([rejected(), rejected()]);
+
+			await loop.start();
+
+			expect(scripted.sent()).toBe(2);
+			expect(loop.getState().state).toBe('retrying');
+			expect(loop.getState().consecutiveFailures).toBe(1);
+		});
+	});
 });

--- a/apps/node/src/core/heartbeat.ts
+++ b/apps/node/src/core/heartbeat.ts
@@ -54,14 +54,16 @@ export const systemScheduler: Scheduler = {
 
 /** Just enough of {@link FleetClient} for the loop — keeps tests tiny. */
 export interface HeartbeatCapableClient {
-	heartbeat(request: {
-		nodeId: string;
-		secret: string;
-		platform?: string;
-		version?: string;
-		capabilities?: string[];
-	}): Promise<HeartbeatResponse>;
+	heartbeat(request: NodeSelfDescription & { nodeId: string; secret: string }): Promise<HeartbeatResponse>;
 }
+
+/**
+ * Self-description fields a heartbeat may drop and still be a valid beat.
+ *
+ * Today: the worker state (EW-776). See {@link HeartbeatLoop} for why
+ * dropping them is ever the right move.
+ */
+const OPTIONAL_DESCRIPTION_FIELDS = ['workerState', 'workerStateReason'] as const;
 
 export interface HeartbeatLoopOptions {
 	client: HeartbeatCapableClient;
@@ -101,6 +103,14 @@ export class HeartbeatLoop {
 	private timer: unknown = null;
 	private running = false;
 	private inFlight: Promise<void> | null = null;
+	/**
+	 * Latched once this platform has proven it predates the worker-state
+	 * fields; from then on the beat carries liveness only. Process-scoped
+	 * on purpose — a platform upgrade is a restart-shaped event for the
+	 * node, and re-probing on every beat would mean one wasted round trip
+	 * per beat, forever, against an API that will never accept them.
+	 */
+	private legacyDescription = false;
 	private state: HeartbeatState = {
 		state: 'idle',
 		lastHeartbeatAt: null,
@@ -176,17 +186,60 @@ export class HeartbeatLoop {
 
 		try {
 			const description = await this.options.describe();
-			const result = await this.options.client.heartbeat({
-				nodeId: this.options.nodeId,
-				secret: this.options.secret,
-				...description
-			});
-			this.onSuccess(result);
+			this.onSuccess(await this.beat(description));
 		} catch (error) {
 			this.onFailure(error);
 		}
 
 		this.scheduleNext();
+	}
+
+	/**
+	 * Send one beat, tolerating a platform that predates the worker-state
+	 * fields (EW-776).
+	 *
+	 * The API validates heartbeats with `whitelist + forbidNonWhitelisted`,
+	 * so a field an older build does not know is not ignored — it 400s the
+	 * whole request. A 400 is a FAILED beat, a failed beat backs off, and
+	 * enough of them sweep the node to `offline`. Which would mean shipping
+	 * a health-reporting feature whose failure mode is "every node in a
+	 * mixed-version fleet goes dark": the exact class of outage this slice
+	 * was written to end.
+	 *
+	 * So a 400 on a beat that CARRIED those fields is retried once,
+	 * immediately, without them. If that succeeds the platform is simply
+	 * older than this daemon; we latch, say so once, and keep reporting
+	 * liveness. The retry costs one request, once per process.
+	 *
+	 * Inferring "the field was rejected" from a bare 400 is deliberate and
+	 * has a cost worth stating: `FleetClient` never surfaces server bodies
+	 * (fixed client-authored messages only), so a 400 caused by something
+	 * else on such a beat also latches, and this node reports liveness only
+	 * until it restarts. That is the safe direction — the node stays
+	 * observable either way, and only the extra signal is lost.
+	 */
+	private async beat(description: NodeSelfDescription): Promise<HeartbeatResponse> {
+		const credential = { nodeId: this.options.nodeId, secret: this.options.secret };
+		if (this.legacyDescription) {
+			return this.options.client.heartbeat({ ...credential, ...stripOptionalFields(description) });
+		}
+
+		try {
+			return await this.options.client.heartbeat({ ...credential, ...description });
+		} catch (error) {
+			if (!carriesOptionalFields(description) || !isFieldRejection(error)) {
+				throw error;
+			}
+			const result = await this.options.client.heartbeat({
+				...credential,
+				...stripOptionalFields(description)
+			});
+			this.legacyDescription = true;
+			this.options.logger?.warn(
+				'Platform rejected the worker-state fields; it predates them. Reporting liveness only until this node restarts.'
+			);
+			return result;
+		}
 	}
 
 	private onSuccess(result: HeartbeatResponse): void {
@@ -248,4 +301,31 @@ export class HeartbeatLoop {
 			listener(snapshot);
 		}
 	}
+}
+
+/** True when this description carries a field an older API would refuse. */
+function carriesOptionalFields(description: NodeSelfDescription): boolean {
+	return OPTIONAL_DESCRIPTION_FIELDS.some((field) => description[field] !== undefined);
+}
+
+/** The same description with the droppable fields removed. */
+function stripOptionalFields(description: NodeSelfDescription): NodeSelfDescription {
+	const out = { ...description };
+	for (const field of OPTIONAL_DESCRIPTION_FIELDS) {
+		delete out[field];
+	}
+	return out;
+}
+
+/**
+ * Is this the shape of "the API refused a field I sent"?
+ *
+ * A literal 400 only. A 401 is a credential problem, a 403 is an edge
+ * refusal, a 429 backs off, and a 5xx or a network error is transient —
+ * retrying any of those without the fields would learn nothing and, for
+ * the transient ones, would latch this node into liveness-only reporting
+ * over a blip.
+ */
+function isFieldRejection(error: unknown): boolean {
+	return error instanceof FleetClientError && error.kind === 'invalid-request' && error.status === 400;
 }

--- a/apps/node/src/core/runtime.spec.ts
+++ b/apps/node/src/core/runtime.spec.ts
@@ -215,6 +215,102 @@ describe('createNodeRuntime', () => {
 		await runtime.worker?.stop();
 	});
 
+	/**
+	 * Fleet health signals (EW-776) — end to end on the node side.
+	 *
+	 * The wiring is the risky part, not the mapping: `describe` is closed
+	 * over the telemetry object at line ~345, BEFORE the worker loop is
+	 * constructed. A naive "pass the worker into describeSelf" would have
+	 * required reordering that construction, and the heartbeat would have
+	 * silently reported nothing. So these drive the REAL beat body.
+	 */
+	describe('worker state on the heartbeat', () => {
+		const beatBodies = (bodies: Record<string, unknown>[]): FetchLike => {
+			return async (url, init) => {
+				if (url.endsWith('/api/fleet/heartbeat')) {
+					bodies.push(JSON.parse(init.body) as Record<string, unknown>);
+					return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: nodeFromApi }) };
+				}
+				return { ok: true, status: 200, text: async () => JSON.stringify({ jobs: [] }) };
+			};
+		};
+
+		const baseConfig = (over: Partial<NodeConfig> = {}): NodeConfig => ({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			kind: 'node',
+			capabilities: ['os:linux'],
+			heartbeatIntervalMs: 30_000,
+			enrolledAt: '2026-07-25T10:00:00.000Z',
+			...over
+		});
+
+		it('reports a restored quarantine, with the reason that was persisted', async () => {
+			// The whole defect, in one test: a machine whose durable safety
+			// marker survived a restart used to beat as a healthy, idle
+			// `online` node while refusing every job.
+			const bodies: Record<string, unknown>[] = [];
+			const { io: deps } = io(beatBodies(bodies));
+			const runtime = createNodeRuntime(
+				baseConfig({
+					unsafe: { since: '2026-08-22T23:00:00.000Z', reason: 'unverified process tree' }
+				}),
+				deps,
+				{ workerEnabled: true }
+			);
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0].workerState).toBe('quarantined');
+			expect(bodies[0].workerStateReason).toBe('unverified process tree');
+		});
+
+		it('reports a node started drained as paused', async () => {
+			const bodies: Record<string, unknown>[] = [];
+			const { io: deps } = io(beatBodies(bodies));
+			const runtime = createNodeRuntime(baseConfig(), deps, {
+				workerEnabled: true,
+				startPaused: true
+			});
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0].workerState).toBe('paused');
+		});
+
+		it('reports idle for a worker that is simply up', async () => {
+			const bodies: Record<string, unknown>[] = [];
+			const { io: deps } = io(beatBodies(bodies));
+			const runtime = createNodeRuntime(baseConfig(), deps, { workerEnabled: true });
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0].workerState).toBe('idle');
+			expect(bodies[0]).not.toHaveProperty('workerStateReason');
+		});
+
+		it('reports NOTHING on a visibility-only node with no worker', async () => {
+			// Absent, not `idle`: there is no worker, so there is no
+			// capacity, and the platform shows "unknown" rather than a
+			// fabricated readiness.
+			const bodies: Record<string, unknown>[] = [];
+			const { io: deps } = io(beatBodies(bodies));
+			const runtime = createNodeRuntime(baseConfig(), deps);
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0]).not.toHaveProperty('workerState');
+			expect(bodies[0]).not.toHaveProperty('workerStateReason');
+			// The rest of the description is unaffected.
+			expect(bodies[0].platform).toBe('linux/x64');
+		});
+	});
+
 	it('wires a client and a loop against the stored config, protecting the secret', async () => {
 		const {
 			io: deps,

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -16,6 +16,7 @@ import { FleetClient, type FetchLike } from './fleet-client';
 import { FleetJobClient } from './job-client';
 import { HeartbeatLoop, type Scheduler } from './heartbeat';
 import type { ResourceProbe } from './resource-limits';
+import { describeWorkerHealth } from './worker-health';
 import { WorkerLoop } from './worker-loop';
 import type { WorkerSafetyGate } from './worker-safety-store';
 import { runAcceptanceChecksJob } from './executors/acceptance-checks';
@@ -390,6 +391,16 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 			...(io.now ? { now: io.now } : {}),
 			...(io.monotonicNow ? { monotonicNow: io.monotonicNow } : {})
 		});
+		// Fleet health signals (EW-776). Wired onto the SAME telemetry
+		// object `describe` already closed over above, so the heartbeat
+		// starts reporting worker state without the loop having to be
+		// constructed before the beat — the two are built in this order for
+		// good reasons and this must not change that.
+		//
+		// Only when the worker exists: a visibility-only node has nothing
+		// to report, and the platform shows "unknown" rather than a
+		// fabricated `idle`.
+		telemetry.workerHealth = () => describeWorkerHealth(worker.getState());
 		const workspaceProvisioner: FleetWorkspaceProvisionerLike =
 			options.workspaceProvisioner ??
 			new FleetTaskWorkspaceProvisioner({

--- a/apps/node/src/core/worker-health.spec.ts
+++ b/apps/node/src/core/worker-health.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { FLEET_MAX_WORKER_STATE_REASON_LENGTH, FLEET_NODE_WORKER_STATES } from '@ever-works/contracts';
+import { describeWorkerHealth } from './worker-health';
+import type { WorkerLoopState, WorkerState } from './worker-loop';
+
+/**
+ * The projection from the loop's internal state machine onto the five
+ * values the fleet wire knows (EW-776).
+ *
+ * Every `WorkerState` is exercised by name below — not a sample — because
+ * the failure this whole slice exists to fix is a state that the platform
+ * never heard about. A new member added to `WorkerState` and forgotten
+ * here would silently fall into the `idle` default, which is exactly the
+ * "healthy and idle" lie a self-quarantined machine was telling.
+ */
+
+const state = (over: Partial<WorkerLoopState> = {}): WorkerLoopState => ({
+	state: 'idle',
+	activeJobIds: [],
+	consecutiveFailures: 0,
+	completed: 0,
+	failed: 0,
+	lastError: null,
+	paused: false,
+	throttleReason: null,
+	...over
+});
+
+/** Every member of the loop's own union, and what it must report as. */
+const MAPPING: Array<[WorkerState, string]> = [
+	['idle', 'idle'],
+	['polling', 'idle'],
+	['retrying', 'idle'],
+	['unauthorized', 'idle'],
+	['stopped', 'idle'],
+	['working', 'working'],
+	['paused', 'paused'],
+	['draining', 'paused'],
+	['throttled', 'throttled'],
+	['unsafe', 'quarantined']
+];
+
+describe('describeWorkerHealth', () => {
+	it.each(MAPPING)('maps the loop state %s to %s', (loopState, expected) => {
+		expect(describeWorkerHealth(state({ state: loopState }))?.workerState).toBe(expected);
+	});
+
+	it('covers every member of WorkerState', () => {
+		// The list above is the contract. If `WorkerState` grows and this
+		// does not, the new member falls into the `idle` default unnoticed.
+		const covered = new Set(MAPPING.map(([loopState]) => loopState));
+		const declared: WorkerState[] = [
+			'idle',
+			'polling',
+			'working',
+			'retrying',
+			'unauthorized',
+			'draining',
+			'throttled',
+			'paused',
+			'unsafe',
+			'stopped'
+		];
+		expect([...covered].sort()).toEqual([...declared].sort());
+	});
+
+	it('only ever reports a value the wire contract knows', () => {
+		for (const [loopState] of MAPPING) {
+			const health = describeWorkerHealth(state({ state: loopState }));
+			expect(FLEET_NODE_WORKER_STATES).toContain(health!.workerState);
+		}
+	});
+
+	it('carries the quarantine reason, which is the sentence the owner needs', () => {
+		const health = describeWorkerHealth(
+			state({ state: 'unsafe', lastError: 'process tree for job 42 could not be proven terminated' })
+		);
+
+		expect(health).toEqual({
+			workerState: 'quarantined',
+			workerStateReason: 'process tree for job 42 could not be proven terminated'
+		});
+	});
+
+	it('falls back to a stated reason when a quarantine carries none', () => {
+		// "Quarantined, reason unknown" is still far better than the old
+		// answer, which was no field at all.
+		expect(describeWorkerHealth(state({ state: 'unsafe', lastError: null }))).toEqual({
+			workerState: 'quarantined',
+			workerStateReason: 'Worker process-tree quarantine is active'
+		});
+	});
+
+	it('carries the throttle reason so an idle-looking node can explain itself', () => {
+		const health = describeWorkerHealth(
+			state({ state: 'throttled', throttleReason: 'free disk 1.2 GB is below the 5 GB floor' })
+		);
+
+		expect(health).toEqual({
+			workerState: 'throttled',
+			workerStateReason: 'free disk 1.2 GB is below the 5 GB floor'
+		});
+	});
+
+	it('omits the reason entirely rather than sending an empty one', () => {
+		// Absent means "no reason"; an empty string would render as a blank
+		// caption under the badge.
+		expect(describeWorkerHealth(state({ state: 'throttled', throttleReason: '   ' }))).toEqual({
+			workerState: 'throttled'
+		});
+		expect(describeWorkerHealth(state({ state: 'paused' }))).toEqual({ workerState: 'paused' });
+	});
+
+	it('does not leak a working node’s last error as a reason', () => {
+		// `lastError` is the last FAILURE, not a description of the current
+		// state. Only the quarantine mapping reads it, because there it IS
+		// the quarantine's message.
+		expect(describeWorkerHealth(state({ state: 'working', lastError: 'a job failed an hour ago' }))).toEqual({
+			workerState: 'working'
+		});
+	});
+
+	it('truncates a reason to the bound the server enforces', () => {
+		const health = describeWorkerHealth(state({ state: 'unsafe', lastError: 'x'.repeat(2_000) }));
+
+		expect(health?.workerStateReason).toHaveLength(FLEET_MAX_WORKER_STATE_REASON_LENGTH);
+	});
+
+	it('reports NOTHING for a node with no worker loop at all', () => {
+		// A visibility-only daemon has no worker. Reporting `idle` would
+		// claim capacity that does not exist; "unknown" is the truth.
+		expect(describeWorkerHealth(null)).toBeNull();
+		expect(describeWorkerHealth(undefined)).toBeNull();
+	});
+});

--- a/apps/node/src/core/worker-health.ts
+++ b/apps/node/src/core/worker-health.ts
@@ -1,0 +1,88 @@
+import { FLEET_MAX_WORKER_STATE_REASON_LENGTH, type FleetNodeWorkerState } from '@ever-works/contracts';
+import type { WorkerLoopState } from './worker-loop';
+
+/**
+ * What the heartbeat says about the worker (fleet health signals, EW-776,
+ * finding OPS-02).
+ *
+ * The defect this closes, precisely: a node that had self-quarantined —
+ * the durable worker safety marker, set when a job's process tree could
+ * not be proven dead, surviving restarts and clearable only at that
+ * keyboard — kept heartbeating and therefore kept reading `online` in
+ * Fleet, while refusing every job it was offered. Under the runbook's
+ * recommended `local-wait` there is no cloud fallback either, so there
+ * was no notification of any kind. The machine was, from the platform's
+ * point of view, perfectly healthy and perfectly idle.
+ *
+ * This is a pure PROJECTION of {@link WorkerLoopState} onto the five
+ * values the wire contract knows, and it lives in its own file for the
+ * same reason `describeSelf`'s probes do: it is the one piece of the
+ * health signal that has real logic in it, and it should be testable
+ * without a loop, a client or a host.
+ *
+ * The mapping collapses the loop's INTERNAL vocabulary on purpose. The
+ * loop distinguishes `polling` from `idle` and `draining` from `paused`
+ * because an operator watching the local process needs to; the platform
+ * does not — for the fleet the question is only "will this machine take
+ * my job, and if not, why not". Adding those names to the contract would
+ * be leaking an implementation detail into a wire format that two tiers
+ * and every future node build have to agree on.
+ */
+export interface WorkerHealth {
+	workerState: FleetNodeWorkerState;
+	/** Present only when there is a reason worth reading. */
+	workerStateReason?: string;
+}
+
+/**
+ * Project the worker loop's state onto the wire contract, or `null` when
+ * there is no worker at all.
+ *
+ * `null` is not the same as `idle`: a visibility-only node (the daemon
+ * running without `workerEnabled`) has no worker loop, so it reports NO
+ * worker state and the platform shows "unknown". Saying `idle` there
+ * would claim capacity that does not exist.
+ */
+export function describeWorkerHealth(state: WorkerLoopState | null | undefined): WorkerHealth | null {
+	if (!state) return null;
+
+	switch (state.state) {
+		// The fail-closed stop. `lastError` carries the quarantine's own
+		// message (`markUnsafe` writes it there), which is the single most
+		// useful sentence in this whole feature — it is what tells the
+		// owner whether to reboot the machine or to look at a runaway
+		// process tree by hand.
+		case 'unsafe':
+			return health('quarantined', state.lastError ?? 'Worker process-tree quarantine is active');
+		// Over a resource ceiling: still running, still holding its jobs,
+		// just not leasing more. The disk-floor refusal from the node
+		// admission gate surfaces here too, through the same field.
+		case 'throttled':
+			return health('throttled', state.throttleReason ?? null);
+		// A drain, in both its forms: `draining` is "paused, still
+		// finishing what it holds", which for the fleet is the same
+		// answer — no new work.
+		case 'paused':
+		case 'draining':
+			return health('paused', null);
+		case 'working':
+			return health('working', null);
+		// `polling`, `retrying`, `unauthorized` and `stopped` are all
+		// "not currently executing a job". They are not throttles and not
+		// refusals — a retrying loop is trying to lease — so they read as
+		// idle, and liveness itself is already carried by the heartbeat.
+		default:
+			return health('idle', null);
+	}
+}
+
+function health(workerState: FleetNodeWorkerState, reason: string | null | undefined): WorkerHealth {
+	const trimmed = typeof reason === 'string' ? reason.trim() : '';
+	if (!trimmed) {
+		return { workerState };
+	}
+	// Truncated to the SAME bound the server enforces, so what the node
+	// shows locally is what Fleet stores. A longer string would not be
+	// rejected — the server caps it — but the two would then disagree.
+	return { workerState, workerStateReason: trimmed.slice(0, FLEET_MAX_WORKER_STATE_REASON_LENGTH) };
+}

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3257,7 +3257,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3437,7 +3438,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "routing": {
                     "title": "Execution routing",
@@ -3502,7 +3516,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -3298,7 +3298,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3481,7 +3482,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3543,7 +3557,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -3230,7 +3230,8 @@
                     "diskFree": "Disk free",
                     "cliNotInstalled": "Not installed",
                     "billingIdentity": "Billing identity",
-                    "identityUnknown": "Not reported"
+                    "identityUnknown": "Not reported",
+                    "worker": "Worker"
                 },
                 "empty": {
                     "title": "No nodes enrolled yet",
@@ -3413,7 +3414,20 @@
                     "queuedReason": "Waiting: {reason}",
                     "queuedReasons": {
                         "waitingForRunner": "no runner can take it yet"
-                    }
+                    },
+                    "outcomes": {
+                        "queued": "Queued",
+                        "running": "Running",
+                        "completed": "Completed",
+                        "failed": "Failed",
+                        "cancelled": "Cancelled",
+                        "unknown": "Unknown"
+                    },
+                    "outcome": "Outcome",
+                    "outcomeText": "{text}",
+                    "summaryTask": "Task {id}",
+                    "summaryRun": "Run {id}",
+                    "summaryAgent": "Agent {id}"
                 },
                 "costCeiling": {
                     "title": "Daily cost ceiling",
@@ -3475,7 +3489,17 @@
                         "done": "Cancel requested for {cancelled} of {requested} jobs ({runs} runs)."
                     },
                     "auditFailed": "The action succeeded, but its audit row could not be written — tell an operator."
-                }
+                },
+                "workerStates": {
+                    "idle": "Idle",
+                    "working": "Working",
+                    "paused": "Paused",
+                    "quarantined": "Quarantined",
+                    "throttled": "Throttled",
+                    "unknown": "Unknown"
+                },
+                "workerStateReason": "Reason: {reason}",
+                "workerStateSince": "Since {time}"
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/src/components/settings/FleetNodeDrawer.tsx
+++ b/apps/web/src/components/settings/FleetNodeDrawer.tsx
@@ -20,6 +20,10 @@ import {
     FLEET_JOB_FILTERS,
     filterFleetJobs,
     fleetJobDurationMs,
+    fleetJobOutcomeKey,
+    fleetJobOutcomeText,
+    fleetWorkerStateBadgeClass,
+    fleetWorkerStateKey,
     formatFleetJobDuration,
     type FleetJobFilter,
 } from './fleet-node-drawer.shared';
@@ -163,6 +167,11 @@ export function FleetNodeDrawer({
             ? t('jobs.queuedReasons.waitingForRunner')
             : reason;
 
+    // Fleet health signals (EW-776). `unknown` for a node that has never
+    // reported — never `idle`, which would claim a readiness nobody has
+    // told us about.
+    const workerStateKey = fleetWorkerStateKey(node);
+
     const addTag = () => {
         const tag = draft.trim().slice(0, MAX_TAG_LENGTH);
         if (!tag || tags.includes(tag) || tags.length >= MAX_TAGS) {
@@ -226,6 +235,46 @@ export function FleetNodeDrawer({
                             </dt>
                             <dd className="text-text dark:text-text-dark">
                                 {formatMoment(node.lastHeartbeatAt)}
+                            </dd>
+                        </div>
+                        {/* Fleet health signals (EW-776): what the MACHINE
+                            says about itself, next to what the platform
+                            infers from heartbeats. `online` + `quarantined`
+                            is the pair that used to be invisible. */}
+                        <div className="col-span-2">
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('table.worker')}
+                            </dt>
+                            <dd
+                                className="text-text dark:text-text-dark"
+                                data-testid="fleet-node-drawer-worker"
+                            >
+                                <span
+                                    className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium ${fleetWorkerStateBadgeClass(workerStateKey)}`}
+                                    data-testid="fleet-node-drawer-worker-state"
+                                >
+                                    {t(`workerStates.${workerStateKey}` as never)}
+                                </span>
+                                {node.workerStateReason ? (
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark break-words"
+                                        data-testid="fleet-node-drawer-worker-reason"
+                                    >
+                                        {t('workerStateReason', {
+                                            reason: node.workerStateReason,
+                                        })}
+                                    </span>
+                                ) : null}
+                                {node.workerStateChangedAt ? (
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark"
+                                        data-testid="fleet-node-drawer-worker-since"
+                                    >
+                                        {t('workerStateSince', {
+                                            time: formatMoment(node.workerStateChangedAt),
+                                        })}
+                                    </span>
+                                ) : null}
                             </dd>
                         </div>
                         {/* Fleet cost accounting (EW-777): the seat this
@@ -479,7 +528,12 @@ export function FleetNodeDrawer({
                         ) : (
                             <ul className="space-y-1.5">
                                 {visibleJobs.map((job) => {
-                                    const failed = job.status === 'failed';
+                                    const outcome = fleetJobOutcomeKey(job);
+                                    // Red on the RECONCILED verdict, not on
+                                    // the job status: a job the node called
+                                    // done whose run failed is a failure.
+                                    const failed = outcome === 'failed';
+                                    const outcomeText = fleetJobOutcomeText(job);
                                     const durationMs = fleetJobDurationMs(job, now);
                                     const duration = formatFleetJobDuration(durationMs);
                                     return (
@@ -503,6 +557,25 @@ export function FleetNodeDrawer({
                                                         data-testid={`fleet-node-job-status-${job.id}`}
                                                     >
                                                         {t(`jobs.statuses.${job.status}` as never)}
+                                                    </span>
+                                                    {/* What actually happened to the WORK
+                                                        (EW-776) — the reconciled run
+                                                        outcome, which can disagree with the
+                                                        job status above and is the answer
+                                                        the operator came for. */}
+                                                    <span
+                                                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium ${jobStatusBadgeClass(
+                                                            outcome === 'completed'
+                                                                ? 'done'
+                                                                : outcome === 'failed'
+                                                                  ? 'failed'
+                                                                  : outcome === 'running'
+                                                                    ? 'running'
+                                                                    : 'queued',
+                                                        )}`}
+                                                        data-testid={`fleet-node-job-outcome-${job.id}`}
+                                                    >
+                                                        {t(`jobs.outcomes.${outcome}` as never)}
                                                     </span>
                                                     {job.targetNodeId === node.id && (
                                                         <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] bg-primary/10 text-primary">
@@ -583,6 +656,52 @@ export function FleetNodeDrawer({
                                                     {t('jobs.queuedReason', {
                                                         reason: queuedReasonLabel(job.queuedReason),
                                                     })}
+                                                </p>
+                                            ) : null}
+                                            {/* The one sentence that explains the row:
+                                                the run's error, else the job's, else the
+                                                run's summary. Never the payload. */}
+                                            {outcomeText ? (
+                                                <p
+                                                    className={`mt-1 text-xs break-words ${
+                                                        failed
+                                                            ? 'text-danger'
+                                                            : 'text-text-muted dark:text-text-muted-dark'
+                                                    }`}
+                                                    data-testid={`fleet-node-job-outcome-text-${job.id}`}
+                                                >
+                                                    {t('jobs.outcomeText', { text: outcomeText })}
+                                                </p>
+                                            ) : null}
+                                            {/* IDs only. `job.payload` is executor input
+                                                composed from user content and is never
+                                                rendered here — the API sends it as null. */}
+                                            {job.summary?.taskId || job.summary?.runId ? (
+                                                <p
+                                                    className="mt-1 flex flex-wrap gap-x-3 text-[11px] font-mono text-text-muted dark:text-text-muted-dark"
+                                                    data-testid={`fleet-node-job-summary-${job.id}`}
+                                                >
+                                                    {job.summary?.taskId ? (
+                                                        <span>
+                                                            {t('jobs.summaryTask', {
+                                                                id: job.summary.taskId,
+                                                            })}
+                                                        </span>
+                                                    ) : null}
+                                                    {job.summary?.runId ? (
+                                                        <span>
+                                                            {t('jobs.summaryRun', {
+                                                                id: job.summary.runId,
+                                                            })}
+                                                        </span>
+                                                    ) : null}
+                                                    {job.summary?.agentId ? (
+                                                        <span>
+                                                            {t('jobs.summaryAgent', {
+                                                                id: job.summary.agentId,
+                                                            })}
+                                                        </span>
+                                                    ) : null}
                                                 </p>
                                             ) : null}
                                         </li>

--- a/apps/web/src/components/settings/FleetNodeDrawer.unit.spec.tsx
+++ b/apps/web/src/components/settings/FleetNodeDrawer.unit.spec.tsx
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { FleetJobView, FleetNodeDetailView, FleetNodeView } from '@ever-works/contracts';
+import type {
+    FleetJobView,
+    FleetNodeDetailView,
+    FleetNodeJobHistoryEntry,
+    FleetNodeView,
+} from '@ever-works/contracts';
 import { FleetNodeDrawer } from './FleetNodeDrawer';
 
 /**
@@ -376,5 +381,171 @@ describe('FleetNodeDrawer — history states', () => {
     it('renders the all-jobs empty state for a node with no history', () => {
         renderDrawer({ detail: detail({ recentJobs: [], failures: [] }) });
         expect(screen.getByTestId('fleet-node-jobs-empty')).toHaveTextContent('jobs.emptyAll');
+    });
+});
+
+/**
+ * Fleet health signals (EW-776) — the three truths slices B and E left
+ * open, plus the one thing the drawer must never do.
+ *
+ * The mocked `useTranslations` renders `key:value1,value2`, so the
+ * assertions below read the KEY the component chose — which is exactly
+ * what is under test here: whether the drawer picks "quarantined" for a
+ * machine that is refusing work, and "failed" for a job whose RUN failed.
+ */
+describe('FleetNodeDrawer — worker state', () => {
+    it('shows a quarantine with its reason and when it started', () => {
+        // The defect: `status: 'online'` on a machine refusing every job.
+        // Both facts are now on screen at once.
+        const quarantined = node({
+            status: 'online',
+            workerState: 'quarantined',
+            workerStateReason: 'process tree for job 42 could not be proven terminated',
+            workerStateChangedAt: '2026-09-01T03:14:00.000Z',
+        });
+        renderDrawer({ node: quarantined, detail: detail({ node: quarantined }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-worker-state')).toHaveTextContent(
+            'workerStates.quarantined',
+        );
+        expect(screen.getByTestId('fleet-node-drawer-worker-reason')).toHaveTextContent(
+            'process tree for job 42 could not be proven terminated',
+        );
+        expect(screen.getByTestId('fleet-node-drawer-worker-since')).toHaveTextContent(
+            'workerStateSince',
+        );
+    });
+
+    it('says unknown — not idle — for a node that has never reported', () => {
+        renderDrawer();
+
+        expect(screen.getByTestId('fleet-node-drawer-worker-state')).toHaveTextContent(
+            'workerStates.unknown',
+        );
+        expect(screen.queryByTestId('fleet-node-drawer-worker-reason')).toBeNull();
+        expect(screen.queryByTestId('fleet-node-drawer-worker-since')).toBeNull();
+    });
+
+    it('shows a throttle reason so an idle-looking machine explains itself', () => {
+        const throttled = node({ workerState: 'throttled', workerStateReason: 'CPU ceiling' });
+        renderDrawer({ node: throttled, detail: detail({ node: throttled }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-worker-state')).toHaveTextContent(
+            'workerStates.throttled',
+        );
+        expect(screen.getByTestId('fleet-node-drawer-worker-reason')).toHaveTextContent(
+            'CPU ceiling',
+        );
+    });
+});
+
+describe('FleetNodeDrawer — reconciled job outcome', () => {
+    const historyRow = (over: Partial<FleetNodeJobHistoryEntry>): FleetNodeJobHistoryEntry => ({
+        ...job(),
+        error: null,
+        summary: null,
+        reconciled: null,
+        ...over,
+    });
+
+    const withHistory = (rows: FleetNodeJobHistoryEntry[]) =>
+        renderDrawer({
+            detail: detail({
+                recentJobs: rows,
+                failures: rows.filter((row) => row.status === 'failed'),
+            }),
+        });
+
+    it('shows a FAILED run behind a job the node called done', () => {
+        withHistory([
+            historyRow({
+                id: 'job-mixed',
+                status: 'done',
+                reconciled: {
+                    runId: 'run-1',
+                    status: 'failed',
+                    summary: null,
+                    error: 'model refused the plan',
+                },
+            }),
+        ]);
+
+        // The job badge still says what the JOB did — both facts, no lie.
+        expect(screen.getByTestId('fleet-node-job-status-job-mixed')).toHaveTextContent(
+            'jobs.statuses.done',
+        );
+        expect(screen.getByTestId('fleet-node-job-outcome-job-mixed')).toHaveTextContent(
+            'jobs.outcomes.failed',
+        );
+        expect(screen.getByTestId('fleet-node-job-outcome-text-job-mixed')).toHaveTextContent(
+            'model refused the plan',
+        );
+    });
+
+    it("shows a failed job's own error text", () => {
+        // Previously a red badge with no reason, whose next step was
+        // "open a database".
+        withHistory([
+            historyRow({ id: 'job-red', status: 'failed', error: 'pnpm install exploded' }),
+        ]);
+
+        expect(screen.getByTestId('fleet-node-job-outcome-text-job-red')).toHaveTextContent(
+            'pnpm install exploded',
+        );
+    });
+
+    it('shows the run summary for a clean completion', () => {
+        withHistory([
+            historyRow({
+                id: 'job-green',
+                reconciled: {
+                    runId: 'run-1',
+                    status: 'completed',
+                    summary: 'Added the missing guard',
+                    error: null,
+                },
+            }),
+        ]);
+
+        expect(screen.getByTestId('fleet-node-job-outcome-job-green')).toHaveTextContent(
+            'jobs.outcomes.completed',
+        );
+        expect(screen.getByTestId('fleet-node-job-outcome-text-job-green')).toHaveTextContent(
+            'Added the missing guard',
+        );
+    });
+
+    it('renders the ids-only summary, and NEVER the payload', () => {
+        // The load-bearing assertion of this whole file: `payload` is
+        // executor input composed from user content. The API sends it as
+        // null, and nothing here may start reading it.
+        withHistory([
+            historyRow({
+                id: 'job-ids',
+                payload: { instructions: 'PAYLOAD-SENTINEL' } as never,
+                summary: {
+                    kind: 'agent-task',
+                    taskId: 'task-77',
+                    runId: 'run-88',
+                    agentId: 'agent-99',
+                },
+            }),
+        ]);
+
+        const summary = screen.getByTestId('fleet-node-job-summary-job-ids');
+        expect(summary).toHaveTextContent('task-77');
+        expect(summary).toHaveTextContent('run-88');
+        expect(summary).toHaveTextContent('agent-99');
+        expect(document.body.textContent).not.toContain('PAYLOAD-SENTINEL');
+    });
+
+    it('renders no outcome line when there is nothing to explain', () => {
+        withHistory([historyRow({ id: 'job-quiet' })]);
+
+        expect(screen.getByTestId('fleet-node-job-outcome-job-quiet')).toHaveTextContent(
+            'jobs.outcomes.completed',
+        );
+        expect(screen.queryByTestId('fleet-node-job-outcome-text-job-quiet')).toBeNull();
+        expect(screen.queryByTestId('fleet-node-job-summary-job-quiet')).toBeNull();
     });
 });

--- a/apps/web/src/components/settings/fleet-node-drawer.shared.ts
+++ b/apps/web/src/components/settings/fleet-node-drawer.shared.ts
@@ -1,4 +1,9 @@
-import { isFleetJobActive, type FleetJobView } from '@ever-works/contracts';
+import {
+    isFleetJobActive,
+    type FleetJobView,
+    type FleetNodeJobHistoryEntry,
+    type FleetNodeView,
+} from '@ever-works/contracts';
 
 /**
  * Node drawer — job-history presentation rules, as pure functions.
@@ -27,13 +32,20 @@ export const FLEET_JOB_FILTERS: readonly FleetJobFilter[] = ['all', 'failed', 'r
  * own `isFleetJobActive` draws that line, so this cannot drift from what
  * "busy" means in the node table.
  */
-export function filterFleetJobs(
-    jobs: readonly FleetJobView[],
+export function filterFleetJobs<T extends FleetJobView>(
+    jobs: readonly T[],
     filter: FleetJobFilter,
-): FleetJobView[] {
+): T[] {
     switch (filter) {
         case 'failed':
-            return jobs.filter((job) => job.status === 'failed');
+            // Judged on the RECONCILED outcome (EW-776), the same rule the
+            // badge on each row uses. Filtering on `job.status` alone
+            // reproduced the original defect one layer up: a row showing a
+            // red "Failed" badge in All, and missing from Failed.
+            // `fleetJobOutcomeKey` falls back to the job status for a row
+            // that carries no reconciled outcome, so a plain
+            // `FleetJobView` behaves exactly as it did before.
+            return jobs.filter((job) => fleetJobOutcomeKey(job) === 'failed');
         case 'running':
             return jobs.filter((job) => isFleetJobActive(job.status));
         default:
@@ -52,12 +64,13 @@ export function filterFleetJobs(
  * spans (clock skew between the two stamps) clamp to zero rather than
  * rendering as a bug.
  *
- * `startedAt` is the FIRST attempt's start: the API keeps it across
- * re-leases (`FleetJobService.lease` reuses `job.startedAt`; reclaim
- * never resets it), so a job on its second attempt reports the
- * wall-clock age since it first ran, not since this node picked it up.
- * That is the number an operator asking "how long has this been going
- * on" wants; per-attempt timing would need the API to reset the stamp.
+ * `startedAt` is THIS ATTEMPT's start (EW-776). The lease CAS clears it
+ * and the attempt's first job heartbeat re-stamps it, so a job on its
+ * third attempt reports how long the CURRENT attempt has been running.
+ * It used to be preserved across re-leases, which meant a job that had
+ * lapsed twice showed "running for 4h 12m" — the age of an attempt that
+ * had ended hours earlier, on a machine that might not even be the one
+ * holding it now. That read as a stuck job and was not one.
  */
 export function fleetJobDurationMs(job: FleetJobView, now: number = Date.now()): number | null {
     if (!job.startedAt) return null;
@@ -86,4 +99,139 @@ export function formatFleetJobDuration(ms: number | null | undefined): string | 
     if (totalMinutes < 60) return `${totalMinutes}m ${totalSeconds % 60}s`;
     const hours = Math.floor(totalMinutes / 60);
     return `${hours}h ${totalMinutes % 60}m`;
+}
+
+/**
+ * Fleet health signals (EW-776) — what the drawer says about the node's
+ * WORKER, as opposed to its registry status.
+ *
+ * The two answer different questions and the drawer shows both: `status`
+ * is what the platform can infer from heartbeats, `workerState` is what
+ * the machine says about itself. A self-quarantined node is `online` and
+ * `quarantined` at the same time, and that pair is the whole point — it
+ * is precisely the combination that used to be invisible.
+ */
+export type FleetWorkerStateKey =
+    | 'idle'
+    | 'working'
+    | 'paused'
+    | 'quarantined'
+    | 'throttled'
+    | 'unknown';
+
+/**
+ * The i18n key for a node's worker state.
+ *
+ * `unknown` for a node that has never reported one — an older daemon, a
+ * visibility-only node, or a value this build did not recognise. NEVER
+ * defaulted to `idle`: a fabricated readiness for a machine we know
+ * nothing about is the exact lie this feature exists to end.
+ */
+export function fleetWorkerStateKey(node: Pick<FleetNodeView, 'workerState'>): FleetWorkerStateKey {
+    switch (node.workerState) {
+        case 'idle':
+        case 'working':
+        case 'paused':
+        case 'quarantined':
+        case 'throttled':
+            return node.workerState;
+        default:
+            return 'unknown';
+    }
+}
+
+/**
+ * Badge classes for a worker state.
+ *
+ * `quarantined` is the one that must stand out — it is a machine that
+ * looks healthy and is refusing every job. `throttled` and `paused` are
+ * warnings (not taking work, but by design), `working` is informational,
+ * and `idle`/`unknown` stay neutral: an idle machine is not an event.
+ */
+export function fleetWorkerStateBadgeClass(key: FleetWorkerStateKey): string {
+    switch (key) {
+        case 'quarantined':
+            return 'bg-danger/10 text-danger';
+        case 'throttled':
+        case 'paused':
+            return 'bg-warning/10 text-warning';
+        case 'working':
+            return 'bg-info/10 text-info';
+        default:
+            return 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark';
+    }
+}
+
+/** Outcome vocabulary for one history row — the reconciled verdict, not the job's. */
+export type FleetJobOutcomeKey =
+    | 'queued'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'cancelled'
+    | 'unknown';
+
+/**
+ * What actually HAPPENED to the work this job carried.
+ *
+ * The reconciled run outcome wins outright when there is one, because a
+ * fleet job and the Agent run it carried settle SEPARATELY: the node
+ * reports a verdict on the job, then the api-side reconciler decides what
+ * that meant for the run. The drawer used to show only the first, which
+ * is how a job whose run had failed rendered a calm green "done".
+ *
+ * It wins even when it is `running` while the job says `done` — that
+ * combination is a run the reconciler has not settled yet, and "still
+ * running" is the true answer for the WORK. Saying "completed" there
+ * would repeat the original mistake with fresher data.
+ *
+ * Without a reconciled outcome the job's own status is the honest answer,
+ * mapped onto the same vocabulary so one badge renders both cases.
+ */
+export function fleetJobOutcomeKey(job: FleetNodeJobHistoryEntry): FleetJobOutcomeKey {
+    switch (job.reconciled?.status) {
+        case 'completed':
+            return 'completed';
+        case 'failed':
+            return 'failed';
+        case 'cancelled':
+            return 'cancelled';
+        case 'running':
+            return 'running';
+        case 'queued':
+            return 'queued';
+        default:
+            break;
+    }
+    switch (job.status) {
+        case 'done':
+            return 'completed';
+        case 'failed':
+            return 'failed';
+        case 'running':
+        case 'leased':
+            return 'running';
+        case 'queued':
+            return 'queued';
+        default:
+            return 'unknown';
+    }
+}
+
+/**
+ * The one sentence that explains a row, or null when there is nothing to
+ * say.
+ *
+ * Order is deliberate: an error beats a summary (a failure's reason is
+ * the thing the operator came for), the RUN's error beats the JOB's (the
+ * run is the reconciled truth), and a summary is shown only when nothing
+ * went wrong. Capped so a pasted stack trace cannot take over the drawer
+ * — the full text lives on the run.
+ */
+export function fleetJobOutcomeText(job: FleetNodeJobHistoryEntry, maxLength = 240): string | null {
+    const candidate = job.reconciled?.error ?? job.error ?? job.reconciled?.summary ?? null;
+    if (typeof candidate !== 'string') return null;
+    const trimmed = candidate.trim();
+    if (!trimmed) return null;
+    return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed;
 }

--- a/apps/web/src/components/settings/fleet-node-drawer.shared.unit.spec.ts
+++ b/apps/web/src/components/settings/fleet-node-drawer.shared.unit.spec.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import type { FleetJobView } from '@ever-works/contracts';
+import type { FleetJobView, FleetNodeJobHistoryEntry } from '@ever-works/contracts';
 import {
     FLEET_JOB_FILTERS,
     filterFleetJobs,
     fleetJobDurationMs,
+    fleetJobOutcomeKey,
+    fleetJobOutcomeText,
+    fleetWorkerStateBadgeClass,
+    fleetWorkerStateKey,
     formatFleetJobDuration,
 } from './fleet-node-drawer.shared';
 
@@ -54,6 +58,36 @@ describe('filterFleetJobs', () => {
 
     it('"failed" keeps only failed jobs', () => {
         expect(filterFleetJobs(jobs, 'failed').map((entry) => entry.id)).toEqual(['failed']);
+    });
+
+    /**
+     * The chip has to agree with the badge sitting next to it (EW-776).
+     * Judging the filter on `job.status` while the badge is judged on the
+     * reconciled run outcome would put a row rendering a red "Failed" in
+     * All and hide it under Failed — the original defect, one layer up.
+     */
+    it('"failed" is judged on the RECONCILED outcome, not the job status', () => {
+        const rows = [
+            {
+                ...job({ id: 'done-but-run-failed', status: 'done' }),
+                reconciled: { runId: 'r1', status: 'failed' as const, summary: null, error: null },
+            },
+            {
+                ...job({ id: 'failed-but-run-completed', status: 'failed' }),
+                reconciled: {
+                    runId: 'r2',
+                    status: 'completed' as const,
+                    summary: null,
+                    error: null,
+                },
+            },
+            { ...job({ id: 'failed-no-run', status: 'failed' }), reconciled: null },
+        ];
+
+        expect(filterFleetJobs(rows, 'failed').map((entry) => entry.id)).toEqual([
+            'done-but-run-failed',
+            'failed-no-run',
+        ]);
     });
 
     /**
@@ -110,5 +144,132 @@ describe('formatFleetJobDuration', () => {
         expect(formatFleetJobDuration(undefined)).toBeNull();
         expect(formatFleetJobDuration(-1)).toBeNull();
         expect(formatFleetJobDuration(Number.NaN)).toBeNull();
+    });
+});
+
+/**
+ * Fleet health signals (EW-776) — the drawer's new derivations.
+ *
+ * Two of these encode the defect directly: a node reads `online` while
+ * its worker is quarantined, and a job reads `done` while the run it
+ * carried failed. Both used to render as "fine".
+ */
+
+function historyJob(over: Partial<FleetNodeJobHistoryEntry> = {}): FleetNodeJobHistoryEntry {
+    return { ...job(), error: null, summary: null, reconciled: null, ...over };
+}
+
+const reconciled = (
+    over: Partial<NonNullable<FleetNodeJobHistoryEntry['reconciled']>> = {},
+): NonNullable<FleetNodeJobHistoryEntry['reconciled']> => ({
+    runId: 'run-1',
+    status: 'completed',
+    summary: null,
+    error: null,
+    ...over,
+});
+
+describe('fleetWorkerStateKey', () => {
+    it.each([['idle'], ['working'], ['paused'], ['quarantined'], ['throttled']] as const)(
+        'passes %s through',
+        (workerState) => {
+            expect(fleetWorkerStateKey({ workerState })).toBe(workerState);
+        },
+    );
+
+    it('reports unknown — never idle — for a node that has never said', () => {
+        // A fabricated readiness for a machine we know nothing about is
+        // the exact lie this feature exists to end.
+        expect(fleetWorkerStateKey({ workerState: null })).toBe('unknown');
+        expect(fleetWorkerStateKey({})).toBe('unknown');
+    });
+
+    it('reports unknown for a value this build does not recognise', () => {
+        expect(fleetWorkerStateKey({ workerState: 'hibernating' as never })).toBe('unknown');
+    });
+});
+
+describe('fleetWorkerStateBadgeClass', () => {
+    it('makes a quarantine stand out and leaves idle neutral', () => {
+        expect(fleetWorkerStateBadgeClass('quarantined')).toContain('danger');
+        expect(fleetWorkerStateBadgeClass('throttled')).toContain('warning');
+        expect(fleetWorkerStateBadgeClass('paused')).toContain('warning');
+        expect(fleetWorkerStateBadgeClass('working')).toContain('info');
+        // An idle machine is not an event.
+        expect(fleetWorkerStateBadgeClass('idle')).not.toContain('danger');
+        expect(fleetWorkerStateBadgeClass('unknown')).not.toContain('danger');
+    });
+});
+
+describe('fleetJobOutcomeKey', () => {
+    it('reports a FAILED run behind a job the node called done', () => {
+        expect(
+            fleetJobOutcomeKey(
+                historyJob({ status: 'done', reconciled: reconciled({ status: 'failed' }) }),
+            ),
+        ).toBe('failed');
+    });
+
+    it('keeps saying running while the reconciler has not settled the run', () => {
+        // "Completed" here would repeat the original mistake with fresher
+        // data: the JOB finished, the WORK has not.
+        expect(
+            fleetJobOutcomeKey(
+                historyJob({ status: 'done', reconciled: reconciled({ status: 'running' }) }),
+            ),
+        ).toBe('running');
+    });
+
+    it('surfaces a cancelled run', () => {
+        expect(
+            fleetJobOutcomeKey(historyJob({ reconciled: reconciled({ status: 'cancelled' }) })),
+        ).toBe('cancelled');
+    });
+
+    it.each([
+        ['done', 'completed'],
+        ['failed', 'failed'],
+        ['running', 'running'],
+        ['leased', 'running'],
+        ['queued', 'queued'],
+    ] as const)('falls back to the job status %s → %s when no run is known', (status, expected) => {
+        expect(fleetJobOutcomeKey(historyJob({ status, reconciled: null }))).toBe(expected);
+    });
+});
+
+describe('fleetJobOutcomeText', () => {
+    it('leads with the RUN error — the reconciled reason is the one that matters', () => {
+        const text = fleetJobOutcomeText(
+            historyJob({
+                error: 'job said: exit 1',
+                reconciled: reconciled({ status: 'failed', error: 'model refused the plan' }),
+            }),
+        );
+        expect(text).toBe('model refused the plan');
+    });
+
+    it("falls back to the job's own error", () => {
+        expect(fleetJobOutcomeText(historyJob({ error: 'pnpm install exploded' }))).toBe(
+            'pnpm install exploded',
+        );
+    });
+
+    it('shows the run summary only when nothing went wrong', () => {
+        expect(
+            fleetJobOutcomeText(
+                historyJob({ reconciled: reconciled({ summary: 'Added a guard' }) }),
+            ),
+        ).toBe('Added a guard');
+    });
+
+    it('returns null when there is nothing to say', () => {
+        expect(fleetJobOutcomeText(historyJob())).toBeNull();
+        expect(fleetJobOutcomeText(historyJob({ error: '   ' }))).toBeNull();
+    });
+
+    it('truncates so a pasted stack trace cannot take over the drawer', () => {
+        const text = fleetJobOutcomeText(historyJob({ error: 'x'.repeat(400) }), 240);
+        expect(text).toHaveLength(241);
+        expect(text?.endsWith('…')).toBe(true);
     });
 });

--- a/apps/web/src/lib/api/fleet.ts
+++ b/apps/web/src/lib/api/fleet.ts
@@ -61,6 +61,12 @@ export type {
     FleetExecutionScopeType,
     FleetRunnerNodeView,
     FleetRunnerStatusView,
+    // Fleet health signals (EW-776) — the worker-state vocabulary and the
+    // richer node-drawer history row.
+    FleetNodeWorkerState,
+    FleetNodeJobHistoryEntry,
+    FleetJobHistorySummary,
+    FleetJobReconciledOutcome,
 } from '@ever-works/contracts';
 
 /** Body of `POST /api/fleet/cancel-in-flight`. */

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -67,11 +67,65 @@ POST   /api/fleet/nodes/:id/rotate   re-key the node; the replacement token is r
 DELETE /api/fleet/nodes/:id          remove the registration
 ```
 
-The **node drawer** on the Fleet page (the details action on a row) renders the same job history: each job's kind, status, attempt count, queued reason, queued / started / completed times and duration, filterable by **All / Failed / Running**.
+The **node drawer** on the Fleet page (the details action on a row) renders the same job history: each job's kind, status, **reconciled outcome and its reason**, attempt count, queued reason, queued / started / completed times and duration, filterable by **All / Failed / Running**. It also shows the node's **worker state** (see [Health signals](#health-signals)). It never renders a job's `payload` — the endpoint sends it as `null` and hands the drawer the task / run / agent ids instead.
 
 **Disabling drains.** A disabled node's heartbeats stop being accepted, so it goes quiet immediately rather than at the next sweep. Re-enabling puts it back to `offline` until its next accepted heartbeat proves it alive. Disabling a node that is still `enrolling` revokes its unused token.
 
 Everything here is owner-scoped: another account's node id is indistinguishable from one that does not exist.
+
+## Health signals
+
+`status` is what the platform can INFER from heartbeats. It cannot answer "will this machine actually take my job" — a node that has self-quarantined keeps heartbeating (that is what makes a quarantine observable instead of a blackout), so it reads `online` while refusing every lease. Before these signals, that machine looked healthy and idle, its owner was told nothing, and under the recommended `local-wait` routing there was no cloud fallback to quietly cover for it.
+
+### Worker state
+
+Every heartbeat now carries what the node's **worker** is doing, alongside the registry status:
+
+| Worker state  | The node reports it when                                                                  |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `idle`        | polling, ready to take work                                                               |
+| `working`     | at least one job in flight                                                                |
+| `paused`      | drained on purpose — an operator pause, or draining the last in-flight jobs before a stop |
+| `quarantined` | the fail-closed stop the node imposed on ITSELF; only clearable at that machine           |
+| `throttled`   | over a resource ceiling (CPU / memory, disk floor): keeps its jobs, leases no more        |
+
+`workerStateReason` carries the sentence that explains it — the quarantine's own message, the ceiling that was crossed — and `workerStateChangedAt` moves only on a TRANSITION, so "quarantined since 03:14" survives the hundreds of beats that follow. A node that has never reported one shows **unknown**, never `idle`: a fabricated readiness for a machine nobody has heard from is the thing these signals exist to end.
+
+Two properties are load-bearing and deliberately awkward:
+
+- **The field is a string on the wire, not an enum.** The heartbeat DTO runs under `whitelist + forbidNonWhitelisted`, so a value an older API rejects fails the whole request — and a failed heartbeat is a node that sweeps to `offline`. A node newer than the platform must be able to report a state this build has never heard of and stay alive; the server normalizes anything unrecognised to "unknown" rather than trusting it.
+- **The node tolerates an older platform.** If a heartbeat carrying the worker state comes back `400`, the daemon retries once immediately without those two fields; if that succeeds it logs once, keeps reporting liveness, and stops sending them until it restarts.
+
+The drawer judges a job FAILED on the reconciled run outcome — the badge, the **Failed** filter chip and the endpoint’s `failures` subset all use the same rule, so a job the node called `done` whose run failed appears in all three.
+
+Availability counts a node as **free** only when its worker state is not `quarantined`, `throttled` or `paused`. It stays counted as ONLINE — the operator must keep seeing it — but the run router no longer places work on a machine that will refuse it.
+
+### Inbox notices
+
+Three notices, each filed **exactly once per event** and re-armed when the node recovers:
+
+| Notice                     | Fired by                                                             | Re-armed by                            |
+| -------------------------- | -------------------------------------------------------------------- | -------------------------------------- |
+| `Fleet node offline`       | the heartbeat-expiry sweep, on the flip to offline                   | the next accepted heartbeat            |
+| `Fleet node still offline` | the sweep, once the node has been gone longer than the notice window | the next accepted heartbeat            |
+| `Fleet node quarantined`   | the first heartbeat reporting `quarantined`                          | the first beat reporting anything else |
+
+Each names the node, its kind, the reason where there is one, and when it was last seen. The dedup markers live on the `fleet_nodes` row (`offlineNoticedAt`, `offlineLongNoticedAt`, `quarantineNoticedAt`) and are claimed by a conditional UPDATE, so two API replicas sweeping the same owner produce one notice rather than two.
+
+The sweep is piggybacked on owner-scoped list reads (there is no cron): the runner pill polls it every 30 seconds while a dashboard is open, and a dispatch triggers it too. An owner with no open page and no dispatch gets the notice on their next visit rather than at the moment of the outage.
+
+### Knobs
+
+| Env                                  | Default | Meaning                                                        |
+| ------------------------------------ | ------- | -------------------------------------------------------------- |
+| `FLEET_NODE_OFFLINE_AFTER_MS`        | 5 min   | silence after which an `online` node sweeps to `offline`       |
+| `FLEET_NODE_OFFLINE_NOTICE_AFTER_MS` | 30 min  | how long a node stays offline before the second, louder notice |
+
+The notice window is floored at the sweep window: an escalation that could fire before the node is even considered offline would be two notices for one event.
+
+### Removing a node takes its pins with it
+
+Deleting a node deletes its `fleet_agent_node_affinities` rows — the durable "run this Agent on THAT machine" pins — in the same transaction. Left behind, they kept resolving: `FleetJobService.enqueue` stamped `targetNodeId` with a machine that no longer existed and the job sat queued forever, pinned to a ghost. Historical `fleet_jobs` rows are untouched; deleting a machine must not delete the record of what it did.
 
 ## Panic controls
 

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -232,6 +232,33 @@ describe('agent/config', () => {
         });
     });
 
+    describe('config.fleet.getNodeOfflineNoticeAfterMs (health signals, EW-776)', () => {
+        it('defaults to 30 minutes', () => {
+            expect(config.fleet.getNodeOfflineNoticeAfterMs()).toBe(30 * 60_000);
+        });
+
+        it('honours an operator override', () => {
+            process.env.FLEET_NODE_OFFLINE_NOTICE_AFTER_MS = String(2 * 3600_000);
+            expect(config.fleet.getNodeOfflineNoticeAfterMs()).toBe(2 * 3600_000);
+        });
+
+        it('is floored at the offline sweep window it escalates', () => {
+            // A "still offline after N" notice that could fire before the
+            // node is even considered offline would be two notices for one
+            // event — so the floor is the sweep window, not a constant.
+            process.env.FLEET_NODE_OFFLINE_NOTICE_AFTER_MS = '1000';
+            expect(config.fleet.getNodeOfflineNoticeAfterMs()).toBe(
+                config.fleet.getNodeOfflineAfterMs(),
+            );
+        });
+
+        it('tracks a RAISED offline window, so the pair can never invert', () => {
+            process.env.FLEET_NODE_OFFLINE_AFTER_MS = String(45 * 60_000);
+            process.env.FLEET_NODE_OFFLINE_NOTICE_AFTER_MS = String(10 * 60_000);
+            expect(config.fleet.getNodeOfflineNoticeAfterMs()).toBe(45 * 60_000);
+        });
+    });
+
     describe('config.fleetNode (Desktop PRD M4 — FLEET_NODE_* operator knobs)', () => {
         describe('getApiUrl', () => {
             it('returns undefined when unset', () => {

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -22,6 +22,7 @@ import {
     FLEET_DEFAULT_MAX_CAPABILITY_TAG_LENGTH,
     FLEET_DEFAULT_MAX_CAPABILITY_TAGS,
     FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
+    FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS,
     FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING,
     FLEET_MAX_CAPABILITY_TAGS_CEILING,
     FLEET_MAX_DAILY_COST_CEILING_CENTS,
@@ -470,6 +471,25 @@ export const config = {
                 process.env.FLEET_NODE_OFFLINE_AFTER_MS,
                 FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS,
                 FLEET_MIN_NODE_OFFLINE_AFTER_MS,
+                Number.MAX_SAFE_INTEGER,
+            );
+        },
+        /**
+         * Fleet health signals (EW-776) — how long an already-offline node
+         * stays gone before its owner gets a SECOND, louder Inbox notice.
+         * Default 30 minutes (`FLEET_NODE_OFFLINE_NOTICE_AFTER_MS`).
+         *
+         * Floored at {@link getNodeOfflineAfterMs}, not at a constant: a
+         * window shorter than the sweep window would fire the escalation
+         * before the node is even considered offline, i.e. two notices for
+         * one event. The floor is read live so lowering it below a raised
+         * `FLEET_NODE_OFFLINE_AFTER_MS` still cannot invert the pair.
+         */
+        getNodeOfflineNoticeAfterMs(): number {
+            return clampedIntEnv(
+                process.env.FLEET_NODE_OFFLINE_NOTICE_AFTER_MS,
+                FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS,
+                this.getNodeOfflineAfterMs(),
                 Number.MAX_SAFE_INTEGER,
             );
         },

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -1,5 +1,5 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
-import type { FleetNodeKind, FleetNodeStatus } from '@ever-works/contracts';
+import type { FleetNodeKind, FleetNodeStatus, FleetNodeWorkerState } from '@ever-works/contracts';
 import { PortableDateColumn } from './_types';
 
 /**
@@ -51,7 +51,7 @@ import { PortableDateColumn } from './_types';
  *
  * `k8s` is list-time only — never persisted as a row.
  */
-export type { FleetNodeKind, FleetNodeStatus } from '@ever-works/contracts';
+export type { FleetNodeKind, FleetNodeStatus, FleetNodeWorkerState } from '@ever-works/contracts';
 /**
  * Statuses in which the platform will NOT lease new work onto a node.
  *
@@ -217,6 +217,78 @@ export class FleetNode {
      */
     @Column({ type: 'varchar', length: 10, nullable: true })
     dailyCostTrippedOn?: string | null;
+
+    /**
+     * Fleet health signals (EW-776) — what the node's WORKER last
+     * reported doing: `idle | working | paused | quarantined | throttled`.
+     *
+     * NULL means the node has never reported one (a daemon predating the
+     * field, a visibility-only node with its worker disabled, or a value
+     * this build did not recognise). Rendered as "unknown", never as
+     * `idle`: the whole reason this column exists is that `status:
+     * 'online'` was being read as "healthy" by a machine that had
+     * self-quarantined and was refusing every job.
+     *
+     * Never stored verbatim from the wire — `FleetService` runs every
+     * incoming value through `normalizeFleetNodeWorkerState` first.
+     * Same additive contract as {@link cliVersion}: a beat that omits the
+     * field leaves the stored value alone.
+     */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    workerState?: FleetNodeWorkerState | null;
+
+    /**
+     * Why the worker is in that state — the quarantine's own message, the
+     * resource ceiling that throttled the lease — sanitized and capped at
+     * `FLEET_MAX_WORKER_STATE_REASON_LENGTH`. NULL when the state carries
+     * no reason worth reading.
+     */
+    @Column({ type: 'varchar', length: 500, nullable: true })
+    workerStateReason?: string | null;
+
+    /**
+     * When {@link workerState} last CHANGED. Stamped only on a transition,
+     * not on every beat: "quarantined since 03:14" is the fact an operator
+     * needs, and re-stamping it twice a minute would erase it.
+     */
+    @PortableDateColumn({ nullable: true })
+    workerStateChangedAt?: Date | null;
+
+    /**
+     * Dedup marker: set when the online → offline notice for the CURRENT
+     * outage was filed, cleared by the beat that brings the node back.
+     *
+     * The marker lives on the row rather than in the Inbox because
+     * `InboxService.notice` files unconditionally — it has no dedup of its
+     * own — so "exactly one notice per transition" has to be a CAS
+     * somewhere, and the node row is the only thing both the sweep and the
+     * heartbeat already touch. Written by
+     * `FleetNodeRepository.markOfflineIfStale`, which is a conditional
+     * UPDATE on `status = 'online'`: two API replicas sweeping the same
+     * owner at once produce one notice, not two.
+     */
+    @PortableDateColumn({ nullable: true })
+    offlineNoticedAt?: Date | null;
+
+    /**
+     * Dedup marker for the SECOND, louder notice: this machine has now
+     * been gone longer than `FLEET_NODE_OFFLINE_NOTICE_AFTER_MS` (default
+     * 30 minutes). One per outage — the sweep runs on every list read, and
+     * without this the owner would get a notice every 30 seconds for as
+     * long as the PC stayed off. Cleared by the beat that brings it back,
+     * so the NEXT outage notifies again.
+     */
+    @PortableDateColumn({ nullable: true })
+    offlineLongNoticedAt?: Date | null;
+
+    /**
+     * Dedup marker for the online → quarantined notice, set on the FIRST
+     * beat that reports the quarantine and cleared by the first beat that
+     * reports anything else. That re-arm is what makes a second
+     * quarantine, hours later, news again.
+     */
+    @PortableDateColumn({ nullable: true })
+    quarantineNoticedAt?: Date | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/fleet/__tests__/fleet-job.repository.integration.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.repository.integration.spec.ts
@@ -59,6 +59,7 @@ describe('fleet job lease generation — repository integration (better-sqlite3)
             attempts: 1,
             queuedReason: null,
             leaseGeneration: 1,
+            startedAt: null,
         });
         expect(won).toBe(true);
         return read(created.id);
@@ -94,6 +95,7 @@ describe('fleet job lease generation — repository integration (better-sqlite3)
                     attempts: 2,
                     queuedReason: null,
                     leaseGeneration: 1,
+                    startedAt: null,
                 }),
             ).toBe(false);
             expect(await read(job.id)).toMatchObject({ status: 'queued', leaseGeneration: 1 });
@@ -107,6 +109,7 @@ describe('fleet job lease generation — repository integration (better-sqlite3)
                     attempts: 2,
                     queuedReason: null,
                     leaseGeneration: 2,
+                    startedAt: null,
                 }),
             ).toBe(true);
             expect(await read(job.id)).toMatchObject({
@@ -152,6 +155,7 @@ describe('fleet job lease generation — repository integration (better-sqlite3)
                 attempts: 2,
                 queuedReason: null,
                 leaseGeneration: 2,
+                startedAt: null,
             });
             const current = await read(job.id);
 
@@ -179,6 +183,7 @@ describe('fleet job lease generation — repository integration (better-sqlite3)
                 attempts: 2,
                 queuedReason: null,
                 leaseGeneration: 2,
+                startedAt: null,
             });
             const current = await read(job.id);
 

--- a/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.service.spec.ts
@@ -237,6 +237,9 @@ function makeRepos(stores: Stores): {
         findByUser: jest.fn(async (userId: string, limit: number) =>
             stores.jobs.filter((j) => j.userId === userId).slice(0, limit),
         ),
+        findByNodeForUser: jest.fn(async (userId: string, nodeId: string, limit: number) =>
+            stores.jobs.filter((j) => j.userId === userId && j.nodeId === nodeId).slice(0, limit),
+        ),
         // Queue SLA + heartbeat promotion (self-build slice S). Mirrored
         // here so the inline expiry on the lease path is EXERCISED by
         // this suite rather than swallowed as a missing method.
@@ -755,6 +758,88 @@ describe('FleetJobService', () => {
             await expect(
                 service.heartbeatJob(NODE_A, secretA, queued.id, undefined, 1),
             ).resolves.toBeNull();
+        });
+
+        it('resets startedAt on a RE-lease so the clock measures this attempt', async () => {
+            // Fleet health signals (EW-776). `startedAt` used to be stamped
+            // once and preserved across re-leases, so the drawer's "running
+            // for 4h 12m" on a job that had lapsed twice was the age of an
+            // attempt that had ended hours earlier — a number that looked
+            // like a stuck job and was not one.
+            await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
+            const first = await service.lease({ nodeId: NODE_A, secret: secretA });
+            await service.heartbeatJob(
+                NODE_A,
+                secretA,
+                first![0].id,
+                undefined,
+                first![0].leaseGeneration,
+            );
+            const firstStart = stores.jobs[0].startedAt;
+            expect(firstStart).toBeInstanceOf(Date);
+
+            // The claim lapses and the job goes back to the pool.
+            stores.jobs[0].leaseExpiresAt = new Date(Date.now() - 60_000);
+            await service.reclaimExpired();
+            expect(stores.jobs[0].status).toBe('queued');
+
+            const second = await service.lease({ nodeId: NODE_A, secret: secretA });
+            // The claim itself clears it — before any heartbeat arrives the
+            // row reports "not started", which is exactly true.
+            expect(stores.jobs[0].startedAt).toBeNull();
+            expect(second![0].startedAt).toBeNull();
+            expect(second![0].attempts).toBe(2);
+
+            const beat = await service.heartbeatJob(
+                NODE_A,
+                secretA,
+                second![0].id,
+                undefined,
+                second![0].leaseGeneration,
+            );
+            // ...and the new attempt's first beat re-stamps it, later than
+            // the first attempt's stamp.
+            expect(beat?.startedAt).not.toBeNull();
+            expect(new Date(beat!.startedAt!).getTime()).toBeGreaterThanOrEqual(
+                (firstStart as Date).getTime(),
+            );
+        });
+    });
+
+    describe('historyForNode', () => {
+        beforeEach(() => {
+            stores.nodes.push(enrolledNode(NODE_A, secretA));
+        });
+
+        it('carries the error text the drawer needs to explain a failure', async () => {
+            // The verdict was on the row all along and never left the
+            // server: the drawer showed a red badge and no way to find out
+            // why, so the operator's next step was to open a database.
+            await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
+            const leased = await service.lease({ nodeId: NODE_A, secret: secretA });
+            await service.completeJob({
+                nodeId: NODE_A,
+                secret: secretA,
+                jobId: leased![0].id,
+                success: false,
+                error: 'pnpm install exploded',
+                leaseGeneration: leased![0].leaseGeneration,
+            });
+
+            const history = await service.historyForNode('owner-1', NODE_A);
+
+            expect(history).toHaveLength(1);
+            expect(history[0].status).toBe('failed');
+            expect(history[0].error).toBe('pnpm install exploded');
+        });
+
+        it('reports a null error for a job that has not failed', async () => {
+            await service.enqueue({ userId: 'owner-1', kind: 'acceptance-checks' });
+            await service.lease({ nodeId: NODE_A, secret: secretA });
+
+            const history = await service.historyForNode('owner-1', NODE_A);
+
+            expect(history[0].error).toBeNull();
         });
     });
 

--- a/packages/agent/src/fleet/__tests__/fleet-node-health.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-node-health.spec.ts
@@ -1,0 +1,401 @@
+import { createHash } from 'crypto';
+import { FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS } from '@ever-works/contracts';
+import { FleetNode } from '../../entities/fleet-node.entity';
+import { FLEET_NODE_OFFLINE_AFTER_MS, FleetService } from '../fleet.service';
+
+/**
+ * Fleet health signals (EW-776, finding OPS-02) — the three Inbox
+ * notices and their dedup.
+ *
+ * The defect these close: a machine that self-quarantined kept beating,
+ * therefore kept reading `online`, and refused every job it was offered.
+ * Nothing told its owner. Nothing told them when a PC went dark either —
+ * and under the runbook's recommended `local-wait` there is no cloud
+ * fallback, so there was no other signal at all.
+ *
+ * What is pinned here is the ONE thing a notification feature can get
+ * wrong in both directions at once: firing more than once per event (an
+ * inbox that cries wolf every 30 seconds is an inbox nobody reads), and
+ * failing to re-arm afterwards (a second outage that says nothing is
+ * worse than the first one that did). `InboxService.notice` has no dedup
+ * of its own, so correctness rests entirely on the per-row CAS markers
+ * exercised below.
+ */
+
+const sha256 = (value: string) => createHash('sha256').update(value, 'utf8').digest('hex');
+
+const SECRET = 'sec_'.padEnd(43, 'f');
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+
+const node = (overrides: Partial<FleetNode> = {}): FleetNode =>
+    ({
+        id: NODE_ID,
+        userId: 'user-1',
+        organizationId: null,
+        name: 'Office PC',
+        kind: 'desktop-node',
+        status: 'online',
+        enrollmentTokenHash: sha256(SECRET),
+        lastHeartbeatAt: new Date(),
+        capabilities: [],
+        platform: null,
+        version: null,
+        createdAt: new Date(),
+        ...overrides,
+    }) as FleetNode;
+
+describe('fleet health signals — Inbox notices', () => {
+    let repository: {
+        create: jest.Mock;
+        findById: jest.Mock;
+        findByCredentialHash: jest.Mock;
+        findByUser: jest.Mock;
+        consumeEnrollment: jest.Mock;
+        update: jest.Mock;
+        delete: jest.Mock;
+        sweepOffline: jest.Mock;
+        findStaleOnline: jest.Mock;
+        markOfflineIfStale: jest.Mock;
+        findOfflineUnnoticed: jest.Mock;
+        markLongOfflineNoticed: jest.Mock;
+    };
+    let inbox: {
+        notice: jest.Mock;
+        escalationRaised: jest.Mock;
+        proposalPending: jest.Mock;
+        questionRaised: jest.Mock;
+    };
+
+    beforeEach(() => {
+        repository = {
+            create: jest.fn(async (data) => node({ ...data })),
+            findById: jest.fn(async () => null),
+            findByCredentialHash: jest.fn(async () => null),
+            findByUser: jest.fn(async () => []),
+            consumeEnrollment: jest.fn(async () => true),
+            update: jest.fn(async () => undefined),
+            delete: jest.fn(async () => undefined),
+            sweepOffline: jest.fn(async () => 0),
+            findStaleOnline: jest.fn(async () => []),
+            markOfflineIfStale: jest.fn(async () => true),
+            findOfflineUnnoticed: jest.fn(async () => []),
+            markLongOfflineNoticed: jest.fn(async () => true),
+        };
+        inbox = {
+            notice: jest.fn(async () => undefined),
+            escalationRaised: jest.fn(async () => undefined),
+            proposalPending: jest.fn(async () => undefined),
+            questionRaised: jest.fn(async () => undefined),
+        };
+    });
+
+    const build = (withInbox = true) =>
+        new FleetService(
+            repository as never,
+            undefined,
+            undefined,
+            withInbox ? (inbox as never) : undefined,
+        );
+
+    const beat = (service: FleetService, refresh: Record<string, unknown>) =>
+        service.heartbeat(NODE_ID, SECRET, refresh);
+
+    describe('online → quarantined', () => {
+        it('files one notice on the first beat that reports the quarantine', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await beat(service, {
+                workerState: 'quarantined',
+                workerStateReason: 'process tree for job 42 could not be proven terminated',
+            });
+
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            const [userId, payload] = inbox.notice.mock.calls[0];
+            expect(userId).toBe('user-1');
+            expect(payload.title).toBe('Fleet node quarantined: Office PC');
+            // The three facts the operator needs: which machine, why, and
+            // when it was last heard from.
+            expect(payload.body).toContain('Office PC');
+            expect(payload.body).toContain('could not be proven terminated');
+            expect(payload.body).toContain('Last seen:');
+            // The marker rides in the same patch as the state it describes.
+            expect(repository.update.mock.calls[0][1].quarantineNoticedAt).toBeInstanceOf(Date);
+        });
+
+        it('says nothing on the SECOND beat that reports the same quarantine', async () => {
+            // A quarantined node keeps beating twice a minute. Without the
+            // marker that is 2,880 notices a day for one event.
+            repository.findById.mockResolvedValue(
+                node({ workerState: 'quarantined', quarantineNoticedAt: new Date() }),
+            );
+            const service = build();
+
+            await beat(service, { workerState: 'quarantined', workerStateReason: 'same reason' });
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+            expect(repository.update.mock.calls[0][1]).not.toHaveProperty('quarantineNoticedAt');
+        });
+
+        it('re-arms when the node reports a healthy state again', async () => {
+            repository.findById.mockResolvedValue(
+                node({ workerState: 'quarantined', quarantineNoticedAt: new Date() }),
+            );
+            const service = build();
+
+            await beat(service, { workerState: 'idle' });
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+            expect(repository.update.mock.calls[0][1].quarantineNoticedAt).toBeNull();
+        });
+
+        it('notifies again after a re-arm — a second quarantine is news', async () => {
+            const service = build();
+            repository.findById.mockResolvedValue(
+                node({ workerState: 'idle', quarantineNoticedAt: null }),
+            );
+
+            await beat(service, { workerState: 'quarantined', workerStateReason: 'second time' });
+
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].body).toContain('second time');
+        });
+
+        it('does not fire for a throttle or a pause', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await beat(service, { workerState: 'throttled', workerStateReason: 'cpu ceiling' });
+            await beat(service, { workerState: 'paused' });
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+        });
+
+        it('does not fire for an unrecognised state a newer daemon reported', async () => {
+            // Normalized to "unknown", which is honest — but it is not a
+            // quarantine and must not be announced as one.
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await beat(service, { workerState: 'hibernating', workerStateReason: 'zzz' });
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+            expect(repository.update.mock.calls[0][1].workerState).toBeNull();
+        });
+
+        it('survives an Inbox that throws — the beat still succeeds', async () => {
+            // The inbox mirrors records; failing to mirror must never fail
+            // the record. A rejected beat is a node that goes offline.
+            inbox.notice.mockRejectedValue(new Error('inbox down'));
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await expect(beat(service, { workerState: 'quarantined' })).resolves.not.toBeNull();
+        });
+    });
+
+    describe('online → offline', () => {
+        it('files exactly one notice per flip and only for the row it won the CAS on', async () => {
+            const stale = node({
+                status: 'online',
+                lastHeartbeatAt: new Date(Date.now() - 60 * 60_000),
+            });
+            repository.findStaleOnline.mockResolvedValue([stale]);
+            const service = build();
+
+            await service.listEnrolledForUser('user-1');
+
+            expect(repository.markOfflineIfStale).toHaveBeenCalledTimes(1);
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].title).toBe('Fleet node offline: Office PC');
+            expect(inbox.notice.mock.calls[0][1].body).toContain('Last seen:');
+        });
+
+        it('says nothing when the CAS is lost — the node beat back, or another replica won', async () => {
+            repository.findStaleOnline.mockResolvedValue([node({ status: 'online' })]);
+            repository.markOfflineIfStale.mockResolvedValue(false);
+            const service = build();
+
+            await service.listEnrolledForUser('user-1');
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+        });
+
+        it('still runs the bulk sweep, with the same cutoff it announced against', async () => {
+            // The per-row pass is the notice; the bulk UPDATE remains the
+            // catch-all for anything it missed between the two statements.
+            const before = Date.now();
+            const service = build();
+
+            await service.listEnrolledForUser('user-1');
+
+            const [, announced] = repository.findStaleOnline.mock.calls[0];
+            const [userId, swept] = repository.sweepOffline.mock.calls[0];
+            expect(userId).toBe('user-1');
+            expect((swept as Date).getTime()).toBe((announced as Date).getTime());
+            const offset = before - (swept as Date).getTime();
+            expect(offset).toBeGreaterThanOrEqual(FLEET_NODE_OFFLINE_AFTER_MS - 1000);
+            expect(offset).toBeLessThanOrEqual(FLEET_NODE_OFFLINE_AFTER_MS + 1000);
+        });
+
+        it('re-arms both offline markers on the next accepted beat', async () => {
+            repository.findById.mockResolvedValue(
+                node({
+                    status: 'offline',
+                    offlineNoticedAt: new Date(),
+                    offlineLongNoticedAt: new Date(),
+                }),
+            );
+            const service = build();
+
+            await beat(service, { workerState: 'idle' });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.offlineNoticedAt).toBeNull();
+            expect(patch.offlineLongNoticedAt).toBeNull();
+        });
+
+        it('re-arms them on a beat that says NOTHING about its worker', async () => {
+            // The daemons that report no worker state are exactly the ones
+            // this must not forget: a build older than the field, a
+            // visibility-only node with its worker disabled, and a daemon
+            // that latched into liveness-only reporting after an older API
+            // 400'd the fields (see `HeartbeatLoop.beat`). Tying the re-arm
+            // to a reported state left `offlineLongNoticedAt` set on all
+            // three forever, so their SECOND outage said nothing at all.
+            repository.findById.mockResolvedValue(
+                node({
+                    status: 'offline',
+                    offlineNoticedAt: new Date(),
+                    offlineLongNoticedAt: new Date(),
+                }),
+            );
+            const service = build();
+
+            await beat(service, { version: '1.4.0' });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.offlineNoticedAt).toBeNull();
+            expect(patch.offlineLongNoticedAt).toBeNull();
+            // ...and the state itself is still left alone, which is the
+            // other half of the old-daemon contract.
+            expect(patch).not.toHaveProperty('workerState');
+        });
+
+        it('re-arms them on a beat whose worker state is unrecognised', async () => {
+            // A newer daemon reporting a value this build cannot name is
+            // still a reachable machine.
+            repository.findById.mockResolvedValue(
+                node({ status: 'offline', offlineLongNoticedAt: new Date() }),
+            );
+            const service = build();
+
+            await beat(service, { workerState: 'hibernating' });
+
+            expect(repository.update.mock.calls[0][1].offlineLongNoticedAt).toBeNull();
+        });
+
+        it('re-arms on a PAUSED node too — a drained machine still beats', async () => {
+            repository.findById.mockResolvedValue(
+                node({ status: 'paused', offlineNoticedAt: new Date() }),
+            );
+            const service = build();
+
+            await beat(service, { workerState: 'paused' });
+
+            // Sticky status preserved (audit A29) AND the marker re-armed.
+            expect(repository.update.mock.calls[0][1].status).toBe('paused');
+            expect(repository.update.mock.calls[0][1].offlineNoticedAt).toBeNull();
+        });
+    });
+
+    describe('offline for longer than the window', () => {
+        it('files one escalation, measured from the configured window', async () => {
+            const gone = node({
+                status: 'offline',
+                lastHeartbeatAt: new Date(Date.now() - 3 * 60 * 60_000),
+                offlineNoticedAt: new Date(),
+            });
+            repository.findOfflineUnnoticed.mockResolvedValue([gone]);
+            const before = Date.now();
+            const service = build();
+
+            await service.listEnrolledForUser('user-1');
+
+            const [userId, longCutoff] = repository.findOfflineUnnoticed.mock.calls[0];
+            expect(userId).toBe('user-1');
+            const offset = before - (longCutoff as Date).getTime();
+            expect(offset).toBeGreaterThanOrEqual(
+                FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS - 1000,
+            );
+            expect(offset).toBeLessThanOrEqual(FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS + 1000);
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].title).toBe('Fleet node still offline: Office PC');
+            expect(inbox.notice.mock.calls[0][1].body).toContain('30 minutes');
+        });
+
+        it('is not repeated on the next list read', async () => {
+            // The repository predicate (`offlineLongNoticedAt IS NULL`) is
+            // what stops the repeat; the CAS is the belt for two replicas.
+            repository.findOfflineUnnoticed.mockResolvedValue([node({ status: 'offline' })]);
+            repository.markLongOfflineNoticed.mockResolvedValue(false);
+            const service = build();
+
+            await service.listEnrolledForUser('user-1');
+
+            expect(inbox.notice).not.toHaveBeenCalled();
+        });
+
+        it('does not take the node list down when the notice bookkeeping fails', async () => {
+            // The node list is the page an operator opens BECAUSE something
+            // is wrong. It must survive a broken notice path.
+            repository.findStaleOnline.mockRejectedValue(new Error('db hiccup'));
+            repository.findByUser.mockResolvedValue([node({ status: 'online' })]);
+            const service = build();
+
+            await expect(service.listEnrolledForUser('user-1')).resolves.toHaveLength(1);
+            expect(repository.sweepOffline).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('without an Inbox producer bound', () => {
+        it('touches none of the notice machinery and sweeps exactly as before', async () => {
+            // Unit tests, the worker's RPC context and installs without the
+            // api layer all run with the token unbound. Extension, not
+            // replacement: today's behaviour byte for byte.
+            const service = build(false);
+
+            await service.listEnrolledForUser('user-1');
+
+            expect(repository.findStaleOnline).not.toHaveBeenCalled();
+            expect(repository.findOfflineUnnoticed).not.toHaveBeenCalled();
+            expect(repository.markOfflineIfStale).not.toHaveBeenCalled();
+            expect(repository.sweepOffline).toHaveBeenCalledTimes(1);
+        });
+
+        it('re-arms nothing either — a later binding must not inherit markers', async () => {
+            repository.findById.mockResolvedValue(
+                node({ status: 'offline', offlineNoticedAt: new Date() }),
+            );
+            const service = build(false);
+
+            await beat(service, { workerState: 'idle' });
+
+            expect(repository.update.mock.calls[0][1]).not.toHaveProperty('offlineNoticedAt');
+        });
+
+        it('writes no dedup markers on a heartbeat', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build(false);
+
+            await beat(service, { workerState: 'quarantined', workerStateReason: 'why' });
+
+            const patch = repository.update.mock.calls[0][1];
+            // The state itself IS still recorded — only the notice
+            // bookkeeping is inert, so a deployment that later binds the
+            // inbox does not inherit stale markers.
+            expect(patch.workerState).toBe('quarantined');
+            expect(patch).not.toHaveProperty('quarantineNoticedAt');
+        });
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet-node-telemetry.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-node-telemetry.spec.ts
@@ -396,4 +396,198 @@ describe('FleetService node telemetry', () => {
             expect(settings.getResolvedSettings).not.toHaveBeenCalled();
         });
     });
+
+    /**
+     * Fleet health signals (EW-776) — the worker state on the wire.
+     *
+     * Same additive contract as the telemetry above, plus one rule of its
+     * own: the value is NORMALIZED before it is stored. A node is an
+     * untrusted machine, and this string ends up in a status badge an
+     * operator makes decisions from.
+     */
+    describe('worker state', () => {
+        it('persists a reported state with its reason and stamps the change time', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'throttled',
+                workerStateReason: 'CPU over the configured ceiling',
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.workerState).toBe('throttled');
+            expect(patch.workerStateReason).toBe('CPU over the configured ceiling');
+            expect(patch.workerStateChangedAt).toBeInstanceOf(Date);
+            expect(result!.node.workerState).toBe('throttled');
+            expect(result!.node.workerStateChangedAt).toEqual(expect.any(String));
+        });
+
+        it('does NOT re-stamp the change time while the state is unchanged', async () => {
+            // "Quarantined since 03:14" has to survive the several hundred
+            // beats that follow it. Re-stamping every 30s would erase the
+            // only durable record of when the machine stopped working.
+            repository.findById.mockResolvedValue(node({ workerState: 'quarantined' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, { workerState: 'quarantined' });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch).not.toHaveProperty('workerState');
+            expect(patch).not.toHaveProperty('workerStateChangedAt');
+        });
+
+        it('updates the reason alone when only the reason moved', async () => {
+            // A throttle that changes from 'CPU' to 'disk floor' is still a
+            // throttle, but the operator needs the new sentence.
+            repository.findById.mockResolvedValue(
+                node({ workerState: 'throttled', workerStateReason: 'CPU ceiling' }),
+            );
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'throttled',
+                workerStateReason: 'free disk below the floor',
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.workerStateReason).toBe('free disk below the floor');
+            expect(patch).not.toHaveProperty('workerStateChangedAt');
+        });
+
+        it('leaves the stored state alone when the beat says nothing about it', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'working' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, { version: '1.1.0' });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch).not.toHaveProperty('workerState');
+            expect(patch).not.toHaveProperty('workerStateReason');
+            expect(patch).not.toHaveProperty('workerStateChangedAt');
+        });
+
+        it('stores an unrecognised value as unknown and discards its reason', async () => {
+            // A value this build has never heard of is never rewritten into
+            // a plausible-looking member, and a reason we cannot vouch for
+            // is not shown under an "unknown" badge.
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'hibernating',
+                workerStateReason: 'lid closed',
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.workerState).toBeNull();
+            // Nothing to clear here (the row carried no reason), and
+            // nothing is written either — see the next case for the clear.
+            expect(patch).not.toHaveProperty('workerStateReason');
+        });
+
+        it('clears a stored reason when the new state is unrecognised', async () => {
+            repository.findById.mockResolvedValue(
+                node({ workerState: 'throttled', workerStateReason: 'CPU ceiling' }),
+            );
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'hibernating',
+                workerStateReason: 'lid closed',
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.workerState).toBeNull();
+            // The OLD reason described a state that is no longer true, and
+            // the new one describes a state we cannot vouch for. Neither
+            // belongs under an "unknown" badge.
+            expect(patch.workerStateReason).toBeNull();
+        });
+
+        it('accepts a non-string worker state without failing the beat', async () => {
+            // A malformed field must never cost a node its liveness: a
+            // rejected beat is an offline node.
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 42 as never,
+            });
+
+            expect(result).not.toBeNull();
+            expect(repository.update.mock.calls[0][1].workerState).toBeNull();
+        });
+
+        it('caps the reason at the contract bound', async () => {
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'quarantined',
+                workerStateReason: 'x'.repeat(900),
+            });
+
+            expect(repository.update.mock.calls[0][1].workerStateReason).toHaveLength(500);
+        });
+
+        it('does not let a quarantine reason leak a credential it quoted', async () => {
+            // The reason is composed on the machine out of error text and
+            // command output, then stored, listed AND quoted into notices.
+            const leaked = 'ghp_' + 'b'.repeat(36);
+            repository.findById.mockResolvedValue(node({ workerState: 'idle' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workerState: 'quarantined',
+                workerStateReason: 'kill failed for: node --token=' + leaked,
+            });
+
+            const stored = repository.update.mock.calls[0][1].workerStateReason as string;
+            expect(stored).not.toContain(leaked);
+        });
+
+        it('stamps the state on ENROLL, where there is nothing to preserve', async () => {
+            const token = 'tok_'.padEnd(43, 'c');
+            repository.findByCredentialHash.mockResolvedValue(
+                node({
+                    status: 'enrolling',
+                    enrollmentTokenHash: sha256(token),
+                    credentialIssuedAt: new Date(),
+                }),
+            );
+            const service = build();
+
+            await service.enroll(token, { workerState: 'idle' });
+
+            const patch = repository.consumeEnrollment.mock.calls[0][2];
+            expect(patch.workerState).toBe('idle');
+            expect(patch.workerStateChangedAt).toBeInstanceOf(Date);
+        });
+
+        it('drops an ENROLL reason whose state it could not recognise', async () => {
+            // Same rule as the heartbeat path: a reason we cannot vouch for
+            // must not end up captioning an "unknown" badge. Enroll is the
+            // easier place to get this wrong because the whole patch is
+            // written unconditionally.
+            const token = 'tok_'.padEnd(43, 'd');
+            repository.findByCredentialHash.mockResolvedValue(
+                node({
+                    status: 'enrolling',
+                    enrollmentTokenHash: sha256(token),
+                    credentialIssuedAt: new Date(),
+                }),
+            );
+            const service = build();
+
+            await service.enroll(token, {
+                workerState: 'hibernating',
+                workerStateReason: 'lid closed',
+            });
+
+            const patch = repository.consumeEnrollment.mock.calls[0][2];
+            expect(patch.workerState).toBeNull();
+            expect(patch.workerStateReason).toBeNull();
+        });
+    });
 });

--- a/packages/agent/src/fleet/__tests__/fleet-node.repository.integration.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-node.repository.integration.spec.ts
@@ -1,0 +1,136 @@
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '../../database/_entities-inventory';
+import { FleetAgentNodeAffinity } from '../../entities/fleet-agent-node-affinity.entity';
+import { FleetNode } from '../../entities/fleet-node.entity';
+import { User } from '../../entities/user.entity';
+import { FleetNodeRepository } from '../fleet-node.repository';
+
+/**
+ * `FleetNodeRepository.delete` against a REAL (better-sqlite3,
+ * synchronize) schema.
+ *
+ * The defect: `fleet_agent_node_affinities` carries a raw uuid `nodeId`
+ * with no foreign key (deliberately — see
+ * `1787508800000-CreateFleetAgentNodeAffinity`), so deleting a node left
+ * its Agent pins behind. The affinity service kept resolving them,
+ * `FleetJobService.enqueue` kept stamping `targetNodeId` with a machine
+ * that no longer existed, and the job sat queued forever pinned to a
+ * ghost — with the runner pill reporting the fleet as idle, because it
+ * was.
+ *
+ * A service-level mock cannot catch this: the whole question is whether
+ * the two statements really run, really scope to the one node, and
+ * really share a transaction. So this drives the real repository against
+ * a real schema, which is also why the AFFINITY repository has an
+ * integration spec of its own.
+ */
+describe('fleet node repository — delete cascade (better-sqlite3)', () => {
+    const ORGANIZATION = '33333333-3333-4333-8333-333333333333';
+    const OTHER_AGENT = '44444444-4444-4444-8444-444444444444';
+
+    let dataSource: DataSource;
+    let nodes: FleetNodeRepository;
+    let nodeRows: Repository<FleetNode>;
+    let affinityRows: Repository<FleetAgentNodeAffinity>;
+    let ownerId: string;
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+
+        nodeRows = dataSource.getRepository(FleetNode);
+        affinityRows = dataSource.getRepository(FleetAgentNodeAffinity);
+        nodes = new FleetNodeRepository(nodeRows);
+
+        const owner = await dataSource.getRepository(User).save(
+            dataSource.getRepository(User).create({
+                username: 'node-delete-owner',
+                email: 'node-delete-owner@example.com',
+                password: 'x',
+            } as Partial<User>),
+        );
+        ownerId = owner.id;
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    afterEach(async () => {
+        await affinityRows.clear();
+        await nodeRows.clear();
+    });
+
+    const createNode = (name: string) =>
+        nodes.create({
+            userId: ownerId,
+            organizationId: ORGANIZATION,
+            name,
+            kind: 'desktop-node',
+            status: 'online',
+            enrollmentTokenHash: `hash-${name}`,
+            capabilities: [],
+        });
+
+    const pin = (agentId: string, nodeId: string) =>
+        affinityRows.save(
+            affinityRows.create({ userId: ownerId, organizationId: ORGANIZATION, agentId, nodeId }),
+        );
+
+    it('deletes the node AND only that node’s Agent pins', async () => {
+        const nodeA = await createNode('Office PC');
+        const nodeB = await createNode('Studio PC');
+        await pin(OTHER_AGENT, nodeA.id);
+        await pin('55555555-5555-4555-8555-555555555555', nodeA.id);
+        await pin('66666666-6666-4666-8666-666666666666', nodeB.id);
+
+        await nodes.delete(nodeA.id);
+
+        expect(await nodes.findById(nodeA.id)).toBeNull();
+        expect(await nodes.findById(nodeB.id)).not.toBeNull();
+        const remaining = await affinityRows.find();
+        expect(remaining).toHaveLength(1);
+        expect(remaining[0].nodeId).toBe(nodeB.id);
+    });
+
+    it('is a no-op-safe delete for a node that has no pins at all', async () => {
+        const node = await createNode('Bare PC');
+
+        await expect(nodes.delete(node.id)).resolves.toBeUndefined();
+
+        expect(await nodes.findById(node.id)).toBeNull();
+    });
+
+    it('rolls the node deletion back when the pin deletion fails', async () => {
+        // Half-applied is the one outcome worse than either whole one: the
+        // machine gone and its pins still resolving to it. Both statements
+        // share a transaction precisely so that cannot happen.
+        const node = await createNode('Office PC');
+        await pin(OTHER_AGENT, node.id);
+
+        // Spied on the PROTOTYPE, not on `dataSource.manager`: the callback
+        // runs against a fresh transactional EntityManager, so an
+        // instance-level spy would never be reached — which is itself the
+        // proof that a separate manager (and therefore a real transaction)
+        // is in play.
+        const managerProto = Object.getPrototypeOf(dataSource.manager) as {
+            delete: (...args: unknown[]) => unknown;
+        };
+        const managerDelete = jest.spyOn(managerProto, 'delete');
+        managerDelete.mockImplementationOnce(() => {
+            throw new Error('affinity delete exploded');
+        });
+
+        await expect(nodes.delete(node.id)).rejects.toThrow('affinity delete exploded');
+        managerDelete.mockRestore();
+
+        expect(await nodes.findById(node.id)).not.toBeNull();
+        expect(await affinityRows.count()).toBe(1);
+    });
+});

--- a/packages/agent/src/fleet/fleet-job.repository.ts
+++ b/packages/agent/src/fleet/fleet-job.repository.ts
@@ -43,6 +43,18 @@ export interface ClaimJobPatch {
      * the same row matches zero rows instead of minting a duplicate.
      */
     leaseGeneration: number;
+    /**
+     * Always cleared by the claim: a claim IS an attempt boundary, and
+     * `startedAt` measures THIS attempt. It is re-stamped by the first job
+     * heartbeat of the new claim (`extendLease`).
+     *
+     * Before this, `startedAt` was stamped once and preserved across
+     * re-leases, so the drawer's "running for 4h 12m" on a job that had
+     * lapsed and been re-leased three times was the age of the FIRST
+     * attempt on a machine that might not even be the one holding it now
+     * — a number that looked like a stuck job and was not one.
+     */
+    startedAt: null;
 }
 
 /** Exact claim snapshot observed by an expiry scan. */

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -11,6 +11,7 @@ import type {
     FleetJobKind,
     FleetJobStatus,
     FleetJobView,
+    FleetNodeJobHistoryEntry,
     FleetNodeLoadView,
 } from '@ever-works/contracts';
 import {
@@ -371,6 +372,11 @@ export class FleetJobService {
                 // being true, so it is the claim that clears the token.
                 queuedReason: null,
                 leaseGeneration,
+                // ...and the moment the PREVIOUS attempt's clock stops
+                // being meaningful. The next job heartbeat re-stamps it, so
+                // the drawer's duration is "how long this attempt has run"
+                // rather than the age of an attempt that ended hours ago.
+                startedAt: null,
             });
             if (!won) {
                 // Another node won the race. Not an error — just skip it.
@@ -384,6 +390,7 @@ export class FleetJobService {
                 attempts,
                 queuedReason: null,
                 leaseGeneration,
+                startedAt: null,
             } as FleetJob);
             leased.push(view);
             this.emit(
@@ -941,13 +948,17 @@ export class FleetJobService {
      * Owner-scoped in the query itself, not just by convention at the
      * edge — a node id is a travelling value.
      */
-    async historyForNode(userId: string, nodeId: string, limit = 20): Promise<FleetJobView[]> {
+    async historyForNode(
+        userId: string,
+        nodeId: string,
+        limit = 20,
+    ): Promise<FleetNodeJobHistoryEntry[]> {
         const rows = await this.jobs.findByNodeForUser(
             userId,
             nodeId,
             Math.min(Math.max(limit, 1), 100),
         );
-        return rows.map(toJobView);
+        return rows.map(toJobHistoryView);
     }
 
     /**
@@ -1036,6 +1047,24 @@ export function toJobView(job: FleetJob): FleetJobView {
         queuedReason: job.queuedReason ?? null,
         cancelRequestedAt: job.cancelRequestedAt ? toIso(job.cancelRequestedAt) : null,
         leaseGeneration: job.leaseGeneration ?? 0,
+    };
+}
+
+/**
+ * Entity → node-drawer history row (fleet health signals, EW-776).
+ *
+ * The only difference from {@link toJobView} is `error`: the verdict text
+ * the node reported was on the row all along and never left the server,
+ * so the drawer showed a red "failed" badge with no way to find out why —
+ * the operator's next step was to open a database. Deliberately a
+ * SEPARATE projection rather than a field added to `toJobView`, because
+ * that view is also the LEASE payload handed to nodes, and a node has no
+ * business being told the error text of a job it is only now picking up.
+ */
+export function toJobHistoryView(job: FleetJob): FleetNodeJobHistoryEntry {
+    return {
+        ...toJobView(job),
+        error: job.error ?? null,
     };
 }
 

--- a/packages/agent/src/fleet/fleet-node.repository.ts
+++ b/packages/agent/src/fleet/fleet-node.repository.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, LessThan, Not, Repository } from 'typeorm';
-import { FleetNode, FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
+import { FleetAgentNodeAffinity } from '../entities/fleet-agent-node-affinity.entity';
+import {
+    FleetNode,
+    FleetNodeKind,
+    FleetNodeStatus,
+    FleetNodeWorkerState,
+} from '../entities/fleet-node.entity';
 
 export interface CreateFleetNodeData {
     userId: string;
@@ -29,6 +35,12 @@ export interface ConsumeEnrollmentPatch {
     diskFreeBytes?: number | null;
     /** Which account / seat the agent CLI is logged in as (EW-777). */
     modelIdentity?: string | null;
+    /** What the node's worker reported doing at enroll time (EW-776). */
+    workerState?: FleetNodeWorkerState | null;
+    /** Why (quarantine / throttle reason), already sanitized and capped. */
+    workerStateReason?: string | null;
+    /** When that state was first observed — the enroll instant. */
+    workerStateChangedAt?: Date | null;
 }
 
 /**
@@ -91,8 +103,33 @@ export class FleetNodeRepository {
         await this.repository.update(id, patch);
     }
 
+    /**
+     * Delete a node registration AND everything that only existed because
+     * the node did.
+     *
+     * Today that is `fleet_agent_node_affinities` — the durable "run this
+     * Agent on THAT machine" pins. There is deliberately no FK on that
+     * table (see `1787508800000-CreateFleetAgentNodeAffinity`), so the
+     * cascade is explicit here rather than in the schema. Left alone, a
+     * removed node left its pins behind: the affinity service kept
+     * resolving them, `FleetJobService.enqueue` kept stamping
+     * `targetNodeId` with a machine that no longer exists, and the job sat
+     * queued forever — pinned to a ghost.
+     *
+     * One transaction, so a failure to delete the pins leaves the node in
+     * place too. A half-applied removal is the one outcome worse than
+     * either whole one: the row is gone and the pins are not, which is
+     * exactly the state this method exists to prevent.
+     *
+     * `fleet_jobs.targetNodeId` is NOT cleaned up on purpose — those rows
+     * are history, and deleting a machine must not delete the record of
+     * what it did.
+     */
     async delete(id: string): Promise<void> {
-        await this.repository.delete(id);
+        await this.repository.manager.transaction(async (manager) => {
+            await manager.delete(FleetAgentNodeAffinity, { nodeId: id });
+            await manager.delete(FleetNode, { id });
+        });
     }
 
     /**
@@ -106,6 +143,82 @@ export class FleetNodeRepository {
             { status: 'offline' },
         );
         return result.affected ?? 0;
+    }
+
+    /**
+     * The rows {@link sweepOffline} is ABOUT to flip, read before the
+     * flip so each one can be named in a notice.
+     *
+     * Separate from the bulk sweep rather than replacing it: the sweep is
+     * one UPDATE and returns a count, which is all the list read needs;
+     * the notice path needs the node's name and last-seen time, and
+     * getting those from a bulk UPDATE is not something either engine
+     * offers portably. The bulk sweep stays as the catch-all — anything
+     * this read missed (a row that went stale between the two statements)
+     * is still flipped, just without a notice.
+     */
+    async findStaleOnline(userId: string, cutoff: Date): Promise<FleetNode[]> {
+        return this.repository.find({
+            where: { userId, status: 'online', lastHeartbeatAt: LessThan(cutoff) },
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /**
+     * CAS one stale `online` row to `offline` and claim its notice.
+     *
+     * True EXACTLY ONCE per online → offline transition: the WHERE clause
+     * still requires `online` and a heartbeat older than the cutoff, so a
+     * node that beat back in the meantime is not flipped at all, and a
+     * second replica sweeping the same owner concurrently loses the race
+     * and files nothing. `offlineNoticedAt` is stamped in the same
+     * statement — a marker written by a second UPDATE could be lost
+     * between the two.
+     */
+    async markOfflineIfStale(id: string, cutoff: Date): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, status: 'online', lastHeartbeatAt: LessThan(cutoff) },
+            { status: 'offline', offlineNoticedAt: new Date() },
+        );
+        return (result.affected ?? 0) === 1;
+    }
+
+    /**
+     * Nodes that have now been `offline` longer than the escalation
+     * window and have not yet had the louder notice filed for THIS
+     * outage.
+     *
+     * `offlineLongNoticedAt IS NULL` is the whole dedup: the marker is
+     * cleared by the beat that brings a node back, so one outage produces
+     * one notice however many times the sweep runs.
+     *
+     * `offlineNoticedAt IS NOT NULL` makes the escalation strictly a
+     * FOLLOW-UP to a first notice this system actually filed. Without it,
+     * the first list read after this feature ships would file a "gone for
+     * over 30 minutes" notice for every node that has been offline since
+     * before the feature existed — an inbox full of news about machines
+     * their owner retired months ago.
+     */
+    async findOfflineUnnoticed(userId: string, longCutoff: Date): Promise<FleetNode[]> {
+        return this.repository.find({
+            where: {
+                userId,
+                status: 'offline',
+                lastHeartbeatAt: LessThan(longCutoff),
+                offlineNoticedAt: Not(IsNull()),
+                offlineLongNoticedAt: IsNull(),
+            },
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /** CAS the long-offline notice marker. True for exactly one caller. */
+    async markLongOfflineNoticed(id: string): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, offlineLongNoticedAt: IsNull() },
+            { offlineLongNoticedAt: new Date() },
+        );
+        return (result.affected ?? 0) === 1;
     }
 
     /**

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'crypto';
 import {
     BadRequestException,
+    Inject,
     Injectable,
     Logger,
     NotFoundException,
@@ -19,10 +20,13 @@ import {
     FLEET_MAX_NODE_NAME_LENGTH,
     FLEET_MAX_PLATFORM_LENGTH,
     FLEET_MAX_VERSION_LENGTH,
+    FLEET_MAX_WORKER_STATE_REASON_LENGTH,
     FLEET_MIN_NODE_NAME_LENGTH,
+    normalizeFleetNodeWorkerState,
 } from '@ever-works/contracts';
-import type { FleetNodeView, FleetNodeLoadView } from '@ever-works/contracts';
+import type { FleetNodeView, FleetNodeLoadView, FleetNodeWorkerState } from '@ever-works/contracts';
 import { config } from '../config';
+import { INBOX_PRODUCER, type InboxProducer } from '../inbox/inbox-producer.port';
 import {
     FleetNode,
     FleetNodeKind,
@@ -145,6 +149,16 @@ export interface EnrollInput {
      * optional contract as {@link cliVersion}.
      */
     modelIdentity?: string;
+    /**
+     * Fleet health signals (EW-776) — what the node's WORKER reports
+     * doing. An untrusted STRING, not the union: the wire has to admit a
+     * value a newer daemon invented (rejecting it would fail the beat and
+     * take a live node offline), and it is normalized here before it is
+     * stored. Same additive contract as {@link cliVersion}.
+     */
+    workerState?: string;
+    /** Why — quarantine message, throttle reason. Sanitized and capped. */
+    workerStateReason?: string;
 }
 
 export interface EnrollResult {
@@ -192,6 +206,11 @@ export class FleetService {
         private readonly repository: FleetNodeRepository,
         @Optional() private readonly pluginRegistry?: PluginRegistryService,
         @Optional() private readonly pluginSettings?: PluginSettingsService,
+        // Fleet health signals (EW-776). Appended LAST and @Optional() per
+        // the positional-construction rule the specs rely on; the token is
+        // bound by the api-side @Global() InboxModule, so unit tests and
+        // the worker's RPC context simply file no notices.
+        @Optional() @Inject(INBOX_PRODUCER) private readonly inbox?: InboxProducer,
     ) {}
 
     /** Issue a one-time enrollment token for a new node (owner-scoped). */
@@ -271,6 +290,7 @@ export class FleetService {
 
         const secret = randomBytes(32).toString('base64url');
         const now = new Date();
+        const enrolledWorkerState = normalizeFleetNodeWorkerState(input.workerState);
         const patch = {
             enrollmentTokenHash: sha256Hex(secret),
             status: 'online' as FleetNodeStatus,
@@ -285,6 +305,17 @@ export class FleetService {
             cliVersion: sanitizeText(input.cliVersion, FLEET_MAX_CLI_VERSION_LENGTH),
             diskFreeBytes: sanitizeByteCount(input.diskFreeBytes),
             modelIdentity: sanitizeModelIdentity(input.modelIdentity),
+            // Health signals (EW-776): normalized, never stored verbatim.
+            // Stamped (possibly null) for the same reason the rest of the
+            // telemetry is — the row is new, there is nothing to preserve.
+            workerState: enrolledWorkerState,
+            // Dropped with the state it explains when that state is one we
+            // could not recognise — same rule the heartbeat path applies.
+            // Captioning an "unknown" badge with text whose meaning we
+            // cannot vouch for is worse than saying nothing.
+            workerStateReason:
+                enrolledWorkerState === null ? null : sanitizeWorkerStateReason(input),
+            workerStateChangedAt: now,
         };
         // CAS: single-use by construction — a raced duplicate enroll
         // matches zero rows and gets the same null as a bad token.
@@ -369,9 +400,205 @@ export class FleetService {
         // the seat leaves the last reported seat in place.
         const modelIdentity = sanitizeModelIdentity(refresh.modelIdentity);
         if (modelIdentity) patch.modelIdentity = modelIdentity;
-
+        // Health signals (EW-776). `undefined` means the daemon said
+        // nothing about its worker — the same "leave alone" contract as
+        // the telemetry above — and is distinct from a REPORTED value this
+        // build does not recognise, which is stored as null / "unknown".
+        const workerState = this.applyWorkerState(node, refresh, patch);
+        // Re-arm the offline notice markers on EVERY accepted beat, not
+        // only on beats that happened to report a worker state. The beat
+        // itself is the proof the machine is reachable, and the daemons
+        // that report nothing are exactly the ones this must not forget:
+        // a build older than the field, a visibility-only node with its
+        // worker disabled, and — created by this very slice — a daemon
+        // that latched into liveness-only reporting after an older API
+        // 400'd the fields. Folding this into `applyWorkerState` left
+        // `offlineLongNoticedAt` set forever on all three, so their
+        // SECOND outage would never have been announced.
+        this.rearmOfflineNotices(node, patch);
         await this.repository.update(node.id, patch);
+        // Best-effort and AFTER the write, so a notice never claims a
+        // transition the database refused. The dedup markers ride in the
+        // same patch, which is what makes each notice fire once: if the
+        // Inbox call then fails we log it rather than re-arming, exactly
+        // as the daily-ceiling notice does.
+        await this.announceWorkerTransition(node, patch, workerState);
         return { node: this.toView({ ...node, ...patch }) };
+    }
+
+    /**
+     * Fold a heartbeat's reported worker state into the update patch.
+     *
+     * Returns the NORMALIZED state (`null` = reported but unknown), or
+     * `undefined` when the beat said nothing at all — the caller uses that
+     * to tell "an old daemon" apart from "a daemon reporting something we
+     * do not understand", which are different facts and must not collapse.
+     *
+     * `workerStateChangedAt` moves only on an actual transition: a
+     * quarantine that started at 03:14 must still say 03:14 after the
+     * three hundred beats that follow it, and re-stamping it every 30
+     * seconds would silently destroy the only durable evidence of when the
+     * machine stopped working.
+     */
+    private applyWorkerState(
+        node: FleetNode,
+        refresh: EnrollInput,
+        patch: Partial<FleetNode>,
+    ): FleetNodeWorkerState | null | undefined {
+        // `null` counts as "said nothing", not as "report unknown": the
+        // DTO's `@IsOptional()` already treats null as absent, so a client
+        // that serializes missing fields as null must not end up clearing a
+        // good reading that an older client would have preserved.
+        if (refresh.workerState === undefined || refresh.workerState === null) return undefined;
+        const state = normalizeFleetNodeWorkerState(refresh.workerState);
+        // A reason for a state we could not understand is not something to
+        // show an operator: it would caption an "unknown" badge with text
+        // whose meaning we cannot vouch for.
+        const reason = state === null ? null : sanitizeWorkerStateReason(refresh);
+        const previous = node.workerState ?? null;
+        if (state !== previous) {
+            patch.workerState = state;
+            patch.workerStateChangedAt = new Date();
+        }
+        if ((node.workerStateReason ?? null) !== reason) {
+            patch.workerStateReason = reason;
+        }
+        if (!this.inbox) return state;
+        // Quarantine dedup marker, written in the same patch as the state
+        // it describes. Set on the FIRST beat that reports the quarantine;
+        // cleared by the first beat that reports anything else, so a
+        // second quarantine hours later is news again.
+        if (state === 'quarantined') {
+            if (!node.quarantineNoticedAt) patch.quarantineNoticedAt = new Date();
+        } else if (node.quarantineNoticedAt) {
+            patch.quarantineNoticedAt = null;
+        }
+        return state;
+    }
+
+    /**
+     * Clear the offline notice markers, so the NEXT outage is announced.
+     *
+     * Called for every accepted heartbeat — whatever the beat said, or
+     * did not say, about its worker. A marker means "the owner has
+     * already been told about the outage that is currently running"; an
+     * accepted beat ends that outage by definition.
+     *
+     * Only bookkeeping the Inbox needs, so it stays inert when no
+     * producer is bound: a deployment that binds one later must not
+     * inherit markers written while nothing was ever notified.
+     */
+    private rearmOfflineNotices(node: FleetNode, patch: Partial<FleetNode>): void {
+        if (!this.inbox) return;
+        if (node.offlineNoticedAt) patch.offlineNoticedAt = null;
+        if (node.offlineLongNoticedAt) patch.offlineLongNoticedAt = null;
+    }
+
+    /**
+     * File the online → quarantined notice, once per quarantine.
+     *
+     * Only this transition is announced from the heartbeat: it is the one
+     * the platform can see NOW and could never see before (the beat
+     * arrives, the node looks perfectly online, and it is refusing every
+     * job). Going offline is announced by the sweep, because a node that
+     * has gone offline is by definition not sending beats.
+     */
+    private async announceWorkerTransition(
+        node: FleetNode,
+        patch: Partial<FleetNode>,
+        state: FleetNodeWorkerState | null | undefined,
+    ): Promise<void> {
+        if (!this.inbox || state !== 'quarantined' || node.quarantineNoticedAt) return;
+        // The reason as it was just STORED: the patch carries it when this
+        // beat changed it, and the row's own value when it did not.
+        const reason =
+            patch.workerStateReason !== undefined
+                ? patch.workerStateReason
+                : (node.workerStateReason ?? null);
+        await this.fileNodeNotice(node, {
+            title: `Fleet node quarantined: ${node.name}`,
+            body: [
+                `${node.name} (${node.kind}) has quarantined itself and is refusing new work.`,
+                'A quarantine is a fail-closed stop the machine imposed on itself and it survives a restart — it can only be cleared at that keyboard.',
+                `Reason: ${reason ?? 'not reported by the node'}`,
+                `Last seen: ${describeLastSeen(node)}`,
+            ].join('\n'),
+        });
+    }
+
+    /**
+     * Announce the offline transitions the SWEEP decides, then let the
+     * bulk sweep run as it always has.
+     *
+     * Two notices, each claimed by a CAS so it fires exactly once per
+     * outage: the flip to `offline`, and — a configurable window later,
+     * default 30 minutes — "this machine is still gone". The second one
+     * exists because the runbook recommends `local-wait`, under which
+     * there is no cloud fallback and therefore no other signal at all
+     * that somebody's PC went dark.
+     *
+     * Whole thing is best-effort: an Inbox or notice-bookkeeping failure
+     * must never take down the node list, which is the page an operator
+     * opens precisely when something is wrong.
+     */
+    private async announceOfflineTransitions(userId: string, cutoff: Date): Promise<void> {
+        if (!this.inbox) return;
+        try {
+            for (const row of await this.repository.findStaleOnline(userId, cutoff)) {
+                // The CAS is the dedup AND the flip: a node that beat back
+                // between the read and here is not flipped and not announced.
+                if (!(await this.repository.markOfflineIfStale(row.id, cutoff))) continue;
+                await this.fileNodeNotice(row, {
+                    title: `Fleet node offline: ${row.name}`,
+                    body: [
+                        `${row.name} (${row.kind}) stopped reporting and has been marked offline.`,
+                        'Work routed to this machine will queue until it comes back.',
+                        `Last seen: ${describeLastSeen(row)}`,
+                    ].join('\n'),
+                });
+            }
+
+            const longAfterMs = config.fleet.getNodeOfflineNoticeAfterMs();
+            const longCutoff = new Date(Date.now() - longAfterMs);
+            for (const row of await this.repository.findOfflineUnnoticed(userId, longCutoff)) {
+                if (!(await this.repository.markLongOfflineNoticed(row.id))) continue;
+                await this.fileNodeNotice(row, {
+                    title: `Fleet node still offline: ${row.name}`,
+                    body: [
+                        `${row.name} (${row.kind}) has now been offline for over ${formatDurationMs(longAfterMs)}.`,
+                        'Nothing will run on it until it is back; if this fleet routes with local-wait there is no cloud fallback covering for it.',
+                        `Last seen: ${describeLastSeen(row)}`,
+                    ].join('\n'),
+                });
+            }
+        } catch (error) {
+            this.logger.warn(
+                `Fleet health notices skipped for user ${userId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /** File one node-scoped notice. Never throws — the inbox mirrors, it does not gate. */
+    private async fileNodeNotice(
+        node: FleetNode,
+        message: { title: string; body: string },
+    ): Promise<void> {
+        if (!this.inbox) return;
+        try {
+            await this.inbox.notice(node.userId, {
+                title: message.title,
+                body: message.body,
+                organizationId: node.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Fleet health notice "${message.title}" was not filed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     /**
@@ -429,10 +656,13 @@ export class FleetService {
      * router route work to a machine that will never poll for it.
      */
     async listEnrolledForUser(userId: string): Promise<FleetNodeView[]> {
-        await this.repository.sweepOffline(
-            userId,
-            new Date(Date.now() - config.fleet.getNodeOfflineAfterMs()),
-        );
+        const cutoff = new Date(Date.now() - config.fleet.getNodeOfflineAfterMs());
+        // Health signals (EW-776): name each node that is about to flip
+        // BEFORE the bulk sweep flips them all silently. The sweep below is
+        // unchanged and still runs — it is the catch-all for anything the
+        // per-row pass missed (or skipped, when no Inbox is bound).
+        await this.announceOfflineTransitions(userId, cutoff);
+        await this.repository.sweepOffline(userId, cutoff);
         const rows = await this.repository.findByUser(userId);
         return rows.map((row) => this.toView(row));
     }
@@ -812,6 +1042,13 @@ export class FleetService {
             modelIdentity: node.modelIdentity ?? null,
             dailyCostCeilingCents: toOptionalNumber(node.dailyCostCeilingCents),
             dailyCostTrippedOn: node.dailyCostTrippedOn ?? null,
+            // Fleet health signals (EW-776). Null is "unknown", never
+            // "idle" — see `normalizeFleetNodeWorkerState`.
+            workerState: node.workerState ?? null,
+            workerStateReason: node.workerStateReason ?? null,
+            workerStateChangedAt: node.workerStateChangedAt
+                ? toIso(node.workerStateChangedAt)
+                : null,
         };
     }
 }
@@ -879,6 +1116,43 @@ function sanitizeModelIdentity(value: unknown): string | null {
     if (!text) return null;
     // The placeholder can be longer than the token it replaces — re-cap.
     return redactSecrets(text).cleaned.slice(0, FLEET_MAX_MODEL_IDENTITY_LENGTH);
+}
+
+/**
+ * Fleet health signals (EW-776) — the free text a node offers to explain
+ * its worker state.
+ *
+ * Scrubbed the same way `modelIdentity` is, and for the same reason: this
+ * string is composed on an untrusted machine out of error messages and
+ * command output, it is stored, listed AND quoted into Inbox notices, and
+ * a quarantine reason is exactly the kind of message that carries a
+ * command line with a token in it. Capped after redaction because a
+ * placeholder can be longer than what it replaced.
+ */
+function sanitizeWorkerStateReason(source: { workerStateReason?: unknown }): string | null {
+    const text = sanitizeText(source.workerStateReason, FLEET_MAX_WORKER_STATE_REASON_LENGTH);
+    if (!text) return null;
+    return redactSecrets(text).cleaned.slice(0, FLEET_MAX_WORKER_STATE_REASON_LENGTH);
+}
+
+/** Last-seen line for a health notice; a node that never beat says so. */
+function describeLastSeen(node: FleetNode): string {
+    if (!node.lastHeartbeatAt) return 'never (this machine has not reported since enrolling)';
+    try {
+        return toIso(node.lastHeartbeatAt);
+    } catch {
+        return 'unknown';
+    }
+}
+
+/** `45s` / `30 minutes` / `2 hours` — for notice prose, not for parsing. */
+function formatDurationMs(ms: number): string {
+    if (!Number.isFinite(ms) || ms <= 0) return '0 minutes';
+    const minutes = Math.round(ms / 60_000);
+    if (minutes < 1) return `${Math.round(ms / 1000)} seconds`;
+    if (minutes < 120) return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+    const hours = Math.round(minutes / 60);
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
 }
 
 /**

--- a/packages/contracts/src/fleet/__tests__/fleet-node.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-node.spec.ts
@@ -20,10 +20,14 @@ import {
 	FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS,
 	FLEET_MIN_NODE_NAME_LENGTH,
 	FLEET_MIN_NODE_OFFLINE_AFTER_MS,
+	FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS,
+	FLEET_MAX_WORKER_STATE_REASON_LENGTH,
 	FLEET_NODE_KINDS,
 	FLEET_NODE_NON_LEASABLE_STATUSES,
 	FLEET_NODE_STATUSES,
-	isFleetEnrollableNodeKind
+	FLEET_NODE_WORKER_STATES,
+	isFleetEnrollableNodeKind,
+	normalizeFleetNodeWorkerState
 } from '../fleet-node.types.js';
 
 /**
@@ -54,7 +58,9 @@ function BOUNDS_AND_TUNABLES(): Array<[string, number]> {
 		['FLEET_MAX_CAPABILITY_TAGS_CEILING', FLEET_MAX_CAPABILITY_TAGS_CEILING],
 		['FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING', FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING],
 		['FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS', FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS],
-		['FLEET_MIN_NODE_OFFLINE_AFTER_MS', FLEET_MIN_NODE_OFFLINE_AFTER_MS]
+		['FLEET_MIN_NODE_OFFLINE_AFTER_MS', FLEET_MIN_NODE_OFFLINE_AFTER_MS],
+		['FLEET_MAX_WORKER_STATE_REASON_LENGTH', FLEET_MAX_WORKER_STATE_REASON_LENGTH],
+		['FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS', FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS]
 	];
 }
 
@@ -329,5 +335,95 @@ describe('relational invariants a careless retune would break silently', () => {
 	it('allows a wider CLI version than a daemon version', () => {
 		// An agent CLI commonly reports `1.2.3 (Claude Code)`, not a bare semver.
 		expect(FLEET_MAX_CLI_VERSION_LENGTH).toBeGreaterThan(FLEET_MAX_VERSION_LENGTH);
+	});
+});
+
+describe('FLEET_NODE_WORKER_STATES', () => {
+	it('lists the five worker states', () => {
+		expect(FLEET_NODE_WORKER_STATES).toEqual(['idle', 'working', 'paused', 'quarantined', 'throttled']);
+	});
+
+	it('has exactly five unique members', () => {
+		expect(FLEET_NODE_WORKER_STATES).toHaveLength(5);
+		expect(new Set(FLEET_NODE_WORKER_STATES).size).toBe(5);
+	});
+
+	it('does not overlap the registry status names', () => {
+		// Worker state and registry status answer different questions
+		// ('what is the machine doing' vs 'what can the platform infer from
+		// heartbeats'), and the UI renders them side by side. `paused` is the
+		// ONE deliberate shared word — a drained node is drained in both
+		// senses — and pinning that keeps a future addition from quietly
+		// making the two lists read as one.
+		const shared = FLEET_NODE_WORKER_STATES.filter((state) =>
+			(FLEET_NODE_STATUSES as readonly string[]).includes(state)
+		);
+		expect(shared).toEqual(['paused']);
+	});
+});
+
+describe('normalizeFleetNodeWorkerState', () => {
+	it.each(FLEET_NODE_WORKER_STATES.map((state) => [state]))('round-trips %s', (state) => {
+		expect(normalizeFleetNodeWorkerState(state)).toBe(state);
+	});
+
+	it.each([
+		// The node's OWN internal state names that are not part of this
+		// contract. `describeWorkerHealth` maps them before they reach the
+		// wire; a daemon that skipped that step must not smuggle them in.
+		['unsafe'],
+		['draining'],
+		['polling'],
+		['retrying'],
+		['unauthorized'],
+		['stopped'],
+		// Case and whitespace are not "close enough" — the contract is exact.
+		['Idle'],
+		[' idle'],
+		['idle '],
+		['']
+	])('refuses the near-miss %p', (value) => {
+		expect(normalizeFleetNodeWorkerState(value)).toBeNull();
+	});
+
+	it.each([[42], [null], [undefined], [true], [{ workerState: 'idle' }], [['idle']]])(
+		'refuses the non-string %p',
+		(value) => {
+			expect(normalizeFleetNodeWorkerState(value)).toBeNull();
+		}
+	);
+
+	it('refuses a boxed String even though it stringifies to a member', () => {
+		// `typeof new String('idle') === 'object'`, and an `includes` on the
+		// raw value would miss it too — but a caller doing `String(value)`
+		// first would let it through. Pinned so nobody adds that coercion.
+		expect(normalizeFleetNodeWorkerState(new String('idle'))).toBeNull();
+	});
+
+	it('maps a value invented by a NEWER node to unknown rather than a member', () => {
+		// The whole compatibility story: a future daemon reporting a state
+		// this build has never heard of shows as unknown. It must never be
+		// rewritten into a plausible-looking `idle`, which is the fabrication
+		// this field exists to end.
+		expect(normalizeFleetNodeWorkerState('hibernating')).toBeNull();
+	});
+});
+
+describe('FLEET_MAX_WORKER_STATE_REASON_LENGTH', () => {
+	it('is wide enough for a real quarantine sentence but still bounded', () => {
+		expect(FLEET_MAX_WORKER_STATE_REASON_LENGTH).toBeGreaterThan(FLEET_MAX_MODEL_IDENTITY_LENGTH);
+		expect(FLEET_MAX_WORKER_STATE_REASON_LENGTH).toBeLessThanOrEqual(2000);
+	});
+});
+
+describe('FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS', () => {
+	it('is longer than the sweep window it escalates', () => {
+		// A "gone for a long time" notice that could fire before the node is
+		// even considered offline would be two notices for one event.
+		expect(FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS).toBeGreaterThan(FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS);
+	});
+
+	it('defaults to 30 minutes', () => {
+		expect(FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS).toBe(30 * 60_000);
 	});
 });

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -97,7 +97,14 @@ const NODE_EXPORTS = [
 	'FLEET_MAX_CAPABILITY_TAGS_CEILING',
 	'FLEET_MAX_CAPABILITY_TAG_LENGTH_CEILING',
 	'FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS',
-	'FLEET_MIN_NODE_OFFLINE_AFTER_MS'
+	'FLEET_MIN_NODE_OFFLINE_AFTER_MS',
+	// Health signals (EW-776): the worker-state vocabulary, its
+	// normaliser, the reason cap and the long-offline notice window.
+	// Covered in `fleet-node.spec.ts`.
+	'FLEET_NODE_WORKER_STATES',
+	'normalizeFleetNodeWorkerState',
+	'FLEET_MAX_WORKER_STATE_REASON_LENGTH',
+	'FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS'
 ] as const;
 
 /** Agent execution v2 — model CLIs on the node (`fleet-jobs.types.js`). */
@@ -207,7 +214,8 @@ const FUNCTION_EXPORTS = [
 	'normalizeFleetTaskWorkspaceMounts',
 	'isReservedMountDir',
 	'parseFleetAgentTaskQuestionMarkdown',
-	'normalizeFleetAgentTaskQuestion'
+	'normalizeFleetAgentTaskQuestion',
+	'normalizeFleetNodeWorkerState'
 ] as const;
 
 const bag = fleet as unknown as Record<string, unknown>;
@@ -222,14 +230,16 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 114 runtime symbols', () => {
+	it('exposes exactly these 118 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
 		// 92 → 98 with fleet cost accounting (EW-777): two node bounds and
 		// four cost-accounting helpers, each pinned in its own spec.
+		// 114 → 118 with fleet health signals (EW-776): the worker-state
+		// list, its normaliser, the reason cap and the long-offline window.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(114);
+		expect(Object.keys(fleet)).toHaveLength(118);
 	});
 
 	it.each([

--- a/packages/contracts/src/fleet/fleet-node.types.ts
+++ b/packages/contracts/src/fleet/fleet-node.types.ts
@@ -102,6 +102,62 @@ export const FLEET_NODE_STATUSES: readonly FleetNodeStatus[] = ['enrolling', 'on
 export const FLEET_NODE_NON_LEASABLE_STATUSES: readonly FleetNodeStatus[] = ['enrolling', 'paused', 'disabled'];
 
 /**
+ * What the node's WORKER is doing, as opposed to {@link FleetNodeStatus},
+ * which is only what the platform can infer from heartbeats.
+ *
+ * The distinction is the whole point of this field (self-build finding
+ * OPS-02). A machine that has self-quarantined — the durable worker
+ * safety marker, set when a process tree could not be proven dead and
+ * clearable only at that keyboard — keeps beating and therefore keeps
+ * reporting `online`, while refusing every job it is offered. Status
+ * said "healthy", the queue said "nothing is running", and nothing
+ * anywhere said why. These five values are the node's own answer:
+ *
+ * - `idle`        — polling, ready to take work.
+ * - `working`     — at least one job in flight.
+ * - `paused`      — drained on purpose (operator pause, or draining
+ *                   the last in-flight jobs before a stop).
+ * - `quarantined` — fail-closed stop the node imposed on ITSELF; only
+ *                   an operator at that machine can clear it.
+ * - `throttled`   — over a resource ceiling (CPU/memory, disk floor):
+ *                   the loop runs and keeps its jobs, it just does not
+ *                   lease more.
+ *
+ * Stored in a plain `varchar(16)` with no enum/check constraint, like
+ * {@link FleetNodeStatus}, so adding a value stays a code change.
+ */
+export type FleetNodeWorkerState = 'idle' | 'working' | 'paused' | 'quarantined' | 'throttled';
+
+/** Canonical worker-state list — one source of truth for the server and the UI. */
+export const FLEET_NODE_WORKER_STATES: readonly FleetNodeWorkerState[] = [
+	'idle',
+	'working',
+	'paused',
+	'quarantined',
+	'throttled'
+];
+
+/**
+ * Normalize a worker state arriving off the wire.
+ *
+ * Returns `null` — meaning "unknown", rendered as such — for ANY value
+ * that is not an exact member: a non-string, a node-internal state name
+ * that is not part of this contract (`unsafe`, `draining`, `polling`),
+ * or a value a NEWER node build invented. Deliberately not a fallback to
+ * `idle`: a fabricated "idle" for a machine whose real state we do not
+ * understand is precisely the lie this whole field exists to stop.
+ *
+ * The wire itself stays permissive on purpose (the heartbeat DTO bounds
+ * `workerState` as a plain string, not an enum), so a future value can
+ * never make a beat fail and turn a live node offline. It is normalized
+ * here, once, before it is ever stored or shown.
+ */
+export function normalizeFleetNodeWorkerState(value: unknown): FleetNodeWorkerState | null {
+	if (typeof value !== 'string') return null;
+	return (FLEET_NODE_WORKER_STATES as readonly string[]).includes(value) ? (value as FleetNodeWorkerState) : null;
+}
+
+/**
  * Self-description a node sends on enroll and refreshes on every
  * heartbeat. Every field is optional: a node that reports nothing is
  * still a valid node, just an undescribed one.
@@ -155,6 +211,29 @@ export interface FleetNodeSelfDescription {
 	 * Capped at {@link FLEET_MAX_MODEL_IDENTITY_LENGTH}.
 	 */
 	modelIdentity?: string;
+	/**
+	 * What the node's WORKER is doing right now — one of
+	 * {@link FLEET_NODE_WORKER_STATES}.
+	 *
+	 * Typed as a plain `string` rather than the union ON PURPOSE: this is
+	 * the WIRE, and a node built after this API must be able to report a
+	 * value this API has never heard of without its heartbeat being
+	 * rejected (a rejected beat is a failed beat, and a node that cannot
+	 * beat goes offline). The server runs every incoming value through
+	 * {@link normalizeFleetNodeWorkerState}, which maps anything
+	 * unrecognised to "unknown" rather than trusting it verbatim.
+	 *
+	 * Same additive contract as {@link cliVersion}: absent leaves the
+	 * stored value alone, so an older daemon never blanks it.
+	 */
+	workerState?: string;
+	/**
+	 * Why the worker is in that state, when there is a reason worth
+	 * reading: the quarantine's own message, the resource ceiling that
+	 * throttled the lease. Free text from the machine, so the server
+	 * sanitizes and caps it at {@link FLEET_MAX_WORKER_STATE_REASON_LENGTH}.
+	 */
+	workerStateReason?: string;
 }
 
 /** Wire view of one fleet node — never carries credentials or hashes. */
@@ -212,6 +291,21 @@ export interface FleetNodeView {
 	 * its owner re-enables it — a ceiling is a stop, not a rate limit.
 	 */
 	dailyCostTrippedOn?: string | null;
+	/**
+	 * What the node's worker last reported doing, or null when it has
+	 * never reported one (an older daemon, or a visibility-only node with
+	 * its worker disabled). Null renders as "unknown", which is the
+	 * honest answer — never as `idle`.
+	 */
+	workerState?: FleetNodeWorkerState | null;
+	/** Why the worker is in that state (quarantine / throttle reason), or null. */
+	workerStateReason?: string | null;
+	/**
+	 * ISO timestamp the worker state last CHANGED, or null. Stamped only
+	 * on a transition, so "quarantined since 03:14" stays true across the
+	 * hundreds of beats that follow rather than resetting every 30s.
+	 */
+	workerStateChangedAt?: string | null;
 }
 
 /**
@@ -290,6 +384,17 @@ export const FLEET_MAX_CLI_VERSION_LENGTH = 64;
 export const FLEET_MAX_MODEL_IDENTITY_LENGTH = 200;
 
 /**
+ * `sanitizeText(workerStateReason, 500)` server-side.
+ *
+ * Wide enough for a real quarantine message ("process tree for job X
+ * could not be proven terminated after N attempts: ..."), and hard
+ * enough that a machine cannot use a heartbeat field as unbounded
+ * storage. The node truncates to the same bound so what it shows locally
+ * matches what Fleet stores.
+ */
+export const FLEET_MAX_WORKER_STATE_REASON_LENGTH = 500;
+
+/**
  * Ceiling on a daily cost ceiling: $100,000 per UTC day, in cents. Not a
  * plausible fleet spend — it is the point past which a figure is a typo
  * (dollars entered as cents, or the reverse) rather than a decision, and
@@ -328,6 +433,21 @@ export const FLEET_DEFAULT_ENROLLMENT_TOKEN_TTL_MS = 15 * 60_000;
 /** Default silence after which an `online` node sweeps to `offline` (5 minutes). */
 export const FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS = 5 * 60_000;
 
+/**
+ * Default silence after which an already-`offline` node earns a SECOND,
+ * louder Inbox notice — "this machine has now been gone for half an
+ * hour" (30 minutes).
+ *
+ * Separate from {@link FLEET_DEFAULT_NODE_OFFLINE_AFTER_MS} because the
+ * two answer different questions. Five minutes of silence is routine (a
+ * reboot, a lid closed, a flaky Wi-Fi minute) and the first notice says
+ * so. Half an hour is somebody's PC that is not coming back on its own,
+ * and under the runbook's recommended `local-wait` there is no cloud
+ * fallback to quietly cover for it. Filed exactly once per outage; the
+ * marker re-arms when the node beats again.
+ */
+export const FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS = 30 * 60_000;
+
 /** Default cap on how many capability tags one node may advertise. */
 export const FLEET_DEFAULT_MAX_CAPABILITY_TAGS = 16;
 
@@ -356,6 +476,63 @@ export const FLEET_MIN_ENROLLMENT_TOKEN_TTL_MS = 30_000;
 export const FLEET_MIN_NODE_OFFLINE_AFTER_MS = 30_000;
 
 /**
+ * The RECONCILED outcome of the platform run a fleet job carried.
+ *
+ * The job row and the run row settle separately: the node reports a
+ * verdict on the job, then the api-side reconciler decides what that
+ * meant for the Agent run (completed with a summary, failed with a
+ * reason, parked on a question). Showing only the job status is how the
+ * drawer ended up saying "done" for a job whose run had failed — the
+ * exact question an operator opens the drawer to answer.
+ */
+export interface FleetJobReconciledOutcome {
+	/** The Agent run this job carried. */
+	runId: string;
+	status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+	/** The run's own summary, or null. */
+	summary: string | null;
+	/** The run's error message, or null. Length-capped server-side. */
+	error: string | null;
+}
+
+/**
+ * IDs-ONLY summary of what a job was for.
+ *
+ * Deliberately not the payload: `FleetJobView.payload` is executor input
+ * — instructions, mount grants, repo coordinates — and the drawer has no
+ * business rendering it (see `FLEET_JOB_MAX_PAYLOAD_BYTES` for how big
+ * it can get, and note that it is composed from user content). The
+ * identities below are what an operator actually needs to follow the
+ * trail from a node row to the Task and the run.
+ */
+export interface FleetJobHistorySummary {
+	kind: string;
+	taskId?: string | null;
+	runId?: string | null;
+	agentId?: string | null;
+}
+
+/**
+ * One row of the node drawer's job history: a {@link FleetJobView} plus
+ * the facts that were on the server and never reached the drawer — the
+ * job's own error text, the reconciled run outcome, and a payload-free
+ * summary.
+ *
+ * `payload` is inherited from {@link FleetJobView} and is always sent as
+ * `null` on this endpoint. Keeping the field (rather than omitting it)
+ * keeps the type a structural superset, so every existing consumer of
+ * the detail view still compiles.
+ */
+export interface FleetNodeJobHistoryEntry extends FleetJobView {
+	/** The verdict text the node reported, or null. Capped server-side. */
+	error?: string | null;
+	/** IDs-only description of the work, never the payload. */
+	summary?: FleetJobHistorySummary | null;
+	/** The reconciled run outcome, or null for a job that carried no run. */
+	reconciled?: FleetJobReconciledOutcome | null;
+}
+
+/**
  * `GET /api/fleet/nodes/:id` — one node plus what it has been doing.
  *
  * Lives in contracts (not at the API edge) because the web tier renders
@@ -365,13 +542,13 @@ export const FLEET_MIN_NODE_OFFLINE_AFTER_MS = 30_000;
 export interface FleetNodeDetailView {
 	node: FleetNodeView;
 	/** Newest-first job history for this node (all outcomes). */
-	recentJobs: FleetJobView[];
+	recentJobs: FleetNodeJobHistoryEntry[];
 	/**
 	 * The failed subset of {@link recentJobs}, newest first — pulled out
 	 * so the drawer can lead with "why is this machine unhappy" instead
 	 * of making the operator filter a mixed list by eye.
 	 */
-	failures: FleetJobView[];
+	failures: FleetNodeJobHistoryEntry[];
 	/**
 	 * True when the job history could not be read at all (job tables
 	 * unavailable). The node itself still renders — a job-runtime hiccup

--- a/packages/contracts/src/fleet/fleet-runner-status.types.ts
+++ b/packages/contracts/src/fleet/fleet-runner-status.types.ts
@@ -23,7 +23,7 @@
  */
 
 import type { FleetJobKind } from './fleet-jobs.types.js';
-import type { FleetNodeKind, FleetNodeStatus } from './fleet-node.types.js';
+import type { FleetNodeKind, FleetNodeStatus, FleetNodeWorkerState } from './fleet-node.types.js';
 
 /**
  * How often the pill re-reads runner status. Shipped in the payload
@@ -72,6 +72,18 @@ export interface FleetRunnerNodeView {
 	activeJobCount: number;
 	/** Kind of the oldest live claim, or null when idle. */
 	currentJobKind: FleetJobKind | null;
+	/**
+	 * What the node's WORKER last reported doing, or null when unknown.
+	 *
+	 * `status` alone cannot answer "will this machine take my job": a
+	 * self-quarantined node keeps beating and reads `online` while
+	 * refusing every lease. That is why availability counts a node as
+	 * FREE only when its worker state is not one of the refusing ones —
+	 * see `FleetRunnerStatusService.availability`.
+	 */
+	workerState?: FleetNodeWorkerState | null;
+	/** Why the worker is in that state (quarantine / throttle reason), or null. */
+	workerStateReason?: string | null;
 }
 
 /** `GET /api/fleet/runner-status` — the whole pill payload. */


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **T** (program note §6, finding OPS-02). Refs **EW-776**. Depends on B, E and S — all merged.

The heartbeat carried no worker state, so a node that had self-quarantined kept reporting itself **online** while refusing every job. Under the runbook's recommended `local-wait` there is no fallback, so there was no notification of any kind. Nothing told an owner a PC had gone offline either.

### What changes

- **Worker state on the wire.** `FleetNodeWorkerState` (`idle | working | paused | quarantined | throttled`) plus a reason, on the self-description, `FleetNodeView` and `FleetRunnerNodeView`, persisted with a changed-at stamp. Migration `1788900000000-AddFleetNodeWorkerState`. On the node a new pure `describeWorkerHealth` maps every existing `WorkerState` member, including `unsafe → quarantined` carrying the durable safety-store reason and `throttled` carrying the admission reason (which is where slice AO's disk-floor refusal now surfaces).
- **The wire stays additive in both directions, and that matters more than it looks.** Under `whitelist + forbidNonWhitelisted` a rejected field is a failed beat, and a failed beat sweeps a *live* node offline. So the DTO bounds `workerState` with `@IsString @MaxLength(32)` and deliberately **not** `@IsIn` — a newer node may invent a state and must still beat — while the node retries once without the fields on a **literal 400** from an older API and then latches, logging once. A 401 / 403 / 429 / 5xx / network error never strips or latches. The server normalises anything unrecognised to *unknown* rather than fabricating `idle`, and the reason is sanitised and capped.
- **Inbox notices** on online → offline, on quarantine, and on a node offline longer than a window, deduped per transition on the node row and re-armed when it returns.
- **Drawer truths B and E left open:** the *reconciled* run outcome and error text, `startedAt` reset per attempt, and a payload-free job summary — `payload` is set to `null` on every row and a controller spec asserts a sentinel never reaches the response.
- **Affinity cascade.** Removing a node deletes its `fleet_agent_node_affinity` rows in the same transaction. It deliberately does **not** rely on a DB-level cascade, because the schema never declared that FK.

### Adversarial review (fixed before this PR)

- **The offline notices would have fired once, ever.** The dedup markers were cleared inside `applyWorkerState`, which early-returns when a beat reports no worker state — so a daemon older than the field, or a visibility-only node, would set its markers on the first outage and never re-arm. Re-arming now happens on every accepted beat, with three specs.
- **Three different definitions of "failed".** The status badge, the drawer's Failed chip and the endpoint's `failures` subset each decided independently, so a job whose reconciled run failed but whose row read `completed` appeared in one and not the others. All three now share one reconciled-aware rule.

### Known limit, documented not fixed

Notices are **poll-driven**: they ride the owner-scoped sweep in `listEnrolledForUser`, which runs when the runner pill polls (every 30 s while a dashboard is open) or on a dispatch. An owner with no open page and no dispatch gets the notice on their next visit rather than at the moment of the outage. A fleet-wide cron pass would fix it but needs a `packages/tasks` change plus adding `FleetService` to the internal RPC map — out of scope here, and recorded in `docs/features/fleet.md`.

### Verified locally

| Check | Result |
| --- | --- |
| `packages/contracts` full vitest + typecheck | 32 files / 1634 tests, no type errors |
| `packages/agent` fleet + entity inventory + config | 20 suites / 510 tests |
| `apps/api` whole migrations tree incl. the directory contract | 40 suites / 176 tests |
| `apps/api` runnable fleet specs (node-history, runner-status, the new DTO spec) | 6 suites / 90 tests |
| `apps/node` (whole suite, plugin aliased to source) | 877 tests, 2 pre-existing environmental failures in untouched files |
| `apps/web` drawer + shared + api client | 67 tests |
| `prettier --check` on all 63 files, i18n | clean; 20 new keys in all 20 non-English locales |
| `tsc` | contracts (both configs) and web exit 0; node/agent/api show only the documented stale-dist and unlinked-package families, zero in any touched file |

### Not verified locally

- **`apps/api/src/fleet/fleet.controller.spec.ts` is modified by this slice and cannot run here** — it fails to load on four pre-existing lines of `fleet.controller.ts` that reference symbols present in the agent *source* but absent from this worktree's stale, unbuildable agent dist. The new heartbeat and enroll worker-state assertions in it are therefore unexecuted locally. Those same paths were type-checked clean against agent source with a throwaway config, and the DTO, runner-status and node-history halves are covered by three passing api specs. **This spec is the first thing to check in CI.**
- Eleven other `apps/api/src/fleet` suites, untouched by this slice, cannot load for the same reason.
- e2e never runs locally. No real node was suspended, quarantined or taken offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fleet nodes now report worker health states, reasons, and state-change times.
  - Fleet views show worker status and distinguish available workers from paused, throttled, or quarantined nodes.
  - Job history now displays reconciled run outcomes, summaries, errors, and failure status without exposing payloads.
  - Added one-time Inbox notices for quarantined and prolonged offline nodes.
  - Heartbeats remain compatible with older platforms that reject worker-health fields.
- **Documentation**
  - Updated Fleet documentation and translations for worker states and job outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->