### PR TITLE
feat(fleet): run env-file delivery that never puts the value on a job row (EW-781)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -483,3 +483,31 @@ GIT_SHA=
 GIT_REF=
 BUILD_RUN=
 BUILD_TIME=
+
+# =============================================================================
+# FLEET NODES (run secrets — see docs/features/fleet.md)
+# =============================================================================
+# Deliver a repository's seed `.env` files to the fleet node that runs its
+# Task. The job carries only WHICH repository's files are needed and at which
+# paths; the node fetches the decrypted content over the node-authenticated
+# job channel while it holds the lease, writes it owner-only inside the
+# checkout, keeps it out of Git, and deletes it when the run ends.
+#
+# Default on (unset = true). The feature is already opt-in per repository: a
+# registry entry with no env files delivers nothing. Set this to `false` only
+# to shut the whole path — a run that NEEDS env files then FAILS CLOSED with
+# `run-secrets-disabled` rather than starting with a partial environment.
+#
+# Requires PLUGIN_SECRET_ENCRYPTION_KEY (above). Without that key env files
+# are stored in PLAIN TEXT, and this setting is what carries them to every
+# machine in the fleet.
+FLEET_NODE_RUN_ENV_FILES=true
+
+# Env var NAMES an `agent-task` step or model CLI may read from the node's own
+# environment, instance-wide (comma-separated). Defaults to the well-known
+# Claude/Codex credential names; empty grants nothing. It can NEVER open the
+# platform-owned families (DATABASE_, AWS_, GH_, ...) — those are opened per
+# repository, one exact name at a time, by that repository's env grants in
+# Settings -> Repositories. Read the warning in docs/features/fleet.md first:
+# a granted name is readable by model-driven code running on your machines.
+# FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH=

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
@@ -109,7 +109,7 @@ describe('FleetAgentTaskPlannerService', () => {
     let tasks: { findById: jest.Mock };
     let agents: { findByIdAndUser: jest.Mock };
     let works: { findById: jest.Mock };
-    let taskWorkspace: { describeFleetWorkspace: jest.Mock };
+    let taskWorkspace: { describeFleetWorkspace: jest.Mock; resolveFleetRunEnvGrants: jest.Mock };
     let skills: { resolveActiveForAgent: jest.Mock };
     let pluginSettings: { getResolvedSettings: jest.Mock };
     let runs: { findById: jest.Mock };
@@ -155,7 +155,13 @@ describe('FleetAgentTaskPlannerService', () => {
                 ],
             }),
         };
