### PR TITLE
fix(uptime): escalate a sustained outage and name what recovered (EW-760)

### DIFF
--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -342,6 +342,18 @@ jobs:
           # comments while an outage is unchanged.
           FINGERPRINT="$(printf '%s' "${FAILING_URLS}" | sort | sha256sum | cut -c1-16)"
 
+          # The exact failing set, comma-joined onto ONE line so it can ride
+          # through $GITHUB_OUTPUT (which is key=value: an embedded newline
+          # would inject extra records or break the parse outright, and every
+          # later `if:` carries an implicit success(), so the monitor would go
+          # SILENT -- the same trap documented for EGRESS_IP above).
+          #
+          # EW-760: the alert step diffs this against the set recorded on the
+          # previous report to name the targets that RECOVERED while others
+          # stayed down. On 2026-08-23 demo.ever.works healed while the whole
+          # web app went down, and the open issue said neither thing.
+          FAILING_CSV="$(printf '%s' "${FAILING_URLS}" | tr '\n' ',' | sed 's/,\{1,\}/,/g; s/^,//; s/,$//')"
+
           # Is any CUSTOMER-FACING surface among the failures? This is what
           # decides whether the alert shouts or merely notes. Without it a total
           # outage and a flaky demo produce an identical-looking issue.
@@ -383,6 +395,7 @@ jobs:
             echo "critical=${CRITICAL_DOWN}"
             echo "fail_summary=${FAIL_SUMMARY}"
             echo "critical_list=${CRITICAL_LIST}"
+            echo "failing_urls=${FAILING_CSV}"
             if [ "${OVERALL_OK}" -eq 1 ]; then echo "status=up"; else echo "status=down"; fi
           } >> "${GITHUB_OUTPUT}"
 
@@ -395,7 +408,11 @@ jobs:
           FINGERPRINT: ${{ steps.probe.outputs.fingerprint }}
           CRITICAL: ${{ steps.probe.outputs.critical }}
           FAIL_SUMMARY: ${{ steps.probe.outputs.fail_summary }}
+          FAILING_URLS_CSV: ${{ steps.probe.outputs.failing_urls }}
           ALERT_LABEL: uptime-alert
+          # Labels applied as an outage crosses a duration threshold, so a
+          # sustained incident is filterable and not just differently worded.
+          SEV_LABEL_PREFIX: uptime-sev
           # Stable substring used ONLY to re-find the issue when the label
           # lookup misses. The visible title is computed per-run now, so it
           # must never be matched exactly.
@@ -432,8 +449,132 @@ jobs:
 
           MARK="<!-- uptime-fingerprint: ${FINGERPRINT} -->"
 
