### PR TITLE
fix(agent): stamp a skill file from its parent Skill, not the request scope

### DIFF
--- a/packages/agent/src/skills/__tests__/skill-files.service.spec.ts
+++ b/packages/agent/src/skills/__tests__/skill-files.service.spec.ts
@@ -73,6 +73,40 @@ describe('SkillFilesService', () => {
             expect(files.create).not.toHaveBeenCalled();
         });
 
+        /**
+         * EW-798. `assertOwnedSkill` checks ownership only — deliberately, since
+         * every Skill read works that way — so a personal-scope request may
+         * legitimately add a file to an Organization-scoped Skill. Left to the
+         * ambient stamp, the row would then contradict its own parent and be
+         * indistinguishable from a genuinely personal file.
+         */
+        it('stamps the file from its parent Skill, not from the ambient request scope', async () => {
+            skills.findByIdAndUser.mockResolvedValueOnce({
+                id: 'sk1',
+                userId: 'u1',
+                tenantId: 'tenant-a',
+                organizationId: 'org-1',
+            });
+
+            await svc.add('u1', addInput());
+
+            expect(files.create).toHaveBeenCalledWith(
+                expect.objectContaining({ tenantId: 'tenant-a', organizationId: 'org-1' }),
+            );
+        });
+
+        it('writes an explicit personal stamp for a personal Skill rather than leaving it to the subscriber', async () => {
+            // `undefined` is what makes ScopeStampingSubscriber fill a column,
+            // so a personal parent has to produce nulls, not absent keys.
+            skills.findByIdAndUser.mockResolvedValueOnce({ id: 'sk1', userId: 'u1' });
+
+            await svc.add('u1', addInput());
+
+            const stamped = files.create.mock.calls[0][0];
+            expect(stamped.tenantId).toBeNull();
+            expect(stamped.organizationId).toBeNull();
+        });
+
         it('defaults the kind by extension and honors an explicit kind', async () => {
             await svc.add('u1', addInput());
             expect(files.create).toHaveBeenCalledWith(expect.objectContaining({ kind: 'script' }));

--- a/packages/agent/src/skills/skill-files.service.ts
+++ b/packages/agent/src/skills/skill-files.service.ts
@@ -7,6 +7,7 @@ import {
     Optional,
 } from '@nestjs/common';
 import { SkillRepository } from '../database/repositories/skill.repository';
+import type { Skill } from '../entities/skill.entity';
 import { SkillFileRepository } from '../database/repositories/skill-file.repository';
 import { SkillFile, SKILL_FILE_KINDS, type SkillFileKind } from '../entities/skill-file.entity';
 import { ActivityLogService } from '../activity-log/activity-log.service';
@@ -93,7 +94,7 @@ export class SkillFilesService {
     }
 
     async add(userId: string, input: AddSkillFileInput): Promise<SkillFile> {
-        await this.assertOwnedSkill(userId, input.skillId);
+        const skill = await this.assertOwnedSkill(userId, input.skillId);
 
         const filename = input.filename?.trim();
         if (!filename || filename.length > 255 || /[/\\]|\.\.|[\0-\x1f]/.test(filename)) {
@@ -139,6 +140,22 @@ export class SkillFilesService {
             kind: input.kind ?? defaultKindForFilename(filename),
             sizeBytes: Math.floor(input.sizeBytes),
             mime: input.mime,
+            // Stamped from the PARENT Skill, not from the request scope.
+            //
+            // `ScopeStampingSubscriber` would otherwise fill these from
+            // whatever scope the request carried, and this path does not
+            // require the two to agree: `assertOwnedSkill` checks ownership
+            // only, so a personal-scope request may legitimately add a file to
+            // an Organization-scoped Skill. The row would then contradict its
+            // own parent, and nothing downstream could tell that from a
+            // genuinely personal file.
+            //
+            // The subscriber only fills a column that is `undefined`, so an
+            // explicit value wins. Reads are untouched — `SkillFileRepository`
+            // filters by `{skillId, userId}` and never by scope — which is why
+            // this fixes the stamp without narrowing anyone's access.
+            tenantId: skill.tenantId ?? null,
+            organizationId: skill.organizationId ?? null,
         });
         await this.logActivity(userId, input.skillId, filename, 'added');
         return created;
@@ -180,8 +197,17 @@ export class SkillFilesService {
         }
     }
 
-    private async assertOwnedSkill(userId: string, skillId: string): Promise<void> {
+    /**
+     * Returns the Skill rather than discarding it, so a caller that needs to
+     * stamp a child row from its parent's scope does not have to load it a
+     * second time. Ownership only — deliberately NOT scope-filtered, because
+     * `SkillRepository.findByIdAndUser` is how every Skill read works and
+     * narrowing it here would hide a user's own Skills from them depending on
+     * which tab they were standing in.
+     */
+    private async assertOwnedSkill(userId: string, skillId: string): Promise<Skill> {
         const skill = await this.skills.findByIdAndUser(skillId, userId);
         if (!skill) throw new NotFoundException(`Skill ${skillId} not found.`);
+        return skill;
     }
 }


### PR DESCRIPTION
Second half of [EW-798](https://evertech.atlassian.net/browse/EW-798) — the follow-up filed from #2358 so its one-shot backfill is not needed twice.

## The defect

`SkillFilesService.assertOwnedSkill` checks **ownership only** (`SkillRepository.findByIdAndUser`, no scope). So a personal-scope request may legitimately add a companion file to an Organization-scoped Skill — and `ScopeStampingSubscriber` then filled the row's `tenantId`/`organizationId` from whatever scope the request happened to carry. The child contradicted its own parent, and nothing downstream could distinguish that from a genuinely personal file.

`add()` now uses the Skill that `assertOwnedSkill` had already loaded and discarded, and stamps from it. The subscriber only fills a column that is `undefined`, so an explicit value wins; a personal parent yields explicit `null`s rather than absent keys, which is what stops the subscriber re-filling them.

Mutation-tested: removing the two explicit fields turns both new tests red.

## The alternative I rejected

Narrowing `assertOwnedSkill` to filter by scope is the obvious fix and it is wrong. That method is how **every** Skill read works (list, get, add, remove), and the Skills UI is not scope-partitioned — so scoping it would hide a user's own Skills and their files from them depending on which tab they were standing in. Fixing a stamp must not narrow access.

## The first half of EW-798 does not exist — the ticket was wrong

I filed that item claiming a `?workId=` upload could be stamped personal against an Organization Work by a header-less client. Checking `ownershipScopeMatches` shows it cannot:

- an **org** request scope requires an exact `tenantId` + `organizationId` match on the Work;
- a **personal** request scope requires `organizationId === null` on the Work.

So `assertWorkAccess` already **404s** a personal-scope upload into an org Work, before any row is written. There is no reachable mismatch, and stamping from the Work would be a no-op in every case that gets that far. I have corrected the ticket rather than shipping a fix for a case that cannot occur.

Also deliberately untouched: the `user_uploads` row holding a skill file's bytes keeps the request scope. Its reader resolves by `(uploadId, userId)` with no scope at all, and stamping it from the Skill would make the generic serve path 404 those bytes from a personal tab — a regression in exchange for nothing.

## Verification

16 tests in `skill-files.service.spec.ts` green (2 new), `tsc` clean for `packages/agent`, Prettier clean.

[EW-798]: https://evertech.atlassian.net/browse/EW-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Skill files now consistently inherit the correct tenant and organization scope from their parent Skill.
  - Files added to personal Skills explicitly retain personal scope instead of inheriting unrelated request context.

- **Tests**
  - Added coverage for organization-scoped and personal Skill file creation to verify correct scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->