-        taskWorkspace = { describeFleetWorkspace: jest.fn().mockResolvedValue(workspace) };
+        taskWorkspace = {
+            describeFleetWorkspace: jest.fn().mockResolvedValue(workspace),
+            // Run secrets (slice Y): the planner asks for the run's env
+            // GRANTS beside the workspace. Empty is the default posture —
+            // every platform-owned name stays refused on the node.
+            resolveFleetRunEnvGrants: jest.fn().mockResolvedValue([]),
+        };
         skills = {
             resolveActiveForAgent: jest.fn().mockResolvedValue([
                 {
@@ -264,6 +270,10 @@ describe('FleetAgentTaskPlannerService', () => {
             'CODEX_ACCESS_TOKEN',
             'OPENAI_API_KEY',
         ]);
+        // Run secrets (slice Y): no repository of this run granted anything,
+        // so the key is ABSENT rather than empty — the node then refuses
+        // every platform-owned name exactly as it did before the slice.
+        expect(execution).not.toHaveProperty('envGrants');
 
         // Instructions: identity + skills from the assembler, the Task
         // brief in the cloud executor's shape, then the fleet sections.
@@ -285,6 +295,22 @@ describe('FleetAgentTaskPlannerService', () => {
         // Order: identity before task before workspace.
         expect(text.indexOf('# IDENTITY')).toBeLessThan(text.indexOf('# TASK'));
         expect(text.indexOf('# TASK')).toBeLessThan(text.indexOf('# WORKSPACE'));
+    });
+
+    it('carries the run env GRANTS as names, read fresh for every plan', async () => {
+        // Run secrets (slice Y). Names, never values — that is what makes a
+        // grant safe on a job payload and an env file not. Read at PLAN time,
+        // which is what makes a revoked grant stop applying on the next run.
+        process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+        taskWorkspace.resolveFleetRunEnvGrants.mockResolvedValue(['DATABASE_URL', 'GH_TOKEN']);
+        const plan = await build().plan(payload);
+        expect(taskWorkspace.resolveFleetRunEnvGrants).toHaveBeenCalledWith({
+            task: expect.objectContaining({ id: 'task-1' }),
+            userId: 'user-1',
+            agentId: 'agent-1',
+        });
+        expect(plan!.execution.envGrants).toEqual(['DATABASE_URL', 'GH_TOKEN']);
+        expect(JSON.stringify(plan)).not.toContain('postgres://');
     });
 
     it('strips chat-template control markers from user-authored Task fields', async () => {
@@ -675,7 +701,7 @@ describe('FleetAgentTaskPlannerService — wire-contract ceilings (review follow
     let tasks: { findById: jest.Mock };
     let agents: { findByIdAndUser: jest.Mock };
     let works: { findById: jest.Mock };
-    let taskWorkspace: { describeFleetWorkspace: jest.Mock };
+    let taskWorkspace: { describeFleetWorkspace: jest.Mock; resolveFleetRunEnvGrants: jest.Mock };
     let pluginSettings: { getResolvedSettings: jest.Mock };
 
     const build = () =>
@@ -695,7 +721,13 @@ describe('FleetAgentTaskPlannerService — wire-contract ceilings (review follow
         tasks = { findById: jest.fn().mockResolvedValue(task()) };
         agents = { findByIdAndUser: jest.fn().mockResolvedValue(agent()) };
         works = { findById: jest.fn().mockResolvedValue({ id: 'work-1', checkDefaults: [] }) };
-        taskWorkspace = { describeFleetWorkspace: jest.fn().mockResolvedValue(workspace) };
+        taskWorkspace = {
+            describeFleetWorkspace: jest.fn().mockResolvedValue(workspace),
+            // Run secrets (slice Y): the planner asks for the run's env
+            // GRANTS beside the workspace. Empty is the default posture —
+            // every platform-owned name stays refused on the node.
+            resolveFleetRunEnvGrants: jest.fn().mockResolvedValue([]),
+        };
         pluginSettings = { getResolvedSettings: jest.fn().mockResolvedValue({}) };
     });
 
@@ -832,7 +864,10 @@ describe('FleetAgentTaskPlannerService — Nest wiring (review follow-up)', () =
         { provide: TaskRepository, useValue: { findById: jest.fn() } },
         { provide: AgentRepository, useValue: { findByIdAndUser: jest.fn() } },
         { provide: WorkRepository, useValue: { findById: jest.fn() } },
-        { provide: TaskWorkspaceService, useValue: { describeFleetWorkspace: jest.fn() } },
+        {
+            provide: TaskWorkspaceService,
+            useValue: { describeFleetWorkspace: jest.fn(), resolveFleetRunEnvGrants: jest.fn() },
+        },
     ];
 
     beforeEach(() => {

--- a/apps/api/src/fleet/__tests__/fleet-run-secrets.service.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-run-secrets.service.spec.ts
@@ -1,0 +1,196 @@
+import { Logger } from '@nestjs/common';
+import {
+    FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON,
+    FLEET_RUN_SECRETS_DISABLED_REASON,
+    FLEET_RUN_SECRETS_UNRESOLVED_REASON,
+} from '@ever-works/contracts';
+import { FleetRunSecretsError, FleetRunSecretsService } from '../fleet-run-secrets.service';
+
+/**
+ * Run secrets (self-build slice Y, EW-781) — the resolution half.
+ *
+ * The load-bearing test in this file is the SENTINEL one. A unique string
+ * is put in a registry row and the assertion is not "the response
+ * contains it" but "nothing else does": not a log line, not a thrown
+ * message, not the authorization argument, not the job the caller was
+ * authorized against. That is the property the whole slice rests on, and
+ * it is the one a refactor is most likely to break silently.
+ *
+ * Everything else here pins fail-closed: an unknown row, a disabled row,
+ * a path the row no longer carries, a value that is still ciphertext, a
+ * decrypt that throws from the TypeORM transformer, and the instance kill
+ * switch each abort the whole delivery with a stable reason rather than
+ * returning a partial file list.
+ */
+
+const SENTINEL = 'sentinel-9d41f0c2-postgres://u:p@db/app';
+const JOB = 'job-1';
+const USER = 'owner-1';
+const NODE = '11111111-1111-4111-8111-111111111111';
+const ROW = '22222222-2222-4222-8222-222222222222';
+
+describe('FleetRunSecretsService', () => {
+    let jobs: { authorizeRunSecretRequest: jest.Mock };
+    let repoConnections: { findByIdAndUser: jest.Mock };
+    let service: FleetRunSecretsService;
+    let logs: string[];
+
+    beforeEach(() => {
+        delete process.env.FLEET_NODE_RUN_ENV_FILES;
+        logs = [];
+        jobs = {
+            authorizeRunSecretRequest: jest
+                .fn()
+                .mockResolvedValue({ jobId: JOB, userId: USER, nodeId: NODE }),
+        };
+        repoConnections = {
+            findByIdAndUser: jest.fn().mockResolvedValue({
+                id: ROW,
+                enabled: true,
+                envFiles: { 'apps/api/.env': `DATABASE_URL=${SENTINEL}` },
+            }),
+        };
+        service = new FleetRunSecretsService(jobs as never, repoConnections as never);
+        for (const level of ['log', 'warn', 'error', 'debug', 'verbose'] as const) {
+            jest.spyOn(Logger.prototype, level).mockImplementation((...args: unknown[]) => {
+                logs.push(args.map((arg) => String(arg)).join(' '));
+            });
+        }
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete process.env.FLEET_NODE_RUN_ENV_FILES;
+    });
+
+    const resolve = (refs = [{ repoConnectionId: ROW, paths: ['apps/api/.env'] }]) =>
+        service.resolve({
+            nodeId: NODE,
+            secret: 's'.repeat(24),
+            jobId: JOB,
+            leaseGeneration: 3,
+            refs,
+        });
+
+    it('delivers the content, and the sentinel appears NOWHERE else', async () => {
+        const response = await resolve();
+        expect(response).toEqual({
+            files: [
+                {
+                    repoConnectionId: ROW,
+                    path: 'apps/api/.env',
+                    content: `DATABASE_URL=${SENTINEL}`,
+                },
+            ],
+        });
+
+        // Not in any log line the service wrote…
+        expect(logs.join('\n')).not.toContain(SENTINEL);
+        expect(logs.join('\n')).toContain(JOB);
+        // …not in what was sent to the authorization gate (which is all the
+        // job row ever sees of this request)…
+        expect(JSON.stringify(jobs.authorizeRunSecretRequest.mock.calls)).not.toContain(SENTINEL);
+        // …and not in the arguments the registry read was made with.
+        expect(JSON.stringify(repoConnections.findByIdAndUser.mock.calls)).not.toContain(SENTINEL);
+    });
+
+    it('scopes the registry read to the JOB owner, never to anything the node sent', async () => {
+        await resolve();
+        expect(repoConnections.findByIdAndUser).toHaveBeenCalledWith(ROW, USER);
+    });
+
+    it('returns null (→ the shared 401) when the claim does not verify', async () => {
+        jobs.authorizeRunSecretRequest.mockResolvedValue(null);
+        await expect(resolve()).resolves.toBeNull();
+        expect(repoConnections.findByIdAndUser).not.toHaveBeenCalled();
+    });
+
+    it('lets a stale-lease refusal propagate untouched (it is the 409 of this channel)', async () => {
+        const stale = Object.assign(new Error('stale'), { name: 'FleetJobStaleLeaseError' });
+        jobs.authorizeRunSecretRequest.mockRejectedValue(stale);
+        await expect(resolve()).rejects.toBe(stale);
+    });
+
+    it.each([
+        ['an unknown or foreign row', null],
+        ['a disabled row', { id: ROW, enabled: false, envFiles: { 'apps/api/.env': 'A=1' } }],
+    ])('fails closed on %s with the unresolved reason', async (_label, row) => {
+        repoConnections.findByIdAndUser.mockResolvedValue(row);
+        await expect(resolve()).rejects.toMatchObject({
+            name: 'FleetRunSecretsError',
+            reason: FLEET_RUN_SECRETS_UNRESOLVED_REASON,
+        });
+    });
+
+    it('fails closed when the row no longer carries a requested path', async () => {
+        repoConnections.findByIdAndUser.mockResolvedValue({
+            id: ROW,
+            enabled: true,
+            envFiles: { '.env': 'A=1' },
+        });
+        await expect(resolve()).rejects.toMatchObject({
+            reason: FLEET_RUN_SECRETS_UNRESOLVED_REASON,
+        });
+    });
+
+    it('delivers NOTHING when one reference of several cannot be resolved', async () => {
+        // All-or-nothing: half an environment is the failure this feature
+        // exists to remove, and it would otherwise look like success.
+        repoConnections.findByIdAndUser.mockImplementation(async (id: string) =>
+            id === ROW ? { id: ROW, enabled: true, envFiles: { '.env': 'A=1' } } : null,
+        );
+        await expect(
+            resolve([
+                { repoConnectionId: ROW, paths: ['.env'] },
+                { repoConnectionId: '33333333-3333-4333-8333-333333333333', paths: ['.env'] },
+            ]),
+        ).rejects.toBeInstanceOf(FleetRunSecretsError);
+    });
+
+    it('refuses a value that is still an encryption envelope rather than writing ciphertext', async () => {
+        // `PluginSecretEncService.decryptValue` returns a malformed envelope
+        // UNCHANGED (its one soft path). Without this check the node would
+        // write ciphertext to `.env` and nothing would say why the suite
+        // failed against a "misconfigured" database.
+        repoConnections.findByIdAndUser.mockResolvedValue({
+            id: ROW,
+            enabled: true,
+            envFiles: { 'apps/api/.env': 'enc::v1::dGhpcyBpcyBub3QgcmVhbA' },
+        });
+        await expect(resolve()).rejects.toMatchObject({
+            reason: FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON,
+        });
+    });
+
+    it('maps a THROWING decrypt transformer to a stable reason, never the crypto message', async () => {
+        // The encrypted column is a TypeORM transformer, so a corrupt
+        // envelope or a missing PLUGIN_SECRET_ENCRYPTION_KEY throws from the
+        // READ, not from the service body.
+        repoConnections.findByIdAndUser.mockRejectedValue(
+            new Error('Unsupported state or unable to authenticate data (aes-256-gcm, row 42)'),
+        );
+        await expect(resolve()).rejects.toMatchObject({
+            reason: FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON,
+        });
+        expect(logs.join('\n')).not.toContain('aes-256-gcm');
+    });
+
+    it('fails closed — not partially — when the instance kill switch is off', async () => {
+        process.env.FLEET_NODE_RUN_ENV_FILES = 'false';
+        await expect(resolve()).rejects.toMatchObject({
+            reason: FLEET_RUN_SECRETS_DISABLED_REASON,
+        });
+        expect(repoConnections.findByIdAndUser).not.toHaveBeenCalled();
+    });
+
+    it('refuses a traversing path even if it somehow passed the DTO', async () => {
+        repoConnections.findByIdAndUser.mockResolvedValue({
+            id: ROW,
+            enabled: true,
+            envFiles: { '../../.env': 'A=1' },
+        });
+        await expect(
+            resolve([{ repoConnectionId: ROW, paths: ['../../.env'] }]),
+        ).rejects.toMatchObject({ reason: FLEET_RUN_SECRETS_UNRESOLVED_REASON });
+    });
+});

--- a/apps/api/src/fleet/dto/fleet-job.dto.spec.ts
+++ b/apps/api/src/fleet/dto/fleet-job.dto.spec.ts
@@ -1,6 +1,11 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './fleet-job.dto';
+import {
+    CompleteFleetJobDto,
+    FleetJobEnvFilesDto,
+    FleetJobHeartbeatDto,
+    LeaseFleetJobsDto,
+} from './fleet-job.dto';
 
 /**
  * Suspend-safe leases (self-build finding R7) at the API edge.
@@ -14,6 +19,7 @@ import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './
 
 const NODE_ID = '11111111-1111-4111-8111-111111111111';
 const SECRET = 'a'.repeat(43);
+const ROW_ID = '22222222-2222-4222-8222-222222222222';
 
 async function failingProperties(dto: object): Promise<string[]> {
     const errors = await validate(dto);
@@ -84,5 +90,79 @@ describe('fleet job DTOs — leaseGeneration', () => {
             const dto = plainToInstance(LeaseFleetJobsDto, { nodeId: NODE_ID, secret: SECRET });
             expect(await failingProperties(dto)).toEqual([]);
         });
+    });
+
+    describe('FleetJobEnvFilesDto (run secrets, slice Y)', () => {
+        it.each(REJECTED)('rejects a generation that is %s', async (_label, leaseGeneration) => {
+            const dto = plainToInstance(FleetJobEnvFilesDto, {
+                nodeId: NODE_ID,
+                secret: SECRET,
+                leaseGeneration,
+                refs: [{ repoConnectionId: ROW_ID, paths: ['.env'] }],
+            });
+            expect(await failingProperties(dto)).toContain('leaseGeneration');
+        });
+    });
+});
+
+/**
+ * Run secrets (self-build slice Y, EW-781) at the API edge.
+ *
+ * The request body is by REFERENCE, so the edge's whole job is to make
+ * sure nothing that is not a repository-relative path can reach the
+ * resolver — traversal, absolute forms, Windows drive prefixes. The
+ * service re-checks with `isValidFleetRunEnvFilePath`; this is the other
+ * half of that pair, and it must never be the looser one.
+ */
+describe('FleetJobEnvFilesDto — path shape', () => {
+    const ROW = ROW_ID;
+    const build = (paths: unknown) =>
+        plainToInstance(FleetJobEnvFilesDto, {
+            nodeId: NODE_ID,
+            secret: SECRET,
+            leaseGeneration: 1,
+            refs: [{ repoConnectionId: ROW, paths }],
+        });
+
+    it.each([['.env'], ['apps/api/.env'], ['packages/agent/.env.local']])(
+        'accepts the repository-relative path %s',
+        async (path) => {
+            expect(await failingProperties(build([path]))).toEqual([]);
+        },
+    );
+
+    it.each([
+        ['parent traversal', '../.env'],
+        ['embedded traversal', 'apps/../../.env'],
+        ['a dot segment', 'apps/./.env'],
+        ['an absolute posix path', '/etc/passwd'],
+        ['a windows drive path', 'C:/Windows/x'],
+        ['a backslash path', String.raw`apps\api\.env`],
+    ])('rejects %s', async (_label, path) => {
+        expect(await failingProperties(build([path]))).toEqual(['refs']);
+    });
+
+    it('requires at least one reference and one path — an empty ask is not a valid one', async () => {
+        expect(await failingProperties(build([]))).toEqual(['refs']);
+        expect(
+            await failingProperties(
+                plainToInstance(FleetJobEnvFilesDto, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    leaseGeneration: 1,
+                    refs: [],
+                }),
+            ),
+        ).toEqual(['refs']);
+    });
+
+    it('rejects a repoConnectionId that is not a row id', async () => {
+        const dto = plainToInstance(FleetJobEnvFilesDto, {
+            nodeId: NODE_ID,
+            secret: SECRET,
+            leaseGeneration: 1,
+            refs: [{ repoConnectionId: '../../etc', paths: ['.env'] }],
+        });
+        expect(await failingProperties(dto)).toEqual(['refs']);
     });
 });

--- a/apps/api/src/fleet/dto/fleet-job.dto.ts
+++ b/apps/api/src/fleet/dto/fleet-job.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
     ArrayMaxSize,
+    ArrayMinSize,
     IsArray,
     IsBoolean,
     IsInt,
@@ -8,16 +10,20 @@ import {
     IsOptional,
     IsString,
     IsUUID,
+    Matches,
     Max,
     MaxLength,
     Min,
     MinLength,
+    ValidateNested,
 } from 'class-validator';
 import {
     FLEET_JOB_MAX_ERROR_LENGTH,
     FLEET_JOB_MAX_LEASE_BATCH,
     FLEET_JOB_MAX_LEASE_TTL_SEC,
     FLEET_JOB_MIN_LEASE_TTL_SEC,
+    FLEET_RUN_ENV_FILE_MAX_COUNT,
+    FLEET_RUN_ENV_FILE_REFS_MAX_COUNT,
 } from '@ever-works/contracts';
 
 /**
@@ -148,4 +154,64 @@ export class CompleteFleetJobDto extends FleetJobNodeCredentialDto {
     @IsString()
     @MaxLength(FLEET_JOB_MAX_ERROR_LENGTH)
     error?: string;
+}
+
+/**
+ * One repository's env-file request (self-build slice Y). PATHS only —
+ * there is no content field on the way in, and the response is the only
+ * place a value ever appears.
+ */
+export class FleetJobEnvFileRefDto {
+    @ApiProperty({ format: 'uuid', description: 'Repository registry row the files belong to.' })
+    @IsUUID()
+    repoConnectionId: string;
+
+    @ApiProperty({
+        type: [String],
+        maxItems: FLEET_RUN_ENV_FILE_MAX_COUNT,
+        description: 'Repository-relative env file paths, e.g. "apps/api/.env".',
+    })
+    @IsArray()
+    @ArrayMinSize(1)
+    @ArrayMaxSize(FLEET_RUN_ENV_FILE_MAX_COUNT)
+    @IsString({ each: true })
+    @MaxLength(200, { each: true })
+    // Repository-relative (never leading `/`), traversal-free (no `.` or
+    // `..` segment anywhere), and restricted to the registry's own path
+    // alphabet. `FleetRunSecretsService` re-checks with
+    // `isValidFleetRunEnvFilePath`; this is the edge half of that pair.
+    @Matches(/^(?!.*(?:^|\/)\.\.?(?:\/|$))[A-Za-z0-9._-][A-Za-z0-9._/-]*$/, {
+        each: true,
+        message: 'each env file path must be repository-relative and free of traversal',
+    })
+    paths: string[];
+}
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/jobs/:id/env-files`
+ * (self-build slice Y, EW-781).
+ *
+ * Same credential posture as its three siblings — the `(nodeId, secret)`
+ * pair IS the credential — plus the `leaseGeneration` the claim was handed
+ * out with, because delivering a decrypted `.env` to a machine is at least
+ * as consequential as letting it settle the job: a node whose claim lapsed
+ * while it slept must be refused here exactly as it is on complete.
+ */
+export class FleetJobEnvFilesDto extends FleetJobNodeCredentialDto {
+    @ApiProperty({
+        minimum: 1,
+        description:
+            'Lease generation returned with the claim. A generation that is not the current one is refused with 409 stale-lease and delivers nothing.',
+    })
+    @IsInt()
+    @Min(1)
+    leaseGeneration: number;
+
+    @ApiProperty({ type: [FleetJobEnvFileRefDto], maxItems: FLEET_RUN_ENV_FILE_REFS_MAX_COUNT })
+    @IsArray()
+    @ArrayMinSize(1)
+    @ArrayMaxSize(FLEET_RUN_ENV_FILE_REFS_MAX_COUNT)
+    @ValidateNested({ each: true })
+    @Type(() => FleetJobEnvFileRefDto)
+    refs: FleetJobEnvFileRefDto[];
 }

--- a/apps/api/src/fleet/fleet-agent-task-planner.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-planner.service.ts
@@ -335,12 +335,24 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
             settings,
         });
 
+        // Run secrets (self-build slice Y): the union of the env var NAMES
+        // every repository of this run granted. NAMES only — the values are
+        // read from the node's own environment and scrubbed back out of
+        // everything the node reports. Read fresh on every plan, which is
+        // what makes a revoked grant stop applying from the next run on.
+        const envGrants = await this.taskWorkspace.resolveFleetRunEnvGrants({
+            task,
+            userId: payload.userId,
+            agentId: payload.agentId,
+        });
+
         const execution: FleetAgentModelExecution = {
             provider: settings.provider,
             instructions,
             permissionMode: settings.permissionMode,
             timeoutSec: settings.timeoutSec,
             envPassthrough: config.fleetNode.getAgentTaskEnvPassthrough(),
+            ...(envGrants.length > 0 ? { envGrants } : {}),
         };
         if (settings.model) execution.model = settings.model;
         if (settings.effort) execution.effort = settings.effort;

--- a/apps/api/src/fleet/fleet-jobs.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.spec.ts
@@ -1,7 +1,12 @@
-import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import {
+    ConflictException,
+    UnauthorizedException,
+    UnprocessableEntityException,
+} from '@nestjs/common';
 import type { FleetJobView } from '@ever-works/contracts';
 import { FLEET_JOB_STALE_LEASE_REASON } from '@ever-works/contracts';
 import { FleetJobsController } from './fleet-jobs.controller';
+import { FleetRunSecretsError, FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetJobStaleLeaseError } from '@ever-works/agent/fleet';
 import type { FleetJobService } from '@ever-works/agent/fleet';
 
@@ -22,6 +27,8 @@ import type { FleetJobService } from '@ever-works/agent/fleet';
 const NODE_ID = '11111111-1111-4111-8111-111111111111';
 const JOB_ID = '22222222-2222-4222-8222-222222222222';
 const SECRET = 'a'.repeat(43);
+/** A repository registry row id (run secrets, slice Y). */
+const ROW_ID = '33333333-3333-4333-8333-333333333333';
 /** The claim identity every heartbeat/complete body must carry (suspend-safe leases). */
 const GENERATION = 3;
 // Frozen: `jobView()` is called on both sides of several assertions, and a
@@ -46,8 +53,14 @@ function jobView(overrides: Partial<FleetJobView> = {}): FleetJobView {
     };
 }
 
-function makeController(service: Partial<FleetJobService>): FleetJobsController {
-    return new FleetJobsController(service as FleetJobService);
+function makeController(
+    service: Partial<FleetJobService>,
+    runSecrets: Partial<FleetRunSecretsService> = { resolve: jest.fn(async () => null) },
+): FleetJobsController {
+    return new FleetJobsController(
+        service as FleetJobService,
+        runSecrets as FleetRunSecretsService,
+    );
 }
 
 describe('FleetJobsController', () => {
@@ -253,11 +266,93 @@ describe('FleetJobsController', () => {
                     success: true,
                     leaseGeneration: GENERATION,
                 }),
+            // Run secrets (slice Y) is the FOURTH route on this channel and
+            // must not become the one that says something different.
+            () =>
+                controller.envFiles(JOB_ID, {
+                    nodeId: NODE_ID,
+                    secret: SECRET,
+                    leaseGeneration: GENERATION,
+                    refs: [{ repoConnectionId: ROW_ID, paths: ['.env'] }],
+                }),
         ]) {
             await call().catch((error: Error) => messages.push(error.message));
         }
 
-        expect(messages).toHaveLength(3);
+        expect(messages).toHaveLength(4);
         expect(new Set(messages).size).toBe(1);
+    });
+
+    /**
+     * Run secrets (self-build slice Y, EW-781) — the only route on this
+     * channel that returns a decrypted secret. It keeps the channel's two
+     * existing answers (one 401, one 409 stale-lease) and adds exactly one
+     * of its own: a 422 carrying a STABLE reason token, which is reachable
+     * only by the authenticated holder of an active job.
+     */
+    describe('POST /api/fleet/jobs/:id/env-files', () => {
+        const body = {
+            nodeId: NODE_ID,
+            secret: SECRET,
+            leaseGeneration: GENERATION,
+            refs: [{ repoConnectionId: ROW_ID, paths: ['apps/api/.env'] }],
+        };
+
+        it('returns the resolved files and forwards the claim as the node sent it', async () => {
+            const resolve = jest.fn(async () => ({
+                files: [{ repoConnectionId: ROW_ID, path: 'apps/api/.env', content: 'A=1' }],
+            }));
+            const controller = makeController({}, { resolve });
+            await expect(controller.envFiles(JOB_ID, body)).resolves.toEqual({
+                files: [{ repoConnectionId: ROW_ID, path: 'apps/api/.env', content: 'A=1' }],
+            });
+            expect(resolve).toHaveBeenCalledWith({
+                nodeId: NODE_ID,
+                secret: SECRET,
+                jobId: JOB_ID,
+                leaseGeneration: GENERATION,
+                refs: body.refs,
+            });
+        });
+
+        it('collapses a refused claim to the SAME 401 as every other route', async () => {
+            const controller = makeController({}, { resolve: jest.fn(async () => null) });
+            await expect(controller.envFiles(JOB_ID, body)).rejects.toBeInstanceOf(
+                UnauthorizedException,
+            );
+        });
+
+        it('answers 422 with the stable reason token, and nothing else', async () => {
+            const controller = makeController(
+                {},
+                {
+                    resolve: jest.fn(async () => {
+                        throw new FleetRunSecretsError('run-secrets-unresolved');
+                    }),
+                },
+            );
+            const error = await controller.envFiles(JOB_ID, body).catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(UnprocessableEntityException);
+            expect((error as UnprocessableEntityException).getStatus()).toBe(422);
+            expect((error as UnprocessableEntityException).getResponse()).toMatchObject({
+                reason: 'run-secrets-unresolved',
+            });
+        });
+
+        it('lets a stale lease surface as the channel-wide 409, not as a 422', async () => {
+            const controller = makeController(
+                {},
+                {
+                    resolve: jest.fn(async () => {
+                        throw new FleetJobStaleLeaseError();
+                    }),
+                },
+            );
+            const error = await controller.envFiles(JOB_ID, body).catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getResponse()).toMatchObject({
+                reason: FLEET_JOB_STALE_LEASE_REASON,
+            });
+        });
     });
 });

--- a/apps/api/src/fleet/fleet-jobs.controller.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.ts
@@ -7,18 +7,26 @@ import {
     ParseUUIDPipe,
     Post,
     UnauthorizedException,
+    UnprocessableEntityException,
     UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type {
     FleetJobCompleteResponse,
+    FleetJobEnvFilesResponse,
     FleetJobHeartbeatResponse,
     FleetJobLeaseResponse,
 } from '@ever-works/contracts';
 import { FleetJobService } from '@ever-works/agent/fleet';
 import { Public } from '../auth/decorators/public.decorator';
-import { CompleteFleetJobDto, FleetJobHeartbeatDto, LeaseFleetJobsDto } from './dto/fleet-job.dto';
+import {
+    CompleteFleetJobDto,
+    FleetJobEnvFilesDto,
+    FleetJobHeartbeatDto,
+    LeaseFleetJobsDto,
+} from './dto/fleet-job.dto';
+import { FleetRunSecretsError, FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
 import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
 
@@ -46,6 +54,22 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  *   POST /api/fleet/jobs/lease          atomic CAS claim, capability-filtered
  *   POST /api/fleet/jobs/:id/heartbeat  extend the claim (leased → running)
  *   POST /api/fleet/jobs/:id/complete   report success or failure
+ *   POST /api/fleet/jobs/:id/env-files  fetch the run's seed .env contents
+ *
+ * The fourth route (run secrets, self-build slice Y) takes the SAME
+ * posture, deliberately: it is the only place a decrypted secret leaves
+ * the platform for a node, so it proves the claim with the same four
+ * checks `complete` uses (credential, recorded holder, active status,
+ * current lease generation) rather than inventing a second scheme. Its
+ * REQUEST carries only registry row ids and file paths; the response body
+ * is the one value-bearing shape in the whole channel, and nothing about
+ * it is persisted, logged or echoed into the job.
+ *
+ * A resolution refusal (`FleetRunSecretsError` — unknown/disabled row, a
+ * path the row no longer carries, a decrypt failure, the instance kill
+ * switch) answers 422 with a STABLE machine token, never a partial file
+ * list: a run that starts with half its environment fails as if the code
+ * were broken, which is the failure this route exists to remove.
  *
  * Throttles are sized for polling: a node with a 5-second idle poll
  * needs ~12 lease calls/minute, and job heartbeats fire at a third of
@@ -69,7 +93,10 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
 @Controller('api/fleet/jobs')
 @UseGuards(FleetEnabledGuard, FleetNodeAuthGuard)
 export class FleetJobsController {
-    constructor(private readonly service: FleetJobService) {}
+    constructor(
+        private readonly service: FleetJobService,
+        private readonly runSecrets: FleetRunSecretsService,
+    ) {}
 
     @Public()
     @Post('lease')
@@ -144,5 +171,43 @@ export class FleetJobsController {
             throw new UnauthorizedException('Invalid node credential');
         }
         return { ok: true, job };
+    }
+
+    @Public()
+    @Post(':id/env-files')
+    @ApiOperation({
+        summary:
+            'Fetch the decrypted seed .env files this run needs (public, node-secret-authenticated). Request carries repository registry row ids and repository-relative PATHS; the response carries their contents, which the node writes 0600 inside the checkout, keeps out of Git, and deletes when the run ends. Only the recorded holder of an active job, echoing the current leaseGeneration, is served. A reference that cannot be resolved fails the delivery whole, with a stable reason.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async envFiles(
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: FleetJobEnvFilesDto,
+    ): Promise<FleetJobEnvFilesResponse> {
+        let response: FleetJobEnvFilesResponse | null;
+        try {
+            response = await this.runSecrets.resolve({
+                nodeId: body.nodeId,
+                secret: body.secret,
+                jobId: id,
+                leaseGeneration: body.leaseGeneration,
+                refs: body.refs,
+            });
+        } catch (error) {
+            // The stable token, and only the stable token. A refusal here
+            // has already been logged server-side with the job id; the node
+            // gets a reason it can report, never a crypto or row detail.
+            if (error instanceof FleetRunSecretsError) {
+                throw new UnprocessableEntityException({ reason: error.reason });
+            }
+            // `FleetJobStaleLeaseError` propagates untouched, as 409
+            // `{ reason: 'stale-lease' }` — same as heartbeat and complete.
+            throw error;
+        }
+        if (!response) {
+            throw new UnauthorizedException('Invalid node credential');
+        }
+        return response;
     }
 }

--- a/apps/api/src/fleet/fleet-run-secrets.service.ts
+++ b/apps/api/src/fleet/fleet-run-secrets.service.ts
@@ -1,0 +1,185 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+    FLEET_RUN_ENV_FILE_MAX_CONTENT_BYTES,
+    FLEET_RUN_ENV_FILES_MAX_TOTAL_BYTES,
+    FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON,
+    FLEET_RUN_SECRETS_DISABLED_REASON,
+    FLEET_RUN_SECRETS_UNRESOLVED_REASON,
+    isValidFleetRunEnvFilePath,
+    type FleetJobEnvFilesResponse,
+    type FleetRunEnvFileContent,
+    type FleetRunEnvFileRequestRef,
+} from '@ever-works/contracts';
+import { FleetJobService } from '@ever-works/agent/fleet';
+import { RepoConnectionRepository } from '@ever-works/agent/database';
+import { config } from '@ever-works/agent/config';
+
+/** Envelope marker written by `PluginSecretEncService`. */
+const SECRET_ENVELOPE_PREFIX = 'enc::v1::';
+
+/**
+ * A refusal the node can act on. Carries a STABLE machine token as its
+ * message and nothing else — no path content, no variable name, no crypto
+ * detail, no row identity beyond what the node already sent us.
+ */
+export class FleetRunSecretsError extends Error {
+    constructor(readonly reason: string) {
+        super(reason);
+        this.name = 'FleetRunSecretsError';
+    }
+}
+
+/**
+ * Run secrets (self-build slice Y, EW-781) — the resolution half of
+ * `POST /api/fleet/jobs/:id/env-files`.
+ *
+ * ## What this service is for
+ *
+ * A repository's seed `.env` files live envelope-encrypted in the
+ * registry and are decrypted only for their owner. The fleet job carries
+ * which repository's files a run needs (`workspace.envFilesRef` — row ids
+ * and PATHS); the node then asks for the contents HERE, over the same
+ * credential-verified channel it uses for lease / heartbeat / complete,
+ * and only while it holds the lease on that job.
+ *
+ * ## The rules this file exists to keep
+ *
+ * - **Scope comes from the JOB.** `FleetJobService.authorizeRunSecretRequest`
+ *   returns the job's `userId`; every registry read is `findByIdAndUser`
+ *   with THAT id. A node that names another tenant's connection gets the
+ *   same "unresolved" answer as a node naming a row that never existed.
+ * - **Fail closed, always.** A missing row, a disabled row, a path the row
+ *   does not carry, a decrypt that throws, a value that is still
+ *   ciphertext, the instance kill switch — each is a stable reason and an
+ *   aborted delivery. There is no partial answer: a run that starts with
+ *   half its environment produces a red suite that looks like a code
+ *   problem, which is the exact failure this feature removes.
+ * - **Nothing is logged about a value.** Log lines name the job and the
+ *   reason token. Never a path's content, never a variable name, never a
+ *   byte count that would leak length.
+ */
+@Injectable()
+export class FleetRunSecretsService {
+    private readonly logger = new Logger(FleetRunSecretsService.name);
+
+    constructor(
+        private readonly jobs: FleetJobService,
+        private readonly repoConnections: RepoConnectionRepository,
+    ) {}
+
+    /**
+     * Authorize the caller, then resolve exactly the requested paths.
+     *
+     * Returns `null` when the node credential / holder / status proof
+     * fails, so the controller can answer the SAME undifferentiated 401
+     * every other route on this channel answers. A stale lease propagates
+     * as `FleetJobStaleLeaseError` (409), exactly as on heartbeat and
+     * complete. Everything else throws {@link FleetRunSecretsError}.
+     */
+    async resolve(input: {
+        nodeId: unknown;
+        secret: unknown;
+        jobId: string;
+        leaseGeneration?: unknown;
+        refs: readonly FleetRunEnvFileRequestRef[];
+    }): Promise<FleetJobEnvFilesResponse | null> {
+        const claim = await this.jobs.authorizeRunSecretRequest({
+            nodeId: input.nodeId,
+            secret: input.secret,
+            jobId: input.jobId,
+            leaseGeneration: input.leaseGeneration,
+        });
+        if (!claim) return null;
+
+        if (!config.fleetNode.isRunEnvFilesEnabled()) {
+            this.logger.warn(
+                `Fleet job ${claim.jobId}: run env-file delivery refused — ${FLEET_RUN_SECRETS_DISABLED_REASON} ` +
+                    '(FLEET_NODE_RUN_ENV_FILES is off on this instance)',
+            );
+            throw new FleetRunSecretsError(FLEET_RUN_SECRETS_DISABLED_REASON);
+        }
+
+        const files: FleetRunEnvFileContent[] = [];
+        let totalBytes = 0;
+        for (const ref of input.refs) {
+            const row = await this.loadConnection(claim.jobId, claim.userId, ref.repoConnectionId);
+            const stored = row.envFiles ?? {};
+            for (const path of ref.paths) {
+                // Re-validated on THIS side too. The DTO and the contracts
+                // normalizer both check it, and this is the last gate before
+                // a path is used as an object key against decrypted data.
+                if (!isValidFleetRunEnvFilePath(path)) {
+                    throw this.refusal(claim.jobId, FLEET_RUN_SECRETS_UNRESOLVED_REASON);
+                }
+                const content = stored[path];
+                if (typeof content !== 'string') {
+                    // The row exists but no longer carries this file: the
+                    // operator removed it between planning and running. Fail
+                    // rather than deliver a checkout that is missing one.
+                    throw this.refusal(claim.jobId, FLEET_RUN_SECRETS_UNRESOLVED_REASON);
+                }
+                // `PluginSecretEncService.decryptValue` returns a malformed or
+                // too-short envelope UNCHANGED rather than throwing (its one
+                // soft path). Without this check the node would write
+                // ciphertext to `.env`, the suite would fail on a
+                // "misconfigured" database, and nothing would say why.
+                if (content.startsWith(SECRET_ENVELOPE_PREFIX)) {
+                    throw this.refusal(claim.jobId, FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON);
+                }
+                const bytes = Buffer.byteLength(content, 'utf8');
+                if (bytes > FLEET_RUN_ENV_FILE_MAX_CONTENT_BYTES) {
+                    throw this.refusal(claim.jobId, FLEET_RUN_SECRETS_UNRESOLVED_REASON);
+                }
+                totalBytes += bytes;
+                if (totalBytes > FLEET_RUN_ENV_FILES_MAX_TOTAL_BYTES) {
+                    throw this.refusal(claim.jobId, FLEET_RUN_SECRETS_UNRESOLVED_REASON);
+                }
+                files.push({ repoConnectionId: ref.repoConnectionId, path, content });
+            }
+        }
+        this.logger.log(
+            `Fleet job ${claim.jobId}: delivered ${files.length} run env file(s) to node ${claim.nodeId}`,
+        );
+        return { files };
+    }
+
+    /**
+     * The registry row, scoped to the JOB's owner.
+     *
+     * `envFiles` is an encrypted column with a TypeORM TRANSFORMER, so a
+     * corrupt envelope or a missing `PLUGIN_SECRET_ENCRYPTION_KEY` throws
+     * from the READ itself, not from anything in this file's body. The
+     * try/catch is therefore load-bearing twice over: it maps that throw to
+     * a stable reason, and it keeps the raw crypto message (which names the
+     * cipher and the row) off the wire.
+     */
+    private async loadConnection(
+        jobId: string,
+        userId: string,
+        repoConnectionId: string,
+    ): Promise<{ envFiles?: Record<string, string> | null }> {
+        let row: Awaited<ReturnType<RepoConnectionRepository['findByIdAndUser']>>;
+        try {
+            row = await this.repoConnections.findByIdAndUser(repoConnectionId, userId);
+        } catch (error) {
+            this.logger.error(
+                `Fleet job ${jobId}: ${FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON} reading repository connection ` +
+                    `${repoConnectionId} (${error instanceof Error ? error.name : 'unknown error'})`,
+            );
+            throw new FleetRunSecretsError(FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON);
+        }
+        // Missing, someone else's, and disabled collapse to ONE answer — the
+        // same posture the registry HTTP surface takes (a row owned by
+        // another user reads as nonexistent, never as forbidden).
+        if (!row || row.enabled === false) {
+            throw this.refusal(jobId, FLEET_RUN_SECRETS_UNRESOLVED_REASON);
+        }
+        return row;
+    }
+
+    /** Log the refusal (job + stable token only) and build the error to throw. */
+    private refusal(jobId: string, reason: string): FleetRunSecretsError {
+        this.logger.warn(`Fleet job ${jobId}: run env-file delivery refused — ${reason}`);
+        return new FleetRunSecretsError(reason);
+    }
+}

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -13,6 +13,7 @@ import { FleetKillSwitchController } from './fleet-kill-switch.controller';
 import { FleetPanicController } from './fleet-panic.controller';
 import { FleetPanicService } from './fleet-panic.service';
 import { FleetRunRouterService } from './fleet-run-router.service';
+import { FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
 import {
     buildNodeJobRuntimeProviders,
@@ -47,8 +48,8 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  *     whose better-auth runtime would otherwise ride into every module
  *     that imports this one).
  *   - `FleetJobsController` — the node work channel (lease / job
- *     heartbeat / complete), node-secret authenticated, public,
- *     fail-closed to one undifferentiated 401.
+ *     heartbeat / complete / env-files), node-secret authenticated,
+ *     public, fail-closed to one undifferentiated 401.
  *
  * `FleetPanicService` holds the per-node drain that `FleetController`
  * and drain-all BOTH call (one implementation, two routes), and the
@@ -117,6 +118,13 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
         FleetRunnerStatusService,
         FleetRunRouterService,
         FleetPanicService,
+        // Run secrets (self-build slice Y): the resolution half of the
+        // node-authenticated env-file fetch. Provided HERE rather than in
+        // the agent-side fleet module on purpose — it needs
+        // `RepoConnectionRepository`, and pulling DatabaseModule into the
+        // agent fleet graph would widen that module's dependency surface
+        // for a route only this app exposes.
+        FleetRunSecretsService,
         // Guards are ordinary providers so Nest can inject them.
         FleetEnabledGuard,
         FleetNodeAuthGuard,

--- a/apps/api/src/migrations/1789200000000-AddRepoConnectionEnvGrants.ts
+++ b/apps/api/src/migrations/1789200000000-AddRepoConnectionEnvGrants.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Run secrets (self-build slice Y, EW-781) — `repo_connections.envGrants`.
+ *
+ * The env var NAMES a repository's runs may read from the RUNNER's own
+ * environment, through the runner's platform-owned refusal. Until now the
+ * only knob was the instance-global `FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH`,
+ * which cannot open `DATABASE_`, `GH_`, `AWS_` and the rest at all — so the
+ * platform's own test suite could not be made to run on a fleet node by
+ * configuration.
+ *
+ * NAMES, not values, and deliberately NOT encrypted (unlike the `envFiles`
+ * column added by `1786850000000-CreateRepoConnections`): a grant is not a
+ * secret, and an operator and an auditor must be able to read, grep and
+ * diff exactly which variables a repository was allowed to see.
+ *
+ * Additive, nullable JSON, no index: read by connection primary key only,
+ * exactly like `envFiles` and `tasks.extraRepos`. Every existing row reads
+ * NULL — "no grants", which is the correct history and the default-empty
+ * posture the feature requires. Forward-only with a guard so a partially
+ * applied database converges; portable `TableColumn` DDL because the e2e
+ * stack and CI run better-sqlite3 while production runs Postgres (TypeORM
+ * maps `simple-json` to `text` on both).
+ */
+export class AddRepoConnectionEnvGrants1789200000000 implements MigrationInterface {
+    name = 'AddRepoConnectionEnvGrants1789200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('repo_connections');
+        if (table && !table.findColumnByName('envGrants')) {
+            await queryRunner.addColumn(
+                'repo_connections',
+                new TableColumn({ name: 'envGrants', type: 'text', isNullable: true }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('repo_connections');
+        if (table?.findColumnByName('envGrants')) {
+            await queryRunner.dropColumn('repo_connections', 'envGrants');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddRepoConnectionEnvGrants.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddRepoConnectionEnvGrants.spec.ts
@@ -1,0 +1,89 @@
+import { DataSource, Table } from 'typeorm';
+import { AddRepoConnectionEnvGrants1789200000000 } from '../1789200000000-AddRepoConnectionEnvGrants';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ *
+ * What matters for run secrets: an existing registry row comes out with a
+ * NULL grant list — "this repository grants nothing", which is exactly the
+ * refusal every runner already performs — re-running is a no-op, and
+ * `down()` reverses it without touching the encrypted `envFiles` beside it.
+ */
+describe('AddRepoConnectionEnvGrants1789200000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddRepoConnectionEnvGrants1789200000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'repo_connections',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'name', type: 'varchar', length: '200' },
+                    { name: 'url', type: 'varchar', length: '512' },
+                    { name: 'envFiles', type: 'text', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO repo_connections (id, "userId", name, url, "envFiles") VALUES (?, ?, ?, ?, ?)`,
+            ['repo-1', 'user-1', 'platform', 'https://github.com/ever-works/ever-works.git', null],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    it('adds a nullable envGrants column and leaves existing repositories granting nothing', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        const table = await runner.getTable('repo_connections');
+        await runner.release();
+        expect(table?.findColumnByName('envGrants')).toMatchObject({ isNullable: true });
+        expect(
+            await dataSource.query(
+                `SELECT id, "envGrants", "envFiles" FROM repo_connections WHERE id = ?`,
+                ['repo-1'],
+            ),
+        ).toEqual([{ id: 'repo-1', envGrants: null, envFiles: null }]);
+    });
+
+    it('is idempotent on re-run and reversible', async () => {
+        await runUp();
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        expect(
+            (await runner.getTable('repo_connections'))?.findColumnByName('envGrants'),
+        ).toBeDefined();
+        await migration.down(runner);
+        expect(
+            (await runner.getTable('repo_connections'))?.findColumnByName('envGrants'),
+        ).toBeUndefined();
+        await migration.down(runner);
+        expect(
+            (await runner.getTable('repo_connections'))?.findColumnByName('envGrants'),
+        ).toBeUndefined();
+        // The encrypted env-file column is untouched by either direction.
+        expect(
+            (await runner.getTable('repo_connections'))?.findColumnByName('envFiles'),
+        ).toBeDefined();
+        await runner.release();
+    });
+});

--- a/apps/api/src/repo-connections/dto/repo-connection.dto.ts
+++ b/apps/api/src/repo-connections/dto/repo-connection.dto.ts
@@ -103,6 +103,26 @@ export class CreateRepoConnectionDto {
     @Type(() => RepoConnectionEnvFileDto)
     envFiles?: RepoConnectionEnvFileDto[];
 
+    @ApiPropertyOptional({
+        type: [String],
+        maxItems: 32,
+        description:
+            'Env var NAMES the runs of this repository may read from the runner own environment, THROUGH ' +
+            'the runner platform-owned refusal. One exact name each — there is no wildcard and no prefix ' +
+            'form — and never a platform-internal namespace (FLEET_, EVER_WORKS_, PLUGIN_, AUTH_, ' +
+            'BETTER_AUTH_, PLATFORM_). Names only; values never leave the machine that holds them.',
+        example: ['DATABASE_URL', 'GH_TOKEN'],
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(32)
+    @IsString({ each: true })
+    @Matches(/^[A-Za-z_][A-Za-z0-9_]{0,127}$/, {
+        each: true,
+        message: 'each env grant must be an environment variable name (no wildcards)',
+    })
+    envGrants?: string[];
+
     @ApiPropertyOptional({ default: true })
     @IsOptional()
     @IsBoolean()
@@ -172,6 +192,26 @@ export class UpdateRepoConnectionDto {
     @ValidateNested({ each: true })
     @Type(() => RepoConnectionEnvFileDto)
     envFiles?: RepoConnectionEnvFileDto[];
+
+    @ApiPropertyOptional({
+        type: [String],
+        maxItems: 32,
+        description:
+            'Env var NAMES the runs of this repository may read from the runner own environment, THROUGH ' +
+            'the runner platform-owned refusal. One exact name each — there is no wildcard and no prefix ' +
+            'form — and never a platform-internal namespace (FLEET_, EVER_WORKS_, PLUGIN_, AUTH_, ' +
+            'BETTER_AUTH_, PLATFORM_). Names only; values never leave the machine that holds them.',
+        example: ['DATABASE_URL', 'GH_TOKEN'],
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(32)
+    @IsString({ each: true })
+    @Matches(/^[A-Za-z_][A-Za-z0-9_]{0,127}$/, {
+        each: true,
+        message: 'each env grant must be an environment variable name (no wildcards)',
+    })
+    envGrants?: string[];
 
     @ApiPropertyOptional()
     @IsOptional()

--- a/apps/node/src/core/executors/acceptance-checks.spec.ts
+++ b/apps/node/src/core/executors/acceptance-checks.spec.ts
@@ -299,3 +299,83 @@ describe('buildNodeCheckEnv — a check never inherits this machine', () => {
 		expect(buildNodeCheckEnv(undefined, parent).CI).toBe('1');
 	});
 });
+
+/**
+ * Per-repository env grants (run secrets, self-build slice Y, EW-781).
+ *
+ * `NODE_PLATFORM_OWNED_ENV_PATTERN` is a PREFIX regex, and the grant that
+ * opens it is an EXACT name. That asymmetry is the entire security of the
+ * feature: matched by prefix, one `DATABASE_URL` grant would also hand
+ * over `DATABASE_PASSWORD`. Every adjacent-name case below exists because
+ * getting this wrong is silent.
+ */
+describe('buildNodeCheckEnv — per-repository grants open the platform-owned refusal', () => {
+	const parent: NodeJS.ProcessEnv = {
+		PATH: '/usr/bin',
+		DATABASE_URL: 'postgres://user:pw@host/db',
+		DATABASE_URL_REPLICA: 'postgres://user:pw@replica/db',
+		DATABASE_HOST: 'db.internal',
+		DATABASE_PASSWORD: 'pw',
+		database_url_extra: 'lowercase-adjacent',
+		GH_TOKEN: 'gho_realtoken',
+		FLEET_NODE_SECRET: 'the-node-credential',
+		EVER_WORKS_API_KEY: 'platform-key',
+		PLUGIN_SECRET_ENCRYPTION_KEY: 'the-key-that-decrypts-every-tenant',
+		BETTER_AUTH_SECRET: 'session-signing',
+		PLATFORM_ADMIN_TOKEN: 'admin'
+	};
+
+	it('admits EXACTLY the granted name and nothing adjacent to it', () => {
+		const env = buildNodeCheckEnv(undefined, parent, ['DATABASE_URL']);
+		expect(env.DATABASE_URL).toBe('postgres://user:pw@host/db');
+		expect(env.DATABASE_URL_REPLICA).toBeUndefined();
+		expect(env.DATABASE_HOST).toBeUndefined();
+		expect(env.DATABASE_PASSWORD).toBeUndefined();
+		expect(env.database_url_extra).toBeUndefined();
+	});
+
+	it('admits a granted name even when the instance passthrough never mentions it', () => {
+		// A grant is a permission in its own right, not a filter over the
+		// instance-global list.
+		expect(buildNodeCheckEnv([], parent, ['GH_TOKEN']).GH_TOKEN).toBe('gho_realtoken');
+	});
+
+	it('with NO grants, behaves exactly as it did before this slice', () => {
+		const env = buildNodeCheckEnv(['DATABASE_URL', 'GH_TOKEN'], parent);
+		expect(env.DATABASE_URL).toBeUndefined();
+		expect(env.GH_TOKEN).toBeUndefined();
+		expect(buildNodeCheckEnv(['DATABASE_URL'], parent, []).DATABASE_URL).toBeUndefined();
+		expect(buildNodeCheckEnv(['DATABASE_URL'], parent, null).DATABASE_URL).toBeUndefined();
+	});
+
+	it.each([
+		'FLEET_NODE_SECRET',
+		'EVER_WORKS_API_KEY',
+		'PLUGIN_SECRET_ENCRYPTION_KEY',
+		'BETTER_AUTH_SECRET',
+		'PLATFORM_ADMIN_TOKEN'
+	])('never admits %s, however explicitly it is granted', (name) => {
+		// The un-grantable core. `FLEET_`/`EVER_WORKS_` is the credential
+		// that leases work on this machine; `PLUGIN_` decrypts every
+		// tenant's env files; the rest sign platform sessions. Opening any
+		// of them turns "read one secret" into "become the platform".
+		const env = buildNodeCheckEnv([name], parent, [name]);
+		expect(env[name]).toBeUndefined();
+	});
+
+	it('ignores a wildcard grant rather than expanding it', () => {
+		const env = buildNodeCheckEnv(undefined, parent, ['DATABASE_*', '*']);
+		expect(env.DATABASE_URL).toBeUndefined();
+		expect(env.DATABASE_PASSWORD).toBeUndefined();
+	});
+
+	it('matches case-insensitively, because Windows env names are', () => {
+		expect(buildNodeCheckEnv(undefined, parent, ['database_url']).DATABASE_URL).toBe('postgres://user:pw@host/db');
+	});
+
+	it('does not let a grant leak into the instance-global list for other repositories', () => {
+		// Two calls, one grant set each: the second must not see the first's.
+		buildNodeCheckEnv(undefined, parent, ['DATABASE_URL']);
+		expect(buildNodeCheckEnv(undefined, parent, ['GH_TOKEN']).DATABASE_URL).toBeUndefined();
+	});
+});

--- a/apps/node/src/core/executors/acceptance-checks.ts
+++ b/apps/node/src/core/executors/acceptance-checks.ts
@@ -85,6 +85,12 @@ export interface WireCheck {
 	timeoutSec?: number;
 	required?: boolean;
 	envPassthrough?: string[];
+	/**
+	 * Per-repository env grants (self-build slice Y): env var NAMES an
+	 * operator explicitly bound to a repository of this run, which open the
+	 * platform-owned refusal for those EXACT names and nothing adjacent.
+	 */
+	envGrants?: string[];
 }
 
 /** Injected so the whole executor is testable without spawning processes. */
@@ -274,7 +280,7 @@ async function executeCheck(
 				shell: true,
 				detached: process.platform !== 'win32',
 				windowsHide: true,
-				env: buildNodeCheckEnv(check.envPassthrough, io.parentEnv)
+				env: buildNodeCheckEnv(check.envPassthrough, io.parentEnv, check.envGrants)
 			});
 		} catch (error) {
 			tail = error instanceof Error ? error.message : String(error);
@@ -624,6 +630,25 @@ export const NODE_SECRETISH_ENV_KEY_PATTERN =
 export const NODE_PLATFORM_OWNED_ENV_PATTERN =
 	/^(DATABASE_|PLATFORM_|PLUGIN_|TRIGGER_|AUTH_|BETTER_AUTH_|EVER_WORKS_|FLEET_|SMTP_|RESEND_|MAILER_|STRIPE_|SENTRY_|POSTHOG_|JITSU_|TWENTY_CRM_|K8S_|STORAGE_|AWS_|REDIS_|S3_|MINIO_|GH_|GOOGLE_|FACEBOOK_|LINKEDIN_)/i;
 
+/**
+ * The subset of the above that stays refused even WITH an explicit
+ * per-repository grant (self-build slice Y).
+ *
+ * `FLEET_` and `EVER_WORKS_` are this node's own credential namespace: a
+ * grant there would let model-driven code read the secret that leases
+ * work on this machine and then lease, complete or cancel jobs as the
+ * node. `PLUGIN_` holds the key that decrypts every tenant's env files.
+ * `AUTH_` / `BETTER_AUTH_` / `PLATFORM_` sign platform sessions. None of
+ * them is ever what an operator means by "let my test suite reach the
+ * database", so refusing them costs nothing and closes the escalation
+ * from "read one secret" to "become the platform".
+ *
+ * Mirrors `FLEET_RUN_ENV_UNGRANTABLE_PATTERN` in `@ever-works/contracts`;
+ * kept as a local literal so the refusal survives even if the payload,
+ * the platform, or the contracts package is the thing that is wrong.
+ */
+export const NODE_UNGRANTABLE_ENV_PATTERN = /^(FLEET_|EVER_WORKS_|PLUGIN_|AUTH_|BETTER_AUTH_|PLATFORM_)/i;
+
 const NODE_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
 const MAX_ENV_PASSTHROUGH = 32;
 const CREDENTIALED_URL_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^/\s@]*:[^/\s@]+@/i;
@@ -635,7 +660,14 @@ const CREDENTIALED_URL_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^/\s@]*:[^/\s@]+@/i;
  */
 export function buildNodeCheckEnv(
 	passthrough?: readonly string[] | null,
-	parentEnv: NodeJS.ProcessEnv = process.env
+	parentEnv: NodeJS.ProcessEnv = process.env,
+	/**
+	 * Per-repository env grants (self-build slice Y). Env var NAMES an
+	 * operator bound to a repository of THIS run, which may pass the
+	 * platform-owned refusal below. Absent / empty = today's behaviour
+	 * exactly: every platform-owned name is refused.
+	 */
+	platformOwnedGrants?: readonly string[] | null
 ): Record<string, string> {
 	// Windows env names are case-insensitive (`Path` vs `PATH`), so index
 	// the parent once by upper-cased name and look everything up through it.
@@ -679,7 +711,25 @@ export function buildNodeCheckEnv(
 	// both would bill the Console org for an agent meant to run on a Claude
 	// plan — silently. Keep one per family, preferring the
 	// subscription-backed credential, and say so in the log.
-	const granted = normalizePassthrough(passthrough);
+	// The instance-global passthrough and the per-repository grants meet in
+	// exactly ONE place, and the grant set is an explicit argument with an
+	// empty default. If the grants ever leaked into the global list, every
+	// repository would inherit every repository's grants.
+	//
+	// A grant is a permission in its own right, not a filter on the
+	// passthrough: a name an operator bound to a repository is admitted
+	// whether or not the instance-global list also mentions it. The two
+	// lists are capped independently (32 each, matching the registry) and
+	// merged case-insensitively here, first spelling wins.
+	const grants = normalizeGrantedPlatformOwnedNames(platformOwnedGrants);
+	const granted: string[] = [];
+	const grantedSeen = new Set<string>();
+	for (const name of [...normalizePassthrough(passthrough, grants), ...grants]) {
+		const upper = name.toUpperCase();
+		if (grantedSeen.has(upper)) continue;
+		grantedSeen.add(upper);
+		granted.push(name);
+	}
 	const { names: exclusiveNames, notes } = resolveExclusiveAgentCredentials(granted, parentEnv);
 	for (const note of notes) {
 		// eslint-disable-next-line no-console
@@ -706,8 +756,60 @@ export function buildNodeCheckEnv(
 	return env;
 }
 
-/** Shape-valid, de-duplicated, capped, never platform-owned. */
-export function normalizePassthrough(names: readonly string[] | null | undefined): string[] {
+/**
+ * Shape-valid, de-duplicated, capped, and platform-owned ONLY where an
+ * operator granted that exact name.
+ *
+ * `platformOwnedGrants` is the keyhole in {@link NODE_PLATFORM_OWNED_ENV_PATTERN},
+ * and the whole security of the feature is in one word: EXACT. The
+ * refusal pattern is a PREFIX regex, so if a grant were matched by prefix
+ * a single `DATABASE_` grant would open `DATABASE_URL`,
+ * `DATABASE_PASSWORD` and everything else that starts that way. A grant
+ * therefore admits `DATABASE_URL` and NOT `DATABASE_URL_REPLICA`, not
+ * `DATABASE_HOST`, not anything adjacent. Case-insensitive because
+ * Windows env names are.
+ *
+ * The un-grantable core (`FLEET_`, `EVER_WORKS_`, `PLUGIN_`, `AUTH_`,
+ * `BETTER_AUTH_`, `PLATFORM_`) is stripped from the grant set before it
+ * reaches here — see {@link normalizeGrantedPlatformOwnedNames} — so no
+ * grant can ever hand a check the credential that leases work on this
+ * machine.
+ */
+export function normalizePassthrough(
+	names: readonly string[] | null | undefined,
+	platformOwnedGrants?: readonly string[] | null
+): string[] {
+	if (!Array.isArray(names)) return [];
+	const grantedUpper = new Set(
+		normalizeGrantedPlatformOwnedNames(platformOwnedGrants).map((name) => name.toUpperCase())
+	);
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const raw of names) {
+		if (typeof raw !== 'string') continue;
+		const name = raw.trim();
+		if (!NODE_ENV_NAME_PATTERN.test(name)) continue;
+		const upper = name.toUpperCase();
+		// EXACT-name grant, never a prefix and never a pattern.
+		if (NODE_PLATFORM_OWNED_ENV_PATTERN.test(name) && !grantedUpper.has(upper)) continue;
+		if (seen.has(upper)) continue;
+		seen.add(upper);
+		out.push(name);
+		if (out.length >= MAX_ENV_PASSTHROUGH) break;
+	}
+	return out;
+}
+
+/**
+ * The grant list as this node will actually honour it: shape-valid,
+ * wildcard-free, outside the un-grantable core, de-duplicated and capped.
+ *
+ * Re-derived here rather than trusted from the payload. The platform
+ * normalizes grants too, but this is the machine the values live on, and
+ * "the platform said so" is not a reason to hand a model-driven process a
+ * credential.
+ */
+export function normalizeGrantedPlatformOwnedNames(names: readonly string[] | null | undefined): string[] {
 	if (!Array.isArray(names)) return [];
 	const out: string[] = [];
 	const seen = new Set<string>();
@@ -715,7 +817,8 @@ export function normalizePassthrough(names: readonly string[] | null | undefined
 		if (typeof raw !== 'string') continue;
 		const name = raw.trim();
 		if (!NODE_ENV_NAME_PATTERN.test(name)) continue;
-		if (NODE_PLATFORM_OWNED_ENV_PATTERN.test(name)) continue;
+		if (name.includes('*') || name.includes('?')) continue;
+		if (NODE_UNGRANTABLE_ENV_PATTERN.test(name)) continue;
 		const upper = name.toUpperCase();
 		if (seen.has(upper)) continue;
 		seen.add(upper);

--- a/apps/node/src/core/executors/agent-task-run-secrets.spec.ts
+++ b/apps/node/src/core/executors/agent-task-run-secrets.spec.ts
@@ -1,0 +1,481 @@
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { FleetJobView } from '@ever-works/contracts';
+import { FleetClientError } from '../fleet-client';
+import { runAgentTaskJob } from './agent-task';
+
+/**
+ * Run secrets in the executor (self-build slice Y, EW-781).
+ *
+ * Two properties are pinned here, and they are the two the whole slice
+ * rests on:
+ *
+ *   1. **Deletion on EVERY exit path the process survives.** Success, a
+ *      reported failure, a thrown model step, and an abort (an operator
+ *      cancel and a lapsed lease both arrive as an aborted signal) all
+ *      pass through the same `finally`. Modelled on
+ *      `agent-task-release.spec.ts`, because it is the same seam.
+ *   2. **Fail CLOSED.** A missing fetch seam, a refused fetch, or a
+ *      response that is short of a file the job asked for stops the run
+ *      before the model starts. A run with half its environment reports a
+ *      red suite that looks like a code problem — the exact failure this
+ *      feature exists to remove.
+ *
+ * Plus the sentinel: the value must never reach the reported outcome.
+ */
+
+const SENTINEL = 'sentinel-4e11-DATABASE_URL=postgres://u:p@db/app';
+const ABSOLUTE = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';
+
+function job(payload: unknown): FleetJobView {
+	return {
+		id: 'job-1',
+		kind: 'agent-task',
+		status: 'leased',
+		nodeId: 'node-1',
+		requiredCapabilities: [],
+		payload: payload as Record<string, unknown>,
+		leaseExpiresAt: null,
+		attempts: 1,
+		maxAttempts: 3,
+		createdAt: null,
+		startedAt: null,
+		completedAt: null
+	};
+}
+
+function fakeSpawn(exitCodeByCommand: Record<string, number | null>) {
+	return ((command: string) => {
+		const handlers = new Map<string, (arg?: unknown) => void>();
+		queueMicrotask(() => {
+			handlers.get('close')?.(command in exitCodeByCommand ? exitCodeByCommand[command] : 0);
+		});
+		return {
+			stdout: { on: () => undefined, destroy: () => undefined },
+			stderr: { on: () => undefined, destroy: () => undefined },
+			on: (event: string, handler: (arg?: unknown) => void) => {
+				handlers.set(event, handler);
+			},
+			kill: () => undefined
+		};
+	}) as never;
+}
+
+const ROW = '22222222-2222-4222-8222-222222222222';
+const workspace = {
+	repositoryId: 'ever/repository',
+	repoUrl: 'https://github.com/ever/repository.git',
+	baseRef: 'develop',
+	branch: 'task/platform-task-12345678',
+	envFilesRef: [{ repoConnectionId: ROW, paths: ['apps/api/.env'] }]
+};
+const descriptor = {
+	path: ABSOLUTE,
+	repositoryId: workspace.repositoryId,
+	baseRef: workspace.baseRef,
+	branch: workspace.branch,
+	baseSha: 'a'.repeat(40),
+	headSha: 'b'.repeat(40),
+	reused: false
+};
+
+function io(overrides: Record<string, unknown> = {}) {
+	return {
+		directoryExists: (path: string) => path === ABSOLUTE,
+		provisionWorkspace: vi.fn().mockResolvedValue(descriptor),
+		fetchRunEnvFiles: vi
+			.fn()
+			.mockResolvedValue([{ repoConnectionId: ROW, path: 'apps/api/.env', content: SENTINEL }]),
+		writeRunEnvFiles: vi.fn(async () => 1),
+		removeRunEnvFiles: vi.fn(async () => 1),
+		spawnFn: vi.fn(fakeSpawn({ passing: 0, failing: 1 }) as never),
+		...overrides
+	};
+}
+
+describe('runAgentTaskJob — run secrets', () => {
+	it('fetches by REFERENCE and writes before the run, and deletes after a success', async () => {
+		const deps = io();
+		const outcome = await runAgentTaskJob(
+			job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+			deps as never
+		);
+
+		expect(outcome.status).toBe('succeeded');
+		// The request carries row ids and PATHS. Never a value, and never
+		// the mountDir (that is node-local placement).
+		expect(deps.fetchRunEnvFiles).toHaveBeenCalledWith([{ repoConnectionId: ROW, paths: ['apps/api/.env'] }]);
+		expect(deps.writeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor, [
+			{ path: 'apps/api/.env', content: SENTINEL }
+		]);
+		expect(deps.removeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor);
+		// …and the value is nowhere in what the node reports back.
+		expect(JSON.stringify(outcome)).not.toContain(SENTINEL);
+	});
+
+	it('deletes after a FAILED run', async () => {
+		const deps = io();
+		const outcome = await runAgentTaskJob(
+			job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'failing' }] }),
+			deps as never
+		);
+		expect(outcome.status).toBe('failed');
+		expect(deps.removeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor);
+		expect(JSON.stringify(outcome)).not.toContain(SENTINEL);
+	});
+
+	it('deletes when the model step THROWS', async () => {
+		const deps = io({ modelCli: {} });
+		await expect(
+			runAgentTaskJob(
+				job({
+					taskId: 'task-1',
+					workspace,
+					execution: { provider: 'claude-code', instructions: '# do it' }
+				}),
+				deps as never
+			)
+		).rejects.toThrowError(/claude-code CLI/);
+		expect(deps.removeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor);
+	});
+
+	it('deletes when the run is CANCELLED (an aborted signal — cancel or a lapsed lease)', async () => {
+		// The cancel has to land AFTER the secrets are on disk, which is the
+		// only interesting shape: an abort before provisioning leaves nothing
+		// to clean up, and the executor already refuses at the top for it.
+		const controller = new AbortController();
+		const deps = io({
+			writeRunEnvFiles: vi.fn(async () => {
+				controller.abort();
+				return 1;
+			})
+		});
+		await expect(
+			runAgentTaskJob(
+				job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+				deps as never,
+				controller.signal
+			)
+		).rejects.toThrow();
+		expect(deps.removeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor);
+	});
+
+	it('deletes even when the WRITE itself failed half way', async () => {
+		const deps = io({
+			writeRunEnvFiles: vi.fn(async () => {
+				throw new Error('EACCES');
+			})
+		});
+		await expect(
+			runAgentTaskJob(
+				job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+				deps as never
+			)
+		).rejects.toThrow(/run-secrets-unavailable/);
+		expect(deps.removeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor);
+	});
+
+	it('never lets a failed deletion change the verdict', async () => {
+		const deps = io({
+			removeRunEnvFiles: vi.fn(async () => {
+				throw new Error('EBUSY');
+			})
+		});
+		const outcome = await runAgentTaskJob(
+			job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+			deps as never
+		);
+		expect(outcome.status).toBe('succeeded');
+	});
+
+	it('does nothing at all — not even a round trip — for a workspace that declares none', async () => {
+		const deps = io();
+		const { envFilesRef: _dropped, ...plain } = workspace;
+		await runAgentTaskJob(
+			job({ taskId: 'task-1', workspace: plain, steps: [{ id: 'run', command: 'passing' }] }),
+			deps as never
+		);
+		expect(deps.fetchRunEnvFiles).not.toHaveBeenCalled();
+		expect(deps.writeRunEnvFiles).not.toHaveBeenCalled();
+	});
+
+	it('fails CLOSED when the node has no way to fetch them', async () => {
+		const deps = io({ fetchRunEnvFiles: undefined });
+		await expect(
+			runAgentTaskJob(
+				job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+				deps as never
+			)
+		).rejects.toThrow(/run-secrets-unavailable/);
+		// The model/steps never ran.
+		expect(deps.spawnFn).not.toHaveBeenCalled();
+	});
+
+	it('fails CLOSED when the platform refuses to resolve the reference', async () => {
+		const deps = io({
+			fetchRunEnvFiles: vi.fn(async () => {
+				throw new FleetClientError('unresolved', 'The platform could not resolve …', 422);
+			})
+		});
+		await expect(
+			runAgentTaskJob(
+				job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+				deps as never
+			)
+		).rejects.toThrow(/run-secrets-unavailable/);
+		expect(deps.writeRunEnvFiles).not.toHaveBeenCalled();
+	});
+
+	it('lets a STALE LEASE keep its own identity, so the worker does not report a failure', async () => {
+		const stale = new FleetClientError('stale-lease', 'newer lease', 409);
+		const deps = io({ fetchRunEnvFiles: vi.fn(async () => Promise.reject(stale)) });
+		await expect(
+			runAgentTaskJob(
+				job({ taskId: 'task-1', workspace, steps: [{ id: 'run', command: 'passing' }] }),
+				deps as never
+			)
+		).rejects.toBe(stale);
+	});
+
+	it('fails CLOSED when the response is short of a file the job asked for', async () => {
+		const deps = io({
+			fetchRunEnvFiles: vi.fn(async () => [])
+		});
+		await expect(
+			runAgentTaskJob(
+				job({
+					taskId: 'task-1',
+					workspace: {
+						...workspace,
+						envFilesRef: [{ repoConnectionId: ROW, paths: ['apps/api/.env', '.env'] }]
+					},
+					steps: [{ id: 'run', command: 'passing' }]
+				}),
+				deps as never
+			)
+		).rejects.toThrow(/run-secrets-unresolved/);
+		expect(deps.writeRunEnvFiles).not.toHaveBeenCalled();
+	});
+
+	it('places a mount reference into the mount it names', async () => {
+		const mountRef = { repoConnectionId: ROW, mountDir: 'api', paths: ['.env'] };
+		const deps = io({
+			fetchRunEnvFiles: vi.fn().mockResolvedValue([{ repoConnectionId: ROW, path: '.env', content: SENTINEL }])
+		});
+		await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace: { ...workspace, envFilesRef: [mountRef] },
+				steps: [{ id: 'run', command: 'passing' }]
+			}),
+			deps as never
+		);
+		// The fetch does NOT carry the mountDir — the platform has no
+		// business knowing the node's on-disk layout — but the write does.
+		expect(deps.fetchRunEnvFiles).toHaveBeenCalledWith([{ repoConnectionId: ROW, paths: ['.env'] }]);
+		expect(deps.writeRunEnvFiles).toHaveBeenCalledWith('task-1', descriptor, [
+			{ mountDir: 'api', path: '.env', content: SENTINEL }
+		]);
+	});
+});
+
+/**
+ * The grant has to reach the ACCEPTANCE CHECKS, not only the model.
+ *
+ * `pnpm test` needing `DATABASE_URL` is the concrete thing this slice
+ * exists to unblock, and the checks are frozen from the Task, so they can
+ * never carry a grant of their own. And because a failing check prints
+ * its connection string, the value has to come back OUT of the log tail
+ * before the result is reported.
+ */
+describe('runAgentTaskJob — run env grants reach every command of the run', () => {
+	const GRANTED_VALUE = 'postgres://user:s3cr3t-value-here@db.internal/app';
+	const CLAUDE = process.platform === 'win32' ? String.raw`C:\cli\claude.exe` : '/usr/local/bin/claude';
+
+	const SCRATCH = process.platform === 'win32' ? String.raw`C:\scratch` : '/tmp/ew-scratch';
+
+	/** In-memory scratch, so the model step runs without touching a disk. */
+	const scratchFs = () => ({
+		createScratchDir: async (root: string, prefix: string) => join(root, prefix),
+		writeFile: async () => undefined,
+		readFile: async () => null,
+		remove: async () => undefined
+	});
+
+	/** Spawn double that echoes `value` on stdout and exits nonzero. */
+	function spawnEchoing(value: string) {
+		return vi.fn(((_command: string) => {
+			const handlers = new Map<string, (arg?: unknown) => void>();
+			const stdoutHandlers = new Map<string, (chunk: Buffer) => void>();
+			queueMicrotask(() => {
+				stdoutHandlers.get('data')?.(
+					Buffer.from(`connecting to ${value}
+`)
+				);
+				handlers.get('close')?.(1);
+			});
+			return {
+				stdout: {
+					on: (event: string, handler: (chunk: Buffer) => void) => stdoutHandlers.set(event, handler),
+					destroy: () => undefined
+				},
+				stderr: { on: () => undefined, destroy: () => undefined },
+				on: (event: string, handler: (arg?: unknown) => void) => handlers.set(event, handler),
+				kill: () => undefined
+			};
+		}) as never);
+	}
+
+	const { envFilesRef: _dropped, ...plainWorkspace } = workspace;
+
+	it('stamps the run grants onto the frozen acceptance checks and the platform steps', async () => {
+		const sawGrantedName: boolean[] = [];
+		const deps = io({
+			spawnFn: vi.fn(((_command: string, options: { env?: Record<string, string> }) => {
+				sawGrantedName.push(options.env?.DATABASE_URL === GRANTED_VALUE);
+				const handlers = new Map<string, (arg?: unknown) => void>();
+				queueMicrotask(() => handlers.get('close')?.(0));
+				return {
+					stdout: { on: () => undefined, destroy: () => undefined },
+					stderr: { on: () => undefined, destroy: () => undefined },
+					on: (event: string, handler: (arg?: unknown) => void) => handlers.set(event, handler),
+					kill: () => undefined
+				};
+			}) as never),
+			parentEnv: { PATH: '/usr/bin', DATABASE_URL: GRANTED_VALUE },
+			modelCli: { 'claude-code': CLAUDE },
+			scratchFs: scratchFs(),
+			scratchRoot: SCRATCH
+		});
+
+		await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace: plainWorkspace,
+				execution: {
+					provider: 'claude-code',
+					instructions: '# do it',
+					envGrants: ['DATABASE_URL']
+				},
+				steps: [{ id: 'run', command: 'passing' }],
+				acceptanceChecks: [{ id: 'unit', command: 'passing' }]
+			}),
+			deps as never
+		);
+
+		// Three spawns: the model CLI, the platform step, and the frozen
+		// acceptance check — and the granted value reached all three.
+		expect(sawGrantedName).toHaveLength(3);
+		expect(sawGrantedName.every(Boolean)).toBe(true);
+	});
+
+	it('scrubs a granted value out of a failing CHECK log tail before it is reported', async () => {
+		const deps = io({
+			spawnFn: spawnEchoing(GRANTED_VALUE),
+			parentEnv: { PATH: '/usr/bin', DATABASE_URL: GRANTED_VALUE },
+			modelCli: { 'claude-code': CLAUDE },
+			scratchFs: scratchFs(),
+			scratchRoot: SCRATCH
+		});
+		const outcome = await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace: plainWorkspace,
+				execution: {
+					provider: 'claude-code',
+					instructions: '# do it',
+					envGrants: ['DATABASE_URL']
+				},
+				acceptanceChecks: [{ id: 'unit', command: 'failing' }]
+			}),
+			deps as never
+		);
+		expect(JSON.stringify(outcome)).not.toContain(GRANTED_VALUE);
+		expect(JSON.stringify(outcome)).toContain('[redacted]');
+	});
+
+	it('scrubs a DELIVERED env file value out of a failing check tail, with no grant involved', async () => {
+		// The env FILE is the other half of this slice, and its values live in
+		// no environment for `collectProtectedValues` to look up. A failing
+		// `pnpm test` prints the connection string it read from
+		// `apps/api/.env`, and that tail is stored verbatim in
+		// `fleet_jobs.result` unless it is carried and scrubbed.
+		const FILE_VALUE = 'postgres://file-user:file-s3cret@db.internal/app';
+		const deps = io({
+			fetchRunEnvFiles: vi.fn().mockResolvedValue([
+				{
+					repoConnectionId: ROW,
+					path: 'apps/api/.env',
+					content: `# seed\nDATABASE_URL=${FILE_VALUE}\n`
+				}
+			]),
+			spawnFn: spawnEchoing(FILE_VALUE),
+			// Nothing granted, nothing in the parent environment: the value is
+			// protected because it was DELIVERED, not because it was named.
+			parentEnv: { PATH: '/usr/bin' }
+		});
+		const outcome = await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace,
+				steps: [{ id: 'run', command: 'failing' }],
+				acceptanceChecks: [{ id: 'unit', command: 'failing' }]
+			}),
+			deps as never
+		);
+		expect(JSON.stringify(outcome)).not.toContain(FILE_VALUE);
+		expect(JSON.stringify(outcome)).toContain('[redacted]');
+	});
+
+	it('takes the delivered env files off the disk BEFORE the first Git command', async () => {
+		// `info/exclude` is the LOWEST-precedence ignore source Git has, and
+		// the model has `acceptEdits` over the checkout: a `.gitignore`
+		// carrying `!/apps/api/.env` would re-include the secret and the node
+		// would commit and push it itself. Nothing after the checks reads the
+		// files, so they come off first.
+		const order: string[] = [];
+		const deps = io({
+			removeRunEnvFiles: vi.fn(async () => {
+				order.push('remove');
+				return 1;
+			}),
+			finalizeWorkspace: vi.fn(async () => {
+				order.push('finalize');
+				return { pushed: true, headSha: 'c'.repeat(40), empty: false, changedFiles: 1 };
+			}),
+			modelCli: { 'claude-code': CLAUDE },
+			scratchFs: scratchFs(),
+			scratchRoot: SCRATCH
+		});
+		await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace,
+				execution: { provider: 'claude-code', instructions: '# do it' },
+				git: { commit: true, push: true, commitMessage: 'chore: run' }
+			}),
+			deps as never
+		);
+		expect(order[0]).toBe('remove');
+		expect(order).toContain('finalize');
+		expect(order.indexOf('remove')).toBeLessThan(order.indexOf('finalize'));
+	});
+
+	it('leaves an ordinary log tail alone when the run granted nothing', async () => {
+		const deps = io({
+			spawnFn: spawnEchoing('some ordinary output that is long enough'),
+			parentEnv: { PATH: '/usr/bin', DATABASE_URL: GRANTED_VALUE }
+		});
+		const outcome = await runAgentTaskJob(
+			job({
+				taskId: 'task-1',
+				workspace: plainWorkspace,
+				steps: [{ id: 'run', command: 'failing' }]
+			}),
+			deps as never
+		);
+		expect(JSON.stringify(outcome)).toContain('some ordinary output that is long enough');
+		// …and an ungranted value is not in the environment to leak anyway.
+		expect(JSON.stringify(outcome)).not.toContain(GRANTED_VALUE);
+	});
+});