-          # 🛑 The title names what is failing RIGHT NOW, and shouts when a
-          # customer-facing surface is among them.
+          # --- What the LAST report said -------------------------------------
+          # Fetched here rather than just above the comment throttle (where it
+          # used to live) because the duration and recovery logic below needs it
+          # to compute the TITLE. Same two calls as before, just earlier; the
+          # create path below skips them entirely.
+          #
+          # Fall back to the ISSUE BODY when there are no comments yet. On the very first repeat
+          # of an outage the comments array is empty, so `.comments[-1]` yielded nothing, the
+          # freshness guard short-circuited, and the monitor posted a redundant full report 15
+          # minutes after opening the issue — the throttle only started working from the third
+          # cycle. Both markers are written into the body at creation, so the body is simply the
+          # zeroth comment.
+          LAST_AT=""
+          LAST_BODY=""
+          if [ -n "${EXISTING}" ]; then
+            LAST_AT="$(gh issue view "${EXISTING}" --json createdAt,comments \
+                         --jq '.comments[-1].createdAt // .createdAt // empty' 2>/dev/null || true)"
+            LAST_BODY="$(gh issue view "${EXISTING}" --json body,comments \
+                           --jq '.comments[-1].body // .body // empty' 2>/dev/null || true)"
+          fi
+
+          NOW_EPOCH="$(date -u +%s)"
+
+          # >>> uptime-escalation-state
+          # Contract-tested by apps/node/src/core/external-uptime-monitor.contract.spec.ts,
+          # which lifts everything between these two sentinels out of this YAML
+          # and runs it under these same Bash flags. KEEP IT FREE OF `gh` CALLS
+          # and of `date` — its only inputs are the four variables below, which
+          # is what makes it runnable, and therefore checkable, in isolation.
+          #
+          # Inputs : FINGERPRINT, FAILING_URLS_CSV, LAST_BODY, NOW_EPOCH
+          # Outputs: SINCE_EPOCH, AGE_MIN, PREV_TIER, TIER, ESCALATED,
+          #          DURATION_LABEL, RECOVERED_LIST, STATE_MARK
+          #
+          # EW-760 (3) and (4): the monitor kept NO state between runs, so the
+          # 2026-08-23 outage — 40 consecutive failing runs across ~18 hours —
+          # rendered exactly like a single 15-minute blip, and an issue whose
+          # original target had healed never said so. The state needed is tiny,
+          # so it rides in an HTML comment on the last thing we wrote instead of
+          # pulling in a store this workflow deliberately does not have.
+          PREV_STATE="$(sed -n '/<!-- uptime-state: /{s/.*<!-- uptime-state: \(.*\) -->.*/\1/p;q;}' <<< "${LAST_BODY}")"
+          # Word splitting is wanted below; pathname expansion is not. The
+          # values come off a GitHub issue, and a stray `*` matching a file in
+          # the runner's cwd would quietly rewrite the outage history.
+          set -f
+          PREV_FP=""
+          PREV_SINCE=""
+          PREV_TIER=0
+          PREV_URLS=""
+          # Word-splitting a `k=v k=v` list beats one sed per field: no \b, no
+          # anchoring games, and an unknown or reordered key is ignored rather
+          # than silently shifting every later capture by one.
+          # shellcheck disable=SC2086  # splitting IS the parser here; `set -f` above kills globbing
+          for KV in ${PREV_STATE}; do
+            case "${KV}" in
+              fp=*) PREV_FP="${KV#fp=}" ;;
+              since=*) PREV_SINCE="${KV#since=}" ;;
+              tier=*) PREV_TIER="${KV#tier=}" ;;
+              urls=*) PREV_URLS="${KV#urls=}" ;;
+            esac
+          done
+          # Non-numeric junk here would abort the arithmetic below and kill the
+          # step, i.e. silence the monitor — the one outcome it must never
+          # produce. Treat anything unparseable as absent.
+          case "${PREV_SINCE}" in ''|*[!0-9]*) PREV_SINCE="" ;; esac
+          case "${PREV_TIER}" in ''|*[!0-9]*) PREV_TIER=0 ;; esac
+
+          # A DIFFERENT failing set is a NEW event, not a continuation, so the
+          # clock restarts with it. Same reasoning as the per-run title: the
+          # duration must describe the outage the title is naming.
+          if [ -n "${PREV_SINCE}" ] && [ "${PREV_FP}" = "${FINGERPRINT}" ]; then
+            SINCE_EPOCH="${PREV_SINCE}"
+          else
+            SINCE_EPOCH="${NOW_EPOCH}"
+            PREV_TIER=0
+          fi
+
+          AGE_MIN=$(( (NOW_EPOCH - SINCE_EPOCH) / 60 ))
+          if [ "${AGE_MIN}" -lt 0 ]; then AGE_MIN=0; fi
+
+          # The schedule is every 15 minutes, so tier 1 is the ticket's "shout
+          # at, say, the fifth" consecutive failure and tier 2 is four hours of
+          # the same thing.
+          TIER=0
+          if [ "${AGE_MIN}" -ge 60 ]; then TIER=1; fi
+          if [ "${AGE_MIN}" -ge 240 ]; then TIER=2; fi
+          ESCALATED=0
+          if [ "${TIER}" -gt "${PREV_TIER}" ]; then ESCALATED=1; fi
+
+          # Bucketed to the probe interval so the title moves when the SEVERITY
+          # moves, not every 15 minutes. A title that churns on every run is the
+          # old noise problem wearing a clock.
+          DURATION_LABEL=""
+          if [ "${TIER}" -ge 1 ]; then
+            BUCKET_MIN=$(( (AGE_MIN / 15) * 15 ))
+            DUR_H=$(( BUCKET_MIN / 60 ))
+            DUR_M=$(( BUCKET_MIN % 60 ))
+            if [ "${DUR_H}" -gt 0 ]; then
+              DURATION_LABEL="${DUR_H}h${DUR_M}m"
+            else
+              DURATION_LABEL="${DUR_M}m"
+            fi
+          fi
+
+          # EW-760 (4): which targets healed while others stayed down. Without
+          # it an updated issue lists only what is broken now, so a reader
+          # cannot tell a partial recovery from a target that was never named.
+          RECOVERED_LIST=""
+          # shellcheck disable=SC2046  # splitting IS the parser here; `set -f` above kills globbing
+          for U in $(tr ',' ' ' <<< "${PREV_URLS}"); do
+            case ",${FAILING_URLS_CSV}," in
+              *",${U},"*) ;;
+              *) RECOVERED_LIST="${RECOVERED_LIST}${U} " ;;
+            esac
+          done
+          set +f
+
+          # Space-separated k=v, values free of spaces, so the reader above can
+          # be a word-split loop. Written alongside MARK, never instead of it:
+          # the comment throttle greps for MARK verbatim and must keep matching.
+          STATE_MARK="<!-- uptime-state: fp=${FINGERPRINT} since=${SINCE_EPOCH} tier=${TIER} urls=${FAILING_URLS_CSV} -->"
+          # <<< uptime-escalation-state
+
+          # 🛑 The title names what is failing RIGHT NOW, shouts when a
+          # customer-facing surface is among them, and says how long it has been
+          # going on.
           #
           # It used to be a constant, and that is what made EW-760 possible: an
           # issue opened for demo.ever.works kept its wording while the entire
