### PR TITLE
test(e2e): align two specs with the URL and DTO shapes this cascade changed

### DIFF
--- a/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
@@ -183,9 +183,15 @@ test.describe('/settings/usage', () => {
 
         const exportLink = page.getByTestId('usage-export-csv');
         await expect(exportLink).toBeVisible();
+        // The export is an `<a href download>`, which cannot send a header, so
+        // the workspace selector rides on the URL as `?scope=` and the BFF
+        // route turns it into `X-Scope-Slug`. Asserted rather than tolerated:
+        // if the carrier ever disappears the export silently goes back to
+        // ignoring the Organization the user is standing in, which is the
+        // defect it was added to fix.
         await expect(exportLink).toHaveAttribute(
             'href',
-            /^\/api\/credits\/usage\/export\?period=(\d{4}-(0[1-9]|1[0-2])|7d|30d)$/,
+            /^\/api\/credits\/usage\/export\?period=(\d{4}-(0[1-9]|1[0-2])|7d|30d)&scope=(personal|org%3A[a-z0-9-]+)$/,
         );
 
         // The proxy must answer with a CSV attachment, not an HTML error

--- a/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
+++ b/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
@@ -124,6 +124,12 @@ interface LinkRow {
 
 const GOAL_DTO_KEYS = [
     'id',
+    // A Goal's KIND (EW-795, "delivery Goal kind + Goal cold start").
+    // `toGoalDto` writes it unconditionally via `normalizeGoalKind`, so the
+    // key is always present even for a Goal created before the column
+    // existed — which is why it belongs in this exact-shape list rather
+    // than being tolerated as optional.
+    'goalKind',
     // Ownership scope: the DTO deliberately surfaces the tenant/Organization
     // pair a Goal is stamped with (e49936d8 "fix(api): expose and enforce
     // organization ownership"), so a client can tell a personal Goal from an


### PR DESCRIPTION
**My own regression from #2357 (Group B).** Stage run [33962668128](https://github.com/ever-works/ever-works/actions/runs/33962668128), shard 7:

```
expect(locator).toHaveAttribute(expected) failed
Expected pattern: /^\/api\/credits\/usage\/export\?period=(\d{4}-(0[1-9]|1[0-2])|7d|30d)$/
Received string:  "/api/credits/usage/export?period=2026-09&scope=personal"
```

The CSV export is an `<a href download>`, which cannot send a header, so Group B moved the workspace selector onto the URL. This spec pins the href shape and was still asserting the pre-carrier one.

## What I got wrong, precisely

I wrote in #2357 that "no e2e exercises these BFF paths". That was **true of the routes and false of the UI**: I grepped for specs calling the endpoints, and never for one asserting the anchor that points at them. Changing a URL means grepping for the URL, not for the route.

I re-checked the other two members of this family the same way this time — the Memory download testids and the uploads serve URL — and no e2e references either.

## The change

The pattern now **requires** `&scope=(personal|org%3A<slug>)` rather than tolerating it. A test that merely allowed the parameter would not notice the carrier disappearing, and its disappearance is precisely the defect Group B fixed: the export silently ignoring the Organization the user is standing in.

Verified against five cases, including the two shapes `buildUsageExportQuery` can emit (`personal` and the URL-encoded `org%3A…`) and two that must still be rejected. The rest of the test already fetches the href and asserts a CSV attachment, so it now exercises the carrier end to end for free.

## Related

Stage e2e also shows four other red shards that are **not** the product — their tests pass and only the artifact upload fails, on `Artifact storage quota has been hit`. #2368 stops that from failing a green shard. The genuinely red shard 10 is a new fleet spec, filed as EW-802.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated billing usage export coverage to verify that download links include the selected workspace scope and reporting period.
  * Updated mission goals evaluation coverage to verify that goal data consistently includes its goal type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->