--- a/apps/node/src/core/executors/agent-task.ts
+++ b/apps/node/src/core/executors/agent-task.ts
@@ -11,6 +11,8 @@ import type {
 	FleetAgentTaskResult,
 	FleetAgentTaskStep,
 	FleetJobView,
+	FleetRunEnvFileContent,
+	FleetRunEnvFileRequestRef,
 	FleetTaskWorkspaceDescriptor,
 	FleetTaskWorkspaceMountDescriptor,
 	FleetTaskWorkspaceSpec,
@@ -19,9 +21,12 @@ import type {
 import type { WorkspacePublishFence } from '@ever-works/plugin';
 import {
 	FLEET_AGENT_TASK_MAX_STEPS,
+	FLEET_RUN_SECRETS_UNAVAILABLE_REASON,
+	FLEET_RUN_SECRETS_UNRESOLVED_REASON,
 	FleetAgentExecutionError,
 	normalizeFleetAgentModelExecution
 } from '@ever-works/contracts';
+import { FleetClientError } from '../fleet-client';
 import {
 	normalizeChecks,
 	runNodeCommandStep,
@@ -41,10 +46,12 @@ import {
 	buildModelCliStep,
 	ModelCliCommandError,
 	parseModelCliResult,
+	redactCommandResult,
 	type ModelCliPaths,
 	MODEL_CLI_MAX_OUTPUT_BYTES
 } from './model-cli';
 import type { FleetTaskWorkspaceErrorCode } from '../workspaces/fleet-task-workspace';
+import { extractRunEnvSecretValues } from '../workspaces/run-env-files';
 
 /**
  * The `agent-task` executor — the node's general job kind.
@@ -202,6 +209,36 @@ export interface AgentTaskIo extends AcceptanceChecksIo {
 	 */
 	releaseWorkspace?: (taskId: string, descriptor: FleetTaskWorkspaceDescriptor) => Promise<void>;
 	/**
+	 * Run secrets (self-build slice Y) — fetch the decrypted seed `.env`
+	 * files this run's repositories declared, over the node-authenticated
+	 * job channel, while this node still holds the lease.
+	 *
+	 * Absent on a caller that holds no lease (the cloud runner). A job
+	 * whose workspace NAMES env files and finds this absent fails naming
+	 * the gap: starting it would run the model against an environment the
+	 * operator did not configure, and every database-touching check would
+	 * go red for a reason nothing on the run explains.
+	 */
+	fetchRunEnvFiles?: (refs: readonly FleetRunEnvFileRequestRef[]) => Promise<readonly FleetRunEnvFileContent[]>;
+	/**
+	 * Place the fetched files 0600 inside the checkouts they belong to.
+	 * Throws (after removing whatever already landed) rather than
+	 * delivering a partial set.
+	 */
+	writeRunEnvFiles?: (
+		taskId: string,
+		descriptor: FleetTaskWorkspaceDescriptor,
+		files: ReadonlyArray<{ mountDir?: string; path: string; content: string }>
+	) => Promise<number>;
+	/**
+	 * Delete every env file this run was given. Called from the SAME
+	 * `finally` that releases the workspace, so it covers success, a
+	 * reported failure, a thrown model step, and an abort — an operator
+	 * cancel and a lapsed lease both arrive as one. Never decides the
+	 * verdict: a cleanup that fails is logged, not reported.
+	 */
+	removeRunEnvFiles?: (taskId: string, descriptor: FleetTaskWorkspaceDescriptor) => Promise<number>;
+	/**
 	 * The lease deadline this run is publishing under, resolved as LATE as
 	 * possible — right before the commit/push — because the keep-alive
 	 * advances it on every renewal and a model step outlives four or five
@@ -277,7 +314,16 @@ export async function runAgentTaskJob(
 				'Set FLEET_NODE_AGENT_TASK_COMMAND on the platform, or switch the fleet runtime to model-cli execution.'
 		);
 	}
-	const checks = resolveAcceptanceChecks(payload);
+	// Run secrets (self-build slice Y): the run's per-repository env grants
+	// live on the model-execution block, and they belong to the RUN, not to
+	// one command. The acceptance checks are the reason the feature exists —
+	// `pnpm test` is what needs `DATABASE_URL` — and the platform-authored
+	// steps run in the same workspace at the same trust level, so the grant
+	// is stamped onto all of them here, once, rather than trusted to arrive
+	// per entry (the checks are frozen from the Task and carry none).
+	const runEnvGrants = Array.isArray(execution?.envGrants) ? execution.envGrants : [];
+	const checks = withRunEnvGrants(resolveAcceptanceChecks(payload), runEnvGrants);
+	const grantedSteps = withRunEnvGrants(steps, runEnvGrants);
 
 	let workspaceResolution: { path: string; descriptor: FleetTaskWorkspaceDescriptor | null };
 	try {
@@ -290,8 +336,30 @@ export async function runAgentTaskJob(
 		throw error;
 	}
 	try {
+		// Run secrets (self-build slice Y): the decrypted `.env` files land
+		// AFTER provisioning (so the Git exclude rules are already written)
+		// and BEFORE the model step. A delivery that cannot be completed
+		// throws HERE, which fails the run closed — the alternative is a
+		// model working against an environment the operator did not
+		// configure and a suite that goes red for reasons nothing explains.
+		// The returned values are the secrets that now live in the checkout.
+		// They are held for the length of the run for ONE purpose: scrubbing
+		// them back out of everything the node reports. Nothing else reads
+		// this array, and it never leaves the process.
+		const runSecretValues = await provisionRunEnvFiles(taskId, payload, workspaceResolution.descriptor, io);
 		return await runResolvedAgentTask(
-			{ job, payload, taskId, runId, execution, steps, checks, workspaceResolution },
+			{
+				job,
+				payload,
+				taskId,
+				runId,
+				execution,
+				steps: grantedSteps,
+				checks,
+				workspaceResolution,
+				runEnvGrants,
+				runSecretValues
+			},
 			io,
 			signal
 		);
@@ -299,10 +367,105 @@ export async function runAgentTaskJob(
 		// Whatever the verdict — and whatever threw — the lease the
 		// provisioner took on the worktree is dropped, or the workspace
 		// reaper would treat this checkout as busy until the process dies.
+		//
+		// Run secrets ride the SAME `finally`, and deliberately BEFORE the
+		// release: success, a reported failure, a thrown model step, an
+		// operator cancel and a lapsed lease (both delivered as an aborted
+		// signal) all pass through here. The one path it cannot cover is a
+		// hard kill, which is why the provisioner also sweeps at provision
+		// time and the files are Git-excluded meanwhile.
+		if (workspaceResolution.descriptor && io.removeRunEnvFiles) {
+			await io.removeRunEnvFiles(taskId, workspaceResolution.descriptor).catch(() => undefined);
+		}
 		if (workspaceResolution.descriptor && io.releaseWorkspace) {
 			await io.releaseWorkspace(taskId, workspaceResolution.descriptor).catch(() => undefined);
 		}
 	}
+}
+
+/**
+ * Fetch and place this run's seed `.env` files.
+ *
+ * No-op — and no round trip — for a workspace that declares none, which is
+ * every workspace before this slice.
+ *
+ * Fails CLOSED on every other outcome: a missing seam, a refused fetch, a
+ * reference the platform could not resolve, or a response missing a file
+ * that was asked for. The thrown message carries a STABLE reason token and
+ * names the repository row and path at most; it never carries a value,
+ * because it lands on the job row, the Task page and the API log.
+ */
+async function provisionRunEnvFiles(
+	taskId: string,
+	payload: FleetAgentTaskPayload,
+	descriptor: FleetTaskWorkspaceDescriptor | null,
+	io: AgentTaskIo
+): Promise<string[]> {
+	const refs = payload.workspace?.envFilesRef ?? [];
+	if (refs.length === 0) return [];
+	if (!descriptor) {
+		throw new AgentTaskPayloadError(
+			`${FLEET_RUN_SECRETS_UNAVAILABLE_REASON}: the job asks for repository env files but no repository workspace was provisioned`
+		);
+	}
+	if (!io.fetchRunEnvFiles || !io.writeRunEnvFiles) {
+		throw new AgentTaskPayloadError(
+			`${FLEET_RUN_SECRETS_UNAVAILABLE_REASON}: this node cannot fetch repository env files (no leased job channel is wired for this run)`
+		);
+	}
+
+	let fetched: readonly FleetRunEnvFileContent[];
+	try {
+		fetched = await io.fetchRunEnvFiles(
+			refs.map((ref) => ({ repoConnectionId: ref.repoConnectionId, paths: [...ref.paths] }))
+		);
+	} catch (error) {
+		// A stale lease must keep its own identity: the worker reads it as
+		// "abort, and do not report", and collapsing it here would turn a
+		// void claim into a reported failure.
+		if (error instanceof FleetClientError && error.kind === 'stale-lease') throw error;
+		throw new AgentTaskPayloadError(
+			`${FLEET_RUN_SECRETS_UNAVAILABLE_REASON}: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+
+	// Index by (row, path) and prove EVERY requested file came back. A
+	// silently short response is exactly the partial environment this
+	// feature exists to prevent, and it would otherwise look like success.
+	const byKey = new Map<string, string>();
+	for (const file of fetched) byKey.set(`${file.repoConnectionId}\u0000${file.path}`, file.content);
+	const writes: Array<{ mountDir?: string; path: string; content: string }> = [];
+	for (const ref of refs) {
+		for (const path of ref.paths) {
+			const content = byKey.get(`${ref.repoConnectionId}\u0000${path}`);
+			if (typeof content !== 'string') {
+				throw new AgentTaskPayloadError(
+					`${FLEET_RUN_SECRETS_UNRESOLVED_REASON}: repository ${ref.repoConnectionId} did not deliver '${path}'`
+				);
+			}
+			writes.push({ ...(ref.mountDir ? { mountDir: ref.mountDir } : {}), path, content });
+		}
+	}
+
+	try {
+		await io.writeRunEnvFiles(taskId, descriptor, writes);
+	} catch (error) {
+		throw new AgentTaskPayloadError(
+			`${FLEET_RUN_SECRETS_UNAVAILABLE_REASON}: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+	// The VALUES inside the delivered files, for the redactor only. The
+	// node's logger is handed each file whole (`FleetJobClient`), which
+	// only ever matches a log line that reproduces the entire file; a
+	// connection string does not leak that way — a failing `pnpm test`
+	// prints the one line it read. So the per-variable values are extracted
+	// here and scrubbed out of every step, check and model result before
+	// the outcome is built.
+	const values = new Set<string>();
+	for (const write of writes) {
+		for (const value of extractRunEnvSecretValues(write.content)) values.add(value);
+	}
+	return [...values];
 }
 
 /** Provision refusals that clear on their own and say nothing about the work. */
@@ -333,6 +496,37 @@ interface ResolvedAgentTask {
 	steps: WireCheck[];
 	checks: WireCheck[];
 	workspaceResolution: { path: string; descriptor: FleetTaskWorkspaceDescriptor | null };
+	/** Env names this run was granted; their VALUES are scrubbed from every report. */
+	runEnvGrants: readonly string[];
+	/**
+	 * The VALUES inside the run's delivered `.env` files. Scrubbed out of
+	 * every step, check and model result, exactly like a granted name's
+	 * value — the difference is only that these live in no environment, so
+	 * they have to be carried rather than looked up.
+	 */
+	runSecretValues: readonly string[];
+}
+
+/**
+ * Stamp the run's env grants onto each command, unioned with whatever the
+ * command already declared. Case-insensitive, because Windows env names
+ * are; the node re-derives what it will actually honour in
+ * `buildNodeCheckEnv`, so this only decides what is OFFERED.
+ */
+function withRunEnvGrants(checks: readonly WireCheck[], runEnvGrants: readonly string[]): WireCheck[] {
+	if (runEnvGrants.length === 0) return [...checks];
+	return checks.map((check) => {
+		const merged: string[] = [];
+		const seen = new Set<string>();
+		for (const name of [...(check.envGrants ?? []), ...runEnvGrants]) {
+			if (typeof name !== 'string') continue;
+			const upper = name.toUpperCase();
+			if (seen.has(upper)) continue;
+			seen.add(upper);
+			merged.push(name);
+		}
+		return { ...check, envGrants: merged };
+	});
 }
 
 /** The run proper, once the payload is validated and the workspace resolved. */
@@ -341,7 +535,8 @@ async function runResolvedAgentTask(
 	io: AgentTaskIo,
 	signal?: AbortSignal
 ): Promise<AgentTaskOutcome> {
-	const { job, payload, taskId, runId, execution, steps, checks, workspaceResolution } = context;
+	const { job, payload, taskId, runId, execution, steps, checks, workspaceResolution, runEnvGrants } = context;
+	const runSecretValues = context.runSecretValues;
 	throwIfAgentTaskAborted(signal);
 
 	const questionFs = io.questionFs ?? defaultQuestionFs;
@@ -371,7 +566,8 @@ async function runResolvedAgentTask(
 			workspaceResolution.path,
 			workspaceResolution.descriptor?.mounts,
 			io,
-			signal
+			signal,
+			runSecretValues
 		);
 		throwIfAgentTaskAborted(signal);
 		if (model.status !== 'succeeded') {
@@ -393,10 +589,20 @@ async function runResolvedAgentTask(
 		throwIfAgentTaskAborted(signal);
 	}
 
+	// Every command's log tail is scrubbed of the values behind the names
+	// this run was granted, on the same footing as the model summary. A
+	// failing `pnpm test` prints its connection string, and that tail lands
+	// in the job result the platform stores.
+	// `runSecretValues` rides the same seam: the contents of the delivered
+	// `.env` files are in no environment to look up, and a failing suite
+	// prints the connection string it read from one.
+	const reported = (result: NodeCheckResult): NodeCheckResult =>
+		redactCommandResult(result, runEnvGrants, io.parentEnv, runSecretValues);
+
 	const stepResults: NodeCheckResult[] = [];
 	for (const step of steps) {
 		throwIfAgentTaskAborted(signal);
-		stepResults.push(await runNodeCommandStep(step, workspaceResolution.path, io, signal));
+		stepResults.push(reported(await runNodeCommandStep(step, workspaceResolution.path, io, signal)));
 		throwIfAgentTaskAborted(signal);
 	}
 	const anyRequiredStepFailed = steps.some(
@@ -409,7 +615,7 @@ async function runResolvedAgentTask(
 	const checkResults: NodeCheckResult[] = [];
 	for (const check of checks) {
 		throwIfAgentTaskAborted(signal);
-		checkResults.push(await runNodeCommandStep(check, workspaceResolution.path, io, signal));
+		checkResults.push(reported(await runNodeCommandStep(check, workspaceResolution.path, io, signal)));
 		throwIfAgentTaskAborted(signal);
 	}
 	const gateStatus: 'green' | 'red' | 'none' =
@@ -420,6 +626,25 @@ async function runResolvedAgentTask(
 				: 'green';
 	if (gateStatus === 'red') {
 		failures.push('a required acceptance check did not pass');
+	}
+
+	// Run secrets (self-build slice Y): the delivered `.env` files come off
+	// the disk BEFORE the first Git command, not only in the `finally`.
+	//
+	// The anchored `info/exclude` rule keeps `git add -A` from staging them,
+	// but `info/exclude` is the LOWEST-precedence ignore source Git has: a
+	// `.gitignore` in the worktree beats it, and the model has `acceptEdits`
+	// over the whole checkout. A prompt-injected run that writes
+	// `!/apps/api/.env` into a `.gitignore` would otherwise have the secret
+	// committed and pushed by the node itself, into the owner's branch and
+	// the pull request the platform opens. Nothing between here and the
+	// commit reads the files — the model, the steps and the checks are all
+	// done — so removing them now costs nothing and closes that channel.
+	//
+	// The `finally` still runs: this is the early half of the same deletion,
+	// and it is idempotent.
+	if (workspaceResolution.descriptor && io.removeRunEnvFiles) {
+		await io.removeRunEnvFiles(taskId, workspaceResolution.descriptor).catch(() => undefined);
 	}
 
 	let git: FleetAgentTaskGitResult | null = null;
@@ -529,7 +754,15 @@ async function runModelStep(
 	workspacePath: string,
 	mounts: readonly FleetTaskWorkspaceMountDescriptor[] | undefined,
 	io: AgentTaskIo,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	/**
+	 * The VALUES of the run's delivered `.env` files (self-build slice Y).
+	 * "Print the contents of apps/api/.env" is the first thing a prompt
+	 * injection asks a CLI that ships a shell tool, and the answer used to
+	 * come straight back as the job result. Scrubbed on the same footing as
+	 * a granted credential.
+	 */
+	runSecretValues: readonly string[] = []
 ): Promise<FleetAgentTaskModelResult> {
 	const executable = io.modelCli?.[execution.provider];
 	if (typeof executable !== 'string' || !executable.trim()) {
@@ -570,13 +803,24 @@ async function runModelStep(
 			if (error instanceof ModelCliCommandError) throw new AgentTaskPayloadError(error.message);
 			throw error;
 		}
-		const step = buildModelCliStep(execution, command, execution.envPassthrough);
+		const step = buildModelCliStep(execution, command, execution.envPassthrough, execution.envGrants);
 		const result = await runNodeCommandStep(step, workspacePath, io, signal);
 		const rawOutput = await scratchFs.readFile(scratch.resultPath);
 		// `envPassthrough` names the credential env vars this CLI was handed;
 		// their values are scrubbed out of the summary and output tail before
-		// the result leaves the node.
-		return parseModelCliResult(execution.provider, rawOutput, result, execution.envPassthrough);
+		// the result leaves the node. `envGrants` (self-build slice Y) names
+		// the per-repository grants and is scrubbed on the SAME footing: a
+		// granted DATABASE_URL is a credential the model could have echoed,
+		// and the whole point of granting one is that it stays on the machine.
+		return parseModelCliResult(
+			execution.provider,
+			rawOutput,
+			result,
+			execution.envPassthrough,
+			execution.envGrants,
+			io.parentEnv,
+			runSecretValues
+		);
 	} finally {
 		try {
 			await scratchFs.remove(scratchDir);
@@ -763,6 +1007,13 @@ export function normalizeAgentTaskSteps(raw: unknown): WireCheck[] {
 		if (typeof step.required === 'boolean') out.required = step.required;
 		if (Array.isArray(step.envPassthrough)) {
 			out.envPassthrough = step.envPassthrough.filter((n): n is string => typeof n === 'string');
+		}
+		// Run secrets (slice Y): the per-repository grants ride the step the
+		// same way. Filtered, not validated, here — `buildNodeCheckEnv`
+		// re-derives what this machine will actually honour, and that is the
+		// gate that matters.
+		if (Array.isArray(step.envGrants)) {
+			out.envGrants = step.envGrants.filter((n): n is string => typeof n === 'string');
 		}
 		return out;
 	});

--- a/apps/node/src/core/executors/model-cli.ts
+++ b/apps/node/src/core/executors/model-cli.ts
@@ -315,14 +315,21 @@ export function assertMountGrantsInCommand(input: {
 export function buildModelCliStep(
 	execution: FleetAgentModelExecution,
 	command: string,
-	envPassthrough: readonly string[] | undefined
+	envPassthrough: readonly string[] | undefined,
+	/**
+	 * Per-repository env grants (self-build slice Y) — NAMES that open the
+	 * platform-owned refusal for this run. Carried onto the step so the ONE
+	 * command runner applies them the same way it applies `envPassthrough`.
+	 */
+	envGrants?: readonly string[]
 ): WireCheck {
 	return {
 		id: MODEL_CLI_STEP_ID,
 		command,
 		timeoutSec: execution.timeoutSec ?? FLEET_AGENT_EXECUTION_DEFAULT_TIMEOUT_SEC,
 		required: true,
-		...(envPassthrough && envPassthrough.length > 0 ? { envPassthrough: [...envPassthrough] } : {})
+		...(envPassthrough && envPassthrough.length > 0 ? { envPassthrough: [...envPassthrough] } : {}),
+		...(envGrants && envGrants.length > 0 ? { envGrants: [...envGrants] } : {})
 	};
 }
 
@@ -465,13 +472,85 @@ export function parseModelCliResult(
 	 * VALUES are read from this process and scrubbed out of everything the
 	 * node reports back — see {@link redactModelResult}.
 	 */
-	envPassthrough?: readonly string[]
+	envPassthrough?: readonly string[],
+	/**
+	 * Per-repository env grants (self-build slice Y). Scrubbed on exactly
+	 * the same footing as `envPassthrough`: a granted `DATABASE_URL` is a
+	 * credential the model could have echoed into its summary, and the
+	 * whole point of granting one is that it never leaves the machine.
+	 */
+	envGrants?: readonly string[],
+	/**
+	 * Where the values are read from. Defaults to this process, which is
+	 * what production uses; injectable so an embedder that supplies its own
+	 * `parentEnv` to the command runner scrubs the SAME values it granted,
+	 * rather than silently scrubbing nothing.
+	 */
+	parentEnv?: NodeJS.ProcessEnv,
+	/**
+	 * Values that are not in ANY environment — the run's delivered `.env`
+	 * file contents (self-build slice Y). The model can read those files,
+	 * and "print the contents of apps/api/.env" is exactly what a prompt
+	 * injection asks for, so they are scrubbed on the same footing as a
+	 * granted name's value.
+	 */
+	extraValues?: readonly string[]
 ): FleetAgentTaskModelResult {
-	return redactModelResult(parseModelCliOutcome(provider, rawOutput, step), collectProtectedValues(envPassthrough));
+	return redactModelResult(
+		parseModelCliOutcome(provider, rawOutput, step),
+		mergeProtectedValues(
+			collectProtectedValues([...(envPassthrough ?? []), ...(envGrants ?? [])], parentEnv),
+			extraValues
+		)
+	);
 }
 
 /** Placeholder left where a credential value was removed. */
 export const MODEL_CLI_REDACTED = '[redacted]';
+
+/**
+ * Scrub the values of `envNames` out of one command result's log tail.
+ *
+ * Run secrets (self-build slice Y): a granted `DATABASE_URL` is read by
+ * the acceptance checks and the platform-authored steps, not only by the
+ * model — and a failing `pnpm test` prints its connection string. The
+ * model result was already scrubbed; without this the SAME value would
+ * still reach the job result through a check's `logTail`.
+ *
+ * Values are read from this process at report time, exactly as
+ * `parseModelCliResult` does: the platform sends names, never values.
+ */
+export function redactCommandResult(
+	result: NodeCheckResult,
+	envNames?: readonly string[],
+	parentEnv?: NodeJS.ProcessEnv,
+	/**
+	 * Values that live in no environment: the run's delivered `.env` file
+	 * contents (self-build slice Y). A failing `pnpm test` prints the
+	 * connection string it read out of `apps/api/.env`, and that tail is
+	 * stored verbatim in `fleet_jobs.result` unless it is scrubbed here.
+	 */
+	extraValues?: readonly string[]
+): NodeCheckResult {
+	const values = mergeProtectedValues(collectProtectedValues(envNames, parentEnv), extraValues);
+	if (values.length === 0 || typeof result.logTail !== 'string') return result;
+	return { ...result, logTail: scrub(result.logTail, values) ?? result.logTail };
+}
+
+/**
+ * Union two protected-value lists, keeping the longest-first ordering
+ * {@link scrub} relies on so a value that contains another is replaced
+ * whole. Applies the same 8-character floor: a short value would redact
+ * ordinary prose out of every tail the node reports.
+ */
+function mergeProtectedValues(values: readonly string[], extra?: readonly string[]): string[] {
+	if (!extra?.length) return [...values];
+	const merged = new Set<string>(values);
+	for (const value of extra) {
+		if (typeof value === 'string' && value.trim().length >= 8) merged.add(value);
+	}
+	return [...merged].sort((a, b) => b.length - a.length);
+}
 
 /**
  * Credential values to scrub, longest first so a token that contains another
@@ -480,11 +559,23 @@ export const MODEL_CLI_REDACTED = '[redacted]';
  * Read from `process.env` at report time rather than carried on the payload:
  * the platform sends only NAMES, and the value never has to leave the node.
  */
-function collectProtectedValues(envPassthrough?: readonly string[]): string[] {
+function collectProtectedValues(
+	envPassthrough?: readonly string[],
+	parentEnv: NodeJS.ProcessEnv = process.env
+): string[] {
 	if (!envPassthrough?.length) return [];
 	const values = new Set<string>();
+	// Windows env names are case-insensitive, and the granted name may be
+	// spelled differently from the one the machine actually set.
+	const byUpperName = new Map<string, string>();
+	for (const key of Object.keys(parentEnv)) {
+		const upper = key.toUpperCase();
+		if (!byUpperName.has(upper)) byUpperName.set(upper, key);
+	}
 	for (const name of envPassthrough) {
-		const value = process.env[name];
+		if (typeof name !== 'string') continue;
+		const key = byUpperName.get(name.toUpperCase());
+		const value = key === undefined ? undefined : parentEnv[key];
 		// A short value would scrub ordinary prose. The node's own logger
 		// applies the same floor for the same reason.
 		if (typeof value === 'string' && value.trim().length >= 8) values.add(value);

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -40,7 +40,21 @@ export type FleetErrorKind =
 	 * the job than the one this node is renewing or finalizing (suspend-safe
 	 * leases). The claim is void; the worker aborts the run at once.
 	 */
-	| 'stale-lease';
+	| 'stale-lease'
+	/**
+	 * 422 from the run-secrets fetch (self-build slice Y): the node IS the
+	 * authenticated holder of an active job, and the platform still could
+	 * not resolve what the job asked for — an unknown or disabled
+	 * repository connection, a path the row no longer carries, a decrypt
+	 * failure, or the instance kill switch.
+	 *
+	 * Kept apart from `invalid-request` because it is not a malformed call
+	 * and retrying it unchanged will not help: the run must fail, closed,
+	 * rather than start with a partial environment. The precise reason is
+	 * logged platform-side against the job id; this client does not read
+	 * server bodies, here or anywhere else.
+	 */
+	| 'unresolved';
 
 export class FleetClientError extends Error {
 	readonly kind: FleetErrorKind;

--- a/apps/node/src/core/job-client.spec.ts
+++ b/apps/node/src/core/job-client.spec.ts
@@ -175,3 +175,87 @@ describe('FleetJobClient lease cancellation', () => {
 		expect(observedSignal?.aborted).toBe(true);
 	});
 });
+
+/**
+ * Run secrets (self-build slice Y, EW-781) — `fetchRunEnvFiles`.
+ *
+ * The request is by REFERENCE (row ids and paths); the response is the
+ * one place in this client where a secret value appears, and it is
+ * handed to the logger's redactor before anything else can touch it. The
+ * client's standing rule — never surface a server body — still holds,
+ * including for the new 422.
+ */
+describe('FleetJobClient run env files', () => {
+	const ROW = '22222222-2222-4222-8222-222222222222';
+	const SENTINEL = 'sentinel-c0de-DATABASE_URL=postgres://u:p@db/app';
+
+	const clientWith = (fetchFn: FetchLike, logger?: { protect: (v: string) => void }) =>
+		new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn,
+			timeoutMs: 0,
+			...(logger ? { logger: logger as never } : {})
+		});
+
+	it('sends only row ids, paths and the claim — never a value', async () => {
+		let sentBody = '';
+		const client = clientWith(async (_url, init) => {
+			sentBody = init.body;
+			return {
+				ok: true,
+				status: 200,
+				text: async () =>
+					JSON.stringify({ files: [{ repoConnectionId: ROW, path: '.env', content: SENTINEL }] })
+			};
+		});
+
+		await expect(
+			client.fetchRunEnvFiles('job-1', [{ repoConnectionId: ROW, paths: ['.env'] }], 3)
+		).resolves.toEqual([{ repoConnectionId: ROW, path: '.env', content: SENTINEL }]);
+
+		const parsed = JSON.parse(sentBody) as Record<string, unknown>;
+		expect(parsed).toMatchObject({
+			nodeId: NODE_ID,
+			leaseGeneration: 3,
+			refs: [{ repoConnectionId: ROW, paths: ['.env'] }]
+		});
+		expect(sentBody).not.toContain(SENTINEL);
+	});
+
+	it('registers every returned value with the redactor before returning it', async () => {
+		const protect = vi.fn();
+		const client = clientWith(
+			response(200, { files: [{ repoConnectionId: ROW, path: '.env', content: SENTINEL }] }),
+			{ protect }
+		);
+		await client.fetchRunEnvFiles('job-1', [{ repoConnectionId: ROW, paths: ['.env'] }], 3);
+		expect(protect).toHaveBeenCalledWith(SENTINEL);
+	});
+
+	it('maps 422 to `unresolved` without echoing what the server said', async () => {
+		const client = clientWith(response(422, { reason: 'run-secrets-decrypt-failed', detail: 'private' }));
+		const error = await client
+			.fetchRunEnvFiles('job-1', [{ repoConnectionId: ROW, paths: ['.env'] }], 3)
+			.catch((e: unknown) => e);
+		expect(error).toMatchObject({ kind: 'unresolved', status: 422 });
+		expect((error as Error).message).not.toContain('private');
+	});
+
+	it('keeps 409 as stale-lease, from the STATUS alone', async () => {
+		const client = clientWith(response(409, { reason: 'stale-lease' }));
+		await expect(
+			client.fetchRunEnvFiles('job-1', [{ repoConnectionId: ROW, paths: ['.env'] }], 3)
+		).rejects.toMatchObject({ kind: 'stale-lease' });
+	});
+
+	it('THROWS rather than resolving empty when the response is malformed', async () => {
+		// Resolving `[]` here would start the run with no environment at all
+		// and look like success.
+		const client = clientWith(response(200, { files: [{ repoConnectionId: ROW, path: '.env' }] }));
+		await expect(
+			client.fetchRunEnvFiles('job-1', [{ repoConnectionId: ROW, paths: ['.env'] }], 3)
+		).rejects.toMatchObject({ kind: 'malformed' });
+	});
+});

--- a/apps/node/src/core/job-client.ts
+++ b/apps/node/src/core/job-client.ts
@@ -1,12 +1,16 @@
 import type {
 	FleetJobCompleteResponse,
+	FleetJobEnvFilesResponse,
 	FleetJobHeartbeatResponse,
 	FleetJobLeaseResponse,
-	FleetJobView
+	FleetJobView,
+	FleetRunEnvFileContent,
+	FleetRunEnvFileRequestRef
 } from '@ever-works/contracts';
 import { FleetClientError, joinUrl, normalizeApiUrl, type FetchLike, type FetchRequestInit } from './fleet-client';
 import type { Logger } from './logger';
 import { MAX_CREDENTIAL_LENGTH, MIN_CREDENTIAL_LENGTH } from './types';
+import { extractRunEnvSecretValues } from './workspaces/run-env-files';
 
 /**
  * HTTP client for the three node-facing fleet-job endpoints:
@@ -14,6 +18,7 @@ import { MAX_CREDENTIAL_LENGTH, MIN_CREDENTIAL_LENGTH } from './types';
  *   POST /api/fleet/jobs/lease           → claim queued work
  *   POST /api/fleet/jobs/:id/heartbeat   → keep the claim alive
  *   POST /api/fleet/jobs/:id/complete    → report the verdict
+ *   POST /api/fleet/jobs/:id/env-files   → fetch the run's seed .env files
  *
  * Same posture as {@link FleetClient}: all three are `@Public()` and
  * self-authenticating (the `(nodeId, secret)` pair in the body IS the
@@ -175,6 +180,64 @@ export class FleetJobClient {
 		return Boolean(payload?.ok);
 	}
 
+	/**
+	 * Fetch the decrypted seed `.env` files this run's repositories declared
+	 * (self-build slice Y, EW-781).
+	 *
+	 * Same channel, same credential, same four-check proof as heartbeat and
+	 * complete — deliberately not a second scheme. The REQUEST carries only
+	 * registry row ids and repository-relative paths; the RESPONSE is the
+	 * one place in this client where a secret value appears, and every
+	 * value is handed to `logger.protect` the moment it arrives, so a later
+	 * error message or debug line cannot echo it even by accident.
+	 *
+	 * Throws rather than returning null on every failure: a run must not
+	 * start with a partial environment, so "could not fetch" has to reach
+	 * the executor as a refusal, not as an empty list. `409` still means
+	 * `stale-lease` from the status alone.
+	 */
+	async fetchRunEnvFiles(
+		jobId: string,
+		refs: readonly FleetRunEnvFileRequestRef[],
+		leaseGeneration?: number
+	): Promise<FleetRunEnvFileContent[]> {
+		const body: Record<string, unknown> = {
+			nodeId: this.nodeId,
+			secret: this.secret,
+			refs: refs.map((ref) => ({ repoConnectionId: ref.repoConnectionId, paths: [...ref.paths] }))
+		};
+		if (leaseGeneration !== undefined) body.leaseGeneration = leaseGeneration;
+
+		const payload = (await this.post(
+			`api/fleet/jobs/${encodeURIComponent(jobId)}/env-files`,
+			'job-env-files',
+			body
+		)) as FleetJobEnvFilesResponse;
+		if (!payload || !Array.isArray(payload.files)) {
+			throw new FleetClientError('malformed', 'Run env-file response did not contain a file list');
+		}
+		const files: FleetRunEnvFileContent[] = [];
+		for (const file of payload.files) {
+			if (
+				!file ||
+				typeof file.repoConnectionId !== 'string' ||
+				typeof file.path !== 'string' ||
+				typeof file.content !== 'string'
+			) {
+				throw new FleetClientError('malformed', 'Run env-file response contained a malformed entry');
+			}
+			// Registered with the redactor BEFORE the value is used anywhere.
+			// The file as a WHOLE only ever matches a log line that reproduces
+			// it verbatim, which is not how a `.env` leaks — a failing command
+			// prints the one variable it read. So each VALUE inside it is
+			// registered as well.
+			this.logger?.protect(file.content);
+			for (const value of extractRunEnvSecretValues(file.content)) this.logger?.protect(value);
+			files.push({ repoConnectionId: file.repoConnectionId, path: file.path, content: file.content });
+		}
+		return files;
+	}
+
 	private async post(
 		path: string,
 		operation: string,
@@ -257,6 +320,21 @@ export function errorForJobStatus(status: number, operation: string): FleetClien
 		return new FleetClientError(
 			'stale-lease',
 			'The platform holds a newer lease on this job (stale-lease); the claim this node is renewing or finalizing is void',
+			status
+		);
+	}
+	if (status === 422) {
+		// Run secrets (slice Y): reachable only by the authenticated holder
+		// of an active job, so it leaks nothing the 401 posture protects.
+		// The body carries a stable reason token which is logged
+		// platform-side against this job; this client still does not read
+		// it, because "never surface what the server wrote" is the rule
+		// that keeps every other message on this channel honest.
+		return new FleetClientError(
+			'unresolved',
+			'The platform could not resolve the env files this run asked for (unknown or disabled repository ' +
+				'connection, a path the repository no longer carries, a decryption failure, or env-file delivery ' +
+				'switched off on the instance). The precise reason is recorded platform-side against this job.',
 			status
 		);
 	}

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -251,7 +251,21 @@ export interface NodeRuntime {
 
 /** The provisioner surface the runtime composes over; the real one and every test double satisfy it. */
 export type FleetWorkspaceProvisionerLike = Pick<FleetTaskWorkspaceProvisioner, 'provision'> &
-	Partial<Pick<FleetTaskWorkspaceProvisioner, 'finalize' | 'finalizeMounts' | 'release' | 'activeBindingKeys'>>;
+	Partial<
+		Pick<
+			FleetTaskWorkspaceProvisioner,
+			| 'finalize'
+			| 'finalizeMounts'
+			| 'release'
+			| 'activeBindingKeys'
+			// Run secrets (self-build slice Y). Optional like the rest, so a
+			// test double or an embedder that predates the feature still
+			// satisfies this type; a job that needs env files and finds the
+			// seam missing fails naming the gap rather than starting without.
+			| 'writeRunEnvFiles'
+			| 'removeRunEnvFiles'
+		>
+	>;
 
 export interface CreateNodeRuntimeOptions {
 	/**
@@ -447,6 +461,25 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 									workspaceProvisioner.release!(taskId, descriptor)
 							}
 						: {}),
+					// Run secrets (self-build slice Y). The WRITE and the
+					// DELETE are the provisioner's — it owns the worktree, its
+					// canonical-path checks and its Git exclude rules — while
+					// the FETCH hangs off the lease below, because "may this
+					// node still be trusted with this job?" is the same
+					// question the publish fence asks and must have the same
+					// answer.
+					...(workspaceProvisioner.writeRunEnvFiles
+						? {
+								writeRunEnvFiles: (taskId, descriptor, files) =>
+									workspaceProvisioner.writeRunEnvFiles!(taskId, descriptor, files)
+							}
+						: {}),
+					...(workspaceProvisioner.removeRunEnvFiles
+						? {
+								removeRunEnvFiles: (_taskId, descriptor) =>
+									workspaceProvisioner.removeRunEnvFiles!(descriptor)
+							}
+						: {}),
 					// `agent-task` is the only kind that writes to a remote, so
 					// it is the only kind that has to know when this node stops
 					// being allowed to. Resolved through the handle, never
@@ -469,7 +502,15 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 								// (below the disk floor, or the reaper mid-removal of
 								// that very worktree) is about this machine, not the
 								// work: hand the job back so a node with room takes it.
-								onProvisionDeclined: (reason: string) => lease.defer(reason)
+								onProvisionDeclined: (reason: string) => lease.defer(reason),
+								// Run secrets: fetched THROUGH the lease, so the
+								// platform proves this node still holds an active
+								// claim on this job before a decrypted `.env`
+								// leaves it. A node with no lease (the cloud
+								// runner) has no seam here, and a job that needs
+								// env files fails naming the gap rather than
+								// running against an environment nobody set up.
+								fetchRunEnvFiles: (refs) => lease.fetchRunEnvFiles(refs)
 							}
 						: {}),
 					modelCli,

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -1,5 +1,10 @@
 import { performance } from 'node:perf_hooks';
-import type { FleetJobKind, FleetJobView } from '@ever-works/contracts';
+import type {
+	FleetJobKind,
+	FleetJobView,
+	FleetRunEnvFileContent,
+	FleetRunEnvFileRequestRef
+} from '@ever-works/contracts';
 import {
 	clampLeaseTtlSec,
 	FLEET_JOB_DEFAULT_LEASE_TTL_SEC,
@@ -217,6 +222,17 @@ export interface JobLeaseCapableClient {
 		outcome: { success: boolean; result?: Record<string, unknown> | null; error?: string | null },
 		leaseGeneration?: number
 	): Promise<boolean>;
+	/**
+	 * Run secrets (self-build slice Y). Optional so an embedder with an
+	 * older client still satisfies this interface; a run that NEEDS env
+	 * files and finds it absent fails naming the gap rather than starting
+	 * without them.
+	 */
+	fetchRunEnvFiles?(
+		jobId: string,
+		refs: readonly FleetRunEnvFileRequestRef[],
+		leaseGeneration?: number
+	): Promise<FleetRunEnvFileContent[]>;
 }
 
 /**
@@ -279,6 +295,22 @@ export interface JobLeaseHandle {
 	 * lapse so `reclaimExpired` re-offers the job inside its attempt budget.
 	 */
 	defer(reason: string): void;
+	/**
+	 * Fetch the decrypted seed `.env` files this run's repositories
+	 * declared (run secrets, self-build slice Y).
+	 *
+	 * On the LEASE handle rather than on a client the executor holds,
+	 * because it is exactly the same question the handle already answers
+	 * for a publish: "may this node still be trusted with this job right
+	 * now?". The platform proves it with the same four checks it uses for
+	 * complete (credential, recorded holder, active status, current lease
+	 * generation), so a claim that lapsed while the machine slept gets no
+	 * secrets — and gets them refused with `stale-lease`, not silently.
+	 *
+	 * Rejects rather than resolving empty on any failure: a run that starts
+	 * with part of its environment is worse than one that does not start.
+	 */
+	fetchRunEnvFiles(refs: readonly FleetRunEnvFileRequestRef[]): Promise<FleetRunEnvFileContent[]>;
 }
 
 /** The keep-alive as the LOOP sees it: the executor's half, plus control. */
@@ -1376,6 +1408,18 @@ export class WorkerLoop {
 				// publish, and a later one would only describe the fallout.
 				defer: (reason: string) => {
 					if (deferral === null) deferral = reason;
+				},
+				// Run secrets: the generation is captured from THIS run, the
+				// same value the beats echo, so a fetch can never be made
+				// against a claim this handle does not represent.
+				fetchRunEnvFiles: async (refs: readonly FleetRunEnvFileRequestRef[]) => {
+					const fetchFn = this.options.client.fetchRunEnvFiles;
+					if (!fetchFn) {
+						throw new Error(
+							'This node cannot fetch run env files (the job client predates the run-secrets protocol)'
+						);
+					}
+					return fetchFn.call(this.options.client, jobId, refs, generation);
 				}
 			}
 		};

--- a/apps/node/src/core/workspaces/fleet-task-workspace.spec.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.spec.ts
@@ -179,6 +179,77 @@ describe.sequential('FleetTaskWorkspaceProvisioner — real Git worktrees', { ti
 	});
 
 	/**
+	 * Run secrets (self-build slice Y, EW-781).
+	 *
+	 * The delivered `.env` files are per-repository and DYNAMIC, so they
+	 * cannot live in the static rule list. What must hold anyway: the rule
+	 * is anchored, Git actually honours it (`git add -A` stages nothing),
+	 * the merge stays idempotent across re-provisions, and the probe is NOT
+	 * slash-terminated — a `dir/` pattern matches directories only, so a
+	 * slashed probe would make `check-ignore` report the rule ineffective
+	 * for a plain file and fail provisioning outright.
+	 */
+	it('excludes the run env files it will deliver, before any content exists', async () => {
+		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath: workspaceRoot });
+		const spec = {
+			...workspace('task/fleet-secrets'),
+			envFilesRef: [
+				{
+					repoConnectionId: '22222222-2222-4222-8222-222222222222',
+					paths: ['.env', 'apps/api/.env']
+				}
+			]
+		};
+		const descriptor = await provisioner.provision('task-0016', spec);
+
+		const commonDir = git(descriptor.path, 'rev-parse', '--path-format=absolute', '--git-common-dir');
+		const excludeLines = async (): Promise<string[]> =>
+			(await fs.readFile(join(commonDir, 'info', 'exclude'), 'utf8')).split(/\r?\n/).map((line) => line.trim());
+		expect(await excludeLines()).toContain('/.env');
+		expect(await excludeLines()).toContain('/apps/api/.env');
+
+		// The delivered files really are invisible to Git — which is the
+		// property the rule exists for, not the rule text itself.
+		writeFileSync(join(descriptor.path, '.env'), 'DATABASE_URL=postgres://u:p@db/app\n');
+		mkdirSync(join(descriptor.path, 'apps', 'api'), { recursive: true });
+		writeFileSync(join(descriptor.path, 'apps', 'api', '.env'), 'DATABASE_URL=postgres://u:p@db/app\n');
+		expect(git(descriptor.path, 'status', '--porcelain')).toBe('');
+		git(descriptor.path, 'add', '-A');
+		expect(git(descriptor.path, 'diff', '--cached', '--name-only')).toBe('');
+
+		// Re-provisioning the same task adds no duplicate rule.
+		await provisioner.provision('task-0016', spec);
+		const merged = await excludeLines();
+		for (const rule of ['/.env', '/apps/api/.env']) {
+			expect(merged.filter((line) => line === rule)).toHaveLength(1);
+		}
+
+		// …and a workspace that declares none adds no env rule of its own.
+		// (It cannot assert the rules are ABSENT: `info/exclude` is shared by
+		// every worktree of the repository's pool, which is exactly why the
+		// rules are anchored and why the merge has to be idempotent.)
+		const before = await fs.readFile(join(commonDir, 'info', 'exclude'), 'utf8');
+		await provisioner.provision('task-0017', workspace('task/fleet-plain'));
+		expect(await fs.readFile(join(commonDir, 'info', 'exclude'), 'utf8')).toBe(before);
+	});
+
+	it('refuses a spec whose env reference names a mount it does not provision', async () => {
+		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath: workspaceRoot });
+		await expect(
+			provisioner.provision('task-0018', {
+				...workspace('task/fleet-badref'),
+				envFilesRef: [
+					{
+						repoConnectionId: '22222222-2222-4222-8222-222222222222',
+						mountDir: 'nowhere',
+						paths: ['.env']
+					}
+				]
+			})
+		).rejects.toMatchObject({ name: 'FleetTaskWorkspaceError', code: 'invalid-spec' });
+	});
+
+	/**
 	 * CI 2026-09-04, `lint-and-test` on #2297: provisioning a workspace with
 	 * NO mounts failed on Linux because `.mounts` existed as a symlink left by
 	 * an earlier run. Git treats a symlink as a FILE, so the then

--- a/apps/node/src/core/workspaces/fleet-task-workspace.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.ts
@@ -4,7 +4,9 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, parse, posix, relative, resolve, win32 } from 'node:path';
 import {
 	FLEET_AGENT_TASK_META_DIR,
+	normalizeFleetRunEnvFileRefs,
 	normalizeFleetTaskWorkspaceMounts,
+	type FleetRunEnvFileRef,
 	type FleetTaskWorkspaceDescriptor,
 	type FleetTaskWorkspaceMountDescriptor,
 	type FleetTaskWorkspaceMountSpec,
@@ -16,6 +18,7 @@ import { formatBytes } from '../resource-limits';
 import type { DiskProbeIo } from '../telemetry-probe';
 import { effectiveMinFreeDiskBytes } from '../types';
 import { measureWorkspaceFreeBytes } from './disk-headroom';
+import { removeRunEnvFiles, sweepStaleRunEnvFiles, writeRunEnvFiles, type RunEnvFileWrite } from './run-env-files';
 
 export type FleetTaskWorkspaceErrorCode =
 	| 'invalid-root'
@@ -421,6 +424,20 @@ export class FleetTaskWorkspaceProvisioner {
 	private readonly now: () => number;
 	/** Leases this process holds, keyed by the worktree's normalized canonical path. */
 	private readonly leases = new Map<string, HeldLease>();
+	/**
+	 * Run secrets (slice Y): the env-file paths THIS process wrote into each
+	 * checkout, keyed the same way as the leases.
+	 *
+	 * The on-disk manifest is the cross-process half of the same record and
+	 * is best-effort by construction — it is skipped entirely when the
+	 * worktree exposes no private gitdir (`resolvePrivateGitDir` returns
+	 * null for a plain clone, and for any transient failure of the `git`
+	 * call it makes), and its write failure is swallowed. Deleting by the
+	 * manifest alone therefore leaves a decrypted `.env` on disk forever in
+	 * exactly the cases where something already went wrong, so what this
+	 * process wrote is remembered here and is what the deletion leads with.
+	 */
+	private readonly runEnvPaths = new Map<string, string[]>();
 
 	constructor(options: FleetTaskWorkspaceProvisionerOptions) {
 		this.rootPath = validateRootPath(options.rootPath);
@@ -474,11 +491,26 @@ export class FleetTaskWorkspaceProvisioner {
 		// link left behind by an earlier spec would otherwise keep a repository
 		// the operator has since removed reachable (and editable) by the model.
 		const mountsDir = await reconcileMountsDir(primary.path, mountSpecs);
+		// Run secrets (slice Y). Two things happen for EVERY repository of
+		// the workspace, in this order and before a byte of content exists:
+		//
+		//   1. sweep whatever a previous run left here. The worktree is
+		//      reused in place, and the one exit path the executor's
+		//      `finally` cannot cover is a hard kill (SIGKILL, power loss).
+		//      The manifest in the private gitdir says exactly what that run
+		//      wrote, so this removes it even if the repository's file list
+		//      has changed since.
+		//   2. write the Git exclude rule. Before the file, never after:
+		//      another Task's finalize (`git add -A`) shares this
+		//      repository's `info/exclude`, and a delivered `.env` that is
+		//      visible to it for even a moment can be committed and pushed.
+		const primaryEnvPaths = runEnvFilePathsFor(spec);
+		await this.sweepRunEnvFiles(primary.path);
 		if (mountSpecs.length === 0) {
 			// Unconditional since slice Q: even a single-repository workspace
 			// may receive an owner-question file, and a forgotten one must
 			// never reach the finalize's `git add -A`.
-			await ensureFleetExcluded(primary.path, signal);
+			await ensureFleetExcluded(primary.path, signal, primaryEnvPaths);
 			return primary;
 		}
 
@@ -526,7 +558,8 @@ export class FleetTaskWorkspaceProvisioner {
 			// The mount is a repository of its own: a question file the model
 			// writes while working under `.mounts/<dir>` must stay out of THAT
 			// repository's Git too (the node scans writable mounts for it).
-			await ensureFleetExcluded(provisioned.path, signal);
+			await this.sweepRunEnvFiles(provisioned.path);
+			await ensureFleetExcluded(provisioned.path, signal, runEnvFilePathsFor(spec, mount.mountDir));
 			const linkPath = await linkMountIntoPrimary(mountsDir, mount.mountDir, provisioned.path);
 			if (mount.writable) {
 				await assertMountWritableThroughLink(mount.mountDir, mount.repositoryId, linkPath, provisioned.path);
@@ -534,8 +567,157 @@ export class FleetTaskWorkspaceProvisioner {
 			mounts.push({ ...provisioned, mountDir: mount.mountDir, linkPath, writable: mount.writable });
 		}
 		throwIfCancelled(signal);
-		await ensureFleetExcluded(primary.path, signal);
+		await ensureFleetExcluded(primary.path, signal, primaryEnvPaths);
 		return { ...primary, mounts };
+	}
+
+	/**
+	 * Run secrets (slice Y) — write the run's decrypted env files into the
+	 * checkouts they belong to, owner-only.
+	 *
+	 * Called by the executor AFTER provisioning (so the exclude rules are
+	 * already in place) and BEFORE the model step. Throws on the first
+	 * failure, after removing whatever already landed: a run that starts
+	 * with part of its environment reports a red suite that looks like a
+	 * code problem, which is the exact failure this feature removes.
+	 *
+	 * The `files` argument is the ONLY place in this class where a secret
+	 * VALUE appears. It is not stored on the provisioner, not put on the
+	 * descriptor, and not logged — only the count is.
+	 */
+	async writeRunEnvFiles(
+		taskId: string,
+		descriptor: FleetTaskWorkspaceDescriptor,
+		files: ReadonlyArray<RunEnvFileWrite & { mountDir?: string }>
+	): Promise<number> {
+		validateTaskId(taskId);
+		if (files.length === 0) return 0;
+		const byTarget = new Map<string | undefined, RunEnvFileWrite[]>();
+		for (const file of files) {
+			const key = file.mountDir ?? undefined;
+			const bucket = byTarget.get(key) ?? [];
+			bucket.push({ path: file.path, content: file.content });
+			byTarget.set(key, bucket);
+		}
+		let written = 0;
+		const done: Array<{ path: string; gitDir: string | null; paths: string[] }> = [];
+		try {
+			for (const [mountDir, bucket] of byTarget) {
+				const target = this.resolveEnvTarget(descriptor, mountDir);
+				if (!target) {
+					throw new FleetTaskWorkspaceError(
+						'invalid-spec',
+						`Run env files name mount '${mountDir}', which this workspace did not provision`
+					);
+				}
+				const canonical = await this.canonicalInsideRoot(target.path);
+				if (!canonical) {
+					throw new FleetTaskWorkspaceError(
+						'provision-failed',
+						'Run env files cannot be written: the checkout is no longer inside the fleet root'
+					);
+				}
+				const gitDir = await resolvePrivateGitDir(canonical);
+				// Remembered BEFORE the write, and by the paths that were
+				// ASKED for rather than the ones that landed: a write that
+				// throws half way rolls its own partial set back, but a crash
+				// between the two must still leave this process able to name
+				// every file it may have created.
+				const key = normalizedLeaseKey(canonical);
+				this.rememberRunEnvPaths(
+					key,
+					bucket.map((file) => file.path)
+				);
+				written += (await writeRunEnvFiles(canonical, gitDir, bucket)).length;
+				done.push({ path: canonical, gitDir, paths: bucket.map((file) => file.path) });
+			}
+		} catch (error) {
+			// All-or-nothing across repositories too, not only within one.
+			for (const entry of done) {
+				await removeRunEnvFiles(entry.path, entry.gitDir, entry.paths).catch(() => undefined);
+				this.runEnvPaths.delete(normalizedLeaseKey(entry.path));
+			}
+			throw error;
+		}
+		return written;
+	}
+
+	/** Union this process's record of what it wrote into one checkout. */
+	private rememberRunEnvPaths(key: string, paths: readonly string[]): void {
+		const known = this.runEnvPaths.get(key) ?? [];
+		const seen = new Set(known);
+		for (const path of paths) {
+			if (seen.has(path)) continue;
+			seen.add(path);
+			known.push(path);
+		}
+		this.runEnvPaths.set(key, known);
+	}
+
+	/**
+	 * Run secrets (slice Y) — delete every env file this run was given,
+	 * from the primary worktree and every mount.
+	 *
+	 * NEVER throws and never decides a verdict: it runs on the executor's
+	 * `finally`, which covers success, failure, a thrown model step and an
+	 * abort (an operator cancel and a lapsed lease both arrive as one), and
+	 * a cleanup error must not turn a finished run into a failed one.
+	 * `release()` calls it as well, so a caller that wires only the release
+	 * seam still gets the deletion.
+	 */
+	async removeRunEnvFiles(descriptor: FleetTaskWorkspaceDescriptor): Promise<number> {
+		let removed = 0;
+		const targets: Array<{ path: string }> = [descriptor, ...(descriptor?.mounts ?? [])];
+		for (const target of targets) {
+			if (!target || typeof target.path !== 'string') continue;
+			try {
+				const canonical = await this.canonicalInsideRoot(target.path);
+				if (!canonical) continue;
+				const key = normalizedLeaseKey(canonical);
+				const gitDir = this.leases.get(key)?.gitDir ?? (await resolvePrivateGitDir(canonical));
+				// This process's own record LEADS; the manifest is the
+				// cross-process half and may legitimately be absent.
+				removed += (await removeRunEnvFiles(canonical, gitDir, this.runEnvPaths.get(key) ?? [])).length;
+				this.runEnvPaths.delete(key);
+			} catch {
+				// Best-effort by contract: what survives here is covered by the
+				// Git exclude rule and swept at the next provision.
+			}
+		}
+		return removed;
+	}
+
+	/** The descriptor entry a `mountDir` names, or the primary when it is absent. */
+	private resolveEnvTarget(
+		descriptor: FleetTaskWorkspaceDescriptor,
+		mountDir: string | undefined
+	): { path: string } | null {
+		if (!mountDir) return descriptor;
+		const wanted = mountDir.toLowerCase();
+		return (descriptor.mounts ?? []).find((mount) => mount.mountDir.toLowerCase() === wanted) ?? null;
+	}
+
+	/** Canonical path when it is a strict descendant of the fleet root; null otherwise. */
+	private async canonicalInsideRoot(path: string): Promise<string | null> {
+		try {
+			const canonicalRoot = await fs.realpath(this.rootPath);
+			const canonical = await fs.realpath(path);
+			return isStrictDescendant(canonicalRoot, canonical) ? canonical : null;
+		} catch {
+			return null;
+		}
+	}
+
+	/** Provision-time sweep of whatever a previous run left in one checkout. Never throws. */
+	private async sweepRunEnvFiles(path: string): Promise<void> {
+		try {
+			const canonical = await this.canonicalInsideRoot(path);
+			if (!canonical) return;
+			await sweepStaleRunEnvFiles(canonical, await resolvePrivateGitDir(canonical));
+		} catch {
+			// A sweep that cannot run leaves the previous run's files behind;
+			// they stay Git-excluded and are overwritten by this run's write.
+		}
 	}
 
 	/**
@@ -567,6 +749,17 @@ export class FleetTaskWorkspaceProvisioner {
 			const held = this.leases.get(key);
 			const gitDir = held?.gitDir ?? (await resolvePrivateGitDir(canonicalPath));
 			this.leases.delete(key);
+			// Run secrets (slice Y): the run is over — however it ended — so
+			// the decrypted `.env` files it was given come off the disk here
+			// too, not only through the executor's own cleanup. Belt AND
+			// braces on purpose: this is the seam every caller wires, and a
+			// secret left behind is worse than a lease left behind.
+			try {
+				await removeRunEnvFiles(canonicalPath, gitDir, this.runEnvPaths.get(key) ?? []);
+			} catch {
+				// Best-effort, exactly like the lease drop below.
+			}
+			this.runEnvPaths.delete(key);
 			if (!gitDir) continue;
 			try {
 				await releaseWorkspaceLease(gitDir, process.pid, 'job');
@@ -976,14 +1169,46 @@ function validateWorkspaceSpec(raw: FleetTaskWorkspaceSpec): FleetTaskWorkspaceS
 	} catch (error) {
 		throw new FleetTaskWorkspaceError('invalid-spec', error instanceof Error ? error.message : String(error));
 	}
+	// Run secrets (self-build slice Y). Re-validated with the node's own
+	// gate, exactly like the mounts and the URL: the platform normalized
+	// these too, but this machine is where they become filesystem paths.
+	let envFilesRef: FleetRunEnvFileRef[];
+	try {
+		envFilesRef = normalizeFleetRunEnvFileRefs(raw.envFilesRef);
+	} catch (error) {
+		throw new FleetTaskWorkspaceError('invalid-spec', error instanceof Error ? error.message : String(error));
+	}
+	// A reference for a mount this spec does not carry cannot be honoured,
+	// and silently dropping it would start the run with a partial
+	// environment — the failure the whole feature exists to remove.
+	const mountDirs = new Set(mounts.map((mount) => mount.mountDir.toLowerCase()));
+	for (const ref of envFilesRef) {
+		if (ref.mountDir && !mountDirs.has(ref.mountDir.toLowerCase())) {
+			throw new FleetTaskWorkspaceError(
+				'invalid-spec',
+				`Fleet workspace envFilesRef names mount '${ref.mountDir}', which this workspace does not provision`
+			);
+		}
+	}
 	return {
 		repositoryId,
 		repoUrl,
 		baseRef,
 		branch,
 		...(depth === undefined ? {} : { depth }),
-		...(mounts.length > 0 ? { mounts } : {})
+		...(mounts.length > 0 ? { mounts } : {}),
+		...(envFilesRef.length > 0 ? { envFilesRef } : {})
 	};
+}
+
+/** Env-file paths this spec delivers into one checkout (primary when `mountDir` is undefined). */
+function runEnvFilePathsFor(spec: FleetTaskWorkspaceSpec, mountDir?: string): string[] {
+	const wanted = mountDir?.toLowerCase();
+	for (const ref of spec.envFilesRef ?? []) {
+		const target = ref.mountDir?.toLowerCase();
+		if (target === wanted) return [...ref.paths];
+	}
+	return [];
 }
 
 function validateRemoteUrl(raw: string): string {
@@ -1606,7 +1831,49 @@ async function assertMountWritableThroughLink(
  * workspace and for every mount, because the owner-question file
  * (slice Q) can appear in any of them.
  */
-async function ensureFleetExcluded(repoPath: string, signal?: AbortSignal): Promise<void> {
+/**
+ * Env-file paths as Git wants to read them: forward slashes, no leading
+ * or trailing slash, de-duplicated, and only paths that already passed
+ * the contracts normalizer (so nothing shell- or pattern-special reaches
+ * `git check-ignore`). Order is preserved so the rules and the probes
+ * line up one-to-one.
+ */
+function normalizeRunEnvExcludePaths(paths: readonly string[]): string[] {
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const raw of paths) {
+		if (typeof raw !== 'string') continue;
+		const path = raw.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+		if (!path) continue;
+		const key = process.platform === 'win32' ? path.toLowerCase() : path;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(path);
+	}
+	return out;
+}
+
+async function ensureFleetExcluded(
+	repoPath: string,
+	signal?: AbortSignal,
+	/**
+	 * Run secrets (self-build slice Y): the env-file paths delivered into
+	 * THIS repository, repository-relative (`apps/api/.env`).
+	 *
+	 * Dynamic and per-repository, so they cannot live in the static rule
+	 * list above. Each becomes an ANCHORED rule (`/apps/api/.env`) — the
+	 * file this run was given, not a same-named file the owner keeps
+	 * elsewhere in the tree — and its probe is NOT slash-terminated,
+	 * because a `dir/` pattern matches directories only and Git would then
+	 * report the rule ineffective for a plain file. That is the mirror
+	 * image of the incident recorded on the rule list above, and the
+	 * reason the probes are built here rather than reused from it.
+	 *
+	 * Written BEFORE any content lands, so there is no window in which a
+	 * concurrent finalize could stage a delivered `.env`.
+	 */
+	extraFilePaths: readonly string[] = []
+): Promise<void> {
 	let commonDir: string;
 	try {
 		commonDir = (await runGitOutput(['rev-parse', '--git-common-dir'], repoPath, signal)).trim();
@@ -1623,7 +1890,9 @@ async function ensureFleetExcluded(repoPath: string, signal?: AbortSignal): Prom
 		current = '';
 	}
 	const lines = current.split(/\r?\n/).map((line) => line.trim());
-	const missing = FLEET_TASK_WORKSPACE_EXCLUDE_RULES.filter((rule) => !lines.includes(rule));
+	const extraProbes = normalizeRunEnvExcludePaths(extraFilePaths);
+	const wantedRules = [...FLEET_TASK_WORKSPACE_EXCLUDE_RULES, ...extraProbes.map((path) => `/${path}`)];
+	const missing = wantedRules.filter((rule) => !lines.includes(rule));
 	if (missing.length > 0) {
 		await fs.mkdir(dirname(excludePath), { recursive: true });
 		const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n';
@@ -1647,7 +1916,7 @@ async function ensureFleetExcluded(repoPath: string, signal?: AbortSignal): Prom
 	// evaluates a slash-terminated pathname as a directory even before it
 	// exists — `.ever-works` never exists at provision time and `.mounts`
 	// only in a multi-repo workspace.
-	for (const probe of FLEET_TASK_WORKSPACE_EXCLUDE_PROBES) {
+	for (const probe of [...FLEET_TASK_WORKSPACE_EXCLUDE_PROBES, ...extraProbes]) {
 		// A probe path that exists as a LINK or a FILE cannot be verified this
 		// way, and does not need to be.
 		//

--- a/apps/node/src/core/workspaces/run-env-files.spec.ts
+++ b/apps/node/src/core/workspaces/run-env-files.spec.ts
@@ -1,0 +1,224 @@
+import { promises as fs } from 'node:fs';
+import { mkdtemp, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	RunEnvFileError,
+	extractRunEnvSecretValues,
+	removeRunEnvFiles,
+	resolveRunEnvFilePath,
+	runEnvFilesManifestPath,
+	sweepStaleRunEnvFiles,
+	writeRunEnvFiles
+} from './run-env-files';
+
+/**
+ * Run secrets on disk (self-build slice Y, EW-781).
+ *
+ * Real files in a real temp directory: the whole point of this module is
+ * what it does to a filesystem, and a mocked `fs` would prove nothing
+ * about permissions, symlinks or traversal.
+ *
+ * The POSIX mode assertion is skipped on Windows deliberately, not
+ * forgotten: `fs.chmod` there only toggles the read-only bit, so a
+ * mode-bits check would PASS while the file stayed readable by every
+ * other local account. The Windows half is an explicit ACL
+ * (`restrictFileToOwnerWindows`), which `icacls` owns and this suite
+ * cannot meaningfully assert without shelling out to it.
+ */
+
+const SENTINEL = 'sentinel-a7f3-DATABASE_URL=postgres://u:p@db/app';
+const isPosix = process.platform !== 'win32';
+
+describe('run env files on disk', () => {
+	let root: string;
+	let worktree: string;
+	let gitDir: string;
+
+	beforeEach(async () => {
+		root = await realpath(await mkdtemp(join(tmpdir(), 'ew-run-env-')));
+		worktree = join(root, 'checkout');
+		gitDir = join(root, 'gitdir');
+		await fs.mkdir(worktree, { recursive: true });
+		await fs.mkdir(gitDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
+	});
+
+	it('writes owner-only, inside the checkout, creating parents', async () => {
+		const written = await writeRunEnvFiles(worktree, gitDir, [{ path: 'apps/api/.env', content: SENTINEL }]);
+		expect(written).toEqual(['apps/api/.env']);
+		const target = join(worktree, 'apps', 'api', '.env');
+		expect(await fs.readFile(target, 'utf8')).toBe(SENTINEL);
+		if (isPosix) {
+			expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+		}
+	});
+
+	it('keeps the manifest OUTSIDE the checkout, so `git add -A` can never stage it', async () => {
+		await writeRunEnvFiles(worktree, gitDir, [{ path: '.env', content: SENTINEL }]);
+		const manifest = runEnvFilesManifestPath(gitDir);
+		expect(manifest.startsWith(worktree)).toBe(false);
+		const parsed = JSON.parse(await fs.readFile(manifest, 'utf8')) as { paths: string[] };
+		expect(parsed.paths).toEqual(['.env']);
+		// PATHS only — a content digest here would be a length oracle.
+		expect(await fs.readFile(manifest, 'utf8')).not.toContain(SENTINEL);
+	});
+
+	it('refuses to write THROUGH a symlink planted at the target', async () => {
+		const outside = join(root, 'stolen.env');
+		await fs.writeFile(outside, 'not-yet');
+		try {
+			await fs.symlink(outside, join(worktree, '.env'));
+		} catch {
+			// Unprivileged Windows cannot create symlinks; the refusal it
+			// guards is unreachable there, so there is nothing to assert.
+			return;
+		}
+		await expect(writeRunEnvFiles(worktree, gitDir, [{ path: '.env', content: SENTINEL }])).rejects.toBeInstanceOf(
+			RunEnvFileError
+		);
+		expect(await fs.readFile(outside, 'utf8')).toBe('not-yet');
+	});
+
+	it('refuses a directory sitting where the file should go', async () => {
+		await fs.mkdir(join(worktree, '.env'));
+		await expect(writeRunEnvFiles(worktree, gitDir, [{ path: '.env', content: SENTINEL }])).rejects.toBeInstanceOf(
+			RunEnvFileError
+		);
+	});
+
+	it.each(['../escape.env', '/etc/passwd', 'a/../../b.env', 'apps/./.env'])(
+		'refuses the traversing path %s',
+		async (path) => {
+			expect(() => resolveRunEnvFilePath(worktree, path)).toThrow(RunEnvFileError);
+			await expect(writeRunEnvFiles(worktree, gitDir, [{ path, content: SENTINEL }])).rejects.toBeInstanceOf(
+				RunEnvFileError
+			);
+		}
+	);
+
+	it('leaves NOTHING behind when one file of a set fails — no partial environment', async () => {
+		await expect(
+			writeRunEnvFiles(worktree, gitDir, [
+				{ path: 'apps/api/.env', content: SENTINEL },
+				{ path: '../escape.env', content: SENTINEL }
+			])
+		).rejects.toBeInstanceOf(RunEnvFileError);
+		await expect(fs.stat(join(worktree, 'apps', 'api', '.env'))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+		await expect(fs.stat(runEnvFilesManifestPath(gitDir))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+	});
+
+	it('removes every written file and the manifest', async () => {
+		await writeRunEnvFiles(worktree, gitDir, [
+			{ path: '.env', content: SENTINEL },
+			{ path: 'apps/api/.env', content: SENTINEL }
+		]);
+		expect(await removeRunEnvFiles(worktree, gitDir)).toEqual(['.env', 'apps/api/.env']);
+		await expect(fs.stat(join(worktree, '.env'))).rejects.toMatchObject({ code: 'ENOENT' });
+		await expect(fs.stat(join(worktree, 'apps', 'api', '.env'))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+		await expect(fs.stat(runEnvFilesManifestPath(gitDir))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+	});
+
+	it('never throws on removal, however broken the state', async () => {
+		await expect(removeRunEnvFiles(worktree, gitDir)).resolves.toEqual([]);
+		await expect(removeRunEnvFiles(worktree, null)).resolves.toEqual([]);
+		await fs.writeFile(runEnvFilesManifestPath(gitDir), 'not json');
+		await expect(removeRunEnvFiles(worktree, gitDir)).resolves.toEqual([]);
+		await fs.rm(worktree, { recursive: true, force: true });
+		await expect(removeRunEnvFiles(worktree, gitDir)).resolves.toEqual([]);
+	});
+
+	it('sweeps what a HARD-KILLED previous run left, by its own manifest', async () => {
+		// Simulates SIGKILL: the files and the manifest survive, no cleanup
+		// ran. The next provision must not hand this run the previous one's
+		// secrets — including for a repository that no longer grants them.
+		await writeRunEnvFiles(worktree, gitDir, [{ path: 'apps/api/.env', content: SENTINEL }]);
+		expect(await sweepStaleRunEnvFiles(worktree, gitDir)).toEqual(['apps/api/.env']);
+		await expect(fs.stat(join(worktree, 'apps', 'api', '.env'))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+	});
+
+	it('deletes what the WRITER remembers even when there is no manifest at all', async () => {
+		// `resolvePrivateGitDir` returns null for a checkout whose `.git` is a
+		// directory rather than a worktree file, and for ANY transient failure
+		// of the `git rev-parse` it shells out to (an index lock, EMFILE under
+		// load). Deleting by the manifest alone would then leave a decrypted
+		// `.env` on disk forever — and the provision-time sweep, which also
+		// reads the manifest, would not find it either.
+		const written = await writeRunEnvFiles(worktree, null, [{ path: 'apps/api/.env', content: SENTINEL }]);
+		expect(written).toEqual(['apps/api/.env']);
+		expect(await removeRunEnvFiles(worktree, null, written)).toEqual(['apps/api/.env']);
+		await expect(fs.stat(join(worktree, 'apps', 'api', '.env'))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+	});
+
+	it('deletes what the WRITER remembers when the manifest write was lost', async () => {
+		await writeRunEnvFiles(worktree, gitDir, [{ path: '.env', content: SENTINEL }]);
+		// A swallowed manifest failure looks exactly like this from here.
+		await fs.rm(runEnvFilesManifestPath(gitDir), { force: true });
+		expect(await removeRunEnvFiles(worktree, gitDir, ['.env'])).toEqual(['.env']);
+		await expect(fs.stat(join(worktree, '.env'))).rejects.toMatchObject({ code: 'ENOENT' });
+	});
+
+	it('unions the writer record with the manifest, and visits each path once', async () => {
+		await writeRunEnvFiles(worktree, gitDir, [
+			{ path: '.env', content: SENTINEL },
+			{ path: 'apps/api/.env', content: SENTINEL }
+		]);
+		// `.env` is in BOTH lists and must not be visited twice; the manifest
+		// still contributes `apps/api/.env`, which the caller did not name.
+		const removed = await removeRunEnvFiles(worktree, gitDir, ['.env', 'web/.env.local']);
+		expect(removed.filter((path) => path === '.env')).toHaveLength(1);
+		expect(removed).toContain('apps/api/.env');
+		await expect(fs.stat(join(worktree, '.env'))).rejects.toMatchObject({ code: 'ENOENT' });
+		await expect(fs.stat(join(worktree, 'apps', 'api', '.env'))).rejects.toMatchObject({
+			code: 'ENOENT'
+		});
+	});
+
+	it('extracts the VALUES of a delivered env file, and only real ones', () => {
+		const values = extractRunEnvSecretValues(
+			[
+				'# a comment',
+				'',
+				'DATABASE_URL=postgres://user:hunter2@db:5432/app',
+				"export GH_TOKEN='ghp_0123456789abcdef'",
+				'QUOTED="a-long-enough-value"',
+				'SHORT=abc',
+				'not a env line',
+				'=novalue'
+			].join('\n')
+		);
+		expect(values).toContain('postgres://user:hunter2@db:5432/app');
+		expect(values).toContain('ghp_0123456789abcdef');
+		expect(values).toContain('a-long-enough-value');
+		// Under the 8-character floor: scrubbing it would redact prose.
+		expect(values).not.toContain('abc');
+		expect(values.some((value) => value.includes('novalue'))).toBe(false);
+		// Longest first, so `scrub` replaces a containing value whole.
+		expect([...values]).toEqual([...values].sort((a, b) => b.length - a.length));
+	});
+
+	it('overwrites a leftover regular file rather than refusing the run', async () => {
+		await fs.writeFile(join(worktree, '.env'), 'stale=1');
+		await writeRunEnvFiles(worktree, gitDir, [{ path: '.env', content: SENTINEL }]);
+		expect(await fs.readFile(join(worktree, '.env'), 'utf8')).toBe(SENTINEL);
+		if (isPosix) {
+			expect((await fs.stat(join(worktree, '.env'))).mode & 0o777).toBe(0o600);
+		}
+	});
+});

--- a/apps/node/src/core/workspaces/run-env-files.ts
+++ b/apps/node/src/core/workspaces/run-env-files.ts
@@ -1,0 +1,292 @@
+import { constants as fsConstants, promises as fs } from 'fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { isValidFleetRunEnvFilePath } from '@ever-works/contracts';
+import { restrictFileToOwnerWindows } from '../../node-io';
+
+/**
+ * Run secrets on disk (self-build slice Y, EW-781).
+ *
+ * The seed `.env` files a run's repositories declared, written into the
+ * checkout the model works in, and removed again when the run ends —
+ * however it ends.
+ *
+ * ## What this module guarantees, and what it deliberately does not
+ *
+ * GUARANTEED:
+ *   - every file lands strictly inside the checkout it belongs to (the
+ *     path is resolved against the CANONICAL worktree and re-checked);
+ *   - nothing is ever written THROUGH a symlink — a link planted at
+ *     `.env` by a previous run or by anything else sharing the service
+ *     account is refused, not followed;
+ *   - the file is owner-only: `0600` on POSIX, and on Windows an explicit
+ *     ACL as well, because `fs.chmod` there only toggles the read-only
+ *     bit and a mode-bits assertion would pass while the file stayed
+ *     readable by every other local account;
+ *   - a MANIFEST of what was written is kept beside the workspace lease
+ *     in the worktree's PRIVATE gitdir — outside the checkout, so it can
+ *     never be committed — which is what lets a later run sweep files a
+ *     hard kill left behind.
+ *
+ * NOT GUARANTEED: survival of `SIGKILL` or a power cut. The executor's
+ * `finally` covers success, failure, a thrown model step and an abort
+ * (cancel, lapsed lease); a killed process runs no cleanup at all. That
+ * is what the provision-time sweep and the Git exclude rules are for, and
+ * the docs say so rather than claiming an absolute.
+ */
+
+/** One file to place, already decrypted. Lives for one write and is dropped. */
+export interface RunEnvFileWrite {
+	/** Repository-relative path, e.g. `apps/api/.env`. */
+	readonly path: string;
+	readonly content: string;
+}
+
+/** Name of the manifest written beside the workspace lease in the private gitdir. */
+export const RUN_ENV_FILES_MANIFEST = 'ever-works-run-env.json';
+
+interface RunEnvFilesManifest {
+	version: 1;
+	/** Repository-relative paths this process wrote. NEVER contents. */
+	paths: string[];
+	writtenAt: string;
+}
+
+export class RunEnvFileError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'RunEnvFileError';
+	}
+}
+
+/** Absolute path of the manifest for a worktree whose private gitdir is `gitDir`. */
+export function runEnvFilesManifestPath(gitDir: string): string {
+	return join(gitDir, RUN_ENV_FILES_MANIFEST);
+}
+
+/**
+ * Resolve one repository-relative env-file path against a CANONICAL
+ * worktree root, refusing anything that would land outside it.
+ *
+ * The contracts normalizer already rejected traversal and absolute forms
+ * on the wire; this is the last gate, on the machine, against the value
+ * that is about to become a real filesystem path.
+ */
+export function resolveRunEnvFilePath(canonicalWorktree: string, path: string): string {
+	if (!isValidFleetRunEnvFilePath(path)) {
+		throw new RunEnvFileError(`Run env file path '${path}' is not repository-relative`);
+	}
+	const target = resolve(canonicalWorktree, path);
+	const child = relative(canonicalWorktree, target);
+	if (child === '' || child.split(/[\\/]/)[0] === '..' || isAbsolute(child)) {
+		throw new RunEnvFileError(`Run env file path '${path}' resolves outside the checkout`);
+	}
+	return target;
+}
+
+/**
+ * Write the run's env files into one checkout, owner-only, and record
+ * what was written in the private gitdir.
+ *
+ * `worktreePath` must already be the canonical path (the provisioner
+ * realpath's it before calling). Any failure throws: a run that starts
+ * with SOME of its environment is the failure this feature exists to
+ * remove, so a half-written set is cleaned up and refused rather than
+ * used.
+ */
+export async function writeRunEnvFiles(
+	canonicalWorktree: string,
+	gitDir: string | null,
+	files: readonly RunEnvFileWrite[]
+): Promise<string[]> {
+	const written: string[] = [];
+	try {
+		for (const file of files) {
+			const target = resolveRunEnvFilePath(canonicalWorktree, file.path);
+			// Never write through a link. A previous run — or anything else
+			// sharing this service account — can pre-place one at `.env` and
+			// have the secret land wherever it points. Same posture the
+			// mounts directory already takes: refuse, do not repair.
+			const existing = await fs.lstat(target).catch(() => null);
+			if (existing?.isSymbolicLink()) {
+				throw new RunEnvFileError(
+					`Refusing to write run env file '${file.path}': a symbolic link is already at that path`
+				);
+			}
+			if (existing && !existing.isFile()) {
+				throw new RunEnvFileError(
+					`Refusing to write run env file '${file.path}': something that is not a regular file is at that path`
+				);
+			}
+			await fs.mkdir(dirname(target), { recursive: true, mode: 0o700 });
+			// O_TRUNC rather than `wx`: the file legitimately exists when a
+			// previous run in this reused worktree was killed before cleanup.
+			// The lstat above is what makes overwriting it safe.
+			await fs.writeFile(target, file.content, {
+				encoding: 'utf8',
+				mode: 0o600,
+				flag: fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC
+			});
+			if (process.platform === 'win32') {
+				// Windows has no mode bits: without this the file inherits the
+				// directory ACL and a 0600 assertion would be a lie.
+				restrictFileToOwnerWindows(target);
+			} else {
+				// `mode` is masked by the umask on create, and the file may have
+				// pre-existed with wider bits. Set them explicitly.
+				await fs.chmod(target, 0o600);
+			}
+			written.push(file.path);
+		}
+	} catch (error) {
+		// Fail closed: remove whatever landed before the failure so the run
+		// cannot proceed on a partial environment, then re-throw.
+		await removeRunEnvFilePaths(canonicalWorktree, written);
+		throw error;
+	}
+	if (gitDir && written.length > 0) {
+		await writeManifest(gitDir, written);
+	}
+	return written;
+}
+
+/**
+ * Delete the run's env files from one checkout and drop the manifest.
+ *
+ * NEVER throws: cleanup runs on every exit path, including one that is
+ * already reporting a failure, and a cleanup error must not become the
+ * verdict. Returns the paths it removed so a caller can log a count.
+ *
+ * `knownPaths` is what the WRITER still remembers, and it is the primary
+ * source — the manifest is only the cross-process half. The manifest is
+ * best-effort by design (it is skipped entirely when the worktree has no
+ * private gitdir, and its write failure is swallowed), so a deletion that
+ * consulted it alone would silently leave a decrypted `.env` on disk
+ * forever in exactly the cases where something had already gone wrong.
+ */
+export async function removeRunEnvFiles(
+	canonicalWorktree: string,
+	gitDir: string | null,
+	knownPaths: readonly string[] = []
+): Promise<string[]> {
+	const paths = new Set<string>(knownPaths.filter((path): path is string => typeof path === 'string'));
+	if (gitDir) {
+		for (const path of await readManifestPaths(gitDir)) paths.add(path);
+	}
+	const removed = await removeRunEnvFilePaths(canonicalWorktree, [...paths]);
+	if (gitDir) {
+		await fs.rm(runEnvFilesManifestPath(gitDir), { force: true }).catch(() => undefined);
+	}
+	return removed;
+}
+
+/**
+ * Provision-time sweep: whatever a PREVIOUS run left in this worktree.
+ *
+ * The one exit path the executor's `finally` cannot cover is a hard kill,
+ * and a reused worktree would otherwise carry that run's `.env` into the
+ * next one — including into a run for a repository that no longer grants
+ * it. Reads the manifest, so it removes exactly what was written even if
+ * the repository's file list has changed since.
+ */
+export async function sweepStaleRunEnvFiles(canonicalWorktree: string, gitDir: string | null): Promise<string[]> {
+	return removeRunEnvFiles(canonicalWorktree, gitDir);
+}
+
+/** Best-effort deletion of specific paths. Never throws. */
+async function removeRunEnvFilePaths(canonicalWorktree: string, paths: readonly string[]): Promise<string[]> {
+	const removed: string[] = [];
+	for (const path of paths) {
+		let target: string;
+		try {
+			target = resolveRunEnvFilePath(canonicalWorktree, path);
+		} catch {
+			// A manifest entry that no longer resolves inside the checkout is
+			// not ours to delete.
+			continue;
+		}
+		try {
+			await fs.rm(target, { force: true });
+			removed.push(path);
+		} catch {
+			// Best-effort by contract. A file that survives here is covered by
+			// the Git exclude rule and swept on the next provision.
+		}
+	}
+	return removed;
+}
+
+/**
+ * The manifest lives in the worktree's PRIVATE gitdir, next to the
+ * workspace lease — never in the checkout, so `git add -A` cannot see it
+ * and no exclude rule has to cover it. Paths only; writing a content
+ * digest here would be a length oracle for a secret.
+ */
+async function writeManifest(gitDir: string, paths: readonly string[]): Promise<void> {
+	const manifest: RunEnvFilesManifest = {
+		version: 1,
+		paths: [...paths],
+		writtenAt: new Date().toISOString()
+	};
+	const target = runEnvFilesManifestPath(gitDir);
+	try {
+		await fs.writeFile(target, `${JSON.stringify(manifest)}\n`, { encoding: 'utf8', mode: 0o600 });
+	} catch {
+		// The manifest is a cleanup AID, not the cleanup itself: the run's
+		// own `finally` deletes by the list it holds in memory. Losing it
+		// costs a sweep on the next provision, never a delivered secret.
+	}
+}
+
+async function readManifestPaths(gitDir: string): Promise<string[]> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(runEnvFilesManifestPath(gitDir), 'utf8');
+	} catch {
+		return [];
+	}
+	try {
+		const parsed = JSON.parse(raw) as Partial<RunEnvFilesManifest>;
+		if (!Array.isArray(parsed.paths)) return [];
+		return parsed.paths.filter((path): path is string => typeof path === 'string');
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * The secret VALUES inside one delivered env file, for the redactor.
+ *
+ * A `.env` is `KEY=VALUE` lines, and it is the VALUES — not the file as a
+ * whole — that a failing `pnpm test` prints into its log tail and that a
+ * model echoes into its summary. Registering the whole blob (which is what
+ * `logger.protect` gets handed) only ever matches if the entire file is
+ * reproduced verbatim, which is not how a connection string leaks.
+ *
+ * Deliberately conservative: `export ` prefixes and matching quotes are
+ * stripped, `${...}` interpolations are left alone (they are not the
+ * value), and anything under 8 characters is dropped, because scrubbing a
+ * short value would redact ordinary prose out of every log the node
+ * reports. Same floor the node's own logger and
+ * `collectProtectedValues` already use.
+ */
+export function extractRunEnvSecretValues(content: string): string[] {
+	if (typeof content !== 'string' || content.length === 0) return [];
+	const values = new Set<string>();
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith('#')) continue;
+		const separator = line.indexOf('=');
+		if (separator <= 0) continue;
+		const name = line
+			.slice(0, separator)
+			.replace(/^export\s+/, '')
+			.trim();
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
+		let value = line.slice(separator + 1).trim();
+		if (value.length >= 2 && (value[0] === '"' || value[0] === "'") && value.at(-1) === value[0]) {
+			value = value.slice(1, -1);
+		}
+		if (value.trim().length >= 8) values.add(value);
+	}
+	return [...values].sort((a, b) => b.length - a.length);
+}

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -292,6 +292,78 @@ directory is excluded from the primary repository's Git, so nothing about the la
 A repository the platform cannot describe (a URL that is not `owner/repository`, a default branch it
 cannot read) fails the plan naming the attachment rather than silently running without it.
 
+### Giving a repository its environment
+
+Most real work needs configuration the repository does not carry: a database URL for the API suite, a
+`GH_TOKEN` for `gh`, an S3 bucket for an upload test. A fleet node deliberately runs every command in
+a **built-from-scratch environment** — an allowlist of toolchain and locale names, nothing inherited —
+so by default none of that is there. Two knobs fill the gap, and they are different in kind.
+
+**Seed `.env` files.** Settings → Repositories → _(a repository)_ → Env files stores files by
+repository-relative path (`.env`, `apps/api/.env`, at most 8, 32 KB each). They are
+envelope-encrypted at rest and only ever decrypted for you. When a run is planned, the fleet job
+records **which repository's files are needed and at which paths** — never their contents. The node
+then fetches the decrypted content over the same credential-verified channel it uses to lease,
+heartbeat and complete, and only while it still holds the lease on that job. On disk the files are:
+
+- written **owner-only** (`0600` on macOS/Linux; an explicit ACL on Windows, where mode bits are not
+  a real permission) inside the checkout, at the path the repository declared;
+- **excluded from Git**, the same way `.mounts/` and `.ever-works/` are, before any content is
+  written — so a concurrent `git add -A` in another Task cannot stage one;
+- **deleted before the run's first Git command**, and again when the run ends, however it ends:
+  success, failure, a crash in the model step, an operator cancel, a lease that lapsed while the
+  machine slept. The early deletion matters because the Git exclusion above is written to
+  `info/exclude`, which is the lowest-precedence ignore source Git has — a `.gitignore` the model
+  wrote would override it — so the files are simply gone by the time anything is committed or
+  pushed. The one case cleanup cannot cover is the machine being killed outright (power loss,
+  `SIGKILL`); those files stay Git-excluded and are swept before the next run reuses that checkout.
+
+A reference the platform cannot resolve — the repository was deleted or disabled, the path is no
+longer stored, the value cannot be decrypted — **fails the run** with a stable reason instead of
+starting it with half an environment. That is deliberate: a suite that runs without its database
+config goes red in a way that looks like a code problem.
+
+Production note: env files are encrypted with `PLUGIN_SECRET_ENCRYPTION_KEY`. **Set it.** Without it
+the platform stores them in plain text (a development convenience), and this feature now carries them
+to every machine in your fleet.
+
+**Env grants.** Some variables are not files — they are already set on the machine, and the node's
+scrub refuses whole families of names outright (`DATABASE_`, `AWS_`, `S3_`, `REDIS_`, `STRIPE_`,
+`GH_`, `SENTRY_`, `POSTHOG_` …) because they usually belong to the platform, not to the run. A
+repository's **env grants** list opens that refusal for names you bind explicitly.
+
+Read this before you add one:
+
+> Naming a variable in a repository's env grants lets **agent-driven code running on your machines
+> read that variable's value from the node's own environment**. The agent is model-driven and runs
+> with edits accepted; a prompt injection in a Task description, an issue body or a dependency's
+> README reaches whatever you grant. Grant the narrowest name that makes the work possible.
+
+The rules that make that trade survivable:
+
+- A grant is **one exact name**. `DATABASE_URL` admits `DATABASE_URL` and not `DATABASE_URL_REPLICA`,
+  not `DATABASE_HOST`, not `DATABASE_PASSWORD`. There is **no wildcard and no prefix form**, and
+  attempts to save one are refused.
+- Some names can **never** be granted, however explicitly you ask: `FLEET_`, `EVER_WORKS_`,
+  `PLUGIN_`, `AUTH_`, `BETTER_AUTH_` and `PLATFORM_`. Those are the node's own credential, the key
+  that decrypts every tenant's env files, and the platform's session signing — granting them would
+  turn "read one secret" into "become the platform".
+- Grants carry **names only**. The value is read from the machine's own environment and scrubbed out
+  of everything the node reports back, exactly as CLI credentials already are.
+- A run is **one process tree over one workspace**, so grants from every repository of that run are
+  unioned for its duration. Bind a grant to the repository that justifies it and expect the run to
+  see it everywhere.
+- Grants are read when a run is **planned**, so revoking one takes effect on the next run. A run
+  already in flight keeps what it was planned with.
+- Grants are stored in plain text and returned unmasked by the API. That is on purpose: a permission
+  you cannot read, grep or diff is a permission nobody reviews.
+- The instance-wide `FLEET_NODE_AGENT_TASK_ENV_PASSTHROUGH` keeps working exactly as before for
+  everything already relying on it, and still cannot open the platform-owned families. Grants apply
+  to model-CLI runs; the legacy `FLEET_NODE_AGENT_TASK_COMMAND` step lane has no repository context
+  and is unchanged.
+- `FLEET_NODE_RUN_ENV_FILES=false` switches env-file delivery off for the whole instance. A run that
+  needs files then fails closed rather than starting without them.
+
 ### When the agent needs you
 
 The agent on your machine has no platform tools — it cannot message you mid-run. What it can do is
@@ -300,9 +372,10 @@ requirement, a risky or irreversible step, a choice between materially different
 writes `.ever-works/QUESTION.md` in the repository root — the first line (or a `# ` heading) is the
 question, the rest is optional context and options — and stops. The node reports the question and
 removes the file. It is never committed: the `.ever-works/` directory is excluded from Git — at the
-repository root and in any subdirectory — the same way `.mounts/` is, in every repository of the
-workspace, and a stale file from an earlier attempt is discarded before the model starts. Only a
-plain file is read: a link, a directory or a pipe at that path is removed without being opened.
+repository root and in any subdirectory — the same way `.mounts/` and any delivered `.env` file are,
+in every repository of the workspace, and a stale file from an earlier attempt is discarded before
+the model starts. Only a plain file is read: a link, a directory or a pipe at that path is removed
+without being opened.
 
 What happens next:
 

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -345,6 +345,28 @@ describe('agent/config', () => {
             );
         });
 
+        describe('isRunEnvFilesEnabled (run secrets, self-build slice Y)', () => {
+            it('defaults ON — the feature is already opt-in per repository', () => {
+                expect(config.fleetNode.isRunEnvFilesEnabled()).toBe(true);
+            });
+
+            it.each(['false', 'FALSE', '0', ' false '])(
+                'is switched off by %s, so a run that needs env files fails closed',
+                (value) => {
+                    process.env.FLEET_NODE_RUN_ENV_FILES = value;
+                    expect(config.fleetNode.isRunEnvFilesEnabled()).toBe(false);
+                },
+            );
+
+            it.each(['true', '1', '', 'yes'])(
+                'stays ON for %s — only an explicit off switches it off',
+                (value) => {
+                    process.env.FLEET_NODE_RUN_ENV_FILES = value;
+                    expect(config.fleetNode.isRunEnvFilesEnabled()).toBe(true);
+                },
+            );
+        });
+
         describe('getQueuedMaxAgeSeconds (queue SLA, self-build slice S)', () => {
             const KINDS = ['agent-task', 'acceptance-checks', 'browser-check'] as const;
 

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -336,6 +336,26 @@ export const config = {
                 .map((name) => name.trim())
                 .filter((name) => name.length > 0);
         },
+        /**
+         * Run secrets (self-build slice Y) — the instance kill switch on
+         * delivering a repository's seed `.env` files to a fleet node.
+         *
+         * Default ON, because the feature is opt-in per repository already:
+         * a registry row with no env files delivers nothing, and turning
+         * this off is for an operator who wants the whole PATH shut, not
+         * for narrowing one repository.
+         *
+         * Turning it OFF fails a run that NEEDS env files closed, with
+         * `FLEET_RUN_SECRETS_DISABLED_REASON` — it never starts the run
+         * with a partial environment, because "the suite ran and every
+         * database test failed" is a far worse answer than "the run
+         * refused, here is the setting".
+         */
+        isRunEnvFilesEnabled(): boolean {
+            const raw = (process.env.FLEET_NODE_RUN_ENV_FILES || '').trim().toLowerCase();
+            if (raw === 'false' || raw === '0') return false;
+            return true;
+        },
 
         // ── Agent execution v2 — model CLIs on the node ─────────────
         //

--- a/packages/agent/src/entities/repo-connection.entity.ts
+++ b/packages/agent/src/entities/repo-connection.entity.ts
@@ -44,6 +44,13 @@ export type RepoConnectionSourceType = 'manual' | 'work' | 'github-app';
 export const REPO_CONNECTION_ENV_FILE_MAX_COUNT = 8;
 export const REPO_CONNECTION_ENV_FILE_MAX_CONTENT_BYTES = 32 * 1024;
 
+/**
+ * Cap on the `envGrants` list (self-build slice Y). Mirrors the runner's
+ * own `MAX_ENV_PASSTHROUGH`, so a list the registry accepts can never be
+ * silently truncated on the machine that applies it.
+ */
+export const REPO_CONNECTION_ENV_GRANT_MAX_COUNT = 32;
+
 /** A single, traversal-free directory segment. */
 export const REPO_CONNECTION_MOUNT_DIR_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 
@@ -169,6 +176,26 @@ export class RepoConnection {
      */
     @EncryptedJsonColumn({ nullable: true })
     envFiles?: Record<string, string> | null;
+
+    /**
+     * Env var NAMES this repository's runs may read from the RUNNER's own
+     * environment, through the runner's platform-owned refusal (self-build
+     * slice Y). Names only — deliberately NOT encrypted, because a grant is
+     * not a secret and an operator (and an auditor) must be able to read,
+     * grep and diff exactly which variables a repository was allowed.
+     *
+     * `null` / `[]` is the default and reproduces today's behaviour: the
+     * runner refuses every platform-owned name. Each entry is one EXACT
+     * name; there is no wildcard and no prefix form, so granting
+     * `DATABASE_URL` admits `DATABASE_URL` and not `DATABASE_URL_REPLICA`.
+     * Names in the un-grantable core (`FLEET_`, `EVER_WORKS_`, `PLUGIN_`,
+     * `AUTH_`, `BETTER_AUTH_`, `PLATFORM_`) are refused at write time AND
+     * ignored at use time — see `FLEET_RUN_ENV_UNGRANTABLE_PATTERN`.
+     *
+     * Capped at {@link REPO_CONNECTION_ENV_GRANT_MAX_COUNT}.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    envGrants?: string[] | null;
 
     /** When true, the repo is offered everywhere without an explicit attach. */
     @Column({ type: 'boolean', default: true })

--- a/packages/agent/src/fleet/__tests__/fleet-job.run-secrets-auth.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-job.run-secrets-auth.spec.ts
@@ -1,0 +1,152 @@
+import { createHash, randomBytes } from 'crypto';
+import { FleetJob } from '../../entities/fleet-job.entity';
+import { FleetJobService, FleetJobStaleLeaseError } from '../fleet-job.service';
+
+/**
+ * Run secrets (self-build slice Y, EW-781) —
+ * `FleetJobService.authorizeRunSecretRequest`.
+ *
+ * This is the gate in front of the only endpoint that hands a decrypted
+ * `.env` to a machine, so it must prove exactly what `completeJob` proves
+ * and in the same order: the credential verifies, the job's recorded
+ * holder IS this node, the job is still active, and the echoed
+ * `leaseGeneration` is the current one. Anything less would let a node
+ * that merely authenticated — or one whose claim lapsed while it slept —
+ * pull another run's secrets.
+ *
+ * The one deliberate asymmetry with `lease` is the intent: a PAUSED node
+ * is served, because pausing is a drain and a drain has to let in-flight
+ * work finish. It already holds the checkout; refusing its env files
+ * would strand the run rather than end it.
+ */
+
+const NODE_A = '11111111-1111-4111-8111-111111111111';
+const NODE_B = '22222222-2222-4222-8222-222222222222';
+const USER = 'owner-1';
+const sha256Hex = (value: string): string =>
+    createHash('sha256').update(value, 'utf8').digest('hex');
+
+describe('FleetJobService.authorizeRunSecretRequest', () => {
+    const secretA = randomBytes(24).toString('base64url');
+    const secretB = randomBytes(24).toString('base64url');
+    let row: FleetJob & { leaseGeneration: number };
+    let nodeStatus: string;
+    let service: FleetJobService;
+
+    beforeEach(() => {
+        nodeStatus = 'online';
+        row = {
+            id: 'job-1',
+            userId: USER,
+            kind: 'agent-task',
+            status: 'running',
+            nodeId: NODE_A,
+            leaseGeneration: 3,
+        } as unknown as FleetJob & { leaseGeneration: number };
+
+        service = new FleetJobService(
+            { findById: jest.fn(async (id: string) => (id === row.id ? row : null)) } as never,
+            {
+                findById: jest.fn(async (id: string) => {
+                    if (id === NODE_A) {
+                        return {
+                            id: NODE_A,
+                            userId: USER,
+                            status: nodeStatus,
+                            enrollmentTokenHash: sha256Hex(secretA),
+                            capabilities: [],
+                        };
+                    }
+                    if (id === NODE_B) {
+                        return {
+                            id: NODE_B,
+                            userId: 'owner-2',
+                            status: 'online',
+                            enrollmentTokenHash: sha256Hex(secretB),
+                            capabilities: [],
+                        };
+                    }
+                    return null;
+                }),
+            } as never,
+            { findForOwnedAgent: jest.fn(async () => null) } as never,
+            { emit: jest.fn() } as never,
+        );
+    });
+
+    const authorize = (overrides: Record<string, unknown> = {}) =>
+        service.authorizeRunSecretRequest({
+            nodeId: NODE_A,
+            secret: secretA,
+            jobId: 'job-1',
+            leaseGeneration: 3,
+            ...overrides,
+        });
+
+    it('answers with the JOB owner, which is the scope every registry read must use', async () => {
+        await expect(authorize()).resolves.toEqual({
+            jobId: 'job-1',
+            userId: USER,
+            nodeId: NODE_A,
+        });
+    });
+
+    it('serves a node the operator has PAUSED, so a drain finishes its run', async () => {
+        nodeStatus = 'paused';
+        await expect(authorize()).resolves.toMatchObject({ jobId: 'job-1' });
+    });
+
+    it.each([
+        ['an unknown node', { nodeId: '33333333-3333-4333-8333-333333333333' }],
+        ['a wrong secret', { secret: randomBytes(24).toString('base64url') }],
+        ['a malformed node id', { nodeId: 'not-a-uuid' }],
+    ])('refuses %s', async (_label, overrides) => {
+        await expect(authorize(overrides)).resolves.toBeNull();
+    });
+
+    it('refuses a node that is authenticated but is not the recorded holder', async () => {
+        await expect(
+            service.authorizeRunSecretRequest({
+                nodeId: NODE_B,
+                secret: secretB,
+                jobId: 'job-1',
+                leaseGeneration: 3,
+            }),
+        ).resolves.toBeNull();
+    });
+
+    it.each(['done', 'failed', 'queued'])('refuses a job in status %s', async (status) => {
+        row.status = status as FleetJob['status'];
+        await expect(authorize()).resolves.toBeNull();
+    });
+
+    it('refuses an unknown job', async () => {
+        await expect(authorize({ jobId: 'job-missing' })).resolves.toBeNull();
+    });
+
+    it.each([
+        ['an older generation', 2],
+        ['a newer generation', 4],
+        ['the migration backfill value', 0],
+        ['a non-integer', 3.5],
+        ['a missing generation', undefined],
+    ])('refuses %s with the differentiated stale-lease error', async (_label, generation) => {
+        await expect(authorize({ leaseGeneration: generation })).rejects.toBeInstanceOf(
+            FleetJobStaleLeaseError,
+        );
+    });
+
+    it('never reaches the stale-lease answer for a node that is not the holder', async () => {
+        // The differentiated 409 must stay unreachable for anyone but the
+        // true holder of an active job — otherwise it becomes an oracle for
+        // which job ids exist.
+        await expect(
+            service.authorizeRunSecretRequest({
+                nodeId: NODE_B,
+                secret: secretB,
+                jobId: 'job-1',
+                leaseGeneration: 999,
+            }),
+        ).resolves.toBeNull();
+    });
+});

--- a/packages/agent/src/fleet/fleet-job.service.ts
+++ b/packages/agent/src/fleet/fleet-job.service.ts
@@ -631,6 +631,58 @@ export class FleetJobService {
     }
 
     /**
+     * Run secrets (self-build slice Y) — prove that THIS node holds an
+     * ACTIVE claim on THIS job right now, and say whose data the job is
+     * allowed to reach.
+     *
+     * This is the authorization half of `POST /api/fleet/jobs/:id/env-files`
+     * and nothing else: it reads no registry row, decrypts nothing and
+     * returns no content. The resolution half lives in the API service, so
+     * the agent-side fleet module gains no database dependency it did not
+     * already have.
+     *
+     * The four checks are the SAME four, in the same order, that
+     * `heartbeatJob` and `completeJob` perform, because delivering a
+     * decrypted `.env` to a machine is at least as consequential as letting
+     * it settle the job:
+     *
+     *   1. the node credential verifies (constant-time, against the stored
+     *      sha256) — intent `'report'`, so a node an operator has just
+     *      PAUSED can still finish the run it already started; refusing
+     *      here would strand a half-provisioned checkout rather than drain
+     *      it, and the node already holds the workspace either way;
+     *   2. the job's recorded holder IS this node;
+     *   3. the job is still `leased` or `running` — a terminal job's
+     *      secrets are nobody's;
+     *   4. the `leaseGeneration` echoed is the current one, or the claim
+     *      lapsed while the machine slept and was re-issued elsewhere.
+     *
+     * `userId` in the answer comes from the JOB, never from the request
+     * body — the caller must scope its registry read with it, or an
+     * authenticated node could name another tenant's connection id.
+     */
+    async authorizeRunSecretRequest(input: {
+        nodeId: unknown;
+        secret: unknown;
+        jobId: string;
+        leaseGeneration?: unknown;
+    }): Promise<{ jobId: string; userId: string; nodeId: string } | null> {
+        const node = await this.authenticateNode(input.nodeId, input.secret, 'report');
+        if (!node) return null;
+
+        const job = await this.jobs.findById(input.jobId);
+        if (!job || job.nodeId !== node.id) return null;
+        if (job.status !== 'leased' && job.status !== 'running') return null;
+        if (!isCurrentLeaseGeneration(job, input.leaseGeneration)) {
+            this.logger.log(
+                `Fleet job ${job.id}: run-secret request refused — stale lease generation from node ${node.id}`,
+            );
+            throw new FleetJobStaleLeaseError();
+        }
+        return { jobId: job.id, userId: job.userId, nodeId: node.id };
+    }
+
+    /**
      * Return lapsed claims to the pool (or fail them once the attempt
      * budget is spent). Scoped to one owner on the lease path, global on
      * the cron. Best-effort per row: one bad row must not abort the sweep.

--- a/packages/agent/src/services/__tests__/repo-registry.service.spec.ts
+++ b/packages/agent/src/services/__tests__/repo-registry.service.spec.ts
@@ -37,6 +37,10 @@ function makeRow(overrides: Partial<RepoConnection> = {}): RepoConnection {
         credentialMode: 'inherit',
         credentialRef: null,
         envFiles: null,
+        // Explicit, not omitted: the `as RepoConnection` cast below would
+        // otherwise hide a missing column, and "this repository grants
+        // nothing" is the default every assertion here relies on.
+        envGrants: null,
         availableInAllProjects: true,
         sourceType: 'manual',
         sourceWorkId: null,
@@ -511,6 +515,7 @@ describe('provisioning resolver', () => {
                 mountPath: null,
                 defaultBranch: 'develop',
                 envFiles: { '.env': 'A=1' },
+                envGrants: ['DATABASE_URL'],
             }),
         },
         {
@@ -534,6 +539,11 @@ describe('provisioning resolver', () => {
                 branch: 'develop',
                 mountDir: 'api',
                 envFiles: [{ path: '.env', content: 'A=1' }],
+                // Run secrets (slice Y): the fleet planner describes a
+                // workspace from the PATHS and never touches `envFiles`, and
+                // the grants ride the payload as names.
+                envFilePaths: ['.env'],
+                envGrants: ['DATABASE_URL'],
                 provider: 'github',
             },
         ]);
@@ -579,5 +589,119 @@ describe('provisioning resolver', () => {
         );
         expect(specs).toEqual([{ url: 'https://github.com/acme/my-service', mountDir: 'web' }]);
         expect(specs[0]).not.toHaveProperty('branch');
+    });
+});
+
+/**
+ * Run secrets (self-build slice Y, EW-781) — per-repository env grants.
+ *
+ * A grant is the operator saying "agent-driven code running for this
+ * repository may read THIS variable's value from the runner's own
+ * environment". The refusals below are the whole security of the feature,
+ * so each is pinned rather than left to the shared normalizer.
+ */
+describe('per-repository env grants', () => {
+    it('persists an operator grant and returns it UNMASKED (a permission is not a secret)', async () => {
+        const { service, repoConnections } = makeMocks();
+        const view = await service.create(USER, {
+            name: 'platform',
+            url: 'https://github.com/ever-works/ever-works',
+            envGrants: ['DATABASE_URL', 'GH_TOKEN'],
+        });
+        expect(repoConnections.create).toHaveBeenCalledWith(
+            expect.objectContaining({ envGrants: ['DATABASE_URL', 'GH_TOKEN'] }),
+        );
+        expect(view.envGrants).toEqual(['DATABASE_URL', 'GH_TOKEN']);
+    });
+
+    it('defaults to granting nothing, which is exactly the pre-slice behaviour', async () => {
+        const { service, repoConnections } = makeMocks();
+        const view = await service.create(USER, {
+            name: 'plain',
+            url: 'https://github.com/acme/plain',
+        });
+        expect(repoConnections.create).toHaveBeenCalledWith(
+            expect.objectContaining({ envGrants: null }),
+        );
+        expect(view.envGrants).toEqual([]);
+    });
+
+    it.each([
+        ['the node credential namespace', 'FLEET_NODE_SECRET'],
+        ['the platform namespace', 'EVER_WORKS_API_KEY'],
+        ['the env-file decryption key', 'PLUGIN_SECRET_ENCRYPTION_KEY'],
+        ['session signing', 'BETTER_AUTH_SECRET'],
+    ])('refuses a grant naming %s', async (_label, name) => {
+        const { service } = makeMocks();
+        await expect(
+            service.create(USER, {
+                name: 'x',
+                url: 'https://github.com/acme/x',
+                envGrants: [name],
+            }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('refuses a wildcard rather than expanding it into a family', async () => {
+        const { service } = makeMocks();
+        await expect(
+            service.create(USER, {
+                name: 'x',
+                url: 'https://github.com/acme/x',
+                envGrants: ['DATABASE_*'],
+            }),
+        ).rejects.toThrow(/wildcard/i);
+    });
+
+    it('refuses a duplicate and an over-long list', async () => {
+        const { service } = makeMocks();
+        await expect(
+            service.create(USER, {
+                name: 'x',
+                url: 'https://github.com/acme/x',
+                envGrants: ['DATABASE_URL', 'database_url'],
+            }),
+        ).rejects.toThrow(/Duplicate env grant/);
+        await expect(
+            service.create(USER, {
+                name: 'x',
+                url: 'https://github.com/acme/x',
+                envGrants: Array.from({ length: 33 }, (_, i) => `VAR_${i}`),
+            }),
+        ).rejects.toThrow(/At most 32 env grants/);
+    });
+
+    it('REVOKES on update: an emptied list is persisted as null and stops applying', async () => {
+        const { service, repoConnections } = makeMocks();
+        const row = makeRow({ envGrants: ['DATABASE_URL'] });
+        repoConnections.findByIdAndUser.mockResolvedValue(row);
+        const view = await service.update(USER, 'rc-1', { envGrants: [] });
+        expect(repoConnections.save).toHaveBeenCalledWith(
+            expect.objectContaining({ envGrants: null }),
+        );
+        expect(view.envGrants).toEqual([]);
+        // And the provisioning resolver — the ONE place the fleet planner
+        // reads grants from — now reports nothing for this repository, so
+        // the next run is planned without it.
+        expect(
+            mapAttachmentEdgesToRepos([
+                { repoConnectionId: 'rc-1', enabled: true, repoConnection: row },
+            ] as never)[0].envGrants,
+        ).toEqual([]);
+    });
+
+    it('re-normalizes a row edited outside the API so the runner never sees an ungrantable name', () => {
+        // A row written straight into the database (or by an older build)
+        // must not be able to hand a runner a name the validator refuses.
+        const resolved = mapAttachmentEdgesToRepos([
+            {
+                repoConnectionId: 'rc-1',
+                enabled: true,
+                repoConnection: makeRow({
+                    envGrants: ['DATABASE_URL', 'FLEET_NODE_SECRET', '*'] as string[],
+                }),
+            },
+        ] as never);
+        expect(resolved[0].envGrants).toEqual(['DATABASE_URL']);
     });
 });

--- a/packages/agent/src/services/repo-registry.service.ts
+++ b/packages/agent/src/services/repo-registry.service.ts
@@ -7,8 +7,14 @@ import {
     Optional,
 } from '@nestjs/common';
 import {
+    FLEET_RUN_ENV_UNGRANTABLE_PATTERN,
+    isGrantableFleetRunEnvName,
+    normalizeFleetRunEnvGrants,
+} from '@ever-works/contracts';
+import {
     REPO_CONNECTION_ENV_FILE_MAX_CONTENT_BYTES,
     REPO_CONNECTION_ENV_FILE_MAX_COUNT,
+    REPO_CONNECTION_ENV_GRANT_MAX_COUNT,
     RepoConnection,
     isSafeMountDir,
     resolveMountDir,
@@ -59,6 +65,13 @@ export interface RepoConnectionView {
     credentialMode: RepoConnectionCredentialMode;
     credentialRef: string | null;
     envFiles: RepoConnectionEnvFileMeta[];
+    /**
+     * Env var names this repository's runs may read from the runner's own
+     * environment (self-build slice Y). Returned UNMASKED, unlike env-file
+     * contents: a grant is a permission, not a secret, and the whole point
+     * of binding it per repository is that it can be reviewed.
+     */
+    envGrants: string[];
     availableInAllProjects: boolean;
     sourceType: RepoConnectionSourceType;
     sourceWorkId: string | null;
@@ -83,6 +96,14 @@ export interface ResolvedAgentRepo {
     branch: string | null;
     mountDir: string;
     envFiles: RepoConnectionEnvFile[];
+    /**
+     * The env-file PATHS alone (self-build slice Y). The fleet planner
+     * describes a workspace with these and never touches `envFiles`, so a
+     * refactor cannot accidentally put a decrypted `.env` on a job payload.
+     */
+    envFilePaths: string[];
+    /** Env var names this repository grants to the runner (names only). */
+    envGrants: string[];
     /** Which git-provider family the connection belongs to (fleet mounts open PRs through it). */
     provider: RepoConnectionProvider;
 }
@@ -97,6 +118,7 @@ export interface CreateRepoConnectionInput {
     credentialMode?: RepoConnectionCredentialMode;
     credentialRef?: string | null;
     envFiles?: RepoConnectionEnvFile[];
+    envGrants?: string[];
     availableInAllProjects?: boolean;
     enabled?: boolean;
 }
@@ -176,6 +198,63 @@ export function assertValidEnvFiles(files: RepoConnectionEnvFile[]): void {
     }
 }
 
+/**
+ * Validate an operator's env-grant list (self-build slice Y).
+ *
+ * LOUD here (BadRequestException naming the offending entry) and silent on
+ * the runner, which re-normalizes whatever arrived: the operator gets told
+ * their grant was refused at the moment they write it, and a run never
+ * fails over a name it was going to ignore anyway.
+ *
+ * Three refusals, in order of how badly they would bite:
+ *   - the un-grantable core — `FLEET_`, `EVER_WORKS_`, `PLUGIN_`, `AUTH_`,
+ *     `BETTER_AUTH_`, `PLATFORM_` — is what leases work on the runner,
+ *     decrypts every other tenant's env files and signs platform sessions.
+ *     No grant may open it, however explicitly asked.
+ *   - wildcards and prefixes. There is no `DATABASE_*`. A grant is one
+ *     EXACT name, so an operator can never accidentally hand over a family.
+ *   - shape and cap, matching the runner's own so a list the registry
+ *     accepts can never be silently truncated on the machine applying it.
+ */
+export function assertValidEnvGrants(names: string[]): void {
+    if (!Array.isArray(names)) {
+        throw new BadRequestException('Env grants must be a list of environment variable names.');
+    }
+    if (names.length > REPO_CONNECTION_ENV_GRANT_MAX_COUNT) {
+        throw new BadRequestException(
+            `At most ${REPO_CONNECTION_ENV_GRANT_MAX_COUNT} env grants are allowed per repository.`,
+        );
+    }
+    const seen = new Set<string>();
+    for (const raw of names) {
+        if (typeof raw !== 'string') {
+            throw new BadRequestException('Each env grant must be an environment variable name.');
+        }
+        const name = raw.trim();
+        if (FLEET_RUN_ENV_UNGRANTABLE_PATTERN.test(name)) {
+            throw new BadRequestException(
+                `Env grant "${name}" names a platform-internal variable that can never be granted ` +
+                    '(FLEET_, EVER_WORKS_, PLUGIN_, AUTH_, BETTER_AUTH_ and PLATFORM_ are reserved).',
+            );
+        }
+        if (name.includes('*') || name.includes('?')) {
+            throw new BadRequestException(
+                `Env grant "${name}" is a wildcard. Grants name ONE variable each; there is no prefix form.`,
+            );
+        }
+        if (!isGrantableFleetRunEnvName(name)) {
+            throw new BadRequestException(
+                `Env grant "${name}" is not a valid environment variable name.`,
+            );
+        }
+        const upper = name.toUpperCase();
+        if (seen.has(upper)) {
+            throw new BadRequestException(`Duplicate env grant: "${name}".`);
+        }
+        seen.add(upper);
+    }
+}
+
 function envFilesToRecord(files: RepoConnectionEnvFile[]): Record<string, string> {
     const record: Record<string, string> = {};
     for (const file of files) {
@@ -231,6 +310,7 @@ export function mapAttachmentEdgesToRepos(
     for (const edge of edges) {
         const repo = edge.repoConnection;
         if (!repo || !repo.enabled) continue;
+        const env = envFilesFromRecord(repo.envFiles);
         resolved.push({
             repoConnectionId: repo.id,
             url: repo.url,
@@ -239,7 +319,14 @@ export function mapAttachmentEdgesToRepos(
             // unsanitized fallback would let `../../etc` escape
             // `/workspace/<dir>` in every path-building consumer.
             mountDir: resolveMountDir(repo.mountPath, repo.name),
-            envFiles: envFilesFromRecord(repo.envFiles).files,
+            envFiles: env.files,
+            // Paths beside the contents so the fleet planner has a field it
+            // can describe a workspace from WITHOUT reaching for `envFiles`.
+            envFilePaths: env.meta.map((entry) => entry.path),
+            // Re-normalized on read as well as on write: a row that predates
+            // the validator, or one edited straight in the database, must not
+            // be able to hand the runner a name the operator could not save.
+            envGrants: normalizeFleetRunEnvGrants(repo.envGrants),
             provider: repo.provider,
         });
     }
@@ -323,6 +410,8 @@ export class RepoRegistryService {
         this.assertValidCore(input);
         const envFiles = input.envFiles ?? [];
         assertValidEnvFiles(envFiles);
+        const envGrants = input.envGrants ?? [];
+        assertValidEnvGrants(envGrants);
 
         const name = input.name.trim();
         const existing = await this.repoConnections.findByUserAndName(userId, name);
@@ -343,6 +432,7 @@ export class RepoRegistryService {
             credentialMode: input.credentialMode ?? 'inherit',
             credentialRef: input.credentialRef?.trim() || null,
             envFiles: envFiles.length > 0 ? envFilesToRecord(envFiles) : null,
+            envGrants: envGrants.length > 0 ? envGrants : null,
             availableInAllProjects: input.availableInAllProjects ?? true,
             sourceType: 'manual',
             enabled: input.enabled ?? true,
@@ -402,6 +492,15 @@ export class RepoRegistryService {
         if (input.envFiles !== undefined) {
             assertValidEnvFiles(input.envFiles);
             row.envFiles = input.envFiles.length > 0 ? envFilesToRecord(input.envFiles) : null;
+        }
+        // Revocation is an ordinary update: clearing the list (or dropping a
+        // name from it) takes effect on the NEXT run, because the planner
+        // reads the row when it builds the job. Nothing has to reach the
+        // machines — a run already in flight keeps the grant it was planned
+        // with, and the one after it does not.
+        if (input.envGrants !== undefined) {
+            assertValidEnvGrants(input.envGrants);
+            row.envGrants = input.envGrants.length > 0 ? [...input.envGrants] : null;
         }
 
         const saved = await this.repoConnections.save(row);
@@ -617,6 +716,9 @@ export class RepoRegistryService {
             credentialMode: 'inherit',
             credentialRef: null,
             envFiles: [],
+            // A derived Work row has no registry record to hang a grant on:
+            // an operator who wants one adds the repository to the registry.
+            envGrants: [],
             availableInAllProjects: false,
             sourceType: 'work',
             sourceWorkId: workId,
@@ -710,6 +812,7 @@ export class RepoRegistryService {
             credentialMode: row.credentialMode,
             credentialRef: row.credentialRef ?? null,
             envFiles: envFilesFromRecord(row.envFiles).meta,
+            envGrants: normalizeFleetRunEnvGrants(row.envGrants),
             availableInAllProjects: row.availableInAllProjects,
             sourceType: row.sourceType,
             sourceWorkId: row.sourceWorkId ?? null,

--- a/packages/agent/src/tasks-domain/__tests__/task-workspace-run-secrets.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-workspace-run-secrets.spec.ts
@@ -1,0 +1,294 @@
+import type { Task } from '../../entities/task.entity';
+import { TaskWorkspaceService } from '../task-workspace.service';
+
+/** Constructor slots, so the doubles are typed against the real contracts. */
+type ServiceArgs = ConstructorParameters<typeof TaskWorkspaceService>;
+
+/**
+ * Run secrets on the PLANNING side (self-build slice Y, EW-781).
+ *
+ * The property this file exists for: a fleet workspace spec names WHICH
+ * repository's env files a run needs and at WHICH paths, and carries no
+ * content whatsoever. Every assertion below therefore also checks the
+ * sentinel is absent from the serialized spec — a future refactor that
+ * "helpfully" attaches the decrypted contents would pass a shape check
+ * and fail here.
+ *
+ * The second property is the grant union: grants are bound per repository
+ * (the operator binds them to something they own) but a run is ONE
+ * process tree over one workspace, so their effect is per run. That is
+ * the trade the docs have to state plainly, and it is pinned here.
+ */
+
+const SENTINEL = 'sentinel-3b70-DATABASE_URL=postgres://u:p@db/app';
+
+const work = {
+    id: 'work-1',
+    gitProvider: 'github',
+    taskIsolationBaseBranch: null,
+    getRepoOwner: () => 'ever-works',
+    getDataRepo: () => 'ever-works',
+};
+
+function makeTask(over: Partial<Task> = {}): Task {
+    return {
+        id: 'task-1',
+        slug: 'TSK-9',
+        title: 'Add field X',
+        userId: 'user-1',
+        workId: 'work-1',
+        branchRef: 'task/tsk-9-task1',
+        branchState: 'created',
+        extraRepos: null,
+        ...over,
+    } as unknown as Task;
+}
+
+function connection(over: Record<string, unknown> = {}) {
+    return {
+        id: 'conn-2',
+        url: 'https://github.com/ever-works/website.git',
+        defaultBranch: 'main',
+        mountPath: null,
+        name: 'website',
+        provider: 'github',
+        enabled: true,
+        envFiles: null,
+        envGrants: null,
+        ...over,
+    };
+}
+
+describe('TaskWorkspaceService — run secrets by reference', () => {
+    let works: { findById: jest.Mock };
+    let tasks: { updateById: jest.Mock; findById: jest.Mock };
+    let gitFacade: { getRepository: jest.Mock };
+    let attachments: { listEnabledForAgentWithRepos: jest.Mock };
+    let repoConnections: { findByIdAndUser: jest.Mock; listByUser: jest.Mock };
+
+    const build = () =>
+        new TaskWorkspaceService(
+            works as unknown as ServiceArgs[0],
+            tasks as unknown as ServiceArgs[1],
+            {} as unknown as ServiceArgs[2],
+            {} as unknown as ServiceArgs[3],
+            gitFacade as unknown as ServiceArgs[4],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            attachments as unknown as ServiceArgs[9],
+            repoConnections as unknown as ServiceArgs[10],
+        );
+
+    beforeEach(() => {
+        works = { findById: jest.fn().mockResolvedValue(work) };
+        tasks = { updateById: jest.fn().mockResolvedValue(undefined), findById: jest.fn() };
+        gitFacade = {
+            getRepository: jest.fn(async (owner: string, repo: string) => ({
+                defaultBranch: 'develop',
+                cloneUrl: `https://github.com/${owner}/${repo}.git`,
+            })),
+        };
+        attachments = { listEnabledForAgentWithRepos: jest.fn().mockResolvedValue([]) };
+        repoConnections = {
+            findByIdAndUser: jest.fn().mockResolvedValue(connection()),
+            listByUser: jest.fn().mockResolvedValue([]),
+        };
+    });
+
+    it('emits no reference at all when nothing declares env files (every pre-slice Task)', async () => {
+        const spec = await build().describeFleetWorkspace({ task: makeTask(), userId: 'user-1' });
+        expect(spec).not.toHaveProperty('envFilesRef');
+    });
+
+    it('resolves the PRIMARY repository through a registry row with the same clone URL', async () => {
+        // The primary of a Task is a Work repository, not a registry row, so
+        // without this the one repository that matters most — the platform
+        // building itself — would silently get nothing.
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                name: 'platform',
+                envFiles: { 'apps/api/.env': SENTINEL, '.env': SENTINEL },
+            }),
+        ]);
+        const spec = await build().describeFleetWorkspace({ task: makeTask(), userId: 'user-1' });
+        expect(spec?.envFilesRef).toEqual([
+            { repoConnectionId: 'conn-primary', paths: ['apps/api/.env', '.env'] },
+        ]);
+        expect(JSON.stringify(spec)).not.toContain(SENTINEL);
+    });
+
+    it('emits a reference per MOUNT, tagged with the directory it lands in', async () => {
+        attachments.listEnabledForAgentWithRepos.mockResolvedValue([
+            {
+                repoConnection: connection({
+                    id: 'conn-1',
+                    url: 'https://github.com/ever-works/directory-web-template.git',
+                    name: 'directory-web-template',
+                    envFiles: { '.env.local': SENTINEL },
+                }),
+            },
+        ]);
+        const spec = await build().describeFleetWorkspace({
+            task: makeTask(),
+            userId: 'user-1',
+            agentId: 'agent-1',
+        });
+        expect(spec?.envFilesRef).toEqual([
+            {
+                repoConnectionId: 'conn-1',
+                mountDir: 'directory-web-template',
+                paths: ['.env.local'],
+            },
+        ]);
+        expect(JSON.stringify(spec)).not.toContain(SENTINEL);
+    });
+
+    it('refuses the plan when two enabled rows claim the Task primary repository', async () => {
+        // Picking one by listing order would make "whose `.env` landed in the
+        // checkout" a matter of luck.
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'a',
+                name: 'platform',
+                url: 'https://github.com/ever-works/ever-works.git',
+                envFiles: { '.env': SENTINEL },
+            }),
+            connection({
+                id: 'b',
+                name: 'platform-copy',
+                url: 'git@github.com:ever-works/ever-works.git',
+                envFiles: { '.env': SENTINEL },
+            }),
+        ]);
+        await expect(
+            build().describeFleetWorkspace({ task: makeTask(), userId: 'user-1' }),
+        ).rejects.toThrow(/disable or remove all but one/);
+    });
+
+    it('fails the plan when the registry cannot be READ, rather than delivering nothing', async () => {
+        repoConnections.listByUser.mockRejectedValue(new Error('db down'));
+        await expect(
+            build().describeFleetWorkspace({ task: makeTask(), userId: 'user-1' }),
+        ).rejects.toThrow(/could not be matched against the repository registry/);
+    });
+
+    it('ignores a DISABLED registry row for the primary', async () => {
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                enabled: false,
+                envFiles: { '.env': SENTINEL },
+            }),
+        ]);
+        const spec = await build().describeFleetWorkspace({ task: makeTask(), userId: 'user-1' });
+        expect(spec).not.toHaveProperty('envFilesRef');
+    });
+});
+
+describe('TaskWorkspaceService.resolveFleetRunEnvGrants', () => {
+    let works: { findById: jest.Mock };
+    let attachments: { listEnabledForAgentWithRepos: jest.Mock };
+    let repoConnections: { findByIdAndUser: jest.Mock; listByUser: jest.Mock };
+
+    const build = () =>
+        new TaskWorkspaceService(
+            works as unknown as ServiceArgs[0],
+            { updateById: jest.fn(), findById: jest.fn() } as unknown as ServiceArgs[1],
+            {} as unknown as ServiceArgs[2],
+            {} as unknown as ServiceArgs[3],
+            {} as unknown as ServiceArgs[4],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            attachments as unknown as ServiceArgs[9],
+            repoConnections as unknown as ServiceArgs[10],
+        );
+
+    beforeEach(() => {
+        works = { findById: jest.fn().mockResolvedValue(work) };
+        attachments = { listEnabledForAgentWithRepos: jest.fn().mockResolvedValue([]) };
+        repoConnections = {
+            findByIdAndUser: jest.fn().mockResolvedValue(null),
+            listByUser: jest.fn().mockResolvedValue([]),
+        };
+    });
+
+    it('grants nothing by default, which is the pre-slice refusal', async () => {
+        await expect(
+            build().resolveFleetRunEnvGrants({ task: makeTask(), userId: 'user-1' }),
+        ).resolves.toEqual([]);
+    });
+
+    it('UNIONS the grants of every repository in the run (one workspace, one process tree)', async () => {
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                envGrants: ['DATABASE_URL'],
+            }),
+        ]);
+        attachments.listEnabledForAgentWithRepos.mockResolvedValue([
+            {
+                repoConnection: connection({
+                    id: 'conn-1',
+                    url: 'https://github.com/ever-works/directory-web-template.git',
+                    envGrants: ['GH_TOKEN', 'DATABASE_URL'],
+                }),
+            },
+        ]);
+        await expect(
+            build().resolveFleetRunEnvGrants({
+                task: makeTask(),
+                userId: 'user-1',
+                agentId: 'agent-1',
+            }),
+        ).resolves.toEqual(['GH_TOKEN', 'DATABASE_URL']);
+    });
+
+    it('drops an ungrantable name even if a row somehow carries one', async () => {
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                envGrants: ['FLEET_NODE_SECRET', 'DATABASE_URL', '*'],
+            }),
+        ]);
+        await expect(
+            build().resolveFleetRunEnvGrants({ task: makeTask(), userId: 'user-1' }),
+        ).resolves.toEqual(['DATABASE_URL']);
+    });
+
+    it('REVOKES on the next run: a cleared list stops appearing in the plan', async () => {
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                envGrants: ['DATABASE_URL'],
+            }),
+        ]);
+        const service = build();
+        await expect(
+            service.resolveFleetRunEnvGrants({ task: makeTask(), userId: 'user-1' }),
+        ).resolves.toEqual(['DATABASE_URL']);
+
+        // The operator clears the grant; grants are read when the job is
+        // PLANNED, so the very next run is planned without it. Nothing has
+        // to reach the machines.
+        repoConnections.listByUser.mockResolvedValue([
+            connection({
+                id: 'conn-primary',
+                url: 'https://github.com/ever-works/ever-works.git',
+                envGrants: null,
+            }),
+        ]);
+        await expect(
+            service.resolveFleetRunEnvGrants({ task: makeTask(), userId: 'user-1' }),
+        ).resolves.toEqual([]);
+    });
+});

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type {
+    FleetRunEnvFileRef,
     FleetTaskWorkspaceMountSpec,
     FleetTaskWorkspaceSpec,
     GateStatus,
@@ -7,7 +8,11 @@ import type {
     MergePolicySource,
     MergeRefusalCode,
 } from '@ever-works/contracts';
-import { normalizeFleetTaskWorkspaceMounts } from '@ever-works/contracts';
+import {
+    normalizeFleetRunEnvFileRefs,
+    normalizeFleetRunEnvGrants,
+    normalizeFleetTaskWorkspaceMounts,
+} from '@ever-works/contracts';
 import { TaskStatus, type Task, type TaskLinkedPullRequest } from '../entities/task.entity';
 import type { Work } from '../entities/work.entity';
 import { WorkRepository } from '../database/repositories/work.repository';
@@ -30,6 +35,7 @@ import {
     resolveAttachedReposForAgent,
     toAdvisoryRepoSpecs,
     type AdvisoryAttachedRepoSpec,
+    type ResolvedAgentRepo,
 } from '../services/repo-registry.service';
 
 export interface ProvisionedTaskWorkspace {
@@ -313,7 +319,7 @@ export class TaskWorkspaceService {
         }
 
         const repositoryId = `${owner}/${repo}`;
-        const mounts = await this.resolveFleetMounts({
+        const { mounts, envFilesRef: mountEnvRefs } = await this.resolveFleetMounts({
             task,
             agentId: input.agentId,
             userId,
@@ -321,13 +327,165 @@ export class TaskWorkspaceService {
             primaryRepositoryId: repositoryId,
             branch,
         });
+        // Run secrets (slice Y): the PRIMARY repository of a Task is a Work
+        // repository, not a registry row, so it has no env files of its own.
+        // Its `.env` comes from a registry connection the operator added for
+        // the same clone URL — resolved explicitly here rather than skipped,
+        // because the one repository that matters most (the platform
+        // building itself) is exactly the primary.
+        const primaryRef = await this.resolvePrimaryEnvFilesRef(userId, repositoryId);
+        const envFilesRef = normalizeFleetRunEnvFileRefs([
+            ...(primaryRef ? [primaryRef] : []),
+            ...mountEnvRefs,
+        ]);
         return {
             repositoryId,
             repoUrl: tokenFreeCloneUrl(repository.cloneUrl),
             baseRef,
             branch,
             ...(mounts.length > 0 ? { mounts } : {}),
+            ...(envFilesRef.length > 0 ? { envFilesRef } : {}),
         };
+    }
+
+    /**
+     * Run secrets (slice Y) — the registry connection whose clone URL IS
+     * the Task's primary repository, if the operator registered one.
+     *
+     * Returns null when no row matches: a Task whose repository has no
+     * registry entry simply gets no env files, exactly as today. REFUSES
+     * when two enabled rows claim the same repository, naming both — the
+     * alternative is picking one by listing order, and "which `.env` landed
+     * in the checkout" is not a question that may be answered by luck.
+     *
+     * Never reads `envFiles`; only `envFilePaths`, which is why nothing
+     * here can put a decrypted value on the job.
+     */
+    private async resolvePrimaryEnvFilesRef(
+        userId: string,
+        primaryRepositoryId: string,
+    ): Promise<FleetRunEnvFileRef | null> {
+        // No registry wired at all (an in-process caller, a narrower module
+        // graph) is "no registry row for the primary", which is the same
+        // answer an empty registry gives and the behaviour every Task had
+        // before this slice. A registry that IS wired and then FAILS is a
+        // different thing and fails the plan below.
+        if (!this.repoConnections || typeof this.repoConnections.listByUser !== 'function') {
+            return null;
+        }
+        let rows: Awaited<ReturnType<RepoConnectionRepository['listByUser']>>;
+        try {
+            rows = await this.repoConnections.listByUser(userId);
+        } catch (error) {
+            // A registry that cannot be read must not silently mean "no env
+            // files": the run would start with a partial environment, which
+            // is the failure this whole feature exists to remove.
+            throw new Error(
+                `Task primary repository ${primaryRepositoryId} could not be matched against the repository registry: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        const wanted = primaryRepositoryId.toLowerCase();
+        const matches = rows.filter(
+            (row) =>
+                row.enabled &&
+                typeof row.url === 'string' &&
+                repositoryIdFromCloneUrl(row.url)?.toLowerCase() === wanted,
+        );
+        if (matches.length > 1) {
+            throw new Error(
+                `Repository registry has ${matches.length} enabled connections for the Task's primary repository ` +
+                    `${primaryRepositoryId} (${matches.map((row) => row.name).join(', ')}); ` +
+                    'disable or remove all but one so the run knows whose env files to use.',
+            );
+        }
+        const [connection] = matches;
+        if (!connection) return null;
+        const [resolved] = mapAttachmentEdgesToRepos([
+            { repoConnection: connection } as unknown as AgentRepoAttachment,
+        ]);
+        if (!resolved || resolved.envFilePaths.length === 0) return null;
+        return { repoConnectionId: resolved.repoConnectionId, paths: resolved.envFilePaths };
+    }
+
+    /**
+     * Run secrets (slice Y) — the union of the env-var NAMES every
+     * repository of this run granted.
+     *
+     * Unioned, and the docs say so plainly: a run is ONE process tree over
+     * one workspace, so a name granted by any repository of that workspace
+     * is readable by the model working in all of them. That is why a grant
+     * is per-repository (the operator binds it to something they own) but
+     * its effect is per-run.
+     *
+     * Deliberately lenient — a connection that no longer resolves is
+     * skipped rather than throwing — because `describeFleetWorkspace` has
+     * already refused a workspace it could not describe, and a grant that
+     * fails to resolve means LESS access, never more.
+     */
+    async resolveFleetRunEnvGrants(input: {
+        task: Task;
+        userId: string;
+        agentId?: string;
+    }): Promise<string[]> {
+        const sources: ResolvedAgentRepo[] = [];
+        if (input.agentId && this.agentRepoAttachments) {
+            sources.push(
+                ...(await resolveAttachedReposForAgent(
+                    this.agentRepoAttachments,
+                    input.agentId,
+                    input.userId,
+                ).catch(() => [])),
+            );
+        }
+        const extras = Array.isArray(input.task.extraRepos) ? input.task.extraRepos : [];
+        for (const extra of extras) {
+            if (!this.repoConnections) break;
+            const connection = await this.repoConnections
+                .findByIdAndUser(extra.repoConnectionId, input.userId)
+                .catch(() => null);
+            if (!connection) continue;
+            const [resolved] = mapAttachmentEdgesToRepos([
+                { repoConnection: connection } as unknown as AgentRepoAttachment,
+            ]);
+            if (resolved) sources.push(resolved);
+        }
+        if (input.task.workId && this.repoConnections && this.works) {
+            const work = await this.works.findById(input.task.workId).catch(() => null);
+            const owner = work?.getRepoOwner();
+            const repo = work?.getDataRepo();
+            if (owner && repo) {
+                const primary = await this.resolvePrimaryConnection(
+                    input.userId,
+                    `${owner}/${repo}`,
+                );
+                if (primary) sources.push(primary);
+            }
+        }
+        return normalizeFleetRunEnvGrants(sources.flatMap((source) => source.envGrants));
+    }
+
+    /** The enabled registry row for `primaryRepositoryId`, or null. Never throws. */
+    private async resolvePrimaryConnection(
+        userId: string,
+        primaryRepositoryId: string,
+    ): Promise<ResolvedAgentRepo | null> {
+        if (!this.repoConnections || typeof this.repoConnections.listByUser !== 'function')
+            return null;
+        const rows = await this.repoConnections.listByUser(userId).catch(() => []);
+        const wanted = primaryRepositoryId.toLowerCase();
+        const matches = rows.filter(
+            (row) =>
+                row.enabled &&
+                typeof row.url === 'string' &&
+                repositoryIdFromCloneUrl(row.url)?.toLowerCase() === wanted,
+        );
+        if (matches.length !== 1) return null;
+        const [resolved] = mapAttachmentEdgesToRepos([
+            { repoConnection: matches[0] } as unknown as AgentRepoAttachment,
+        ]);
+        return resolved ?? null;
     }
 
     /**
@@ -350,7 +508,12 @@ export class TaskWorkspaceService {
         workId: string;
         primaryRepositoryId: string;
         branch: string;
-    }): Promise<FleetTaskWorkspaceMountSpec[]> {
+    }): Promise<{ mounts: FleetTaskWorkspaceMountSpec[]; envFilesRef: FleetRunEnvFileRef[] }> {
+        // Run secrets (slice Y): mountDir → the registry row it came from, so
+        // the env-file PATHS can be attached to the final mount list after
+        // the Task-extra-vs-attachment precedence has been settled. PATHS
+        // only — `resolved.envFiles` (the decrypted contents) is never read.
+        const sourceByMountDir = new Map<string, ResolvedAgentRepo>();
         const extras = Array.isArray(input.task.extraRepos) ? input.task.extraRepos : [];
         const attached =
             input.agentId && this.agentRepoAttachments
@@ -360,7 +523,7 @@ export class TaskWorkspaceService {
                       input.userId,
                   )
                 : [];
-        if (attached.length === 0 && extras.length === 0) return [];
+        if (attached.length === 0 && extras.length === 0) return { mounts: [], envFilesRef: [] };
         if (!this.gitFacade) {
             throw new Error(
                 extras.length > 0
@@ -404,6 +567,7 @@ export class TaskWorkspaceService {
                 mountDir: repo.mountDir,
                 writable: true,
             });
+            sourceByMountDir.set(repo.mountDir.toLowerCase(), repo);
         }
         // The contracts normalizer is the same gate the node applies; failing
         // HERE names the attachment while the plan is still on the platform.
@@ -483,6 +647,7 @@ export class TaskWorkspaceService {
                 mountDir,
                 writable: extra.writable !== false,
             });
+            sourceByMountDir.set(mountDir.toLowerCase(), resolved);
         }
         const keptAttachments = mounts.filter(
             (candidate) =>
@@ -492,10 +657,21 @@ export class TaskWorkspaceService {
                         extra.mountDir.toLowerCase() === candidate.mountDir.toLowerCase(),
                 ),
         );
-        return normalizeFleetTaskWorkspaceMounts(
+        const normalized = normalizeFleetTaskWorkspaceMounts(
             [...keptAttachments, ...extraMounts],
             input.primaryRepositoryId,
         );
+        const envFilesRef: FleetRunEnvFileRef[] = [];
+        for (const mount of normalized) {
+            const source = sourceByMountDir.get(mount.mountDir.toLowerCase());
+            if (!source || source.envFilePaths.length === 0) continue;
+            envFilesRef.push({
+                repoConnectionId: source.repoConnectionId,
+                mountDir: mount.mountDir,
+                paths: source.envFilePaths,
+            });
+        }
+        return { mounts: normalized, envFilesRef };
     }
 
     /**

--- a/packages/contracts/src/fleet/__tests__/fleet-run-secrets.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-run-secrets.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	FLEET_RUN_ENV_FILE_MAX_COUNT,
+	FLEET_RUN_ENV_FILE_REFS_MAX_COUNT,
+	FLEET_RUN_ENV_GRANT_MAX_COUNT,
+	FleetRunEnvFileError,
+	isGrantableFleetRunEnvName,
+	isValidFleetRunEnvFilePath,
+	normalizeFleetRunEnvFileRefs,
+	normalizeFleetRunEnvGrants
+} from '../fleet-run-secrets.types.js';
+import * as runSecrets from '../fleet-run-secrets.types.js';
+
+/**
+ * Run secrets (self-build slice Y, EW-781).
+ *
+ * The load-bearing assertion of this file is the FIRST one: no shape this
+ * module declares can carry a secret value except the fetch-response entry.
+ * Everything else pins the refusals a partial environment would otherwise
+ * slip through.
+ */
+describe('fleet run secrets — the by-reference invariant', () => {
+	it('never lets a normalized reference carry content', () => {
+		const [ref] = normalizeFleetRunEnvFileRefs([
+			{ repoConnectionId: 'row-1', paths: ['apps/api/.env'], content: 'SENTINEL', envFiles: { a: 'b' } }
+		]);
+		expect(Object.keys(ref).sort()).toEqual(['paths', 'repoConnectionId']);
+		expect(JSON.stringify(ref)).not.toContain('SENTINEL');
+	});
+
+	it('exposes no runtime symbol whose name suggests it holds a value', () => {
+		// A future field named `content`/`value`/`secret` on the SPEC side is
+		// the regression this module exists to prevent; the one legitimate
+		// carrier (`FleetRunEnvFileContent`) is a type, so it is invisible here.
+		for (const name of Object.keys(runSecrets)) {
+			expect(name).not.toMatch(/^(FLEET_RUN_ENV_FILE_CONTENTS?|.*_SECRET_VALUE)$/);
+		}
+	});
+});
+
+describe('isValidFleetRunEnvFilePath', () => {
+	it.each(['.env', 'apps/api/.env', 'packages/agent/.env.local', 'a/b/c/.env-test'])('accepts %s', (path) => {
+		expect(isValidFleetRunEnvFilePath(path)).toBe(true);
+	});
+
+	it.each([
+		['absolute posix', '/etc/passwd'],
+		['absolute windows', 'C:/Windows/x'],
+		['backslash', 'apps\\api\\.env'],
+		['parent traversal', '../.env'],
+		['embedded traversal', 'apps/../../.env'],
+		['dot segment', 'apps/./.env'],
+		['option-shaped segment', '--upload-pack/.env'],
+		['empty', ''],
+		['nul byte', 'apps/\0/.env'],
+		['not a string', 42]
+	])('refuses %s', (_label, path) => {
+		expect(isValidFleetRunEnvFilePath(path)).toBe(false);
+	});
+
+	it('refuses a path longer than 200 characters', () => {
+		expect(isValidFleetRunEnvFilePath(`${'a/'.repeat(120)}.env`)).toBe(false);
+	});
+});
+
+describe('normalizeFleetRunEnvFileRefs', () => {
+	it('treats undefined, null and [] as "no env files"', () => {
+		expect(normalizeFleetRunEnvFileRefs(undefined)).toEqual([]);
+		expect(normalizeFleetRunEnvFileRefs(null)).toEqual([]);
+		expect(normalizeFleetRunEnvFileRefs([])).toEqual([]);
+	});
+
+	it('keeps the mount target when one is named', () => {
+		expect(normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', mountDir: 'api', paths: ['.env'] }])).toEqual(
+			[{ repoConnectionId: 'row-1', mountDir: 'api', paths: ['.env'] }]
+		);
+	});
+
+	it('refuses a second reference for the same checkout', () => {
+		expect(() =>
+			normalizeFleetRunEnvFileRefs([
+				{ repoConnectionId: 'row-1', paths: ['.env'] },
+				{ repoConnectionId: 'row-2', paths: ['.env.local'] }
+			])
+		).toThrow(FleetRunEnvFileError);
+	});
+
+	it('refuses a reserved mount directory', () => {
+		expect(() =>
+			normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', mountDir: '.git', paths: ['.env'] }])
+		).toThrow(/mountDir/);
+	});
+
+	it('refuses an empty path list rather than silently delivering nothing', () => {
+		expect(() => normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', paths: [] }])).toThrow(/non-empty/);
+	});
+
+	it('refuses a traversing path naming the entry', () => {
+		expect(() => normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', paths: ['../../.env'] }])).toThrow(
+			/envFilesRef\[0\]\.paths/
+		);
+	});
+
+	it('refuses the same path twice in one reference', () => {
+		expect(() => normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', paths: ['.env', '.ENV'] }])).toThrow(
+			/twice/
+		);
+	});
+
+	it('caps the paths per reference and the references per run', () => {
+		const tooManyPaths = Array.from({ length: FLEET_RUN_ENV_FILE_MAX_COUNT + 1 }, (_, i) => `.env${i}`);
+		expect(() => normalizeFleetRunEnvFileRefs([{ repoConnectionId: 'row-1', paths: tooManyPaths }])).toThrow(
+			/the limit is/
+		);
+		const tooManyRefs = Array.from({ length: FLEET_RUN_ENV_FILE_REFS_MAX_COUNT + 1 }, (_, i) => ({
+			repoConnectionId: `row-${i}`,
+			mountDir: `m${i}`,
+			paths: ['.env']
+		}));
+		expect(() => normalizeFleetRunEnvFileRefs(tooManyRefs)).toThrow(/the limit is/);
+	});
+
+	it('refuses a repoConnectionId that is not a row id', () => {
+		expect(() => normalizeFleetRunEnvFileRefs([{ repoConnectionId: '../../etc', paths: ['.env'] }])).toThrow(
+			/repoConnectionId/
+		);
+	});
+});
+
+describe('isGrantableFleetRunEnvName', () => {
+	it.each(['DATABASE_URL', 'GH_TOKEN', 'AWS_ACCESS_KEY_ID', 'REDIS_URL', 'STRIPE_SECRET_KEY'])(
+		'admits the platform-owned name %s, which is exactly the point',
+		(name) => {
+			expect(isGrantableFleetRunEnvName(name)).toBe(true);
+		}
+	);
+
+	it.each([
+		'FLEET_NODE_SECRET',
+		'EVER_WORKS_NODE_TOKEN',
+		'PLUGIN_SECRET_ENCRYPTION_KEY',
+		'AUTH_SECRET',
+		'BETTER_AUTH_SECRET',
+		'PLATFORM_API_KEY'
+	])('never admits the un-grantable core name %s', (name) => {
+		expect(isGrantableFleetRunEnvName(name)).toBe(false);
+	});
+
+	it.each(['*', 'DATABASE_*', 'DATABASE URL', '1DATABASE', '', 'a'.repeat(200)])(
+		'refuses the malformed or wildcard name %s',
+		(name) => {
+			expect(isGrantableFleetRunEnvName(name)).toBe(false);
+		}
+	);
+});
+
+describe('normalizeFleetRunEnvGrants', () => {
+	it('drops what it cannot accept instead of failing a run', () => {
+		expect(normalizeFleetRunEnvGrants(['DATABASE_URL', 'FLEET_NODE_SECRET', '*', 42, 'GH_TOKEN'])).toEqual([
+			'DATABASE_URL',
+			'GH_TOKEN'
+		]);
+	});
+
+	it('de-duplicates case-insensitively, keeping the first spelling', () => {
+		expect(normalizeFleetRunEnvGrants(['DATABASE_URL', 'database_url'])).toEqual(['DATABASE_URL']);
+	});
+
+	it('caps the list', () => {
+		const many = Array.from({ length: FLEET_RUN_ENV_GRANT_MAX_COUNT + 5 }, (_, i) => `VAR_${i}`);
+		expect(normalizeFleetRunEnvGrants(many)).toHaveLength(FLEET_RUN_ENV_GRANT_MAX_COUNT);
+	});
+
+	it('treats a non-array as no grants', () => {
+		expect(normalizeFleetRunEnvGrants(undefined)).toEqual([]);
+		expect(normalizeFleetRunEnvGrants('DATABASE_URL')).toEqual([]);
+	});
+});

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -159,6 +159,27 @@ const WORKSPACE_EXPORTS = [
 	'isReservedMountDir'
 ] as const;
 
+/** Run secrets: envFiles by reference + per-repository grants (slice Y, `fleet-run-secrets.types.js`). */
+const RUN_SECRETS_EXPORTS = [
+	'FLEET_RUN_ENV_FILE_MAX_COUNT',
+	'FLEET_RUN_ENV_FILE_MAX_CONTENT_BYTES',
+	'FLEET_RUN_ENV_FILES_MAX_TOTAL_BYTES',
+	'FLEET_RUN_ENV_FILE_REFS_MAX_COUNT',
+	'FLEET_RUN_ENV_FILE_PATH_PATTERN',
+	'FLEET_RUN_ENV_GRANT_MAX_COUNT',
+	'FLEET_RUN_ENV_GRANT_NAME_PATTERN',
+	'FLEET_RUN_ENV_UNGRANTABLE_PATTERN',
+	'FLEET_RUN_SECRETS_UNRESOLVED_REASON',
+	'FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON',
+	'FLEET_RUN_SECRETS_DISABLED_REASON',
+	'FLEET_RUN_SECRETS_UNAVAILABLE_REASON',
+	'FleetRunEnvFileError',
+	'isValidFleetRunEnvFilePath',
+	'isGrantableFleetRunEnvName',
+	'normalizeFleetRunEnvFileRefs',
+	'normalizeFleetRunEnvGrants'
+] as const;
+
 /** Owner question from a fleet run (self-build slice Q, `fleet-jobs.types.js`). */
 const QUESTION_EXPORTS = [
 	'FLEET_AGENT_TASK_META_DIR',
@@ -186,6 +207,7 @@ const ALL_EXPORTS = [
 	...NODE_EXPORTS,
 	...RUNNER_STATUS_EXPORTS,
 	...WORKSPACE_EXPORTS,
+	...RUN_SECRETS_EXPORTS,
 	...QUESTION_EXPORTS
 ];
 
@@ -218,6 +240,11 @@ const FUNCTION_EXPORTS = [
 	'FleetTaskWorkspaceMountError',
 	'normalizeFleetTaskWorkspaceMounts',
 	'isReservedMountDir',
+	'FleetRunEnvFileError',
+	'isValidFleetRunEnvFilePath',
+	'isGrantableFleetRunEnvName',
+	'normalizeFleetRunEnvFileRefs',
+	'normalizeFleetRunEnvGrants',
 	'parseFleetAgentTaskQuestionMarkdown',
 	'normalizeFleetAgentTaskQuestion',
 	'normalizeFleetNodeWorkerState'
@@ -235,7 +262,7 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 121 runtime symbols', () => {
+	it('exposes exactly these 138 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
@@ -246,8 +273,10 @@ describe('fleet barrel', () => {
 		// → 121 with the credential lifecycle (EW-799): the three rotation-
 		// overlap bounds. Both groups live in `fleet-node.types.ts`, an
 		// existing module, so the witness table below needs no new row.
+		// → 138 with run secrets (EW-781): the twelve constants and five
+		// helpers of `fleet-run-secrets.types.ts`, pinned in their own spec.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(121);
+		expect(Object.keys(fleet)).toHaveLength(138);
 	});
 
 	it.each([
@@ -256,6 +285,7 @@ describe('fleet barrel', () => {
 		['fleet-jobs.types.js', 'FLEET_JOB_STATUSES'],
 		['fleet-node.types.js', 'FLEET_NODE_KINDS'],
 		['fleet-panic.types.js', 'FLEET_KILL_SWITCH_ID'],
+		['fleet-run-secrets.types.js', 'FLEET_RUN_ENV_FILE_MAX_COUNT'],
 		['fleet-runner-status.types.js', 'FLEET_RUNNER_STATUS_REFRESH_SEC'],
 		['fleet-task-workspace.types.js', 'FLEET_TASK_WORKSPACE_MAX_MOUNTS']
 	])('keeps the %s module represented via %s', (_module, sentinel) => {

--- a/packages/contracts/src/fleet/fleet-jobs.types.ts
+++ b/packages/contracts/src/fleet/fleet-jobs.types.ts
@@ -1,5 +1,6 @@
 import { INBOX_MAX_TITLE_CHARS } from '../inbox/inbox.types.js';
 import type { TaskAcceptanceCheck, TaskCheckResult } from '../tasks/task-gates.types.js';
+import { normalizeFleetRunEnvGrants } from './fleet-run-secrets.types.js';
 import type { FleetTaskWorkspaceDescriptor, FleetTaskWorkspaceSpec } from './fleet-task-workspace.types.js';
 
 /**
@@ -385,6 +386,19 @@ export interface FleetAgentTaskStep {
 	required?: boolean;
 	/** Extra env names this step may see; never platform-owned ones. */
 	envPassthrough?: string[];
+	/**
+	 * Per-repository env grants (self-build slice Y). Env var NAMES an
+	 * operator explicitly bound to a repository of this run, which the node
+	 * admits THROUGH the platform-owned refusal — exact names only, never a
+	 * prefix, never a family, and never one of the un-grantable core
+	 * namespaces (`FLEET_`, `EVER_WORKS_`, `PLUGIN_`, `AUTH_`,
+	 * `BETTER_AUTH_`, `PLATFORM_`).
+	 *
+	 * Names, not values: the VALUE is read from the node's own environment
+	 * and scrubbed out of everything the node reports back, exactly as
+	 * `envPassthrough` values already are.
+	 */
+	envGrants?: string[];
 }
 
 /**
@@ -589,6 +603,12 @@ export interface FleetAgentModelExecution {
 	 * (its credential), same semantics as `FleetAgentTaskStep.envPassthrough`.
 	 */
 	envPassthrough?: string[];
+	/**
+	 * Per-repository env grants, same semantics as
+	 * `FleetAgentTaskStep.envGrants` — NAMES the run's repositories were
+	 * granted, which the node admits through the platform-owned refusal.
+	 */
+	envGrants?: string[];
 }
 
 /** What the node does with the working tree after the model ran. */
@@ -695,6 +715,16 @@ export function normalizeFleetAgentModelExecution(raw: unknown): FleetAgentModel
 			throw new FleetAgentExecutionError('Fleet agent execution envPassthrough must be an array of names');
 		}
 		out.envPassthrough = input.envPassthrough.filter((name): name is string => typeof name === 'string');
+	}
+	if (input.envGrants !== undefined && input.envGrants !== null) {
+		if (!Array.isArray(input.envGrants)) {
+			throw new FleetAgentExecutionError('Fleet agent execution envGrants must be an array of names');
+		}
+		// Normalized, not filtered: a grant naming the un-grantable core, a
+		// wildcard or a malformed name is DROPPED here as well as on the
+		// node, so nothing downstream has to re-decide what a grant may say.
+		const grants = normalizeFleetRunEnvGrants(input.envGrants);
+		if (grants.length > 0) out.envGrants = grants;
 	}
 	return out;
 }

--- a/packages/contracts/src/fleet/fleet-run-secrets.types.ts
+++ b/packages/contracts/src/fleet/fleet-run-secrets.types.ts
@@ -1,0 +1,288 @@
+/**
+ * Run secrets — how a fleet node gets a repository's `.env` files, and how
+ * an operator opens a keyhole in the platform-owned env refusal.
+ *
+ * ## THE INVARIANT OF THIS MODULE
+ *
+ * **No shape declared here can hold a secret VALUE except
+ * {@link FleetRunEnvFileContent}, which exists only as the body of the
+ * node-authenticated fetch response.** The job payload, the fleet job row,
+ * the workspace spec and the grant list carry NAMES and PATHS — never
+ * contents. A reviewer checking that claim only has to read the field
+ * lists below: `paths`, `repoConnectionId`, `mountDir`, grant names.
+ *
+ * ## Why by reference
+ *
+ * `RepoConnection.envFiles` is envelope-encrypted at rest and only ever
+ * decrypted for its owner. Putting the decrypted content on a fleet job
+ * would persist it in `fleet_jobs.payload`, echo it into every job view
+ * the owner's dashboard renders, and hand it to any log line that dumps a
+ * payload. So the payload names WHICH repository's files a run needs, and
+ * the node fetches the content over the same credential-verified channel
+ * it already uses for lease / heartbeat / complete, while it holds the
+ * lease on that job.
+ *
+ * ## Why grants are names on the wire
+ *
+ * A grant is the operator saying "agent-driven code on my machines may
+ * read THIS variable from the node's own environment". Only the name
+ * travels; the value is read from `process.env` on the node and is
+ * scrubbed back out of everything the node reports. That is why a grant
+ * is safe to carry on a payload and an env file is not.
+ */
+
+import { FLEET_TASK_WORKSPACE_MOUNT_DIR_PATTERN, isReservedMountDir } from './fleet-task-workspace.types.js';
+
+/** Env files a single repository may deliver to one run (registry cap). */
+export const FLEET_RUN_ENV_FILE_MAX_COUNT = 8;
+
+/** Per-file content ceiling, mirroring `REPO_CONNECTION_ENV_FILE_MAX_CONTENT_BYTES`. */
+export const FLEET_RUN_ENV_FILE_MAX_CONTENT_BYTES = 32 * 1024;
+
+/** Ceiling on everything one run may receive, across every repository. */
+export const FLEET_RUN_ENV_FILES_MAX_TOTAL_BYTES = 256 * 1024;
+
+/** Repositories one run may pull env files from (primary + every mount). */
+export const FLEET_RUN_ENV_FILE_REFS_MAX_COUNT = 9;
+
+/** One traversal-free path segment of an env-file path. */
+export const FLEET_RUN_ENV_FILE_PATH_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
+
+/** Env names one repository may grant. Matches the node's `MAX_ENV_PASSTHROUGH`. */
+export const FLEET_RUN_ENV_GRANT_MAX_COUNT = 32;
+
+/** Shape of a grantable env var name — the node's own `NODE_ENV_NAME_PATTERN`. */
+export const FLEET_RUN_ENV_GRANT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+
+/**
+ * The un-grantable CORE: namespaces no per-repository grant can ever open,
+ * however explicitly an operator asks.
+ *
+ * `FLEET_` and `EVER_WORKS_` are the node's OWN credential namespace — a
+ * grant there would let model-driven code read the secret that leases work
+ * on that machine and then lease, complete or cancel jobs as the node.
+ * `PLUGIN_` holds `PLUGIN_SECRET_ENCRYPTION_KEY`, which decrypts every
+ * other tenant's env files. `AUTH_` / `BETTER_AUTH_` / `PLATFORM_` sign
+ * and validate platform sessions. None of these is ever what an operator
+ * means by "let my test suite reach the database", so refusing them costs
+ * nothing and closes the escalation from "read one secret" to "become the
+ * platform".
+ *
+ * Everything else the platform-owned pattern refuses — `DATABASE_`, `GH_`,
+ * `AWS_`, `S3_`, `REDIS_`, `STRIPE_`, `SENTRY_`, `POSTHOG_` … — IS
+ * grantable, one exact name at a time.
+ */
+export const FLEET_RUN_ENV_UNGRANTABLE_PATTERN = /^(FLEET_|EVER_WORKS_|PLUGIN_|AUTH_|BETTER_AUTH_|PLATFORM_)/i;
+
+/** A reference named a repository/path the platform could not resolve. */
+export const FLEET_RUN_SECRETS_UNRESOLVED_REASON = 'run-secrets-unresolved';
+
+/** A stored env file could not be decrypted (bad key, tampered envelope). */
+export const FLEET_RUN_SECRETS_DECRYPT_FAILED_REASON = 'run-secrets-decrypt-failed';
+
+/** The instance kill switch (`FLEET_NODE_RUN_ENV_FILES=false`) is off. */
+export const FLEET_RUN_SECRETS_DISABLED_REASON = 'run-secrets-disabled';
+
+/** The node could not obtain the files (transport, 401, stale lease). */
+export const FLEET_RUN_SECRETS_UNAVAILABLE_REASON = 'run-secrets-unavailable';
+
+/**
+ * One repository's env files, BY REFERENCE, as carried on the workspace
+ * spec of a fleet job.
+ *
+ * `mountDir` says which checkout the files land in: absent means the
+ * primary worktree, a value names a mount of the SAME spec. `paths` are
+ * relative to that checkout root. There is no `content` field, and adding
+ * one would defeat the whole design.
+ */
+export interface FleetRunEnvFileRef {
+	/** Registry row the content is fetched from; the node never reads it itself. */
+	readonly repoConnectionId: string;
+	/** Mount the files belong to; absent means the primary worktree. */
+	readonly mountDir?: string;
+	/** Repository-relative paths, e.g. `apps/api/.env`. Never contents. */
+	readonly paths: readonly string[];
+}
+
+/** What the node ASKS for. `mountDir` is node-local placement, so it is not sent. */
+export interface FleetRunEnvFileRequestRef {
+	readonly repoConnectionId: string;
+	readonly paths: readonly string[];
+}
+
+/**
+ * One decrypted env file, as it crosses the node-authenticated channel.
+ *
+ * THE ONLY value-bearing shape in this module. It exists for the duration
+ * of one HTTPS response and one 0600 file write, and is never persisted,
+ * logged, echoed into a result, or put on a job.
+ */
+export interface FleetRunEnvFileContent {
+	readonly repoConnectionId: string;
+	readonly path: string;
+	readonly content: string;
+}
+
+/** Response body of `POST /api/fleet/jobs/:id/env-files`. */
+export interface FleetJobEnvFilesResponse {
+	readonly files: readonly FleetRunEnvFileContent[];
+}
+
+/** Refusal raised by the normalizers below. Never carries a secret value. */
+export class FleetRunEnvFileError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'FleetRunEnvFileError';
+	}
+}
+
+/**
+ * True when `path` is a repository-relative env-file path: slash-joined
+ * segments, each of the registry's segment alphabet, no `.`/`..`, no
+ * absolute or Windows-style prefix, and no segment that a shell or Git
+ * would read as an option (`-f`).
+ *
+ * Deliberately the registry's rule PLUS the leading-dash refusal: the node
+ * builds real filesystem paths out of these, and the registry gate is the
+ * looser of the two.
+ */
+export function isValidFleetRunEnvFilePath(path: unknown): boolean {
+	if (typeof path !== 'string' || !path || path.length > 200) return false;
+	if (path.startsWith('/') || path.includes('\\') || /^[A-Za-z]:/.test(path)) return false;
+	if (path.includes('\0')) return false;
+	const segments = path.split('/');
+	return segments.every(
+		(segment) =>
+			FLEET_RUN_ENV_FILE_PATH_PATTERN.test(segment) &&
+			segment !== '.' &&
+			segment !== '..' &&
+			!segment.startsWith('-')
+	);
+}
+
+/**
+ * True when a per-repository grant is allowed to name `name` at all.
+ *
+ * Shape-valid, wildcard-free, and outside the un-grantable core. Note what
+ * this does NOT do: it never decides whether the name is platform-owned.
+ * That is the point of a grant — `DATABASE_URL` is platform-owned and
+ * grantable, and the node admits it only because an operator bound that
+ * exact name to a repository.
+ */
+export function isGrantableFleetRunEnvName(name: unknown): boolean {
+	if (typeof name !== 'string') return false;
+	const trimmed = name.trim();
+	if (!FLEET_RUN_ENV_GRANT_NAME_PATTERN.test(trimmed)) return false;
+	// The shape pattern already excludes `*`; the explicit check is here so
+	// a future widening of the pattern cannot quietly introduce wildcards.
+	if (trimmed.includes('*') || trimmed.includes('?')) return false;
+	return !FLEET_RUN_ENV_UNGRANTABLE_PATTERN.test(trimmed);
+}
+
+/**
+ * Validate the `envFilesRef` of a workspace spec.
+ *
+ * REFUSES rather than coerces, exactly like
+ * `normalizeFleetTaskWorkspaceMounts`: a reference the node cannot honour
+ * as written must fail naming the field, because a silently dropped env
+ * file is a run that starts with a partial environment — the one outcome
+ * this whole feature exists to prevent.
+ *
+ * `undefined`, `null` and `[]` all mean "this run needs no env files".
+ */
+export function normalizeFleetRunEnvFileRefs(raw: unknown): FleetRunEnvFileRef[] {
+	if (raw === undefined || raw === null) return [];
+	if (!Array.isArray(raw)) {
+		throw new FleetRunEnvFileError('workspace.envFilesRef must be an array');
+	}
+	if (raw.length > FLEET_RUN_ENV_FILE_REFS_MAX_COUNT) {
+		throw new FleetRunEnvFileError(
+			`workspace.envFilesRef has ${raw.length} entries; the limit is ${FLEET_RUN_ENV_FILE_REFS_MAX_COUNT}`
+		);
+	}
+	const seenTargets = new Set<string>();
+	return raw.map((entry, index) => {
+		const at = `workspace.envFilesRef[${index}]`;
+		if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+			throw new FleetRunEnvFileError(`${at} must be an object`);
+		}
+		const ref = entry as Record<string, unknown>;
+		const repoConnectionId = typeof ref.repoConnectionId === 'string' ? ref.repoConnectionId.trim() : '';
+		if (!repoConnectionId || repoConnectionId.length > 64 || !/^[A-Za-z0-9._-]+$/.test(repoConnectionId)) {
+			throw new FleetRunEnvFileError(`${at}.repoConnectionId is not a valid registry row id`);
+		}
+		let mountDir: string | undefined;
+		if (ref.mountDir !== undefined && ref.mountDir !== null) {
+			const value = typeof ref.mountDir === 'string' ? ref.mountDir.trim() : '';
+			if (!FLEET_TASK_WORKSPACE_MOUNT_DIR_PATTERN.test(value) || isReservedMountDir(value)) {
+				throw new FleetRunEnvFileError(`${at}.mountDir must be a mount directory of this workspace`);
+			}
+			mountDir = value;
+		}
+		// One entry per CHECKOUT: two refs for the same target would make
+		// "which repository's `.env` won" depend on array order.
+		const targetKey = (mountDir ?? '').toLowerCase();
+		if (seenTargets.has(targetKey)) {
+			throw new FleetRunEnvFileError(
+				`${at} targets ${mountDir ? `mount '${mountDir}'` : 'the primary worktree'}, which another entry already claims`
+			);
+		}
+		seenTargets.add(targetKey);
+		if (!Array.isArray(ref.paths) || ref.paths.length === 0) {
+			throw new FleetRunEnvFileError(`${at}.paths must be a non-empty array of repository-relative paths`);
+		}
+		if (ref.paths.length > FLEET_RUN_ENV_FILE_MAX_COUNT) {
+			throw new FleetRunEnvFileError(
+				`${at}.paths has ${ref.paths.length} entries; the limit is ${FLEET_RUN_ENV_FILE_MAX_COUNT}`
+			);
+		}
+		const paths: string[] = [];
+		const seenPaths = new Set<string>();
+		for (const candidate of ref.paths) {
+			if (!isValidFleetRunEnvFilePath(candidate)) {
+				// The PATH is echoed (it is not a secret and the operator needs
+				// to know which entry is wrong); the content never is.
+				throw new FleetRunEnvFileError(
+					`${at}.paths contains '${String(candidate)}', which is not a repository-relative env file path`
+				);
+			}
+			const path = (candidate as string).trim();
+			const key = path.toLowerCase();
+			if (seenPaths.has(key)) {
+				throw new FleetRunEnvFileError(`${at}.paths lists '${path}' twice`);
+			}
+			seenPaths.add(key);
+			paths.push(path);
+		}
+		return {
+			repoConnectionId,
+			...(mountDir === undefined ? {} : { mountDir }),
+			paths
+		};
+	});
+}
+
+/**
+ * Shape-valid, wildcard-free, de-duplicated, capped grant names.
+ *
+ * Unlike {@link normalizeFleetRunEnvFileRefs} this one DROPS what it
+ * cannot accept rather than throwing, because it runs on both sides: the
+ * API validates an operator's edit loudly (see `assertValidEnvGrants` in
+ * the registry service), while the node re-normalizes whatever arrived
+ * and must never fail a run over a name it is going to ignore anyway.
+ */
+export function normalizeFleetRunEnvGrants(names: unknown): string[] {
+	if (!Array.isArray(names)) return [];
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const raw of names) {
+		if (!isGrantableFleetRunEnvName(raw)) continue;
+		const name = (raw as string).trim();
+		const upper = name.toUpperCase();
+		if (seen.has(upper)) continue;
+		seen.add(upper);
+		out.push(name);
+		if (out.length >= FLEET_RUN_ENV_GRANT_MAX_COUNT) break;
+	}
+	return out;
+}

--- a/packages/contracts/src/fleet/fleet-task-workspace.types.ts
+++ b/packages/contracts/src/fleet/fleet-task-workspace.types.ts
@@ -1,3 +1,5 @@
+import type { FleetRunEnvFileRef } from './fleet-run-secrets.types.js';
+
 /**
  * Repository metadata a Fleet node needs to provision one Task-owned Git
  * workspace. Clone URLs are deliberately token-free: node-local Git
@@ -23,6 +25,20 @@ export interface FleetTaskWorkspaceSpec {
 	 * absent or empty means the single-repository workspace of slices A/B.
 	 */
 	readonly mounts?: readonly FleetTaskWorkspaceMountSpec[];
+	/**
+	 * Run secrets (self-build slice Y). Which repositories' seed `.env`
+	 * files this run needs, BY REFERENCE — registry row ids and
+	 * repository-relative PATHS, never contents. The node fetches the
+	 * decrypted content over the node-authenticated job channel while it
+	 * holds the lease, writes it 0600 inside the checkout, keeps it out of
+	 * Git, and deletes it when the run ends.
+	 *
+	 * A ref whose `mountDir` is absent targets the primary worktree; a ref
+	 * that names a `mountDir` targets that mount of THIS spec. Validated by
+	 * `normalizeFleetRunEnvFileRefs`; absent or empty means the run needs no
+	 * env files, which is every workspace before this slice.
+	 */
+	readonly envFilesRef?: readonly FleetRunEnvFileRef[];
 }
 
 /**

--- a/packages/contracts/src/fleet/index.ts
+++ b/packages/contracts/src/fleet/index.ts
@@ -3,5 +3,6 @@ export * from './fleet-execution-preference.types.js';
 export * from './fleet-jobs.types.js';
 export * from './fleet-node.types.js';
 export * from './fleet-panic.types.js';
+export * from './fleet-run-secrets.types.js';
 export * from './fleet-runner-status.types.js';
 export * from './fleet-task-workspace.types.js';


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **Y** (program note §6). Refs **EW-781**.

A fleet run that has to `pnpm test` against a real database needs the repo's `.env`. Today the only way to give it one is the job payload — which means the value lands in `fleet_jobs.payload`, in the lease response, in the job view the owner's browser renders, and, because a failing check prints the variable it read, in `fleet_jobs.result`.

This adds a delivery channel where the value exists for **exactly one HTTPS response and one 0600 file write**.

### What changes

- **`POST /api/fleet/jobs/:id/env-files`**, authenticated as the node that *holds the lease*. The answering owner id comes from the **job**, never from the request body, so an authenticated node cannot name another tenant's connection id. The route applies the same four lease checks as complete: node identity, job-to-node binding, non-terminal status, and a current `leaseGeneration`.
- **Grants on the repo connection**, matched as exact upper-cased names. No prefix, no wildcard — an owner opts a file in per connection.
- **Nothing value-bearing on the wire.** The job carries `envFilesRef` — `{repoConnectionId, paths, mountDir?}`. There is no `content` field on any job, lease or result shape; the one value-bearing interface in the module is the endpoint's own response body.
- **On the node**, files are written 0600 into the checkout, excluded from Git, and deleted on every exit path: success, crash, cancel, lapsed lease and the reaper.
- Migration `1789200000000-AddRepoConnectionEnvGrants`, with a spec.

### Adversarial review — three of the four fixes were security defects

- **A delivered value reached `fleet_jobs.result`.** The redactor scrubs values it looks up *by name* from `parentEnv`, which is right for grants and useless for env files: their values live in no environment. `logger.protect(file.content)` registered the file as **one blob**, so it only matched a log line reproducing the entire file — and a `.env` does not leak that way. A failing `pnpm test` prints the single variable it read. A delivered `DATABASE_URL` sailed into a check's `logTail` verbatim, with no grant involved. Values are now extracted per `KEY=VALUE` line and registered separately.
- **Deletion could never happen** on the path that mattered: it read the on-disk manifest and nothing else, and the manifest is best-effort.
- **The node would have committed and pushed the secret itself.** The exclude rule went to `info/exclude`, the *lowest-precedence* ignore source Git has. The model holds `acceptEdits` over the whole checkout, so a prompt-injected run writing `!/apps/api/.env` into a `.gitignore` would have had `git add -A` stage the secret and the node push it into the owner's branch and the pull request the platform opens. Removal now also runs **before the first Git command**, where nothing downstream still reads the files. A spec pins the ordering.
- `agent-task.ts` contained **two raw NUL bytes** where a map-key separator was intended, which would have made Git treat the file as binary and show **no diff at all** in this review.

### Verified locally

The three security claims were re-checked directly against source after the review, not taken on report: the owner id comes off the job row, no job/lease/result type names a content field, and the pre-finalize deletion sits immediately above the Git block.

| Check | Result |
| --- | --- |
| whole `packages/contracts` vitest | 33 files / 1704 tests, no type errors |
| barrel inventory guard | 118 → **135**, `toHaveLength(135)` + witness row |
| `packages/agent` fleet, database, events, config, tasks-domain, repo-registry | 121 suites / 1937 tests |
| `apps/api` migrations + fleet + repo-connections | 398 tests, 0 failures |
| `apps/node` `src/core` | 858 tests |
| `apps/node` tsc | clean |
| `prettier --check` over all 42 changed files | clean |

### Not verified locally

- **6 `apps/api` suites cannot load here** — `@ever-works/agent-plugins` has no `dist/` in this checkout and rebuilding it needs a `pnpm install` this environment does not run. They are unrelated to this diff by import path and run normally in CI.
- Two `apps/node` failures are environmental and untouched by this branch: the Windows trust spec needs a Rust binary that is not built here, and the mounts spec needs a `local-workspace` dist rebuild.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