@@ -445,10 +586,17 @@ jobs:
           else
             ALERT_TITLE="🔴 Uptime: ${FAIL_SUMMARY} unreachable"
           fi
+          # Duration goes in the TITLE, not only in a comment (EW-760 suggestion
+          # 3). Forty consecutive failures used to render identically to the
+          # first one; the top of the issue is the only thing a reader who has
+          # already triaged it will look at again.
+          if [ -n "${DURATION_LABEL}" ]; then
+            ALERT_TITLE="${ALERT_TITLE} (down ${DURATION_LABEL}+)"
+          fi
 
           if [ -z "${EXISTING}" ]; then
             echo "No open alert issue — creating one."
-            printf '\n%s\n' "${MARK}" >> "${REPORT_PATH}"
+            printf '\n%s\n%s\n' "${MARK}" "${STATE_MARK}" >> "${REPORT_PATH}"
             if ! gh issue create --title "${ALERT_TITLE}" \
                                  --label "${ALERT_LABEL}" \
                                  --assignee evereq \
@@ -481,26 +629,30 @@ jobs:
             gh issue edit "${EXISTING}" --title "${ALERT_TITLE}" >/dev/null 2>&1               || echo "::warning::Could not retitle #${EXISTING}; the comment below still records the change."
           fi
 
+          # An escalation makes itself heard through machinery that already
+          # exists: a louder title (above), a severity label, and one comment
+          # allowed past the throttle (below). Deliberately NOT a second issue —
+          # the single-open-issue property is what keeps this monitor from being
+          # muted, and muting it is how EW-760 stayed invisible for 18 hours.
+          if [ "${ESCALATED}" -eq 1 ]; then
+            echo "Outage sustained ${AGE_MIN}m — escalating to duration tier ${TIER} (was ${PREV_TIER})."
+            SEV_LABEL="${SEV_LABEL_PREFIX}${TIER}"
+            gh label create "${SEV_LABEL}" \
+              --color 'B60205' \
+              --description 'External uptime alert sustained past a duration threshold' \
+              >/dev/null 2>&1 || true
+            gh issue edit "${EXISTING}" --add-label "${SEV_LABEL}" >/dev/null 2>&1 \
+              || echo "::warning::Could not add ${SEV_LABEL} to #${EXISTING}; the retitled issue still carries the escalation."
+          fi
+
           # Only add a comment when something actually changed, or once an hour.
           # Without this, a multi-hour outage produces a comment every 15 min.
-          #
-          # Fall back to the ISSUE BODY when there are no comments yet. On the very first repeat
-          # of an outage the comments array is empty, so `.comments[-1]` yielded nothing, the
-          # freshness guard short-circuited, and the monitor posted a redundant full report 15
-          # minutes after opening the issue — the throttle only started working from the third
-          # cycle. The fingerprint marker is written into the body at creation, so the body is
-          # simply the zeroth comment.
-          LAST_AT="$(gh issue view "${EXISTING}" --json createdAt,comments \
-                       --jq '.comments[-1].createdAt // .createdAt // empty' 2>/dev/null || true)"
-          LAST_BODY="$(gh issue view "${EXISTING}" --json body,comments \
-                         --jq '.comments[-1].body // .body // empty' 2>/dev/null || true)"
-
+          # (LAST_AT / LAST_BODY were fetched above, before the title needed them.)
           SHOULD_COMMENT=1
           # No pipe in a decision: under `pipefail`, a producer killed by SIGPIPE can make an
           # already-matched grep report failure, defeating the throttle exactly when it matters.
           if [ -n "${LAST_AT}" ] && grep -qF -- "${MARK}" <<< "${LAST_BODY}"; then
             LAST_EPOCH="$(date -u -d "${LAST_AT}" +%s 2>/dev/null || echo 0)"
-            NOW_EPOCH="$(date -u +%s)"
             AGE=$(( NOW_EPOCH - LAST_EPOCH ))
             if [ "${LAST_EPOCH}" -gt 0 ] && [ "${AGE}" -lt 3600 ]; then
               SHOULD_COMMENT=0
@@ -508,8 +660,44 @@ jobs:
             fi
           fi
 
+          # ...but an escalation is precisely the "something changed" the
+          # throttle exists to let through, so it is never swallowed.
+          if [ "${ESCALATED}" -eq 1 ]; then
+            SHOULD_COMMENT=1
+          fi
+
           if [ "${SHOULD_COMMENT}" -eq 1 ]; then
-            printf '\n%s\n' "${MARK}" >> "${REPORT_PATH}"
+            # Lead with what CHANGED since the last report. An issue that only
+            # ever lists what is broken right now cannot show a partial
+            # recovery, and a reader who triaged the first version of this issue
+            # needs the delta, not the same table a second time.
+            PREAMBLE="${RUNNER_TEMP}/uptime-preamble.md"
+            : > "${PREAMBLE}"
+            if [ "${TIER}" -ge 1 ]; then
+              {
+                echo "> 🚨 **Sustained outage — down for ${DURATION_LABEL}+** (duration tier ${TIER}, first seen \`$(date -u -d "@${SINCE_EPOCH}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)\`)."
+                echo
+              } >> "${PREAMBLE}"
+            fi
+            if [ -n "${RECOVERED_LIST}" ]; then
+              # Same deal as the parser above: split on spaces, never glob.
+              set -f
+              {
+                echo "### ✅ Recovered since the last report"
+                echo
+                # shellcheck disable=SC2086  # deliberate split of the space-joined list
+                for U in ${RECOVERED_LIST}; do echo "- \`${U}\`"; done
+                echo
+                echo "Everything below is what is **still** failing."
+                echo
+              } >> "${PREAMBLE}"
+              set +f
+            fi
+            if [ -s "${PREAMBLE}" ]; then
+              cat "${REPORT_PATH}" >> "${PREAMBLE}"
+              REPORT_PATH="${PREAMBLE}"
+            fi
+            printf '\n%s\n%s\n' "${MARK}" "${STATE_MARK}" >> "${REPORT_PATH}"
             gh issue comment "${EXISTING}" --body-file "${REPORT_PATH}"
           fi
 

--- a/apps/node/src/core/external-uptime-monitor.contract.spec.ts
+++ b/apps/node/src/core/external-uptime-monitor.contract.spec.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -20,8 +20,13 @@ async function summaryBlock(): Promise<string> {
 		.replace(/^ {10}/gm, '');
 }
 
-function exerciseSummary(block: string, failingUrls: string) {
-	const shellLiteral = failingUrls.replace(/'/g, `'"'"'`);
+/**
+ * Runs a block lifted out of the workflow under the SAME shell flags GitHub
+ * gives a `run:` step (`bash -e` plus the step's own `set -uo pipefail`), with
+ * a scrubbed environment so a runner's Bash startup hooks cannot change the
+ * semantics under test.
+ */
+function runWorkflowBash(script: string): SpawnSyncReturns<string> {
 	const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : 'bash';
 	// The self-hosted runners may inject Bash startup hooks through either
 	// BASH_ENV or ENV. Give this contract only the OS variables it needs so a
@@ -31,20 +36,19 @@ function exerciseSummary(block: string, failingUrls: string) {
 			.map((key) => [key, process.env[key]])
 			.filter((entry): entry is [string, string] => typeof entry[1] === 'string')
 	);
-	return spawnSync(
-		bash,
-		[
-			'--noprofile',
-			'--norc',
-			'-euo',
-			'pipefail',
-			'-c',
-			`FAILING_URLS='${shellLiteral}'\n${block}\nprintf '<%s>|<%s>|<%s>' "\${FAIL_COUNT}" "\${FIRST_FAIL}" "\${FAIL_SUMMARY}"\n`
-		],
-		{
-			encoding: 'utf8',
-			env: cleanEnv
-		}
+	return spawnSync(bash, ['--noprofile', '--norc', '-euo', 'pipefail', '-c', script], {
+		encoding: 'utf8',
+		env: cleanEnv
+	});
+}
+
+function shellSingleQuote(value: string): string {
+	return value.replace(/'/g, `'"'"'`);
+}
+
+function exerciseSummary(block: string, failingUrls: string) {
+	return runWorkflowBash(
+		`FAILING_URLS='${shellSingleQuote(failingUrls)}'\n${block}\nprintf '<%s>|<%s>|<%s>' "\${FAIL_COUNT}" "\${FIRST_FAIL}" "\${FAIL_SUMMARY}"\n`
 	);
 }
 
@@ -66,5 +70,251 @@ describe('external uptime monitor summary contract', () => {
 		expect(result.stderr).toBe('');
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe('<2>|<demo.ever.works>|<demo.ever.works +1 more>');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// EW-760 (3) + (4): duration escalation and partial-recovery reporting.
+//
+// The workflow deliberately keeps no external store, so the entire cross-run
+// memory of an outage is one `<!-- uptime-state: ... -->` comment that the
+// previous run wrote onto the alert issue. That parse-decide-reemit block is
+// the only new logic with branches worth pinning, and it is pure text plus
+// arithmetic, so it is lifted out of the YAML and exercised under the
+// workflow's own Bash flags exactly like the summary contract above.
+// ---------------------------------------------------------------------------
+
+const ESCALATION_START = '# >>> uptime-escalation-state';
+const ESCALATION_END = '# <<< uptime-escalation-state';
+
+async function escalationBlock(): Promise<string> {
+	const workflow = await readFile(workflowPath, 'utf8');
+	const start = workflow.indexOf(ESCALATION_START);
+	const end = workflow.indexOf(ESCALATION_END, start + 1);
+
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+
+	return workflow
+		.slice(start, end)
+		.replace(/\r\n/g, '\n')
+		.replace(/^ {10}/gm, '');
+}
+
+interface EscalationInput {
+	fingerprint: string;
+	failingUrlsCsv: string;
+	lastBody: string;
+	nowEpoch: number;
+}
+
+interface EscalationResult {
+	tier: string;
+	prevTier: string;
+	escalated: string;
+	duration: string;
+	recovered: string;
+	since: string;
+	ageMin: string;
+	stateMark: string;
+}
+
+function stateMark(fp: string, since: number, tier: number, urls: string): string {
+	return `<!-- uptime-state: fp=${fp} since=${since} tier=${tier} urls=${urls} -->`;
+}
+
+/** A realistic previous report: prose, the throttle marker, then the state marker. */
+function issueBody(mark: string): string {
+	return [
+		'## 🔴 Ever Works endpoint(s) unreachable from outside the homelab',
+		'',
+		'| | Surface | URL |',
+		'',
+		'<!-- uptime-fingerprint: deadbeefdeadbeef -->',
+		mark
+	].join('\n');
+}
+
+function exerciseEscalation(block: string, input: EscalationInput): EscalationResult {
+	const prelude = [
+		`FINGERPRINT='${shellSingleQuote(input.fingerprint)}'`,
+		`FAILING_URLS_CSV='${shellSingleQuote(input.failingUrlsCsv)}'`,
+		`LAST_BODY='${shellSingleQuote(input.lastBody)}'`,
+		`NOW_EPOCH=${input.nowEpoch}`
+	].join('\n');
+	const report =
+		`printf '<%s>\\n<%s>\\n<%s>\\n<%s>\\n<%s>\\n<%s>\\n<%s>\\n<%s>\\n' ` +
+		`"\${TIER}" "\${PREV_TIER}" "\${ESCALATED}" "\${DURATION_LABEL}" ` +
+		`"\${RECOVERED_LIST}" "\${SINCE_EPOCH}" "\${AGE_MIN}" "\${STATE_MARK}"`;
+
+	const result = runWorkflowBash(`${prelude}\n${block}\n${report}\n`);
+
+	expect(result.stderr).toBe('');
+	expect(result.status).toBe(0);
+
+	const fields = result.stdout.split('\n').map((line) => line.replace(/^</, '').replace(/>$/, ''));
+	return {
+		tier: fields[0],
+		prevTier: fields[1],
+		escalated: fields[2],
+		duration: fields[3],
+		recovered: fields[4],
+		since: fields[5],
+		ageMin: fields[6],
+		stateMark: fields[7]
+	};
+}
+
+describe('external uptime monitor escalation contract', () => {
+	const NOW = 1_800_000_000;
+	const FP = 'aaaabbbbccccdddd';
+
+	it('starts the outage clock on a fresh issue with no previous state', async () => {
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://demo.ever.works/',
+			lastBody: '',
+			nowEpoch: NOW
+		});
+
+		expect(result.since).toBe(String(NOW));
+		expect(result.ageMin).toBe('0');
+		expect(result.tier).toBe('0');
+		expect(result.escalated).toBe('0');
+		expect(result.duration).toBe('');
+		expect(result.recovered).toBe('');
+		expect(result.stateMark).toBe(stateMark(FP, NOW, 0, 'https://demo.ever.works/'));
+	});
+
+	it('escalates to tier 1 once the same failing set has been down an hour', async () => {
+		const since = NOW - 65 * 60;
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://app.ever.works/login',
+			lastBody: issueBody(stateMark(FP, since, 0, 'https://app.ever.works/login')),
+			nowEpoch: NOW
+		});
+
+		expect(result.since).toBe(String(since));
+		expect(result.ageMin).toBe('65');
+		expect(result.tier).toBe('1');
+		expect(result.prevTier).toBe('0');
+		expect(result.escalated).toBe('1');
+		// Bucketed to the 15-minute probe interval, so the title moves when the
+		// severity moves rather than on every single run.
+		expect(result.duration).toBe('1h0m');
+	});
+
+	it('stays put at tier 1 on the next run, then escalates again at four hours', async () => {
+		const block = await escalationBlock();
+
+		const steady = exerciseEscalation(block, {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://app.ever.works/login',
+			lastBody: issueBody(stateMark(FP, NOW - 80 * 60, 1, 'https://app.ever.works/login')),
+			nowEpoch: NOW
+		});
+		expect(steady.tier).toBe('1');
+		expect(steady.escalated).toBe('0');
+		expect(steady.duration).toBe('1h15m');
+
+		const louder = exerciseEscalation(block, {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://app.ever.works/login',
+			lastBody: issueBody(stateMark(FP, NOW - 300 * 60, 1, 'https://app.ever.works/login')),
+			nowEpoch: NOW
+		});
+		expect(louder.tier).toBe('2');
+		expect(louder.escalated).toBe('1');
+		expect(louder.duration).toBe('5h0m');
+	});
+
+	it('restarts the clock when the failing set changes, because that is a new event', async () => {
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: 'ffff0000ffff0000',
+			failingUrlsCsv: 'https://app.ever.works/login,https://api.ever.works/',
+			lastBody: issueBody(stateMark(FP, NOW - 300 * 60, 2, 'https://demo.ever.works/')),
+			nowEpoch: NOW
+		});
+
+		expect(result.since).toBe(String(NOW));
+		expect(result.tier).toBe('0');
+		expect(result.prevTier).toBe('0');
+		expect(result.escalated).toBe('0');
+		expect(result.duration).toBe('');
+	});
+
+	it('names the targets that recovered while others stayed down', async () => {
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: 'ffff0000ffff0000',
+			failingUrlsCsv: 'https://app.ever.works/login',
+			lastBody: issueBody(
+				stateMark(FP, NOW - 60 * 60, 1, 'https://demo.ever.works/,https://app.ever.works/login')
+			),
+			nowEpoch: NOW
+		});
+
+		// This is the 2026-08-23 shape exactly: demo healed, the app went down,
+		// and the open issue said nothing about either change.
+		expect(result.recovered).toBe('https://demo.ever.works/ ');
+	});
+
+	it('reports nothing recovered when the failing set only grew', async () => {
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: 'ffff0000ffff0000',
+			failingUrlsCsv: 'https://demo.ever.works/,https://app.ever.works/login',
+			lastBody: issueBody(stateMark(FP, NOW - 60 * 60, 1, 'https://demo.ever.works/')),
+			nowEpoch: NOW
+		});
+
+		expect(result.recovered).toBe('');
+	});
+
+	it('round-trips the state marker it emits', async () => {
+		const block = await escalationBlock();
+		const first = exerciseEscalation(block, {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://demo.ever.works/',
+			lastBody: '',
+			nowEpoch: NOW
+		});
+
+		const later = exerciseEscalation(block, {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://demo.ever.works/',
+			lastBody: issueBody(first.stateMark),
+			nowEpoch: NOW + 90 * 60
+		});
+
+		expect(later.since).toBe(String(NOW));
+		expect(later.ageMin).toBe('90');
+		expect(later.tier).toBe('1');
+	});
+
+	it('treats a corrupt state marker as absent instead of failing the run', async () => {
+		// A monitor that dies on bad input goes SILENT, which is the one outcome
+		// this workflow must never produce.
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: FP,
+			failingUrlsCsv: 'https://demo.ever.works/',
+			lastBody: issueBody('<!-- uptime-state: fp= since=not-a-number tier=huge urls= -->'),
+			nowEpoch: NOW
+		});
+
+		expect(result.since).toBe(String(NOW));
+		expect(result.tier).toBe('0');
+		expect(result.escalated).toBe('0');
+	});
+
+	it('survives an entirely empty input set under the workflow Bash flags', async () => {
+		const result = exerciseEscalation(await escalationBlock(), {
+			fingerprint: '',
+			failingUrlsCsv: '',
+			lastBody: '',
+			nowEpoch: NOW
+		});
+
+		expect(result.tier).toBe('0');
+		expect(result.recovered).toBe('');
 	});
 });

--- a/docs/specs/architecture/monitoring.md
+++ b/docs/specs/architecture/monitoring.md
@@ -280,6 +280,71 @@ returns `200` with a degraded subset list when any check is
 A separate `/api/health/deep` (admin-only) actually pings the DB,
 cache, Sentry, PostHog, and Trigger.dev — used for incident response.
 
+### 10.1 External uptime monitor — alert presentation contract
+
+`.github/workflows/external-uptime-monitor.yml` probes the public
+surfaces every 15 minutes from a **GitHub-hosted** runner, i.e. from
+outside the homelab uplink that every in-cluster probe shares. Its
+header comment explains why that vantage point is load-bearing; this
+section covers only how a failure is **presented**, which is a separate
+concern and has its own failure mode.
+
+The monitor keeps exactly one open `uptime-alert` issue. Issue spam is
+the main reason monitors get muted, so a second issue is never opened.
+The cost of that choice — logged as EW-760 — is that a new, worse
+outage can fold into an issue a reader has already triaged. On
+2026-08-23 the entire web app went down while an alert issue stood open
+for `demo.ever.works`; the escalation was invisible for ~18 hours.
+Detection worked the whole time. Presentation did not.
+
+Four properties keep the single-issue design honest. All of them work by
+changing what the issue **says**, never by opening another one.
+
+1. **The title names the current failing set.** It is recomputed every
+   run from the failing URLs and re-applied when it differs from the
+   live title. A comment appended to a long-open issue is low-salience;
+   the title is what people re-read.
+2. **The title shouts for customer-facing surfaces.** A separate
+   `CRITICAL_URLS` list (the marketing site, the app login and health
+   routes, the API and its version endpoint) switches the title between
+   `🔴 Uptime: …` and `🚨 Uptime: CRITICAL — …`. It is a separate array,
+   not a fourth `TARGETS` field, because the target parser treats
+   everything after the second `|` as the body marker — a trailing
+   severity field would be swallowed and every target would read as
+   non-critical.
+3. **Duration escalates.** The workflow has no store, so the outage
+   clock rides in an HTML comment on the last report it wrote:
+   `<!-- uptime-state: fp=… since=… tier=… urls=… -->`. On a run where
+   the fingerprint still matches, `since` is carried forward; when the
+   failing set changes the clock restarts, because a different set is a
+   new event. At 60 minutes the alert reaches **tier 1** and at 240
+   minutes **tier 2**. Each escalation appends `(down 1h15m+)` to the
+   title (bucketed to the 15-minute probe interval so the title moves on
+   severity, not on every run), adds an `uptime-sev<tier>` label, and is
+   allowed past the one-comment-per-hour throttle exactly once.
+4. **A partial recovery is named.** The `urls=` field records the failing
+   set, so the next run can diff it and lead its comment with
+   `### ✅ Recovered since the last report`. Without this an issue lists
+   only what is broken now, and a reader cannot tell a partial recovery
+   from a target that was never mentioned. Full auto-close stays
+   all-or-nothing: the issue closes when every target is green.
+
+The state marker is written **alongside** the pre-existing
+`<!-- uptime-fingerprint: … -->` marker, never instead of it — the
+comment throttle greps for that marker verbatim.
+
+The parse-decide-reemit logic lives between the sentinels
+`# >>> uptime-escalation-state` and `# <<< uptime-escalation-state` and
+is pure text plus arithmetic: no `gh`, no `date`. That is what makes it
+testable. `apps/node/src/core/external-uptime-monitor.contract.spec.ts`
+lifts the block straight out of the YAML and runs it under the same Bash
+flags GitHub gives a `run:` step (`bash -e` plus `set -uo pipefail`),
+covering a fresh outage, each escalation threshold, a changed fingerprint
+resetting the clock, a partial recovery, a corrupt marker, and the empty
+input. The empty case is not hypothetical — an all-green run once failed
+the whole monitor because `grep` on an empty list returned non-zero under
+`pipefail`.
+
 ## 11. Sentry-PostHog Cross-Linking
 
 When both providers are enabled, the platform threads each Sentry
@@ -322,6 +387,8 @@ sends goes through them, regardless of caller.
     - `packages/monitoring/src/`
     - `packages/monitoring/src/sentry/sentry.config.ts`
     - `packages/monitoring/src/posthog/posthog.config.ts`
+    - `.github/workflows/external-uptime-monitor.yml` (see §10.1)
+    - `apps/node/src/core/external-uptime-monitor.contract.spec.ts`
 - Related specs:
     - [`activity-log`](./activity-log.md)
     - [`auth`](./auth.md)


### PR DESCRIPTION
## Summary

Closes out EW-760 by giving the external uptime monitor a memory between runs.

The monitor keeps exactly one open `uptime-alert` issue. That is the right call for noise control and it is also why EW-760 happened: on 2026-08-23 the whole web app went down while an issue stood open for `demo.ever.works`, and the escalation was invisible for ~18 hours. #2247 fixed half of it — the title now names the currently-failing set and shouts when a customer-facing surface is among it (suggestions 1 and 2). Suggestions 3 and 4 both needed something the workflow did not have: cross-run state.

Without it, 40 consecutive failing runs rendered identically to the first one, and an issue whose original target had healed never said so.

### How the state is kept

No store. The alert step writes one more HTML comment onto the report it already posts, and reads it back next run:

```
<!-- uptime-state: fp=<fingerprint> since=<epoch> tier=<n> urls=<csv> -->
```

It is written **alongside** the pre-existing `<!-- uptime-fingerprint: … -->` marker, never instead of it, because the one-comment-per-hour throttle greps for that marker verbatim.

### Suggestion 3 — alert on duration

- `since` carries forward while the fingerprint holds, and **restarts when the failing set changes**, because a different set is a new event rather than a continuation of the old one (same reasoning as the per-run title).
- The schedule is `*/15`, so **tier 1 at 60 minutes** is the ticket's "shout at, say, the fifth" consecutive failure; **tier 2 at 240 minutes**.
- Each escalation does three things through machinery that already exists: appends `(down 1h15m+)` to the **title**, adds an `uptime-sev<tier>` label, and is allowed past the comment throttle exactly once. Crossing a threshold is precisely the "something changed" the throttle exists to let through.
- The duration is bucketed to the probe interval, so the title moves when the **severity** moves rather than every 15 minutes — a title that churns on every run is the old noise problem wearing a clock.

### Suggestion 4 — say what recovered

- The probe step now exports the failing set as a single-line CSV (`$GITHUB_OUTPUT` is key=value, so a newline there would break the parse and silence the monitor — the trap already documented for `EGRESS_IP`).
- The alert step diffs it against `urls=` from the previous report and leads its comment with `### ✅ Recovered since the last report`.
- That is the 2026-08-23 shape exactly: demo healed while the app broke, and the open issue reported neither change.
- Full auto-close stays all-or-nothing — the issue closes when every target is green. See "Deliberately left out".

### Deliberately NOT changed

Dedup is untouched: still label-first, still a single open issue, never a second one. Issue spam is the main reason monitors get muted, and a muted monitor is exactly how this outage stayed invisible. Every new signal here changes what the issue *says*.

## Tests

The parse-decide-reemit logic lives between `# >>> uptime-escalation-state` and `# <<< uptime-escalation-state` and is deliberately pure text plus arithmetic — no `gh`, no `date`. That is what makes it checkable: `apps/node/src/core/external-uptime-monitor.contract.spec.ts` lifts the block straight out of the YAML and runs it under the workflow's own Bash flags (`bash -e` + `set -uo pipefail`), the same harness #2269 introduced.

Nine new cases: fresh outage, tier-1 threshold, a steady tier-1 run that must **not** re-escalate, tier 2, a changed fingerprint resetting the clock, a partial recovery, a set that only grew, a corrupt marker (a monitor that dies on bad input goes silent — the one outcome it must never produce), and the empty input that once failed an entire all-green run.

## Jira

- https://evertech.atlassian.net/browse/EW-760

## Test plan

| What | Result |
| --- | --- |
| `npx vitest run src/core/external-uptime-monitor.contract.spec.ts` (apps/node) | 11/11 pass |
| Red-first, on the unpatched workflow | 9 new fail, 2 pre-existing pass |
| Mutation: tier-1 threshold `60` → `6000` | 3 tests red, restored |
| Mutation: drop the `PREV_FP = FINGERPRINT` clock-reset guard | 1 test red, restored |
| `bash -n` on all four `run:` blocks + YAML parse | clean |
| `prettier --check` on the touched `.ts` and `.md` | clean |
| `tsc --noEmit` (apps/node) | no errors in the touched file |

Also replayed the real 2026-08-23 transition against the extracted block: `demo only` → `demo + 1h escalation` → `app down / demo recovered` produces a retitled `🚨 Uptime: CRITICAL — app.ever.works/login unreachable` plus a comment naming `demo.ever.works` as recovered.

## Docs

`docs/specs/architecture/monitoring.md` §10.1 now documents the alert-presentation contract: the four properties that keep the single-issue design honest, the state-marker format, the tier thresholds, and where the contract test binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
