### PR TITLE
fix(fleet): make the node disk floor fail closed and report housekeeping upward (EW-803)

### DIFF
--- a/apps/api/src/fleet/dto/fleet-heartbeat-housekeeping.dto.spec.ts
+++ b/apps/api/src/fleet/dto/fleet-heartbeat-housekeeping.dto.spec.ts
@@ -1,0 +1,154 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { FLEET_MAX_DISK_FREE_BYTES, FLEET_MAX_WORKSPACE_COUNT } from '@ever-works/contracts';
+import { FleetHeartbeatDto } from './fleet.dto';
+
+/**
+ * Node housekeeping (EW-803) — the heartbeat DTO's half of the contract.
+ *
+ * The global pipe runs `whitelist + forbidNonWhitelisted`, which makes
+ * this file load-bearing in a way most DTOs are not: a field the DTO does
+ * not accept is not dropped, it fails the whole request — and a failed
+ * heartbeat is a node swept offline. Adding five fields to the beat is
+ * therefore only safe if all three of these hold, and each is pinned
+ * below:
+ *
+ *   - an OLDER daemon that sends none of them still beats;
+ *   - a NEWER daemon that sends all of them is accepted, rather than
+ *     400'd by an API that predates the fields;
+ *   - a MALFORMED value costs the machine that one figure and nothing
+ *     more — which is why `lastReclaimAt` is a bounded string here and is
+ *     parsed in `FleetService`, not validated as an ISO date at the edge.
+ *
+ * The service-side refusal policy (nonsense dropped rather than clamped,
+ * null-clears-the-floor, the instant/bytes pairing) lives in
+ * `packages/agent/src/fleet/__tests__/fleet-node-telemetry.spec.ts`.
+ */
+
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const SECRET = 'a'.repeat(43);
+
+async function failingProperties(dto: object): Promise<string[]> {
+    const errors = await validate(dto);
+    return errors.map((error) => error.property).sort();
+}
+
+const beat = (extra: Record<string, unknown>) =>
+    plainToInstance(FleetHeartbeatDto, { nodeId: NODE_ID, secret: SECRET, ...extra });
+
+describe('FleetHeartbeatDto — housekeeping', () => {
+    it('accepts a full housekeeping report', async () => {
+        const dto = beat({
+            minFreeDiskBytes: 2 * 1024 ** 3,
+            workspaceCount: 12,
+            workspaceBytes: 40 * 1024 ** 3,
+            lastReclaimAt: '2026-09-05T09:30:00.000Z',
+            lastReclaimFreedBytes: 3 * 1024 ** 3,
+        });
+        await expect(failingProperties(dto)).resolves.toEqual([]);
+    });
+
+    it('accepts a beat that says nothing about housekeeping at all', async () => {
+        // Every daemon in the field before this slice. Absent must stay
+        // valid or the whole fleet 400s on its next beat.
+        await expect(failingProperties(beat({}))).resolves.toEqual([]);
+    });
+
+    it('accepts an explicit null floor — "the operator switched it off"', async () => {
+        // `@IsOptional()` skips null as well as undefined, which is what
+        // lets this state be expressed at all. The service tells the two
+        // apart; the pipe must not reject either.
+        await expect(failingProperties(beat({ minFreeDiskBytes: null }))).resolves.toEqual([]);
+    });
+
+    it('accepts a zero floor, a zero count and a zero reclaim', async () => {
+        // Zero is a real answer for each of these, and `@Min(0)` must not
+        // be tightened to `@Min(1)` by someone who assumes otherwise.
+        const dto = beat({
+            minFreeDiskBytes: 0,
+            workspaceCount: 0,
+            workspaceBytes: 0,
+            lastReclaimFreedBytes: 0,
+        });
+        await expect(failingProperties(dto)).resolves.toEqual([]);
+    });
+
+    it('accepts each numeric field at exactly its contract ceiling', async () => {
+        await expect(
+            failingProperties(beat({ workspaceCount: FLEET_MAX_WORKSPACE_COUNT })),
+        ).resolves.toEqual([]);
+        await expect(
+            failingProperties(beat({ workspaceBytes: FLEET_MAX_DISK_FREE_BYTES })),
+        ).resolves.toEqual([]);
+    });
+
+    it.each([
+        ['workspaceCount', FLEET_MAX_WORKSPACE_COUNT + 1],
+        ['workspaceBytes', FLEET_MAX_DISK_FREE_BYTES * 2],
+        ['lastReclaimFreedBytes', FLEET_MAX_DISK_FREE_BYTES * 2],
+    ])('rejects %s past its ceiling', async (field, value) => {
+        await expect(failingProperties(beat({ [field]: value }))).resolves.toEqual([field]);
+    });
+
+    it.each([
+        ['minFreeDiskBytes', -1],
+        ['workspaceCount', -1],
+        ['workspaceBytes', -1],
+        ['lastReclaimFreedBytes', -1],
+    ])('rejects a negative %s', async (field, value) => {
+        await expect(failingProperties(beat({ [field]: value }))).resolves.toEqual([field]);
+    });
+
+    it('rejects a fractional workspace count', async () => {
+        await expect(failingProperties(beat({ workspaceCount: 3.5 }))).resolves.toEqual([
+            'workspaceCount',
+        ]);
+    });
+
+    it.each([
+        ['a string', '12'],
+        ['an object', { count: 12 }],
+        ['an array', [12]],
+    ])('rejects %s as a workspace count', async (_label, workspaceCount) => {
+        await expect(failingProperties(beat({ workspaceCount }))).resolves.toEqual([
+            'workspaceCount',
+        ]);
+    });
+
+    it('accepts an UNPARSEABLE reclaim instant rather than failing the beat', async () => {
+        // The deliberate design decision this case exists to protect. An
+        // `@IsISO8601()` here would take a live machine offline over a
+        // cosmetic timestamp; the service refuses the value instead and
+        // the node keeps its liveness.
+        await expect(failingProperties(beat({ lastReclaimAt: 'last Tuesday' }))).resolves.toEqual(
+            [],
+        );
+    });
+
+    it('accepts a reclaim instant with an offset and with nanosecond precision', async () => {
+        // A node is an ordinary PC in an ordinary timezone; the edge cap
+        // has to fit the long forms, not just the Z-normalized one.
+        await expect(
+            failingProperties(beat({ lastReclaimAt: '2026-09-05T14:03:07.123456789+05:30' })),
+        ).resolves.toEqual([]);
+    });
+
+    it('rejects an absurdly long reclaim instant', async () => {
+        // A heartbeat field with no cap is unbounded storage on an
+        // unauthenticated-by-token public endpoint.
+        await expect(failingProperties(beat({ lastReclaimAt: 'x'.repeat(65) }))).resolves.toEqual([
+            'lastReclaimAt',
+        ]);
+    });
+
+    it('rejects a non-string reclaim instant', async () => {
+        await expect(failingProperties(beat({ lastReclaimAt: 1757064600000 }))).resolves.toEqual([
+            'lastReclaimAt',
+        ]);
+    });
+
+    it('still requires the credential — the new fields buy no authority', async () => {
+        const dto = plainToInstance(FleetHeartbeatDto, { workspaceCount: 1 });
+        await expect(failingProperties(dto)).resolves.toEqual(['nodeId', 'secret']);
+    });
+});

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -27,6 +27,7 @@ import {
     FLEET_MAX_PLATFORM_LENGTH,
     FLEET_MAX_VERSION_LENGTH,
     FLEET_MAX_WORKER_STATE_REASON_LENGTH,
+    FLEET_MAX_WORKSPACE_COUNT,
     FLEET_MIN_NODE_NAME_LENGTH,
     FLEET_NODE_WORKER_STATES,
 } from '@ever-works/contracts';
@@ -51,6 +52,19 @@ import {
  * constraints in `./fleet-capability.validators`.
  */
 const ENROLLABLE_KINDS: readonly FleetEnrollableNodeKind[] = FLEET_ENROLLABLE_NODE_KINDS;
+
+/**
+ * Edge cap on a node-reported ISO-8601 instant (`lastReclaimAt`).
+ *
+ * Local rather than a shared contract constant on purpose: it is not a
+ * protocol bound both tiers must agree on, it is this edge refusing an
+ * oversized body before `FleetService` — the actual source of truth —
+ * parses the string. The longest legitimate form
+ * (`2026-09-05T14:03:07.123456789+05:30`) is 35 characters; 64 leaves
+ * room for every variant without leaving a heartbeat field usable as
+ * unbounded storage.
+ */
+const FLEET_MAX_INSTANT_LENGTH = 64;
 
 /**
  * Request body for `POST /api/fleet/nodes/enrollment-token` — issue a
@@ -308,6 +322,92 @@ export class FleetNodeSelfDescriptionDto {
     @IsString()
     @MaxLength(FLEET_MAX_WORKER_STATE_REASON_LENGTH)
     workerStateReason?: string;
+
+    /**
+     * Node housekeeping (EW-803) — the disk floor the node enforces on
+     * itself. Reported for visibility; the platform never sets it and
+     * never routes on it.
+     *
+     * `@IsOptional()` skips validation for `null` as well as `undefined`,
+     * which is what makes "the operator switched the floor off" (an
+     * explicit null) expressible without the pipe rejecting the beat.
+     * The service tells the two apart: absent leaves the stored value
+     * alone, null clears it.
+     */
+    @ApiProperty({
+        required: false,
+        nullable: true,
+        minimum: 0,
+        maximum: FLEET_MAX_DISK_FREE_BYTES,
+        description:
+            'Free-space floor the node refuses to lease or provision below, in bytes. Null means the operator switched the floor off. Enforced on the node; reported here for visibility only.',
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(FLEET_MAX_DISK_FREE_BYTES)
+    minFreeDiskBytes?: number | null;
+
+    /** Workspaces the node retained after its last reclaim sweep. */
+    @ApiProperty({
+        required: false,
+        minimum: 0,
+        maximum: FLEET_MAX_WORKSPACE_COUNT,
+        description: 'Task worktrees the node was holding when its last reclaim sweep finished.',
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(FLEET_MAX_WORKSPACE_COUNT)
+    workspaceCount?: number;
+
+    /** Bytes those retained workspaces occupy. */
+    @ApiProperty({
+        required: false,
+        minimum: 0,
+        maximum: FLEET_MAX_DISK_FREE_BYTES,
+        description: 'Bytes the node’s retained workspaces occupy.',
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(FLEET_MAX_DISK_FREE_BYTES)
+    workspaceBytes?: number;
+
+    /**
+     * When the node's last reclaim sweep completed, on the NODE's clock.
+     *
+     * Bounded as a plain `@IsString()` and NOT `@IsISO8601()`, for
+     * exactly the reason `workerState` is not an `@IsIn`: the global pipe
+     * runs `whitelist + forbidNonWhitelisted`, so a value this build
+     * rejects fails the whole request — and a failed heartbeat is a node
+     * swept offline. A malformed instant must cost the operator that one
+     * figure, never the machine's liveness. `FleetService` parses it and
+     * refuses anything it cannot trust.
+     */
+    @ApiProperty({
+        required: false,
+        maxLength: FLEET_MAX_INSTANT_LENGTH,
+        description:
+            'ISO-8601 instant at which the node’s last reclaim sweep completed (the node’s own clock). An unparseable value is recorded as unknown rather than rejected, so a node never loses its heartbeat to a bad timestamp.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(FLEET_MAX_INSTANT_LENGTH)
+    lastReclaimAt?: string;
+
+    /** Bytes that sweep reclaimed. Zero is a real answer. */
+    @ApiProperty({
+        required: false,
+        minimum: 0,
+        maximum: FLEET_MAX_DISK_FREE_BYTES,
+        description: 'Bytes the node’s last reclaim sweep freed.',
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(FLEET_MAX_DISK_FREE_BYTES)
+    lastReclaimFreedBytes?: number;
 }
 
 /**

--- a/apps/api/src/fleet/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/fleet.controller.spec.ts
@@ -415,8 +415,85 @@ describe('FleetController', () => {
                 modelIdentity: undefined,
                 workerState: undefined,
                 workerStateReason: undefined,
+                // Node housekeeping (EW-803).
+                minFreeDiskBytes: undefined,
+                workspaceCount: undefined,
+                workspaceBytes: undefined,
+                lastReclaimAt: undefined,
+                lastReclaimFreedBytes: undefined,
             });
+            // …and the KEY SET, because the assertion above does not check
+            // it (review AO-12). `toHaveBeenCalledWith` uses the same
+            // recursive equality as `toEqual`, which treats `{a: undefined}`
+            // and `{}` as equal — so every `x: undefined` line above would
+            // still pass with all five mappings deleted from the controller.
+            // A field added to the DTO and forgotten in the controller's map
+            // has to fail HERE, on a call that carries no values at all,
+            // rather than only in the sibling case below.
+            expect(Object.keys(service.enroll.mock.calls[0][1] as object).sort()).toEqual(
+                [
+                    'platform',
+                    'version',
+                    'capabilities',
+                    'cliVersion',
+                    'diskFreeBytes',
+                    'modelIdentity',
+                    'workerState',
+                    'workerStateReason',
+                    'minFreeDiskBytes',
+                    'workspaceCount',
+                    'workspaceBytes',
+                    'lastReclaimAt',
+                    'lastReclaimFreedBytes',
+                ].sort(),
+            );
             expect(result.secret).toBe('node-secret');
+        });
+
+        it('forwards the housekeeping report on BOTH enroll and heartbeat (EW-803)', async () => {
+            // Same trap as the worker state below: the mapping, not the DTO,
+            // is what decides whether a field ever reaches the service.
+            service.enroll.mockResolvedValue({
+                nodeId: nodeView.id,
+                secret: 'node-secret',
+                node: nodeView,
+            });
+            await controller.enroll({
+                token: 'x'.repeat(43),
+                minFreeDiskBytes: 2 * 1024 ** 3,
+                workspaceCount: 12,
+                workspaceBytes: 40 * 1024 ** 3,
+                lastReclaimAt: '2026-09-05T09:30:00.000Z',
+                lastReclaimFreedBytes: 3 * 1024 ** 3,
+            } as EnrollFleetNodeDto);
+            expect(service.enroll).toHaveBeenCalledWith(
+                'x'.repeat(43),
+                expect.objectContaining({
+                    minFreeDiskBytes: 2 * 1024 ** 3,
+                    workspaceCount: 12,
+                    workspaceBytes: 40 * 1024 ** 3,
+                    lastReclaimAt: '2026-09-05T09:30:00.000Z',
+                    lastReclaimFreedBytes: 3 * 1024 ** 3,
+                }),
+            );
+
+            service.heartbeat.mockResolvedValue({ node: nodeView });
+            await controller.heartbeat({
+                nodeId: nodeView.id,
+                secret: 'x'.repeat(43),
+                // The explicit null the node sends when the operator turned
+                // the floor off. It has to survive the mapping as `null`,
+                // not be normalized to `undefined` on the way through —
+                // `undefined` means "said nothing" and would leave a floor
+                // on screen that no longer exists.
+                minFreeDiskBytes: null,
+                workspaceCount: 0,
+            } as FleetHeartbeatDto);
+            expect(service.heartbeat).toHaveBeenCalledWith(
+                nodeView.id,
+                'x'.repeat(43),
+                expect.objectContaining({ minFreeDiskBytes: null, workspaceCount: 0 }),
+            );
         });
 
         it('forwards the worker state on BOTH enroll and heartbeat (EW-776)', async () => {

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -541,6 +541,16 @@ export class FleetController {
             modelIdentity: body.modelIdentity,
             workerState: body.workerState,
             workerStateReason: body.workerStateReason,
+            // Node housekeeping (EW-803). Named here, like everything
+            // above, because this mapping is the thing that decides what
+            // actually reaches the service — a field added to the DTO and
+            // forgotten on this line is accepted at the edge and then
+            // silently dropped.
+            minFreeDiskBytes: body.minFreeDiskBytes,
+            workspaceCount: body.workspaceCount,
+            workspaceBytes: body.workspaceBytes,
+            lastReclaimAt: body.lastReclaimAt,
+            lastReclaimFreedBytes: body.lastReclaimFreedBytes,
         });
         if (!result) {
             // One undifferentiated message — never say WHICH check failed.
@@ -568,6 +578,16 @@ export class FleetController {
             modelIdentity: body.modelIdentity,
             workerState: body.workerState,
             workerStateReason: body.workerStateReason,
+            // Node housekeeping (EW-803). Named here, like everything
+            // above, because this mapping is the thing that decides what
+            // actually reaches the service — a field added to the DTO and
+            // forgotten on this line is accepted at the edge and then
+            // silently dropped.
+            minFreeDiskBytes: body.minFreeDiskBytes,
+            workspaceCount: body.workspaceCount,
+            workspaceBytes: body.workspaceBytes,
+            lastReclaimAt: body.lastReclaimAt,
+            lastReclaimFreedBytes: body.lastReclaimFreedBytes,
         });
         if (!result) {
             throw new UnauthorizedException('Invalid node credential');

--- a/apps/api/src/migrations/1789500000000-AddFleetNodeHousekeeping.ts
+++ b/apps/api/src/migrations/1789500000000-AddFleetNodeHousekeeping.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Node housekeeping visibility (EW-803, self-build findings OPS-12 and R8).
+ *
+ * The defect this closes: both halves of node housekeeping were enforced
+ * on the machine and invisible from the platform.
+ *
+ *  - The disk FLOOR was node-local. `diskFreeBytes` had been on the wire
+ *    since `1786920000000`, so Fleet could say "1.2 GB free" — but not
+ *    whether 1.2 GB was comfortable or the reason that node had quietly
+ *    stopped leasing.
+ *  - The workspace REAPER wrote its outcome to the node's own log file
+ *    and nowhere else. From Fleet there was no way to distinguish a
+ *    machine whose reaper is keeping up from one where it has not run
+ *    since March — which is how a founder's PC reached 38 MB free.
+ *
+ * Five nullable columns on `fleet_nodes`:
+ *
+ *  1. `minFreeDiskBytes` — the floor the node enforces on ITSELF. Stored
+ *     for display only. Nothing routes on it and no path pushes a value
+ *     back down: the limit stays enforced on the machine, which is the
+ *     point of lending one.
+ *  2. `workspaceCount` / `workspaceBytes` — what the last sweep retained.
+ *  3. `lastReclaimAt` / `lastReclaimFreedBytes` — when it last ran and
+ *     what it took.
+ *
+ * NO DEFAULTS, and NULL is the honest backfill on every one of them. A
+ * `0` default on `workspaceCount` would state in the schema that every
+ * already-enrolled node is holding no workspaces — reassuring, and
+ * exactly backwards from the truth, which is that we have never asked.
+ *
+ * The byte columns are `bigint` for the same reason `diskFreeBytes` is:
+ * a modern volume overflows a 32-bit int by three orders of magnitude.
+ * `workspaceCount` is a plain `int` — 100,000 is the contract ceiling.
+ *
+ * `lastReclaimAt` is `timestamp` and, unlike every other instant on this
+ * table, carries a value the NODE supplied rather than one the server
+ * stamped. `FleetService` refuses anything unparseable or implausibly
+ * far in the future before it reaches this column.
+ *
+ * Portable DDL (`TableColumn`) because CI and the e2e stack run
+ * better-sqlite3 while production runs Postgres. Forward-only with a
+ * guard per step, so a partially-applied database converges rather than
+ * aborting; `down()` reverses all of it through `dropColumn` (never a raw
+ * `ALTER TABLE ... DROP COLUMN`, which sqlite only learned in 3.35 and
+ * which desynchronises the query runner's metadata).
+ */
+export class AddFleetNodeHousekeeping1789500000000 implements MigrationInterface {
+    name = 'AddFleetNodeHousekeeping1789500000000';
+
+    /** Column name → its portable definition. Order is the order they are added. */
+    private static readonly COLUMNS: ReadonlyArray<{ name: string; column: () => TableColumn }> = [
+        {
+            name: 'minFreeDiskBytes',
+            column: () =>
+                new TableColumn({ name: 'minFreeDiskBytes', type: 'bigint', isNullable: true }),
+        },
+        {
+            name: 'workspaceCount',
+            column: () =>
+                new TableColumn({ name: 'workspaceCount', type: 'int', isNullable: true }),
+        },
+        {
+            name: 'workspaceBytes',
+            column: () =>
+                new TableColumn({ name: 'workspaceBytes', type: 'bigint', isNullable: true }),
+        },
+        {
+            name: 'lastReclaimAt',
+            column: () =>
+                new TableColumn({ name: 'lastReclaimAt', type: 'timestamp', isNullable: true }),
+        },
+        {
+            name: 'lastReclaimFreedBytes',
+            column: () =>
+                new TableColumn({
+                    name: 'lastReclaimFreedBytes',
+                    type: 'bigint',
+                    isNullable: true,
+                }),
+        },
+    ];
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const nodes = await queryRunner.getTable('fleet_nodes');
+        if (!nodes) return;
+
+        for (const { name, column } of AddFleetNodeHousekeeping1789500000000.COLUMNS) {
+            if (!nodes.findColumnByName(name)) {
+                await queryRunner.addColumn('fleet_nodes', column());
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const nodes = await queryRunner.getTable('fleet_nodes');
+        if (!nodes) return;
+
+        for (const { name } of [...AddFleetNodeHousekeeping1789500000000.COLUMNS].reverse()) {
+            if (nodes.findColumnByName(name)) {
+                await queryRunner.dropColumn('fleet_nodes', name);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddFleetNodeHousekeeping.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddFleetNodeHousekeeping.spec.ts
@@ -1,0 +1,197 @@
+import { DataSource } from 'typeorm';
+import { AddFleetNodeHousekeeping1789500000000 } from '../1789500000000-AddFleetNodeHousekeeping';
+
+/**
+ * Migration test for the node-housekeeping schema (EW-803).
+ *
+ * Same in-memory better-sqlite3 harness as the sibling migration specs,
+ * with one deliberate difference: every schema assertion goes through
+ * `PRAGMA table_info`, i.e. the PHYSICAL schema, rather than through
+ * `queryRunner.getTable()`.
+ *
+ * That matters here specifically. `getTable()` answers from the query
+ * runner's own metadata, which is the thing a raw `ALTER TABLE ... DROP
+ * COLUMN` desynchronises — so a `down()` that used the raw form could
+ * pass a `getTable()` assertion while leaving the column on disk. Asking
+ * sqlite directly is the only way this spec can tell the difference.
+ *
+ * Asserting the schema is also stronger than watching an INSERT fail:
+ * an INSERT proves only that SOME constraint rejected the row, and it is
+ * flaky under load. The column list is the actual contract.
+ */
+describe('AddFleetNodeHousekeeping1789500000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddFleetNodeHousekeeping1789500000000();
+
+    const NEW_COLUMNS = [
+        'minFreeDiskBytes',
+        'workspaceCount',
+        'workspaceBytes',
+        'lastReclaimAt',
+        'lastReclaimFreedBytes',
+    ];
+
+    /** The physical column list, straight from sqlite. */
+    const physicalColumns = async (): Promise<
+        Array<{ name: string; type: string; notnull: number; dflt_value: string | null }>
+    > => dataSource.query(`PRAGMA table_info("fleet_nodes")`);
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        // The subset of `fleet_nodes` this migration touches, plus the
+        // telemetry column the new floor is meant to be read against.
+        await dataSource.query(`
+            CREATE TABLE "fleet_nodes" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "userId" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                "kind" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "diskFreeBytes" bigint
+            )
+        `);
+        await dataSource.query(
+            `INSERT INTO "fleet_nodes" ("id", "userId", "name", "kind", "status", "diskFreeBytes")
+             VALUES ('n1', 'u1', 'Office PC', 'desktop-node', 'online', 1288490188)`,
+        );
+    });
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    it('adds every housekeeping column to the physical schema, nullable and without a default', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const columns = await physicalColumns();
+        for (const name of NEW_COLUMNS) {
+            const column = columns.find((candidate) => candidate.name === name);
+            expect(column).toBeDefined();
+            // `notnull: 0` — an existing row cannot be forced to invent a value.
+            expect(column?.notnull).toBe(0);
+            // No DEFAULT: a `0` default would assert in the schema that every
+            // already-enrolled node holds no workspaces and reclaimed nothing,
+            // which is reassuring and false. NULL says "never reported".
+            expect(column?.dflt_value).toBeNull();
+        }
+    });
+
+    it('uses bigint for the byte columns and int for the count', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const byName = new Map((await physicalColumns()).map((column) => [column.name, column]));
+        // A modern volume overflows a 32-bit int by three orders of
+        // magnitude, so the byte columns must match `diskFreeBytes`.
+        expect(byName.get('minFreeDiskBytes')?.type.toLowerCase()).toBe('bigint');
+        expect(byName.get('workspaceBytes')?.type.toLowerCase()).toBe('bigint');
+        expect(byName.get('lastReclaimFreedBytes')?.type.toLowerCase()).toBe('bigint');
+        // …and the count is deliberately NOT a bigint: 100,000 is the
+        // contract ceiling, so a 32-bit column is the honest width.
+        expect(byName.get('workspaceCount')?.type.toLowerCase()).toBe('int');
+    });
+
+    it('leaves existing rows NULL rather than inventing a tidy machine', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const rows = await dataSource.query(
+            `SELECT "minFreeDiskBytes", "workspaceCount", "workspaceBytes",
+                    "lastReclaimAt", "lastReclaimFreedBytes", "diskFreeBytes"
+             FROM "fleet_nodes"`,
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0].minFreeDiskBytes).toBeNull();
+        expect(rows[0].workspaceCount).toBeNull();
+        expect(rows[0].workspaceBytes).toBeNull();
+        expect(rows[0].lastReclaimAt).toBeNull();
+        expect(rows[0].lastReclaimFreedBytes).toBeNull();
+        // The reading these new columns give meaning to is untouched.
+        expect(Number(rows[0].diskFreeBytes)).toBe(1288490188);
+    });
+
+    it('accepts a byte count far beyond a 32-bit int', async () => {
+        // The whole reason for `bigint`. 8 TiB is an ordinary external
+        // volume and would silently truncate in an `int` column.
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+
+        const eightTib = 8 * 1024 ** 4;
+        await dataSource.query(`UPDATE "fleet_nodes" SET "workspaceBytes" = ? WHERE "id" = 'n1'`, [
+            eightTib,
+        ]);
+        const rows = await dataSource.query(`SELECT "workspaceBytes" FROM "fleet_nodes"`);
+        expect(Number(rows[0].workspaceBytes)).toBe(eightTib);
+    });
+
+    it('is idempotent — re-running up() does not throw', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+
+        // And adds nothing a second time.
+        const names = (await physicalColumns()).map((column) => column.name);
+        for (const name of NEW_COLUMNS) {
+            expect(names.filter((candidate) => candidate === name)).toHaveLength(1);
+        }
+    });
+
+    it('down() removes every column from the PHYSICAL schema and keeps the row', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+
+        // Asked of sqlite, not of the query runner's cache: a raw
+        // `ALTER TABLE ... DROP COLUMN` can leave the two disagreeing, and
+        // this is the assertion that would catch it.
+        const names = (await physicalColumns()).map((column) => column.name);
+        for (const name of NEW_COLUMNS) {
+            expect(names).not.toContain(name);
+        }
+        // The runner's own metadata agrees, so a later migration in the
+        // same connection sees the same table this spec just checked.
+        const table = await runner.getTable('fleet_nodes');
+        for (const name of NEW_COLUMNS) {
+            expect(table?.findColumnByName(name)).toBeUndefined();
+        }
+        const rows = await dataSource.query(`SELECT "id", "status" FROM "fleet_nodes"`);
+        expect(rows).toEqual([{ id: 'n1', status: 'online' }]);
+    });
+
+    it('down() is safe to re-run', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+    });
+
+    it('survives up() → down() → up(), which is what a rollback and redeploy is', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await migration.down(runner);
+        await migration.up(runner);
+
+        const names = (await physicalColumns()).map((column) => column.name);
+        for (const name of NEW_COLUMNS) {
+            expect(names).toContain(name);
+        }
+    });
+
+    it('does not explode when fleet_nodes does not exist at all', async () => {
+        // A stripped-down or not-yet-created schema must converge, not abort
+        // — the API self-applies migrations on every boot.
+        await dataSource.query(`DROP TABLE "fleet_nodes"`);
+        const runner = dataSource.createQueryRunner();
+
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+    });
+});

--- a/apps/node/README.md
+++ b/apps/node/README.md
@@ -43,8 +43,8 @@ pointing at that checkout.
 ## Commands
 
 ```bash
-ever-works-node enroll --api-url <url> --token <one-time-token> [--name <label>] [-i <seconds>] [--min-free-disk <mb>] [--workspace-max-age <days>]
-ever-works-node start [-i <seconds>] [--work] [--concurrency <count>] [--claude-path <file>] [--codex-path <file>] [--workspace-root <dir>] [--min-free-disk <mb> | --no-disk-floor] [--workspace-max-age <days>] [--workspace-max-count <n>]
+ever-works-node enroll --api-url <url> --token <one-time-token> [--name <label>] [-i <seconds>] [--min-free-disk <mib>] [--workspace-max-age <days>]
+ever-works-node start [-i <seconds>] [--work] [--concurrency <count>] [--claude-path <file>] [--codex-path <file>] [--workspace-root <dir>] [--min-free-disk <mib> | --no-disk-floor] [--workspace-max-age <days>] [--workspace-max-count <n>]
 ever-works-node pause [--local-only]
 ever-works-node resume [--local-only]
 ever-works-node unenroll [--local-only]
@@ -79,6 +79,11 @@ ever-works-node gc [--workspace-root <dir>] [--max-age <days>] [--max-count <n>]
 - **`doctor`** is read-only: free space on the workspace volume against the disk floor, the workspace
   root, how many Task worktrees and repository pools it holds, and — per worktree — what `gc` would do
   and why. `--json` emits one object for scripts. Works whether or not the machine is enrolled.
+  Both `doctor` and `gc` inspect the root the node's last `start --workspace-root` recorded in the
+  config, and the header says where the root came from — `--workspace-root`, the config, or the
+  process default. That matters when the service runs as its own account: the default resolves under
+  the account running the CLI, so a bare `doctor` there would answer about an empty directory that is
+  not the node's tree at all. Pass `--workspace-root` when the header says the root is only a default.
 - **`gc`** runs the workspace reaper (see "Disk floor and workspace GC" below). `--dry-run` prints the
   plan and removes nothing; `--max-age` / `--max-count` override the stored policy for that run only.
   Exit `1` when a planned removal failed — nothing is ever force-deleted.
@@ -285,7 +290,7 @@ Two node-side guards keep a machine from filling its disk with Task worktrees (s
 §6, findings OPS-12 and R8).
 
 **Disk floor.** A node refuses to lease work while the volume that holds its workspace root has fewer
-free bytes than the floor — **2 GiB by default**, set with `--min-free-disk <mb>` (persisted by
+free bytes than the floor — **2 GiB by default**, set with `--min-free-disk <mib>` in **mebibytes** (persisted by
 `enroll`, process-only on `start`, like `--max-cpu`), switched off with `--no-disk-floor`. The floor is
 measured on the **workspace root's volume** (the nearest existing ancestor of it), never on the system
 drive, and it is checked twice: at the lease, and again by the provisioner right before it writes
@@ -293,9 +298,25 @@ anything — once before the primary worktree and once before every mount, becau
 the two. A refused lease shows the node as `throttled` with the reason in the status window and one
 warning in the log (one more line when it clears); a provision refused for disk (`disk-low`) is not a
 verdict about the work — the node hands the job back **unsettled**, its claim lapses and the platform
-re-offers it to a node with room, and the very next poll throttles this one. An unreadable volume never blocks anything: the
-heartbeat simply carries no `diskFreeBytes`, which is now measured on the same volume, so the Fleet
-runner pill finally shows the number that matters.
+re-offers it to a node with room, and the very next poll throttles this one.
+
+Both checks treat an **unreadable** volume the same way: they refuse. The floor fails closed, because
+the provision-time check is the last one before a clone, a fetch and a model's whole budget land on a
+volume nobody can size — and the lease check has to be at least as strict, or the node takes every job
+it is offered and then defers it here, spending one of the job's attempts per lapsed lease until the
+platform fails it with a message that never mentions disk. The node therefore goes `throttled` with a
+reason instead, in the log, in the drawer and in `doctor`; `--no-disk-floor` is the explicit way to
+switch the control off on a host whose `statfs` cannot answer. The heartbeat's `diskFreeBytes` is taken
+with the same measurement as the gates (the nearest existing ancestor of the root), so a node that has
+never provisioned still reports a figure to compare the floor against.
+
+**What the platform sees (EW-803).** The heartbeat also reports the floor in force
+(`minFreeDiskBytes`; `null` when `--no-disk-floor` is set), what the last sweep retained
+(`workspaceCount`, `workspaceBytes`) and when it ran and what it took (`lastReclaimAt`,
+`lastReclaimFreedBytes`). These travel **upward only** — the platform never sets them and never routes
+on them; the limit stays enforced here. The CPU and memory ceilings are not reported at all: there is no
+CPU or memory reading beside them to make a ceiling meaningful. A node without `--work` enforces no
+floor and runs no reaper, so it reports none of this and Fleet shows "not reported" rather than zeros.
 
 **Workspace reaper.** With `--work`, the node runs a reaper over its workspace root a minute after start
 and then every six hours (skipped, and retried in half an hour, while a job is running); `ever-works-node
@@ -306,6 +327,9 @@ gc` runs the same reaper by hand. It removes a Task worktree only when it can **
 2. no provisioning intent is pending for it;
 3. no live process holds its lease (see below), and this process is not using it;
 4. `git status --porcelain --untracked-files=all` is empty and no `index.lock` / `HEAD.lock` exists;
+   plus the two things that command structurally cannot see, because the node excludes them itself:
+   `.mounts` is a plain directory (not a junction someone put there), and `.ever-works/` — the
+   owner-question channel — is empty or absent;
 5. no commit on `HEAD` is missing from every remote-tracking ref;
 6. the remote was reachable, **and** the branch is gone from it or merged into its default branch — a
    branch still open on the remote keeps the worktree, however old;
@@ -328,15 +352,19 @@ first — a junction there points at **another** Task's worktree — then the pr
 re-proves ownership and runs `git worktree remove --force` (which also deletes ignored files such as
 `node_modules`; that is intended, the worktree was proven clean, pushed and closed) and `git worktree
 prune`. A bare repository pool is deleted only once Git lists no worktree for it, no intent is pending,
-its remote was refreshed by this scan, **and** no commit on any of its _local_ branches is missing from
-every remote-tracking ref — `git worktree remove` leaves the branch behind, so an emptied pool can still
-hold the only copy of unpushed work (a branch-change re-cut, a manual clean-up), and that keeps it. A
+its remote was refreshed by this scan, **and** nothing it can still reach — branches, tags, the stash,
+the **reflog** — carries a commit missing from every remote-tracking ref (`rev-list --count --all
+--reflog --not --remotes`). `git worktree remove` leaves the branch behind and the provider's `worktree
+add -B` force-resets one into its reflog, so an emptied pool can still hold the only copy of unpushed
+work, and that keeps it. A
 pool is dated by its `worktrees/` and intents directories, never by `FETCH_HEAD`, which the scan itself
 rewrites. Anything the reaper does not recognise under the root is reported and left alone.
 
 Two files in each worktree's **private gitdir** (`<pool>/worktrees/<id>/`, never in the working tree,
 gone with the worktree) carry the evidence: `ew-workspace-lease.json` (`{purpose: job|gc, pid, taskId}`,
-created with `O_EXCL`; a lease held by a dead pid is reclaimable; one held by a live foreign job is a
+created atomically and exclusively; a lease held by a dead pid is reclaimable; one this build cannot
+PARSE — a future `version`, an unknown `purpose`, a torn write — is treated as HELD, never reclaimed;
+one held by a live foreign job is a
 `path-collision` that preserves the worktree and fails the job naming the holder; one held by the reaper
 mid-removal is a transient `workspace-busy` that hands the job back unsettled, and the retry lands on a
 fresh checkout) and

--- a/apps/node/src/cli/program.housekeeping.spec.ts
+++ b/apps/node/src/cli/program.housekeeping.spec.ts
@@ -112,6 +112,8 @@ function record(overrides: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
 		intentPending: false,
 		lease: null,
 		mountLinks: [],
+		mountsDir: 'absent',
+		excludedOutput: false,
 		...overrides
 	};
 }
@@ -278,7 +280,7 @@ describe('disk floor flags', () => {
 			)
 		).toBe(EXIT_OK);
 		expect(parseConfig(h.files.get(CONFIG_PATH) ?? null)?.limits?.minFreeDiskBytes).toBe(512 * MIB);
-		expect(h.output()).toContain('disk floor 512 MB');
+		expect(h.output()).toContain('disk floor 512 MiB');
 	});
 
 	it('status shows the default floor and the default reaper policy', async () => {
@@ -379,12 +381,12 @@ describe('ever-works-node doctor', () => {
 		const out = h.output();
 		expect(out).toContain(`enrolled     yes (node ${NODE_ID})`);
 		expect(out).toContain('workspace    /srv/fleet');
-		expect(out).toContain('disk free    38 MB on the workspace volume (floor 2.0 GiB) — BELOW FLOOR');
+		expect(out).toContain('disk free    38 MiB on the workspace volume (floor 2.0 GiB) — BELOW FLOOR');
 		expect(out).toContain('workspace gc max age 14 d, no count budget');
-		expect(out).toContain('workspaces   2 worktree(s), 0 pool(s), 420 MB, oldest unused for 30 d');
-		expect(out).toMatch(/REMOVE\s+fleet-abc\s+task\/abc\s+30 d\s+300 MB\s+clean, branch gone from the remote/);
-		expect(out).toMatch(/KEEP\s+fleet-dirty\s+task\/dirty\s+3 d\s+120 MB\s+uncommitted changes/);
-		expect(out).toContain('gc would remove 1 worktree(s) and 0 pool(s) (300 MB), keep 1 worktree(s)');
+		expect(out).toContain('workspaces   2 worktree(s), 0 pool(s), 420 MiB, oldest unused for 30 d');
+		expect(out).toMatch(/REMOVE\s+fleet-abc\s+task\/abc\s+30 d\s+300 MiB\s+clean, branch gone from the remote/);
+		expect(out).toMatch(/KEEP\s+fleet-dirty\s+task\/dirty\s+3 d\s+120 MiB\s+uncommitted changes/);
+		expect(out).toContain('gc would remove 1 worktree(s) and 0 pool(s) (300 MiB), keep 1 worktree(s)');
 		expect(h.reap).not.toHaveBeenCalled();
 	});
 
@@ -502,6 +504,77 @@ describe('ever-works-node doctor', () => {
 			expect(h.output()).toContain('workspace    /srv/fleet');
 		});
 	});
+
+	it('explains an unreadable volume, in both floor states (review AO-13)', async () => {
+		// This line is the only place `doctor` explains why jobs are being
+		// deferred on a machine with no visible disk problem, and neither of
+		// its two branches was executed by any test. Both halves matter and
+		// they differ: with a floor in force the node refuses at the lease
+		// AND at provision; with the floor switched off nothing refuses.
+		const withFloor = harness({ files: { [CONFIG_PATH]: storedConfig }, freeBytes: null });
+		expect(await runCli(['doctor', '--workspace-root', '/srv/fleet'], withFloor.deps)).toBe(EXIT_OK);
+		expect(withFloor.output()).toContain(
+			'disk free    unknown on the workspace volume (floor 2.0 GiB) — this node will not lease or provision'
+		);
+
+		const noFloor = harness({
+			files: {
+				[CONFIG_PATH]: JSON.stringify({
+					...(JSON.parse(storedConfig) as Record<string, unknown>),
+					limits: { maxConcurrentJobs: 1, maxCpuPercent: null, maxMemoryMb: null, minFreeDiskBytes: null }
+				})
+			},
+			freeBytes: null
+		});
+		expect(await runCli(['doctor', '--workspace-root', '/srv/fleet'], noFloor.deps)).toBe(EXIT_OK);
+		expect(noFloor.output()).toContain('disk free    unknown on the workspace volume (no floor)');
+		expect(noFloor.output()).not.toContain('will not lease');
+	});
+
+	it('inspects the root the SERVICE recorded, and says where the root came from (review AO-6)', async () => {
+		// `doctor` and `gc` resolved the root independently of the running
+		// node — flag, else `homedir()`. The Windows installer's preflight
+		// ERRORS unless the operator passes an explicit `-WorkspaceRoot`, and the
+		// service runs as its own account, so an admin following the disk
+		// refusal's own advice landed on an empty directory in their profile
+		// and was told `0 worktree(s), 0 B` about a machine whose real root
+		// was full and refusing every job.
+		const started = harness({ files: { [CONFIG_PATH]: storedConfig } });
+		started.deps.waitForShutdown = () => Promise.resolve();
+		expect(await runCli(['start', '--workspace-root', '/srv/fleet'], started.deps)).toBe(EXIT_OK);
+		expect(parseConfig(started.files.get(CONFIG_PATH) ?? null)?.workspaceRoot).toBe('/srv/fleet');
+
+		// Now `doctor`, with NO flag, on that same machine's config.
+		const later = harness({
+			files: { [CONFIG_PATH]: started.files.get(CONFIG_PATH) ?? '' },
+			inventory: inventory([record()])
+		});
+		expect(await runCli(['doctor'], later.deps)).toBe(EXIT_OK);
+		expect(later.scan).toHaveBeenCalledWith('/srv/fleet', expect.objectContaining({ refreshRemote: true }));
+		expect(later.output()).toContain("workspace    /srv/fleet (from this node's last `start`)");
+		// And `gc` reaps that tree, not a guess.
+		const collected = harness({
+			files: { [CONFIG_PATH]: started.files.get(CONFIG_PATH) ?? '' },
+			inventory: inventory([record()])
+		});
+		expect(await runCli(['gc'], collected.deps)).toBe(EXIT_OK);
+		expect(collected.scan.mock.calls[0][0]).toBe('/srv/fleet');
+	});
+
+	it('warns when the root is only a guess (review AO-6)', async () => {
+		// Nothing recorded and no flag: the answer may be about a completely
+		// different tree, and an operator reading "0 worktree(s)" has to be
+		// able to tell that from "this machine is tidy".
+		const h = harness({ files: { [CONFIG_PATH]: storedConfig } });
+		expect(await runCli(['doctor'], h.deps)).toBe(EXIT_OK);
+		expect(h.output()).toContain('(default — NOT recorded by any `start`');
+		expect(h.output()).toContain('pass --workspace-root');
+
+		// The flag says so too, so all three provenances are distinguishable.
+		const flagged = harness({ files: { [CONFIG_PATH]: storedConfig } });
+		expect(await runCli(['doctor', '--workspace-root', '/srv/fleet'], flagged.deps)).toBe(EXIT_OK);
+		expect(flagged.output()).toContain('workspace    /srv/fleet (from --workspace-root)');
+	});
 });
 
 describe('ever-works-node gc', () => {
@@ -522,9 +595,9 @@ describe('ever-works-node gc', () => {
 		expect(await runCli(['gc', '--workspace-root', '/srv/fleet'], h.deps)).toBe(EXIT_OK);
 		expect(h.reap).toHaveBeenCalledOnce();
 		expect(h.reap.mock.calls[0][0].remove.map((verdict) => verdict.record.bindingKey)).toEqual(['fleet-abc']);
-		expect(h.output()).toContain('removed fleet-abc (300 MB)');
+		expect(h.output()).toContain('removed fleet-abc (300 MiB)');
 		expect(h.output()).toContain('kept    fleet-young: used 24 h ago');
-		expect(h.output()).toContain('Removed 1 worktree(s) and 0 pool(s), freed 300 MB; kept 1 worktree(s).');
+		expect(h.output()).toContain('Removed 1 worktree(s) and 0 pool(s), freed 300 MiB; kept 1 worktree(s).');
 	});
 
 	it('exits with a failure code when a removal errored, naming it', async () => {

--- a/apps/node/src/cli/program.ts
+++ b/apps/node/src/cli/program.ts
@@ -186,7 +186,7 @@ export interface EnrollCommandOptions {
 	concurrency?: string;
 	maxCpu?: string;
 	maxMemory?: string;
-	/** Disk floor in MB (`--min-free-disk`); `--no-disk-floor` sets `diskFloor: false`. */
+	/** Disk floor in MEBIbytes (`--min-free-disk`); `--no-disk-floor` sets `diskFloor: false`. */
 	minFreeDisk?: string;
 	diskFloor?: boolean;
 	/** Workspace reaper policy (`--workspace-max-age <days>`, `--workspace-max-count <n>`). */
@@ -418,17 +418,27 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 		...(stored.workspaceGc ?? DEFAULT_WORKSPACE_GC_POLICY),
 		...(workspaceGcOverrides ?? {})
 	});
-	if (workspaceGcOverrides !== undefined) {
+	// `--workspace-root` is persisted for the same reason (EW-803, review
+	// AO-6): `doctor` and `gc` have no other way to learn which tree the
+	// SERVICE runs against, and both disk-refusal messages send the
+	// operator to those two commands. The Windows installer's preflight
+	// errors unless `-WorkspaceRoot` is passed, so on the shipped layout
+	// the un-persisted root was routinely the wrong one — an empty
+	// directory in the admin's own profile, reported as "nothing to
+	// reclaim" while the node refused every job for want of space on D:.
+	const rootChanged = workspaceRoot !== undefined && workspaceRoot !== stored.workspaceRoot;
+	if (workspaceGcOverrides !== undefined || rootChanged) {
 		await saveConfig(
 			deps.fs,
 			deps.configPath,
-			{ ...stored, workspaceGc },
+			{ ...stored, workspaceGc, ...(workspaceRoot !== undefined ? { workspaceRoot } : {}) },
 			{ platform: deps.platform, secrets: deps.secrets ?? null, logger: deps.io.logger }
 		);
 	}
 	const config: NodeConfig = {
 		...stored,
 		workspaceGc,
+		...(workspaceRoot !== undefined ? { workspaceRoot } : {}),
 		...(override === undefined ? {} : { heartbeatIntervalMs: override })
 	};
 
@@ -540,6 +550,12 @@ export async function runStart(deps: CliDeps, options: StartCommandOptions): Pro
 					logger: deps.io.logger,
 					activeBindings: () => runtime.workspaceProvisioner?.activeBindingKeys?.() ?? new Set<string>(),
 					isBusy: () => worker.getState().activeJobIds.length > 0,
+					// Node housekeeping (EW-803): every completed cycle goes
+					// to the heartbeat's reporter, so Fleet can show that this
+					// machine is reclaiming — and, more usefully, when it has
+					// stopped. Without it the reaper's outcome reached the
+					// local log file and nowhere else.
+					onResult: (result) => runtime.housekeeping?.record(result),
 					...(deps.io.scheduler ? { scheduler: deps.io.scheduler } : {}),
 					...(deps.workspaceHousekeeping ? { scan: deps.workspaceHousekeeping.scan } : {}),
 					...(deps.workspaceHousekeeping ? { reap: deps.workspaceHousekeeping.reap } : {}),
@@ -846,9 +862,13 @@ export interface GcCommandOptions extends HousekeepingCommandOptions {
 	dryRun?: boolean;
 }
 
+/** Where `doctor` / `gc` got the root they are inspecting. Printed, because getting it wrong is silent. */
+export type HousekeepingRootSource = 'flag' | 'config' | 'default';
+
 interface HousekeepingReport {
 	config: NodeConfig | null;
 	workspaceRoot: string;
+	workspaceRootSource: HousekeepingRootSource;
 	floor: number | null;
 	freeBytes: number | null;
 	policy: NodeWorkspaceGcPolicy;
@@ -864,8 +884,7 @@ interface HousekeepingReport {
  */
 async function gatherHousekeeping(deps: CliDeps, options: HousekeepingCommandOptions): Promise<HousekeepingReport> {
 	// Usage errors first, before anything is read.
-	const workspaceRoot =
-		parseWorkspaceRoot(options.workspaceRoot, deps.platform) ?? defaultFleetTaskWorkspaceRoot(process.env);
+	const rootFlag = parseWorkspaceRoot(options.workspaceRoot, deps.platform);
 	const maxAgeDays = parseBounded(
 		options.maxAge,
 		'--max-age',
@@ -876,6 +895,18 @@ async function gatherHousekeeping(deps: CliDeps, options: HousekeepingCommandOpt
 	const now = deps.now ?? (() => Date.now());
 
 	const config = await loadConfig(deps.fs, deps.configPath, loadOptions(deps));
+	// Precedence: the flag the operator typed, then the root the SERVICE
+	// recorded on its last `start`, then the process default. The middle
+	// step is the one that was missing: without it these two commands
+	// inspected `homedir()` — the account running the CLI, not the service
+	// account — and answered "0 worktree(s), 0 B" about the wrong tree
+	// (review AO-6).
+	const workspaceRoot = rootFlag ?? config?.workspaceRoot ?? defaultFleetTaskWorkspaceRoot(process.env);
+	const workspaceRootSource: HousekeepingRootSource = rootFlag
+		? 'flag'
+		: config?.workspaceRoot
+			? 'config'
+			: 'default';
 	const limits = clampResourceLimits(config?.limits);
 	const floor = effectiveMinFreeDiskBytes(limits);
 	const policy = clampWorkspaceGcPolicy({
@@ -906,7 +937,17 @@ async function gatherHousekeeping(deps: CliDeps, options: HousekeepingCommandOpt
 		{ ...policyFromConfig(policy), requireUsageRecord: workerSessionActive },
 		now()
 	);
-	return { config, workspaceRoot, floor, freeBytes, policy, workerSessionActive, inventory, plan };
+	return {
+		config,
+		workspaceRoot,
+		workspaceRootSource,
+		floor,
+		freeBytes,
+		policy,
+		workerSessionActive,
+		inventory,
+		plan
+	};
 }
 
 function printHousekeepingHeader(deps: CliDeps, report: HousekeepingReport, now: number): void {
@@ -915,11 +956,31 @@ function printHousekeepingHeader(deps: CliDeps, report: HousekeepingReport, now:
 	// which made "the fleet cannot reach the platform" undiagnosable from the
 	// one command an operator is told to run.
 	deps.out(`api          ${describeControlPlane(report.config)}`);
-	deps.out(`workspace    ${report.workspaceRoot}${report.inventory.exists ? '' : ' (not created yet)'}`);
+	// The provenance, always — an operator reading "0 worktree(s), 0 B"
+	// has to be able to tell "this machine is tidy" from "I am looking at
+	// the wrong tree", and the wrong tree is the likelier of the two when
+	// the service runs as another account (review AO-6).
+	const rootSource =
+		report.workspaceRootSource === 'flag'
+			? ' (from --workspace-root)'
+			: report.workspaceRootSource === 'config'
+				? " (from this node's last `start`)"
+				: ' (default — NOT recorded by any `start`; if the service runs as another account or with' +
+					' --workspace-root, this is not its tree: pass --workspace-root)';
+	deps.out(`workspace    ${report.workspaceRoot}${report.inventory.exists ? '' : ' (not created yet)'}${rootSource}`);
 	const floorText = report.floor === null ? 'no floor' : `floor ${formatBytes(report.floor)}`;
 	if (report.freeBytes === null) {
+		// The only place `doctor` explains a node that has gone quiet with
+		// no visible disk problem. Both branches are pinned by
+		// `program.housekeeping.spec.ts` (review AO-13); they differ because
+		// a floor that was switched off refuses nothing, while a floor in
+		// force fails CLOSED on a reading it cannot take — at the lease and
+		// at provisioning alike (review AO-11), so the node throttles rather
+		// than leasing work it will only defer.
 		deps.out(
-			`disk free    unknown on the workspace volume (${floorText}) — an unreadable volume never blocks leasing`
+			report.floor === null
+				? `disk free    unknown on the workspace volume (${floorText})`
+				: `disk free    unknown on the workspace volume (${floorText}) — this node will not lease or provision until the volume can be read; \`--no-disk-floor\` switches the floor off explicitly`
 		);
 	} else if (report.floor !== null && report.freeBytes < report.floor) {
 		deps.out(
@@ -998,6 +1059,7 @@ function housekeepingJson(report: HousekeepingReport): Record<string, unknown> {
 		enrolled: report.config !== null,
 		...controlPlaneJson(report.config),
 		workspaceRoot: report.workspaceRoot,
+		workspaceRootSource: report.workspaceRootSource,
 		workspaceRootExists: report.inventory.exists,
 		diskFreeBytes: report.freeBytes,
 		minFreeDiskBytes: report.floor,
@@ -1131,10 +1193,10 @@ export function buildProgram(deps: CliDeps): Command {
 			`Refuse new work while host memory in use is at or above this many MB (min ${MIN_MEMORY_MB})`
 		)
 		.option(
-			'--min-free-disk <mb>',
-			`Refuse new work while the workspace volume has fewer free MB than this (default ${formatBytes(
+			'--min-free-disk <mib>',
+			`Refuse new work while the workspace volume has fewer free MiB than this (default ${formatBytes(
 				effectiveMinFreeDiskBytes({}) ?? 0
-			)}, min ${MIN_MIN_FREE_DISK_BYTES / MIB})`
+			)}, min ${MIN_MIN_FREE_DISK_BYTES / MIB} MiB)`
 		)
 		.option('--no-disk-floor', 'Switch the disk floor off entirely (not recommended)')
 		.option(
@@ -1160,7 +1222,7 @@ export function buildProgram(deps: CliDeps): Command {
 		)
 		.option('--max-cpu <percent>', 'Override the stored CPU admission ceiling, in percent')
 		.option('--max-memory <mb>', 'Override the stored memory admission ceiling, in MB')
-		.option('--min-free-disk <mb>', 'Override the stored disk floor for this process, in MB')
+		.option('--min-free-disk <mib>', 'Override the stored disk floor for this process, in MiB (1 MiB = 1024 KiB)')
 		.option('--no-disk-floor', 'Switch the disk floor off for this process (not recommended)')
 		.option(
 			'--workspace-max-age <days>',

--- a/apps/node/src/core/capabilities.spec.ts
+++ b/apps/node/src/core/capabilities.spec.ts
@@ -319,4 +319,88 @@ describe('describeSelf', () => {
 			expect('workerState' in description).toBe(false);
 		});
 	});
+
+	/**
+	 * Node housekeeping (EW-803) — the disk floor this machine enforces on
+	 * itself and what its reaper last reclaimed, joined through the same
+	 * optional-probe seam and inheriting the same contract, with one
+	 * documented exception: `minFreeDiskBytes` may legitimately travel as
+	 * `null`, because "the operator switched the floor off" has no other
+	 * way to be said.
+	 */
+	describe('housekeeping', () => {
+		it('carries the floor and the last sweep', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => ({
+					minFreeDiskBytes: 2 * 1024 ** 3,
+					workspaceCount: 12,
+					workspaceBytes: 40 * 1024 ** 3,
+					lastReclaimAt: '2026-09-05T09:30:00.000Z',
+					lastReclaimFreedBytes: 3 * 1024 ** 3
+				})
+			});
+
+			expect(description.minFreeDiskBytes).toBe(2 * 1024 ** 3);
+			expect(description.workspaceCount).toBe(12);
+			expect(description.workspaceBytes).toBe(40 * 1024 ** 3);
+			expect(description.lastReclaimAt).toBe('2026-09-05T09:30:00.000Z');
+			expect(description.lastReclaimFreedBytes).toBe(3 * 1024 ** 3);
+		});
+
+		it('forwards an explicit null floor, which is the one null this payload may carry', async () => {
+			// Absent means "leave the stored value alone" server-side, so an
+			// operator who turned the floor off needs the null to reach the
+			// platform or Fleet keeps showing a floor that no longer exists.
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => ({ minFreeDiskBytes: null })
+			});
+
+			expect(description.minFreeDiskBytes).toBeNull();
+			expect('minFreeDiskBytes' in description).toBe(true);
+		});
+
+		it('omits reclaim fields the report does not carry', async () => {
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => ({ minFreeDiskBytes: 2 * 1024 ** 3 })
+			});
+
+			expect('workspaceCount' in description).toBe(false);
+			expect('lastReclaimAt' in description).toBe(false);
+			expect('lastReclaimFreedBytes' in description).toBe(false);
+		});
+
+		it('never sends freed bytes without the instant they belong to', async () => {
+			// A figure whose meaning depends entirely on "when" must not
+			// reach the platform with the "when" missing.
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => ({ lastReclaimFreedBytes: 4 * 1024 ** 3 })
+			});
+
+			expect('lastReclaimFreedBytes' in description).toBe(false);
+		});
+
+		it('omits everything when the probe returns null or throws, rather than failing the beat', async () => {
+			const none = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => null
+			});
+			expect('minFreeDiskBytes' in none).toBe(false);
+
+			const thrown = await describeSelf(runnerWith([]), environment(), '0.1.0', null, {
+				housekeeping: () => {
+					throw new Error('reaper is mid-cycle');
+				}
+			});
+			expect('minFreeDiskBytes' in thrown).toBe(false);
+			// One broken probe never costs the node its whole description.
+			expect(thrown.platform).toBe('linux/x64');
+		});
+
+		it('omits everything when no probe is supplied at all', async () => {
+			// A visibility-only node, and every older build of this app.
+			const description = await describeSelf(runnerWith([]), environment(), '0.1.0');
+
+			expect('minFreeDiskBytes' in description).toBe(false);
+			expect('workspaceBytes' in description).toBe(false);
+		});
+	});
 });

--- a/apps/node/src/core/capabilities.ts
+++ b/apps/node/src/core/capabilities.ts
@@ -2,6 +2,7 @@ import { FLEET_BROWSER_CAPABILITY, FLEET_GPU_CAPABILITY } from '@ever-works/cont
 import type { BrowserProbeIo } from './browser-probe';
 import type { ModelCliPaths } from './executors/model-cli';
 import { detectGpu } from './gpu-probe';
+import type { NodeHousekeepingReport } from './housekeeping-report';
 import type { WorkerHealth } from './worker-health';
 import {
 	MAX_CAPABILITY_TAG_LENGTH,
@@ -304,6 +305,18 @@ export interface SelfDescriptionTelemetry {
 	 * does not wipe the quarantine an operator is currently reading.
 	 */
 	workerHealth?: () => Promise<WorkerHealth | null> | WorkerHealth | null;
+	/**
+	 * What this machine is doing about its own disk (node housekeeping,
+	 * EW-803), via `NodeHousekeepingReporter.describe()` — the floor it
+	 * enforces on itself, and what its last reclaim sweep retained and
+	 * freed.
+	 *
+	 * A probe like the others: absent on a visibility-only node, which
+	 * has neither a floor nor a reaper. Every field inside the report is
+	 * itself optional, so a worker whose first sweep has not run yet
+	 * reports the floor alone.
+	 */
+	housekeeping?: () => Promise<NodeHousekeepingReport | null> | NodeHousekeepingReport | null;
 }
 
 /**
@@ -354,6 +367,38 @@ export async function describeSelf(
 		description.workerState = workerHealth.workerState;
 		if (workerHealth.workerStateReason) {
 			description.workerStateReason = workerHealth.workerStateReason;
+		}
+	}
+	// Node housekeeping (EW-803). Copied field by field rather than
+	// spread, for the reason the API controller's mapping carries the same
+	// warning: this is a WIRE payload, and a spread would forward whatever
+	// a future reporter happens to put on the object — straight into a
+	// server whose validation pipe runs `forbidNonWhitelisted` and answers
+	// an unexpected field with a 400. A 400 here is a failed beat, and a
+	// node that cannot beat is swept offline.
+	//
+	// `minFreeDiskBytes` is the one field that IS forwarded as `null`: the
+	// server reads absent as "leave alone", so an operator who switched
+	// the floor off needs an explicit null to say so.
+	const housekeeping = await resolveTelemetry(telemetry.housekeeping);
+	if (housekeeping) {
+		if (housekeeping.minFreeDiskBytes === null || typeof housekeeping.minFreeDiskBytes === 'number') {
+			description.minFreeDiskBytes = housekeeping.minFreeDiskBytes;
+		}
+		if (typeof housekeeping.workspaceCount === 'number') {
+			description.workspaceCount = housekeeping.workspaceCount;
+		}
+		if (typeof housekeeping.workspaceBytes === 'number') {
+			description.workspaceBytes = housekeeping.workspaceBytes;
+		}
+		if (typeof housekeeping.lastReclaimAt === 'string' && housekeeping.lastReclaimAt) {
+			description.lastReclaimAt = housekeeping.lastReclaimAt;
+			if (typeof housekeeping.lastReclaimFreedBytes === 'number') {
+				// Only ever alongside the instant it belongs to. A freed-bytes
+				// figure with no time attached is unreadable: "4.1 GB freed"
+				// is reassuring or alarming entirely depending on when.
+				description.lastReclaimFreedBytes = housekeeping.lastReclaimFreedBytes;
+			}
 		}
 	}
 	return description;

--- a/apps/node/src/core/config-store.ts
+++ b/apps/node/src/core/config-store.ts
@@ -112,6 +112,16 @@ function clampInterval(value: unknown): number {
  * the desktop shell's `loadConfig` posture: a corrupt file must not wedge the
  * node, it must send the operator back through enrollment.
  */
+/**
+ * Rooted POSIX or Windows path. Written out rather than taken from
+ * `node:path` on purpose: this module is deliberately free of node
+ * builtins (it runs behind an injected filesystem seam), and
+ * `path.isAbsolute` would answer differently depending on which OS the
+ * process happens to be running on, for a config file that can be copied
+ * between them.
+ */
+const ABSOLUTE_PATH = /^(?:[/\\]|[A-Za-z]:[/\\])/;
+
 export function parseConfig(raw: string | null): NodeConfig | null {
 	if (!raw) {
 		return null;
@@ -178,6 +188,14 @@ export function parseConfig(raw: string | null): NodeConfig | null {
 	// an out-of-range stored value is clamped rather than refused.
 	if (candidate.workspaceGc && typeof candidate.workspaceGc === 'object') {
 		config.workspaceGc = clampWorkspaceGcPolicy(candidate.workspaceGc);
+	}
+	// The workspace root the service runs against, so `doctor` and `gc`
+	// inspect the same tree (EW-803). Only ever an absolute path: a
+	// relative one would be resolved against whatever directory the
+	// operator happened to run the CLI from, which is the confusion this
+	// key exists to end.
+	if (typeof candidate.workspaceRoot === 'string' && ABSOLUTE_PATH.test(candidate.workspaceRoot.trim())) {
+		config.workspaceRoot = candidate.workspaceRoot.trim();
 	}
 	if (
 		candidate.unsafe &&

--- a/apps/node/src/core/executors/agent-task.spec.ts
+++ b/apps/node/src/core/executors/agent-task.spec.ts
@@ -252,6 +252,49 @@ describe('runAgentTaskJob — verdicts', () => {
 		expect(provisionWorkspace).not.toHaveBeenCalled();
 	});
 
+	it('applies the disk floor to a workspacePath the provisioner never sees (review AO-10)', async () => {
+		// The lease gate measures the FLEET workspace root's volume, which in
+		// the Windows installer's own recommended layout is a different drive
+		// from a `workspacePath` the payload names. Without this the job ran
+		// the model and spent its whole budget on a volume neither gate had
+		// looked at, and died inside the first git or npm step — the exact
+		// loss this slice exists to prevent, reached through a payload shape
+		// the executor accepts by design.
+		const checkWorkspaceHeadroom = vi.fn(async (path: string) => {
+			const error = new Error(`Refusing to provision: 40 MiB free on the workspace volume (${path})`);
+			error.name = 'FleetTaskWorkspaceError';
+			(error as Error & { code: string }).code = 'disk-low';
+			throw error;
+		});
+		const onProvisionDeclined = vi.fn();
+		const spawnFn = vi.fn();
+
+		await expect(
+			runAgentTaskJob(job({ taskId: 't1', workspacePath: ABSOLUTE, steps: [{ id: 'run', command: 'x' }] }), {
+				...alwaysExists,
+				checkWorkspaceHeadroom,
+				onProvisionDeclined,
+				spawnFn: spawnFn as never
+			})
+		).rejects.toMatchObject({ code: 'disk-low' });
+
+		expect(checkWorkspaceHeadroom).toHaveBeenCalledWith(ABSOLUTE, undefined);
+		// Nothing ran, and the refusal is a DEFERRAL — the same treatment the
+		// provisioner's own `disk-low` gets, so the job goes back unsettled
+		// rather than being retired as a failure of the work.
+		expect(spawnFn).not.toHaveBeenCalled();
+		expect(onProvisionDeclined).toHaveBeenCalledOnce();
+
+		// And a volume with room is transparent: the check runs, the job runs.
+		const ok = vi.fn(async () => undefined);
+		const outcome = await runAgentTaskJob(
+			job({ taskId: 't1', workspacePath: ABSOLUTE, steps: [{ id: 'run', command: 'passing' }] }),
+			{ ...alwaysExists, checkWorkspaceHeadroom: ok, spawnFn: fakeSpawn({ passing: 0 }) }
+		);
+		expect(ok).toHaveBeenCalledOnce();
+		expect(outcome.status).toBe('succeeded');
+	});
+
 	it('aborts the active command and never starts the next step after lease cancellation', async () => {
 		const controller = new AbortController();
 		const commands: string[] = [];

--- a/apps/node/src/core/executors/agent-task.ts
+++ b/apps/node/src/core/executors/agent-task.ts
@@ -151,6 +151,28 @@ export interface AgentTaskScratchFs {
 export interface AgentTaskIo extends AcceptanceChecksIo {
 	/** Directory used when the job carries no `workspacePath`. */
 	defaultWorkspacePath?: string;
+	/**
+	 * The node's disk floor, applied to a workspace the PROVISIONER never
+	 * sees: a payload carrying `workspacePath`, or carrying neither field
+	 * (which runs in the node's own working directory).
+	 *
+	 * Absent means no floor is enforced on that path — the same "the
+	 * control was never asked for" case as an unwired probe. Present, it
+	 * throws a `FleetTaskWorkspaceError` with code `disk-low`, which
+	 * `isProvisionDeclined` treats as a deferral exactly like the
+	 * provisioner's own refusal.
+	 *
+	 * A deferral rather than a failure, deliberately, and unlike the
+	 * lease-gate case in `judgeDiskFloor` it cannot idle the node: the
+	 * lease gate measures the FLEET root's volume and cannot know about
+	 * this one, so a node whose payload volume is full keeps leasing. What
+	 * bounds it is the job's own attempt budget — it fails after
+	 * `maxAttempts` either way, and deferring at least saves three runs'
+	 * worth of model spend on a volume that was going to die inside the
+	 * first git or npm step. The reason reaches the node's log through
+	 * `settleDeferred`.
+	 */
+	checkWorkspaceHeadroom?: (path: string, signal?: AbortSignal) => Promise<void>;
 	/** Repository/worktree adapter supplied by the node composition root. */
 	provisionWorkspace?: (
 		taskId: string,
@@ -1251,7 +1273,13 @@ async function resolveAgentTaskWorkspace(
 		const descriptor = await io.provisionWorkspace(taskId, payload.workspace, signal);
 		return { path: resolveWorkspacePath(descriptor.path, io), descriptor };
 	}
-	return { path: resolveWorkspacePath(payload.workspacePath, io), descriptor: null };
+	// No provision, and therefore none of the provisioner's checks. The
+	// disk floor is the one that matters here: this path runs a model and
+	// spends its whole budget on a volume nothing has measured, and the
+	// lease gate measured a DIFFERENT one (the fleet workspace root).
+	const path = resolveWorkspacePath(payload.workspacePath, io);
+	await io.checkWorkspaceHeadroom?.(path, signal);
+	return { path, descriptor: null };
 }
 
 /**

--- a/apps/node/src/core/fleet-client.spec.ts
+++ b/apps/node/src/core/fleet-client.spec.ts
@@ -296,6 +296,56 @@ describe('heartbeat', () => {
 		expect(JSON.parse(calls[1].init.body)).not.toHaveProperty('workerStateReason');
 	});
 
+	it('carries the housekeeping report, and omits every field the caller left out', async () => {
+		// Node housekeeping (EW-803), same whitelist trap as above — and the
+		// one this slice actually had to fix: a floor and a reclaim summary
+		// the node computes, logs and never sends is exactly the invisible
+		// housekeeping the slice exists to end.
+		const { fetchFn, calls } = fakeFetch(() => ({ status: 200, body: { ok: true, node: nodeView } }));
+
+		await client(fetchFn).heartbeat({
+			nodeId: NODE_ID,
+			secret: SECRET,
+			minFreeDiskBytes: 2 * 1024 ** 3,
+			workspaceCount: 12,
+			workspaceBytes: 40 * 1024 ** 3,
+			lastReclaimAt: '2026-09-05T09:30:00.000Z',
+			lastReclaimFreedBytes: 3 * 1024 ** 3
+		});
+		const body = JSON.parse(calls[0].init.body);
+		expect(body.minFreeDiskBytes).toBe(2 * 1024 ** 3);
+		expect(body.workspaceCount).toBe(12);
+		expect(body.workspaceBytes).toBe(40 * 1024 ** 3);
+		expect(body.lastReclaimAt).toBe('2026-09-05T09:30:00.000Z');
+		expect(body.lastReclaimFreedBytes).toBe(3 * 1024 ** 3);
+
+		await client(fetchFn).heartbeat({ nodeId: NODE_ID, secret: SECRET });
+		const bare = JSON.parse(calls[1].init.body);
+		for (const field of [
+			'minFreeDiskBytes',
+			'workspaceCount',
+			'workspaceBytes',
+			'lastReclaimAt',
+			'lastReclaimFreedBytes'
+		]) {
+			expect(bare).not.toHaveProperty(field);
+		}
+	});
+
+	it('sends an explicit null floor rather than dropping it as falsy', async () => {
+		// The one field in the whole projection that may travel as null.
+		// A truthiness test here would silently turn "the operator switched
+		// the floor off" into "this daemon said nothing", and the server
+		// would keep showing a floor that no longer exists.
+		const { fetchFn, calls } = fakeFetch(() => ({ status: 200, body: { ok: true, node: nodeView } }));
+
+		await client(fetchFn).heartbeat({ nodeId: NODE_ID, secret: SECRET, minFreeDiskBytes: null });
+
+		const body = JSON.parse(calls[0].init.body);
+		expect(body).toHaveProperty('minFreeDiskBytes');
+		expect(body.minFreeDiskBytes).toBeNull();
+	});
+
 	it('sends a state without a reason when there is nothing to explain', async () => {
 		const { fetchFn, calls } = fakeFetch(() => ({ status: 200, body: { ok: true, node: nodeView } }));
 

--- a/apps/node/src/core/fleet-client.ts
+++ b/apps/node/src/core/fleet-client.ts
@@ -381,6 +381,26 @@ function selfDescription(source: NodeSelfDescription): NodeSelfDescription {
 	if (source.workerStateReason !== undefined) {
 		out.workerStateReason = source.workerStateReason;
 	}
+	// Node housekeeping (EW-803). `minFreeDiskBytes` is the ONE field in
+	// this whole projection that may legitimately go out as `null` — the
+	// server reads absent as "leave alone", so an operator who switched
+	// the floor off needs an explicit null to say so, and `!== undefined`
+	// (not a truthiness test) is what lets it through.
+	if (source.minFreeDiskBytes !== undefined) {
+		out.minFreeDiskBytes = source.minFreeDiskBytes;
+	}
+	if (source.workspaceCount !== undefined) {
+		out.workspaceCount = source.workspaceCount;
+	}
+	if (source.workspaceBytes !== undefined) {
+		out.workspaceBytes = source.workspaceBytes;
+	}
+	if (source.lastReclaimAt !== undefined) {
+		out.lastReclaimAt = source.lastReclaimAt;
+	}
+	if (source.lastReclaimFreedBytes !== undefined) {
+		out.lastReclaimFreedBytes = source.lastReclaimFreedBytes;
+	}
 	return out;
 }
 

--- a/apps/node/src/core/heartbeat.spec.ts
+++ b/apps/node/src/core/heartbeat.spec.ts
@@ -298,6 +298,75 @@ describe('HeartbeatLoop', () => {
 			expect(entries.some((entry) => entry.message.includes('predates them'))).toBe(true);
 		});
 
+		it('drops the HOUSEKEEPING fields too, not just the worker state (EW-803)', async () => {
+			// Every field added to the self-description after an API release
+			// has to be in `OPTIONAL_DESCRIPTION_FIELDS`, or a node talking to
+			// an older platform 400s forever and sweeps to offline. This
+			// pins the housekeeping five, which are the newest additions —
+			// and it is the case that would have caught them being forgotten.
+			const scheduler = fakeScheduler();
+			const scripted = scriptedClient([rejected(), ok]);
+			const loop = new HeartbeatLoop({
+				client: scripted.client,
+				nodeId: NODE_ID,
+				secret: SECRET,
+				describe: async () => ({
+					platform: 'linux/x64',
+					capabilities: ['os:linux'],
+					// No worker state at all: the housekeeping fields alone
+					// must be enough to trigger the fallback, or a node whose
+					// worker probe happened to return nothing goes dark.
+					minFreeDiskBytes: 2 * 1024 ** 3,
+					workspaceCount: 12,
+					workspaceBytes: 40 * 1024 ** 3,
+					lastReclaimAt: '2026-09-05T09:30:00.000Z',
+					lastReclaimFreedBytes: 3 * 1024 ** 3
+				}),
+				intervalMs: INTERVAL,
+				scheduler: scheduler.scheduler
+			});
+
+			await loop.start();
+
+			expect(scripted.sent()).toBe(2);
+			for (const field of [
+				'minFreeDiskBytes',
+				'workspaceCount',
+				'workspaceBytes',
+				'lastReclaimAt',
+				'lastReclaimFreedBytes'
+			]) {
+				expect(scripted.requests[0]).toHaveProperty(field);
+				expect(scripted.requests[1]).not.toHaveProperty(field);
+			}
+			expect(scripted.requests[1]).toMatchObject({ platform: 'linux/x64' });
+			expect(loop.getState().state).toBe('connected');
+			expect(loop.getState().consecutiveFailures).toBe(0);
+		});
+
+		it('treats an explicit NULL floor as a carried field, so it still triggers the fallback', async () => {
+			// `minFreeDiskBytes: null` is the one legitimate null on this
+			// payload ("the operator switched the floor off"). A truthiness
+			// test in `carriesOptionalFields` would miss it, and the beat
+			// would 400 in a loop with no retry.
+			const scheduler = fakeScheduler();
+			const scripted = scriptedClient([rejected(), ok]);
+			const loop = new HeartbeatLoop({
+				client: scripted.client,
+				nodeId: NODE_ID,
+				secret: SECRET,
+				describe: async () => ({ platform: 'linux/x64', minFreeDiskBytes: null }),
+				intervalMs: INTERVAL,
+				scheduler: scheduler.scheduler
+			});
+
+			await loop.start();
+
+			expect(scripted.sent()).toBe(2);
+			expect(scripted.requests[1]).not.toHaveProperty('minFreeDiskBytes');
+			expect(loop.getState().state).toBe('connected');
+		});
+
 		it('latches, so it costs one extra request per process and not per beat', async () => {
 			const { loop, scripted } = workerBeat([rejected(), ok]);
 

--- a/apps/node/src/core/heartbeat.ts
+++ b/apps/node/src/core/heartbeat.ts
@@ -60,10 +60,24 @@ export interface HeartbeatCapableClient {
 /**
  * Self-description fields a heartbeat may drop and still be a valid beat.
  *
- * Today: the worker state (EW-776). See {@link HeartbeatLoop} for why
- * dropping them is ever the right move.
+ * The worker state (EW-776) and the housekeeping report (EW-803). See
+ * {@link HeartbeatLoop} for why dropping them is ever the right move.
+ *
+ * EVERY field added to the self-description after an API release belongs
+ * here. The API validates beats with `whitelist + forbidNonWhitelisted`,
+ * so a field an older platform does not know 400s the WHOLE request — a
+ * new field that is not in this list is a node that goes dark the moment
+ * it talks to a platform older than itself.
  */
-const OPTIONAL_DESCRIPTION_FIELDS = ['workerState', 'workerStateReason'] as const;
+const OPTIONAL_DESCRIPTION_FIELDS = [
+	'workerState',
+	'workerStateReason',
+	'minFreeDiskBytes',
+	'workspaceCount',
+	'workspaceBytes',
+	'lastReclaimAt',
+	'lastReclaimFreedBytes'
+] as const;
 
 export interface HeartbeatLoopOptions {
 	client: HeartbeatCapableClient;
@@ -195,8 +209,9 @@ export class HeartbeatLoop {
 	}
 
 	/**
-	 * Send one beat, tolerating a platform that predates the worker-state
-	 * fields (EW-776).
+	 * Send one beat, tolerating a platform that predates the optional
+	 * self-description fields (the worker state, EW-776; the housekeeping
+	 * report, EW-803).
 	 *
 	 * The API validates heartbeats with `whitelist + forbidNonWhitelisted`,
 	 * so a field an older build does not know is not ignored — it 400s the
@@ -236,7 +251,7 @@ export class HeartbeatLoop {
 			});
 			this.legacyDescription = true;
 			this.options.logger?.warn(
-				'Platform rejected the worker-state fields; it predates them. Reporting liveness only until this node restarts.'
+				'Platform rejected the optional self-description fields (worker state, housekeeping); it predates them. Reporting liveness only until this node restarts.'
 			);
 			return result;
 		}

--- a/apps/node/src/core/housekeeping-report.spec.ts
+++ b/apps/node/src/core/housekeeping-report.spec.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import { FLEET_MAX_WORKSPACE_COUNT } from '@ever-works/contracts';
+import { NodeHousekeepingReporter, summarizeWorkspaceReap } from './housekeeping-report';
+import type { WorkspaceReapResult } from './workspaces/workspace-reaper';
+import type { WorkspacePoolRecord, WorkspaceRecord } from './workspaces/workspace-inventory';
+
+/**
+ * Node housekeeping reporting (EW-803) — what the heartbeat says about
+ * this machine's disk floor and its reclaim activity.
+ *
+ * The properties worth pinning are the ones an operator would be misled
+ * by if they broke: a figure this cannot vouch for must be ABSENT rather
+ * than zero, a dry run must never look like a reclaim, and the freed-bytes
+ * figure must never be shown against the wrong instant.
+ */
+
+const GIB = 1024 ** 3;
+
+const record = (sizeBytes: number, path = '/w/a'): WorkspaceRecord =>
+	({ path, sizeBytes }) as unknown as WorkspaceRecord;
+
+const pool = (sizeBytes: number, path = '/p/a'): WorkspacePoolRecord =>
+	({ path, sizeBytes }) as unknown as WorkspacePoolRecord;
+
+function reapResult(over: Partial<WorkspaceReapResult> = {}): WorkspaceReapResult {
+	return {
+		dryRun: false,
+		removed: [],
+		kept: [],
+		removedPools: [],
+		keptPools: [],
+		freedBytes: 0,
+		errors: [],
+		...over
+	};
+}
+
+describe('summarizeWorkspaceReap', () => {
+	it('counts what SURVIVED the sweep, not what the scan started with', () => {
+		const result = reapResult({
+			removed: [{ record: record(5 * GIB, '/w/gone'), freedBytes: 5 * GIB }],
+			kept: [
+				{ record: record(2 * GIB, '/w/a'), reason: 'uncommitted changes' },
+				{ record: record(1 * GIB, '/w/b'), reason: 'within the max age' }
+			],
+			keptPools: [{ pool: pool(3 * GIB), reason: '2 worktree(s) still registered' }],
+			freedBytes: 5 * GIB
+		});
+
+		const summary = summarizeWorkspaceReap(result);
+		expect(summary.workspaceCount).toBe(2);
+		expect(summary.workspaceBytes).toBe(6 * GIB);
+		expect(summary.freedBytes).toBe(5 * GIB);
+		expect(summary.dryRun).toBe(false);
+	});
+
+	it('counts a removal that FAILED its final re-check as still on disk', () => {
+		// `runWorkspaceReap` pushes a refused removal onto `kept`, which is
+		// exactly why the post-sweep picture is read off `kept` rather than
+		// derived as `totalBytes - freedBytes`: the derived form would
+		// under-report the moment a removal was refused.
+		const result = reapResult({
+			kept: [{ record: record(4 * GIB, '/w/refused'), reason: 'lease appeared during removal' }],
+			errors: ['/w/refused: lease appeared during removal']
+		});
+
+		const summary = summarizeWorkspaceReap(result);
+		expect(summary.workspaceCount).toBe(1);
+		expect(summary.workspaceBytes).toBe(4 * GIB);
+		expect(summary.freedBytes).toBe(0);
+	});
+
+	it('reports a dry run as reclaiming NOTHING, and counts what it only planned to remove', () => {
+		// A dry run leaves every byte where it was. Reporting its
+		// `freedBytes` — which is what COULD be freed — as an accomplished
+		// reclaim is the single way this figure could actively mislead.
+		const result = reapResult({
+			dryRun: true,
+			removed: [{ record: record(7 * GIB, '/w/would-go'), freedBytes: 7 * GIB }],
+			kept: [{ record: record(1 * GIB, '/w/stays'), reason: 'within the max age' }],
+			freedBytes: 7 * GIB
+		});
+
+		const summary = summarizeWorkspaceReap(result);
+		expect(summary.freedBytes).toBe(0);
+		// Both are still there.
+		expect(summary.workspaceCount).toBe(2);
+		expect(summary.workspaceBytes).toBe(8 * GIB);
+		expect(summary.dryRun).toBe(true);
+	});
+
+	it('treats a missing or nonsensical size as zero rather than propagating NaN', () => {
+		const result = reapResult({
+			kept: [
+				{ record: record(Number.NaN, '/w/nan'), reason: 'size unknown' },
+				{ record: record(-1, '/w/negative'), reason: 'size unknown' },
+				{ record: record(2 * GIB, '/w/real'), reason: 'within the max age' }
+			]
+		});
+
+		const summary = summarizeWorkspaceReap(result);
+		expect(summary.workspaceBytes).toBe(2 * GIB);
+		expect(Number.isFinite(summary.workspaceBytes)).toBe(true);
+	});
+});
+
+describe('NodeHousekeepingReporter', () => {
+	it('reports the floor from startup, before any sweep has run', () => {
+		// The floor is known immediately; the first reaper cycle is a
+		// minute away and on a heartbeat-only machine never comes. An
+		// operator must not have to wait for a sweep to learn where the
+		// line is.
+		const reporter = new NodeHousekeepingReporter({ minFreeDiskBytes: 2 * GIB });
+
+		expect(reporter.describe()).toEqual({ minFreeDiskBytes: 2 * GIB });
+	});
+
+	it('reports a switched-off floor as an explicit null, not as an absent field', () => {
+		// Absent means "leave the stored value alone" on the server, so an
+		// operator who turned the floor off needs a null to say so —
+		// otherwise Fleet keeps showing the floor they just removed.
+		const reporter = new NodeHousekeepingReporter({ minFreeDiskBytes: null });
+
+		const report = reporter.describe();
+		expect(report.minFreeDiskBytes).toBeNull();
+		expect('minFreeDiskBytes' in report).toBe(true);
+	});
+
+	it('omits every reclaim field until a sweep has actually completed', () => {
+		// Absent, never zero. "0 workspaces, 0 bytes freed" reads as a tidy
+		// machine; the truth is that nothing has looked yet.
+		const report = new NodeHousekeepingReporter({ minFreeDiskBytes: 2 * GIB }).describe();
+
+		expect('workspaceCount' in report).toBe(false);
+		expect('workspaceBytes' in report).toBe(false);
+		expect('lastReclaimAt' in report).toBe(false);
+		expect('lastReclaimFreedBytes' in report).toBe(false);
+	});
+
+	it('records a completed sweep and stamps it with the injected clock', () => {
+		const reporter = new NodeHousekeepingReporter({
+			minFreeDiskBytes: 2 * GIB,
+			now: () => Date.parse('2026-09-05T09:30:00.000Z')
+		});
+		reporter.record(
+			reapResult({
+				removed: [{ record: record(3 * GIB, '/w/gone'), freedBytes: 3 * GIB }],
+				kept: [{ record: record(1 * GIB, '/w/stays'), reason: 'within the max age' }],
+				freedBytes: 3 * GIB
+			})
+		);
+
+		expect(reporter.describe()).toEqual({
+			minFreeDiskBytes: 2 * GIB,
+			workspaceCount: 1,
+			workspaceBytes: 1 * GIB,
+			lastReclaimAt: '2026-09-05T09:30:00.000Z',
+			lastReclaimFreedBytes: 3 * GIB
+		});
+	});
+
+	it('records a sweep that freed nothing, because that is the reassuring answer', () => {
+		// The timestamp is the whole point: "ran an hour ago, took nothing"
+		// and "has not run since March" are opposite findings, and only a
+		// moving stamp distinguishes them.
+		const reporter = new NodeHousekeepingReporter({
+			minFreeDiskBytes: 2 * GIB,
+			now: () => Date.parse('2026-09-05T09:30:00.000Z')
+		});
+		reporter.record(reapResult({ kept: [{ record: record(1 * GIB), reason: 'within the max age' }] }));
+
+		const report = reporter.describe();
+		expect(report.lastReclaimAt).toBe('2026-09-05T09:30:00.000Z');
+		expect(report.lastReclaimFreedBytes).toBe(0);
+	});
+
+	it('does NOT let a dry run refresh the reclaim stamp', () => {
+		// `gc --dry-run` runs in a second process against the same root. If
+		// it moved this stamp, an in-process reaper that had been dead for
+		// weeks would look freshly run — which is the failure this whole
+		// field exists to make visible.
+		let clock = Date.parse('2026-09-05T09:30:00.000Z');
+		const reporter = new NodeHousekeepingReporter({ minFreeDiskBytes: 2 * GIB, now: () => clock });
+		reporter.record(reapResult({ freedBytes: 3 * GIB, kept: [{ record: record(GIB), reason: 'young' }] }));
+		const afterRealSweep = reporter.describe();
+
+		clock = Date.parse('2026-09-19T09:30:00.000Z');
+		reporter.record(
+			reapResult({
+				dryRun: true,
+				removed: [{ record: record(9 * GIB, '/w/would-go'), freedBytes: 9 * GIB }],
+				freedBytes: 9 * GIB
+			})
+		);
+
+		const report = reporter.describe();
+		expect(report.lastReclaimAt).toBe(afterRealSweep.lastReclaimAt);
+		expect(report.lastReclaimFreedBytes).toBe(3 * GIB);
+		// The inventory it measured IS fresher, and is reported.
+		expect(report.workspaceCount).toBe(1);
+	});
+
+	it('drops a workspace count past the contract ceiling rather than clamping it', () => {
+		// A clamped count is one an operator would believe. Absent renders
+		// as "unknown", which is the honest reading of a broken probe.
+		const reporter = new NodeHousekeepingReporter({ minFreeDiskBytes: 2 * GIB });
+		const kept = { record: record(1), reason: 'young' };
+		reporter.record(reapResult({ kept: new Array(FLEET_MAX_WORKSPACE_COUNT + 1).fill(kept) }));
+
+		const report = reporter.describe();
+		expect('workspaceCount' in report).toBe(false);
+		// The bytes it could vouch for still travel.
+		expect(report.workspaceBytes).toBe(FLEET_MAX_WORKSPACE_COUNT + 1);
+	});
+
+	it('never reports freed bytes without the instant they belong to', () => {
+		// "4.1 GB freed" is reassuring or alarming entirely depending on
+		// when, so the pair is all-or-nothing.
+		const reporter = new NodeHousekeepingReporter({
+			minFreeDiskBytes: null,
+			now: () => Number.NaN
+		});
+		reporter.record(reapResult({ freedBytes: 4 * GIB }));
+
+		const report = reporter.describe();
+		expect('lastReclaimAt' in report).toBe(false);
+		expect('lastReclaimFreedBytes' in report).toBe(false);
+	});
+});

--- a/apps/node/src/core/housekeeping-report.ts
+++ b/apps/node/src/core/housekeeping-report.ts
@@ -1,0 +1,201 @@
+import { FLEET_MAX_DISK_FREE_BYTES, FLEET_MAX_WORKSPACE_COUNT } from '@ever-works/contracts';
+import type { WorkspaceReapResult } from './workspaces/workspace-reaper';
+
+/**
+ * What the heartbeat says about this machine's HOUSEKEEPING (EW-803,
+ * self-build program note §6, findings OPS-12 and R8).
+ *
+ * The defect this closes: both halves of node housekeeping were invisible
+ * from the platform. A node refusing work because its workspace volume
+ * had fallen under the floor reported `throttled` with a reason — good —
+ * but the floor itself was never reported, so `12.4 GB free` in the
+ * drawer could not be read as "fine" or "about to stop". And the reaper,
+ * the thing that actually reclaims those gigabytes, wrote its outcome to
+ * the node's own log file and nowhere else: from Fleet there was no way
+ * to tell a machine whose reaper is keeping up from one where it has not
+ * run since March.
+ *
+ * ## This reports; it does not obey
+ *
+ * `minFreeDiskBytes` travels UP only. The floor is still evaluated
+ * entirely on the node — `admitByResourceLimits` at the lease,
+ * `FleetTaskWorkspaceProvisioner.assertDiskHeadroom` before the first
+ * byte — and nothing on the platform sets it, reads it back down, or is
+ * entitled to assume a node respects it. That is deliberate and it is
+ * the invariant in `types.ts`: lending a machine has to stay bounded from
+ * the machine's own side. Publishing a read-only figure for an operator
+ * to look at does not weaken that; accepting one from the platform would,
+ * which is why no such path exists.
+ *
+ * The CPU and memory ceilings are NOT reported. They have the same
+ * enforcement story, but no reported figure beside them to make sense of
+ * — the node sends no CPU or memory reading at all — so a ceiling on its
+ * own would be a number with nothing to compare it against.
+ *
+ * ## Every field is optional, and absent is not zero
+ *
+ * A field the node cannot vouch for is OMITTED rather than sent as a
+ * zero or a null, because the server reads an absent field as "leave the
+ * stored value alone". A machine whose first reclaim sweep has not run
+ * yet reports the floor and nothing else, and the drawer says "unknown"
+ * — never "0 workspaces", which would read as a tidy machine rather than
+ * an unmeasured one.
+ */
+export interface NodeHousekeepingReport {
+	/** The disk floor in force, in bytes; `null` when the operator switched it off. */
+	minFreeDiskBytes?: number | null;
+	/** Workspaces retained by the last completed sweep. */
+	workspaceCount?: number;
+	/** Bytes those retained workspaces occupy. */
+	workspaceBytes?: number;
+	/** ISO-8601 instant the last sweep completed, on this machine's clock. */
+	lastReclaimAt?: string;
+	/** Bytes that sweep reclaimed. */
+	lastReclaimFreedBytes?: number;
+}
+
+/** The post-sweep picture, derived from a reap result alone. */
+export interface WorkspaceReapSummary {
+	/** Worktrees still on disk when the sweep finished. */
+	workspaceCount: number;
+	/** Bytes those worktrees and their retained pools occupy. */
+	workspaceBytes: number;
+	/** Bytes the sweep actually reclaimed (always 0 for a dry run). */
+	freedBytes: number;
+	/** True when the sweep only planned; nothing was removed. */
+	dryRun: boolean;
+}
+
+/**
+ * Project a reap result onto the figures the heartbeat carries.
+ *
+ * Read off `kept`, not off the inventory the scan started from, because
+ * `kept` is the POST-sweep truth: it holds the plan's keeps plus every
+ * removal that failed its final re-check, which is exactly the set still
+ * occupying the volume. Deriving it as `totalBytes - freedBytes` instead
+ * would quietly drift the moment a removal was refused.
+ *
+ * A dry run reports the inventory it measured but claims NO reclaim: its
+ * `freedBytes` is what could be freed, and reporting a hypothetical as an
+ * accomplished reclaim is the one way this figure could actively mislead.
+ */
+export function summarizeWorkspaceReap(result: WorkspaceReapResult): WorkspaceReapSummary {
+	const dryRun = result.dryRun === true;
+	// A dry run leaves everything on disk, so its retained set is
+	// `kept` PLUS everything it merely planned to remove.
+	const worktrees = dryRun ? result.kept.length + result.removed.length : result.kept.length;
+	const keptBytes = result.kept.reduce((sum, verdict) => sum + safeBytes(verdict.record.sizeBytes), 0);
+	const keptPoolBytes = result.keptPools.reduce((sum, verdict) => sum + safeBytes(verdict.pool.sizeBytes), 0);
+	const plannedBytes = dryRun
+		? result.removed.reduce((sum, entry) => sum + safeBytes(entry.freedBytes), 0) +
+			result.removedPools.reduce((sum, entry) => sum + safeBytes(entry.freedBytes), 0)
+		: 0;
+	return {
+		workspaceCount: worktrees,
+		workspaceBytes: keptBytes + keptPoolBytes + plannedBytes,
+		freedBytes: dryRun ? 0 : safeBytes(result.freedBytes),
+		dryRun
+	};
+}
+
+function safeBytes(value: unknown): number {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+export interface NodeHousekeepingReporterOptions {
+	/** The floor in force on this node, from `effectiveMinFreeDiskBytes(limits)`. */
+	minFreeDiskBytes: number | null;
+	/** Wall clock for the reclaim stamp; tests inject one. */
+	now?: () => number;
+}
+
+/**
+ * Holds what the last reclaim sweep found, so the heartbeat can report
+ * it.
+ *
+ * A tiny mutable box on purpose. The reaper timer is started by the CLI
+ * shell, AFTER `createNodeRuntime` has already built the `describe`
+ * closure the beat calls — the same ordering constraint `telemetry.
+ * workerHealth` lives with — so the two are joined by an object both can
+ * reach rather than by passing the result through a constructor.
+ */
+export class NodeHousekeepingReporter {
+	private readonly minFreeDiskBytes: number | null;
+	private readonly now: () => number;
+	/** What is on disk. Refreshed by EVERY sweep, dry runs included — they measure too. */
+	private inventory: { workspaceCount: number; workspaceBytes: number } | null = null;
+	/**
+	 * The last real reclaim. The instant and the bytes are held TOGETHER,
+	 * as one value, because they are only meaningful as a pair: a dry run
+	 * that refreshed the bytes but not the instant would report "0 bytes
+	 * freed" against a real sweep that freed four gigabytes.
+	 */
+	private reclaim: { at: number; freedBytes: number } | null = null;
+
+	constructor(options: NodeHousekeepingReporterOptions) {
+		this.minFreeDiskBytes = options.minFreeDiskBytes;
+		this.now = options.now ?? (() => Date.now());
+	}
+
+	/**
+	 * Record a completed sweep. Called by the reaper timer after every
+	 * cycle, including one that removed nothing — "it ran and found
+	 * nothing to take" is the reassuring answer, and it is only reassuring
+	 * if the timestamp moves.
+	 */
+	record(result: WorkspaceReapResult): void {
+		const summary = summarizeWorkspaceReap(result);
+		this.inventory = {
+			workspaceCount: summary.workspaceCount,
+			workspaceBytes: summary.workspaceBytes
+		};
+		// A dry run is not a reclaim and must not touch the reclaim pair:
+		// `gc --dry-run` in a second process would otherwise make an
+		// in-process reaper that has been dead for weeks look freshly run.
+		if (!summary.dryRun) this.reclaim = { at: this.now(), freedBytes: summary.freedBytes };
+	}
+
+	/** The heartbeat's view. Never throws; a field it cannot vouch for is absent. */
+	describe(): NodeHousekeepingReport {
+		const report: NodeHousekeepingReport = {};
+		// The floor is reported even as `null` ("switched off"), because
+		// that is a decision an operator made and needs to see, and it is
+		// known from startup rather than waiting on the first sweep.
+		if (this.minFreeDiskBytes === null || isReportableBytes(this.minFreeDiskBytes)) {
+			report.minFreeDiskBytes = this.minFreeDiskBytes;
+		}
+		const inventory = this.inventory;
+		if (inventory) {
+			// Dropped, not clamped, past the contract's ceiling: a clamped
+			// count is one an operator would believe.
+			if (
+				Number.isInteger(inventory.workspaceCount) &&
+				inventory.workspaceCount >= 0 &&
+				inventory.workspaceCount <= FLEET_MAX_WORKSPACE_COUNT
+			) {
+				report.workspaceCount = inventory.workspaceCount;
+			}
+			if (isReportableBytes(inventory.workspaceBytes)) {
+				report.workspaceBytes = Math.floor(inventory.workspaceBytes);
+			}
+		}
+		const reclaim = this.reclaim;
+		if (reclaim && Number.isFinite(reclaim.at)) {
+			const stamp = new Date(reclaim.at);
+			// All or nothing: a freed-bytes figure with no instant attached
+			// is unreadable, and an instant is worth reporting on its own.
+			if (!Number.isNaN(stamp.getTime())) {
+				report.lastReclaimAt = stamp.toISOString();
+				if (isReportableBytes(reclaim.freedBytes)) {
+					report.lastReclaimFreedBytes = Math.floor(reclaim.freedBytes);
+				}
+			}
+		}
+		return report;
+	}
+}
+
+/** A byte count this node is willing to put on the wire: finite, non-negative, under the contract ceiling. */
+function isReportableBytes(value: number): boolean {
+	return Number.isFinite(value) && value >= 0 && value <= FLEET_MAX_DISK_FREE_BYTES;
+}

--- a/apps/node/src/core/node-contract.conformance.spec.ts
+++ b/apps/node/src/core/node-contract.conformance.spec.ts
@@ -121,7 +121,11 @@ describe('what the node actually puts on the wire', () => {
 			expect(Object.keys(baseline.routes[route].requests).sort()).toEqual([...variants].sort());
 		}
 		expect(baseline.selfDescription.nodeEmits).toHaveLength(6);
-		expect(baseline.selfDescription.nodeEmitsOptional).toHaveLength(2);
+		// 2 → 7 with node housekeeping (EW-803): the disk floor the node is
+		// enforcing plus the four reclaim figures. All conditional for the
+		// same reason as slice T's pair — a node that has never reported one
+		// sends nothing rather than a null, so an older platform is unaffected.
+		expect(baseline.selfDescription.nodeEmitsOptional).toHaveLength(7);
 	});
 
 	it('enroll sends exactly the pinned body, to the pinned path', async () => {
@@ -185,7 +189,7 @@ describe('what the node actually puts on the wire', () => {
 		expect(emitted.sort()).toEqual([...baseline.selfDescription.nodeEmits].sort());
 	});
 
-	it('adds the optional health fields only when the node has a worker state', async () => {
+	it('adds every optional field only when the node actually has one', async () => {
 		// Slice T's two fields are CONDITIONAL, and that is the compatibility
 		// property worth pinning in both directions: a node with nothing to say
 		// about its worker must not start sending nulls at a platform that
@@ -205,7 +209,17 @@ describe('what the node actually puts on the wire', () => {
 			diskFreeBytes: 1,
 			modelIdentity: 'x',
 			workerState: 'quarantined',
-			workerStateReason: 'helper trust check failed'
+			workerStateReason: 'helper trust check failed',
+			// Node housekeeping (EW-803). Supplied here for the same reason as
+			// the pair above: this case exists to prove that EVERY field the
+			// contract lists as optional is actually put on the wire when the
+			// node has one, so it has to supply all of them or the equality
+			// below stops meaning anything as the list grows.
+			minFreeDiskBytes: 5_000_000_000,
+			workspaceCount: 3,
+			workspaceBytes: 12_000_000_000,
+			lastReclaimAt: '2026-09-06T00:00:00.000Z',
+			lastReclaimFreedBytes: 4_000_000_000
 		});
 		const emitted = Object.keys(bodyOf(sent)).filter((key) => key !== 'nodeId' && key !== 'secret');
 		expect(emitted.sort()).toEqual(
@@ -213,6 +227,8 @@ describe('what the node actually puts on the wire', () => {
 		);
 		expect(bodyOf(sent).workerState).toBe('quarantined');
 		expect(bodyOf(sent).workerStateReason).toBe('helper trust check failed');
+		expect(bodyOf(sent).workspaceCount).toBe(3);
+		expect(bodyOf(sent).lastReclaimAt).toBe('2026-09-06T00:00:00.000Z');
 	});
 
 	it('pause and unenroll send exactly the pinned bodies', async () => {

--- a/apps/node/src/core/resource-limits.spec.ts
+++ b/apps/node/src/core/resource-limits.spec.ts
@@ -7,6 +7,7 @@ import {
 	formatBytes,
 	hasAdmissionCeilings,
 	hasDiskFloor,
+	judgeDiskFloor,
 	type ResourceSample
 } from './resource-limits';
 import {
@@ -18,6 +19,7 @@ import {
 	MIN_MIN_FREE_DISK_BYTES
 } from './types';
 import { WorkerLoop, type JobLeaseCapableClient } from './worker-loop';
+import { assertWorkspaceDiskHeadroom } from './workspaces/fleet-task-workspace';
 
 /**
  * Resource limits (A16) and pause/resume (A18).
@@ -438,7 +440,7 @@ describe('admitByResourceLimits — disk floor', () => {
 		);
 		expect(decision.admit).toBe(false);
 		expect(decision.dimension).toBe('disk');
-		expect(decision.reason).toContain('38 MB');
+		expect(decision.reason).toContain('38 MiB');
 		expect(decision.reason).toContain('2.0 GiB');
 	});
 
@@ -457,14 +459,52 @@ describe('admitByResourceLimits — disk floor', () => {
 		expect(decision.reason).toContain(formatBytes(DEFAULT_MIN_FREE_DISK_BYTES));
 	});
 
-	it('admits when the reading is missing, null or NaN — an unreadable volume must not idle the node', () => {
+	it('admits when the disk was never sampled — a dimension nobody asked about cannot refuse', () => {
+		// `checkResourceAdmission` only sets `diskFreeBytes` when a floor is
+		// in force AND a probe is wired, so an ABSENT field means "not
+		// measured on this poll" and must stay silent.
 		expect(admitByResourceLimits({ ...noCeilings, minFreeDiskBytes: 2 * GIB }, sample())).toEqual(ADMIT);
+		expect(judgeDiskFloor({ minFreeDiskBytes: 2 * GIB }, sample())).toBeNull();
+	});
+
+	it('REFUSES a reading that was taken and came back unreadable (review AO-11)', () => {
+		// This assertion is the reverse of the one it replaces, and the
+		// reversal is the fix. The old contract — "null admits, an
+		// unreadable volume must not idle the node" — did not compose with
+		// `assertWorkspaceDiskHeadroom`, which REFUSES the identical null
+		// from the identical probe because it is the last gate before a
+		// model's whole budget lands on the volume. While this gate
+		// admitted, a host whose `statfs` cannot answer (a persistent
+		// condition per `createDiskProbe`) leased every job it was offered
+		// and then declined it at provision time; the deferral reports
+		// nothing, so the claim lapsed over the full lease TTL and burned
+		// one of the job's attempts, until the platform failed it with a
+		// message that never mentioned disk. Refusing here throttles the
+		// node instead, with a reason an operator can read.
+		for (const free of [null, Number.NaN]) {
+			const decision = admitByResourceLimits(
+				{ ...noCeilings, minFreeDiskBytes: 2 * GIB },
+				sample({ diskFreeBytes: free })
+			);
+			expect(decision.admit).toBe(false);
+			expect(decision.dimension).toBe('disk');
+			expect(decision.reason).toContain('could not be measured');
+		}
+		// Still silent when the operator switched the floor off.
 		expect(
-			admitByResourceLimits({ ...noCeilings, minFreeDiskBytes: 2 * GIB }, sample({ diskFreeBytes: null }))
+			admitByResourceLimits({ ...noCeilings, minFreeDiskBytes: null }, sample({ diskFreeBytes: null }))
 		).toEqual(ADMIT);
-		expect(
-			admitByResourceLimits({ ...noCeilings, minFreeDiskBytes: 2 * GIB }, sample({ diskFreeBytes: Number.NaN }))
-		).toEqual(ADMIT);
+	});
+
+	it('judgeDiskFloor answers about DISK alone, whatever CPU and memory did (review AO-7)', () => {
+		// `admitByResourceLimits` reports only the first refusing dimension,
+		// so the worker loop's refuse/resume latch cannot be driven from it:
+		// a CPU refusal would read as "the disk recovered".
+		const limits = { maxCpuPercent: 50, maxMemoryMb: null, minFreeDiskBytes: 2 * GIB };
+		const bothOver = sample({ cpuPercent: 90, diskFreeBytes: 190 * MIB });
+		expect(admitByResourceLimits(limits, bothOver).dimension).toBe('cpu');
+		expect(judgeDiskFloor(limits, bothOver)?.reason).toContain('below the 2.0 GiB floor');
+		expect(judgeDiskFloor(limits, sample({ cpuPercent: 90, diskFreeBytes: 10 * GIB }))).toBeNull();
 	});
 
 	it('never blocks when the floor is switched off', () => {
@@ -481,10 +521,15 @@ describe('admitByResourceLimits — disk floor', () => {
 		expect(decision.dimension).toBe('cpu');
 	});
 
-	it('formats bytes the way an operator reads them', () => {
-		expect(formatBytes(38 * MIB)).toBe('38 MB');
+	it('formats bytes in binary units and LABELS them binary (review AO-14)', () => {
+		// It divided by 1024 and printed "MB"/"KB", so one refusal line read
+		// `524 MB free ... below the 2.0 GiB floor` — two unit systems in one
+		// sentence, only one of them named correctly. The Fleet drawer is
+		// deliberately decimal (it agrees with Explorer/Finder); the two only
+		// reconcile if each says which it is.
+		expect(formatBytes(38 * MIB)).toBe('38 MiB');
 		expect(formatBytes(2 * GIB)).toBe('2.0 GiB');
-		expect(formatBytes(1_536)).toBe('2 KB');
+		expect(formatBytes(1_536)).toBe('2 KiB');
 		expect(formatBytes(-1)).toBe('unknown');
 	});
 });
@@ -539,7 +584,13 @@ describe('WorkerLoop honours the disk floor', () => {
 		await loop.stop();
 	});
 
-	it('leases anyway when the disk probe throws or answers null', async () => {
+	it('refuses to lease when the disk probe throws or answers null (review AO-11)', async () => {
+		// Composition, not preference. The provisioner's
+		// `assertWorkspaceDiskHeadroom` refuses this same unreadable reading;
+		// if the lease gate admitted it, the node would take every job and
+		// then defer it, silently spending one attempt per lapsed lease until
+		// the platform failed the job for "attempt budget exhausted" — a
+		// message that never mentions disk. Throttling here says why.
 		for (const freeBytes of [
 			() => {
 				throw new Error('statfs unsupported');
@@ -557,10 +608,76 @@ describe('WorkerLoop honours the disk floor', () => {
 			});
 
 			await loop.start();
-			expect(client.leaseRequests).toHaveLength(1);
-			expect(loop.getState().state).not.toBe('throttled');
+			expect(client.leaseRequests).toHaveLength(0);
+			expect(loop.getState().state).toBe('throttled');
+			expect(loop.getState().throttleReason).toContain('could not be measured');
 			await loop.stop();
 		}
+	});
+
+	it('the two disk gates agree on an unreadable volume, so nothing loops (review AO-11)', async () => {
+		// The composition itself, asserted in one place: ONE probe, both
+		// gates. Neither test on its own could see the defect — the lease
+		// side only checked that admission succeeded, the provision side only
+		// that the provisioner threw.
+		const probe = { freeBytes: () => null };
+		const client = recordingClient([[]]);
+		const scheduler = controllableScheduler();
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			limits: clampResourceLimits({ maxConcurrentJobs: 1 }),
+			diskProbe: probe,
+			workspacePath: process.cwd()
+		});
+		await loop.start();
+		// The lease never happens, so the provisioner is never reached...
+		expect(client.leaseRequests).toHaveLength(0);
+		await loop.stop();
+		// ...and had it been reached, it would have refused the same reading.
+		await expect(assertWorkspaceDiskHeadroom(probe, 2 * GIB, process.cwd())).rejects.toMatchObject({
+			code: 'disk-low'
+		});
+	});
+
+	it('does not claim the volume recovered when CPU refuses first (review AO-7)', async () => {
+		// `admitByResourceLimits` returns only the FIRST refusing dimension.
+		// Driving the latch from it logged "Workspace volume is back above
+		// the disk floor — leasing resumes" the moment CPU also went over,
+		// about a machine still at 190 MB and still leasing nothing; when CPU
+		// dropped the warning re-fired, so a permanently full disk produced
+		// an alternating refuse/resume log.
+		const lines: string[] = [];
+		const logger = {
+			info: (message: string) => lines.push(`info ${message}`),
+			warn: (message: string) => lines.push(`warn ${message}`),
+			error: (message: string) => lines.push(`error ${message}`),
+			debug: () => undefined,
+			protect: () => undefined,
+			redact: (value: string) => value
+		};
+		const client = recordingClient([[], []]);
+		const scheduler = controllableScheduler();
+		let cpuPercent = 40;
+		const loop = new WorkerLoop({
+			client,
+			scheduler,
+			logger: logger as never,
+			limits: clampResourceLimits({ maxConcurrentJobs: 1, maxCpuPercent: 80 }),
+			resourceProbe: { sample: () => sample({ cpuPercent }) },
+			diskProbe: { freeBytes: () => 190 * MIB },
+			workspacePath: process.cwd()
+		});
+
+		await loop.start();
+		expect(lines.filter((line) => line.startsWith('warn Refusing to lease work'))).toHaveLength(1);
+
+		// Same poll cadence, now with CPU over the ceiling as well.
+		cpuPercent = 85;
+		scheduler.runNext();
+		await vi.waitFor(() => expect(loop.getState().throttleReason).toContain('CPU'));
+		expect(lines.some((line) => line.includes('back above the disk floor'))).toBe(false);
+		await loop.stop();
 	});
 
 	it('takes no reading at all when the floor is switched off', async () => {

--- a/apps/node/src/core/resource-limits.ts
+++ b/apps/node/src/core/resource-limits.ts
@@ -66,11 +66,15 @@ export const ADMIT: AdmissionDecision = { admit: true, reason: null };
  * observation. Treating a noisy reading as a hard cap would let one
  * unrelated process on the machine wedge the node permanently.
  *
- * The disk FLOOR follows the same three rules, with one difference in
- * defaults: it is on unless the operator switched it off (see
- * `effectiveMinFreeDiskBytes`). A node with 200 MB free that keeps leasing
- * fails deep inside git or pnpm, after the lease and the plan are already
- * spent — refusing up front hands the job to a machine with room.
+ * The disk FLOOR follows the same rules with two differences, both in
+ * {@link judgeDiskFloor}: it is on unless the operator switched it off
+ * (see `effectiveMinFreeDiskBytes`), and a reading that was TAKEN and came
+ * back unreadable refuses rather than admits, because the provisioner's
+ * gate refuses it too and two gates only compose when the earlier one is
+ * at least as strict. A dimension that was never sampled still never
+ * blocks. A node with 200 MB free that keeps leasing fails deep inside git
+ * or pnpm, after the lease and the plan are already spent — refusing up
+ * front hands the job to a machine with room.
  */
 export function admitByResourceLimits(
 	limits: Pick<NodeResourceLimits, 'maxCpuPercent' | 'maxMemoryMb' | 'minFreeDiskBytes'>,
@@ -101,19 +105,65 @@ export function admitByResourceLimits(
 		}
 	}
 
-	const floor = effectiveMinFreeDiskBytes(limits);
-	const free = sample.diskFreeBytes;
-	if (typeof floor === 'number' && typeof free === 'number' && Number.isFinite(free)) {
-		if (free < floor) {
-			return {
-				admit: false,
-				reason: `workspace volume has ${formatBytes(free)} free, below the ${formatBytes(floor)} floor`,
-				dimension: 'disk'
-			};
-		}
-	}
+	return judgeDiskFloor(limits, sample) ?? ADMIT;
+}
 
-	return ADMIT;
+/**
+ * The disk floor's own verdict, independent of CPU and memory.
+ *
+ * Separate from {@link admitByResourceLimits}, which reports only the
+ * FIRST refusing dimension, because two callers need the disk answer even
+ * when something else refused first: the worker loop's refuse/resume latch
+ * (which otherwise logged "the volume is back above the floor" the moment
+ * CPU also went over — review AO-7), and any caller that wants to say why
+ * a node went quiet. Null means the floor is satisfied or not in force.
+ *
+ * ## An unreadable reading REFUSES (review AO-11)
+ *
+ * `undefined` means the disk was never sampled (no probe, or no floor) and
+ * never blocks. `null` — and a non-finite number — is different: it is what
+ * `measureWorkspaceFreeBytes` returns when it TRIED and could not answer,
+ * and it now refuses.
+ *
+ * It used to admit, on the reasoning that a broken `statfs` must not idle
+ * a machine. But the provisioner's `assertWorkspaceDiskHeadroom` refuses
+ * that same reading — it is the last gate before a model's whole budget
+ * lands on the volume — so the pair did not compose: the node leased every
+ * job it was offered and then declined it at provision time, and each
+ * deferral silently burned one of the job's attempts (the claim just
+ * lapses; nothing is reported) until the platform failed the job with a
+ * message that never mentioned disk. On a single-node fleet that is every
+ * job, forever.
+ *
+ * Refusing here instead makes the node THROTTLED with a reason an operator
+ * can read in the drawer, in the log and in `ever-works-node doctor` —
+ * which is what "see why a node stopped accepting work" means — and
+ * `--no-disk-floor` remains the explicit way to switch the control off.
+ * `createDiskProbe` documents null as a persistent condition (an
+ * unavailable API, an unmounted path, a permission error), not a blip.
+ */
+export function judgeDiskFloor(
+	limits: Pick<NodeResourceLimits, 'minFreeDiskBytes'>,
+	sample: Pick<ResourceSample, 'diskFreeBytes'> | null | undefined
+): AdmissionDecision | null {
+	const floor = effectiveMinFreeDiskBytes(limits);
+	if (typeof floor !== 'number' || !sample) return null;
+	const free = sample.diskFreeBytes;
+	// Never sampled: the control was not asked for on this poll.
+	if (free === undefined) return null;
+	if (typeof free !== 'number' || !Number.isFinite(free)) {
+		return {
+			admit: false,
+			reason: `free space on the workspace volume could not be measured, so the ${formatBytes(floor)} floor cannot be checked`,
+			dimension: 'disk'
+		};
+	}
+	if (free >= floor) return null;
+	return {
+		admit: false,
+		reason: `workspace volume has ${formatBytes(free)} free, below the ${formatBytes(floor)} floor`,
+		dimension: 'disk'
+	};
 }
 
 /** True when at least one CPU/memory ceiling is set (i.e. probing is worth it). */
@@ -127,16 +177,25 @@ export function hasDiskFloor(limits: Pick<NodeResourceLimits, 'minFreeDiskBytes'
 }
 
 /**
- * Human-readable byte count for log lines and the CLI: `38 MB`, `2.0 GiB`.
- * Binary units above the MB mark because that is what the floor is set in
- * and what an operator compares against a disk-usage dialog.
+ * Human-readable byte count for log lines and the CLI: `38 MiB`,
+ * `2.0 GiB`.
+ *
+ * Binary throughout, and LABELLED binary (review AO-14). It divided by
+ * 1024 and printed "MB" and "KB", so one refusal line read
+ * `524 MB free ... below the 2.0 GiB floor` with two different unit
+ * systems in one sentence and only one of them named correctly. The node
+ * speaks binary because that is the unit `--min-free-disk` takes and the
+ * unit `effectiveMinFreeDiskBytes` clamps in; the Fleet drawer
+ * deliberately speaks DECIMAL (`runner-status.shared.ts`) to agree with
+ * Explorer and Finder, and the two only reconcile if each says which it
+ * is.
  */
 export function formatBytes(bytes: number): string {
 	if (!Number.isFinite(bytes) || bytes < 0) return 'unknown';
 	const gib = 1024 ** 3;
 	const mib = 1024 ** 2;
 	if (bytes >= gib) return `${(bytes / gib).toFixed(1)} GiB`;
-	if (bytes >= mib) return `${Math.round(bytes / mib)} MB`;
-	if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+	if (bytes >= mib) return `${Math.round(bytes / mib)} MiB`;
+	if (bytes >= 1024) return `${Math.round(bytes / 1024)} KiB`;
 	return `${Math.round(bytes)} B`;
 }

--- a/apps/node/src/core/runtime-housekeeping.spec.ts
+++ b/apps/node/src/core/runtime-housekeeping.spec.ts
@@ -99,6 +99,54 @@ describe('createNodeRuntime — disk floor', () => {
 		}
 	});
 
+	it('still reports a figure before the workspace root exists (review AO-8)', async () => {
+		// The beat used the RAW probe while both gates used
+		// `measureWorkspaceFreeBytes`, which walks to the nearest existing
+		// ancestor. `statfs` on a missing path throws, so on every freshly
+		// enrolled node — the root is not created until the first provision
+		// — the beat omitted `diskFreeBytes` entirely while reporting
+		// `minFreeDiskBytes` beside it. The drawer then showed a floor with
+		// no reading to compare it against and could never say "below", on
+		// exactly the machines whose lease gate was already enforcing
+		// against the parent volume.
+		const bodies: Record<string, unknown>[] = [];
+		const probed: string[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const parent = mkdtempSync(join(tmpdir(), 'ew-runtime-disk-absent-'));
+		const root = join(parent, 'fleet-workspaces');
+		try {
+			const runtime = createNodeRuntime(
+				config,
+				{
+					...io(fetchFn),
+					diskProbe: {
+						freeBytes: (path) => {
+							probed.push(path);
+							return 77 * 1024 ** 3;
+						}
+					}
+				},
+				{ workerEnabled: true, agentTaskWorkspaceRoot: root }
+			);
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			// Measured on the nearest EXISTING ancestor, exactly as the gates do.
+			expect(probed).toContain(parent);
+			expect(bodies[0]?.diskFreeBytes).toBe(77 * 1024 ** 3);
+			// So the floor beside it now has something to be compared against.
+			expect(bodies[0]?.minFreeDiskBytes).toBe(2 * 1024 ** 3);
+			await runtime.worker?.stop();
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
 	it('gates the lease on the workspace volume and exposes the root and provisioner to the shell', async () => {
 		let leaseCalls = 0;
 		const fetchFn: FetchLike = async (url) => {
@@ -287,6 +335,181 @@ describe('createNodeRuntime — disk floor', () => {
 			expect(completions).toEqual([]);
 			expect(runtime.worker?.getState().failed).toBe(1);
 			expect(runtime.worker?.getState().lastError).toContain('floor');
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+/**
+ * Housekeeping reporting wiring (EW-803).
+ *
+ * The floor and the reaper's outcome were enforced on the machine and
+ * invisible from the platform. These pin the composition root's half of
+ * the fix: the reporter exists only where there is a worker to report
+ * about, it reads the SAME effective floor the gates were built from, and
+ * what it records reaches the actual heartbeat body.
+ */
+describe('createNodeRuntime — housekeeping reporting', () => {
+	it('puts the effective floor on the heartbeat, matching the floor the gates enforce', async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const root = mkdtempSync(join(tmpdir(), 'ew-runtime-hk-floor-'));
+		try {
+			const runtime = createNodeRuntime(
+				{ ...config, limits: clampResourceLimits({ maxConcurrentJobs: 1, minFreeDiskBytes: 4 * 1024 ** 3 }) },
+				{ ...io(fetchFn), diskProbe: { freeBytes: () => 9 * 1024 ** 3 } },
+				{ workerEnabled: true, agentTaskWorkspaceRoot: root }
+			);
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			// The number Fleet displays is the number this machine enforces,
+			// not a second reading of the config that could drift from it.
+			expect(bodies[0]?.minFreeDiskBytes).toBe(4 * 1024 ** 3);
+			// Nothing has swept yet, so there is no reclaim to claim.
+			expect(bodies[0]).not.toHaveProperty('lastReclaimAt');
+			await runtime.worker?.stop();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('reports a recorded sweep on the NEXT beat', async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const root = mkdtempSync(join(tmpdir(), 'ew-runtime-hk-sweep-'));
+		try {
+			const runtime = createNodeRuntime(
+				config,
+				{ ...io(fetchFn), diskProbe: { freeBytes: () => 9 * 1024 ** 3 } },
+				{ workerEnabled: true, agentTaskWorkspaceRoot: root }
+			);
+			expect(runtime.housekeeping).toBeDefined();
+			// What the reaper timer hands over after a cycle.
+			runtime.housekeeping!.record({
+				dryRun: false,
+				removed: [
+					{ record: { path: '/w/gone', sizeBytes: 3 * 1024 ** 3 } as never, freedBytes: 3 * 1024 ** 3 }
+				],
+				kept: [{ record: { path: '/w/stays', sizeBytes: 1024 ** 3 } as never, reason: 'within the max age' }],
+				removedPools: [],
+				keptPools: [],
+				freedBytes: 3 * 1024 ** 3,
+				errors: []
+			});
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0]?.workspaceCount).toBe(1);
+			expect(bodies[0]?.workspaceBytes).toBe(1024 ** 3);
+			expect(bodies[0]?.lastReclaimFreedBytes).toBe(3 * 1024 ** 3);
+			expect(typeof bodies[0]?.lastReclaimAt).toBe('string');
+			await runtime.worker?.stop();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('reports NOTHING about housekeeping on a visibility-only node', async () => {
+		// No worker means no floor in force and no reaper. Reporting a
+		// floor there would claim a control that is not running.
+		const bodies: Record<string, unknown>[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const root = mkdtempSync(join(tmpdir(), 'ew-runtime-hk-none-'));
+		try {
+			const runtime = createNodeRuntime(
+				config,
+				{ ...io(fetchFn), diskProbe: { freeBytes: () => 9 * 1024 ** 3 } },
+				{ agentTaskWorkspaceRoot: root }
+			);
+			expect(runtime.housekeeping).toBeUndefined();
+
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0]).not.toHaveProperty('minFreeDiskBytes');
+			// The disk READING still travels — that half was never gated on
+			// having a worker.
+			expect(bodies[0]?.diskFreeBytes).toBe(9 * 1024 ** 3);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('reports an operator-disabled floor as an explicit null', async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const root = mkdtempSync(join(tmpdir(), 'ew-runtime-hk-off-'));
+		try {
+			const runtime = createNodeRuntime(
+				{ ...config, limits: clampResourceLimits({ maxConcurrentJobs: 1, minFreeDiskBytes: null }) },
+				{ ...io(fetchFn), diskProbe: { freeBytes: () => 9 * 1024 ** 3 } },
+				{ workerEnabled: true, agentTaskWorkspaceRoot: root }
+			);
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			expect(bodies[0]).toHaveProperty('minFreeDiskBytes');
+			expect(bodies[0]?.minFreeDiskBytes).toBeNull();
+			await runtime.worker?.stop();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('reports NO floor when no disk probe is wired, because none is enforced (review AO-9)', async () => {
+		// `diskProbe` is optional on `NodeIo`, and BOTH gates switch
+		// themselves off without it — `wantsDisk` requires one and
+		// `assertWorkspaceDiskHeadroom` returns before it measures. Reporting
+		// `2 GiB` anyway put a control on the operator's screen that was
+		// doing nothing: the drawer rendered "Above floor" for a node
+		// leasing and provisioning with no free-space check at all.
+		const bodies: Record<string, unknown>[] = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/heartbeat')) {
+				bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			}
+			return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, node: apiNode }) };
+		};
+		const root = mkdtempSync(join(tmpdir(), 'ew-runtime-hk-noprobe-'));
+		try {
+			const runtime = createNodeRuntime(
+				{ ...config, limits: clampResourceLimits({ maxConcurrentJobs: 1, minFreeDiskBytes: 4 * 1024 ** 3 }) },
+				io(fetchFn),
+				{ workerEnabled: true, agentTaskWorkspaceRoot: root }
+			);
+			await runtime.loop.start();
+			runtime.loop.stop();
+
+			// Null, not 4 GiB: "no floor in force" is the true statement, and
+			// `hasFleetNodeHousekeeping` deliberately does not count a null
+			// floor as a report, so the drawer says "not reported".
+			expect(bodies[0]?.minFreeDiskBytes).toBeNull();
+			// And no reading either, which is the honest pair.
+			expect(bodies[0]).not.toHaveProperty('diskFreeBytes');
+			await runtime.worker?.stop();
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -6,16 +6,11 @@ import {
 	type CommandRunner,
 	type SelfDescriptionTelemetry
 } from './capabilities';
-import {
-	cacheProbe,
-	detectAgentCliVersion,
-	detectDiskFreeBytes,
-	detectModelIdentity,
-	type DiskProbeIo
-} from './telemetry-probe';
+import { cacheProbe, detectAgentCliVersion, detectModelIdentity, type DiskProbeIo } from './telemetry-probe';
 import { FleetClient, type FetchLike } from './fleet-client';
 import { FleetJobClient } from './job-client';
 import { HeartbeatLoop, type Scheduler } from './heartbeat';
+import { NodeHousekeepingReporter } from './housekeeping-report';
 import type { ResourceProbe } from './resource-limits';
 import { describeWorkerHealth } from './worker-health';
 import { WorkerLoop } from './worker-loop';
@@ -24,7 +19,12 @@ import { runAcceptanceChecksJob } from './executors/acceptance-checks';
 import { runAgentTaskJob } from './executors/agent-task';
 import { runBrowserCheckJob } from './executors/browser-check';
 import type { ModelCliPaths } from './executors/model-cli';
-import { defaultFleetTaskWorkspaceRoot, FleetTaskWorkspaceProvisioner } from './workspaces/fleet-task-workspace';
+import {
+	assertWorkspaceDiskHeadroom,
+	defaultFleetTaskWorkspaceRoot,
+	FleetTaskWorkspaceProvisioner
+} from './workspaces/fleet-task-workspace';
+import { measureWorkspaceFreeBytes } from './workspaces/disk-headroom';
 import type { Logger } from './logger';
 import {
 	clampResourceLimits,
@@ -97,7 +97,15 @@ export function buildSelfDescriptionTelemetry(io: NodeIo): SelfDescriptionTeleme
 	if (io.diskProbe) {
 		const probe = io.diskProbe;
 		const path = io.workspacePath ?? process.cwd();
-		telemetry.diskFreeBytes = () => detectDiskFreeBytes(probe, path);
+		// The SAME measurement both gates use — walking to the nearest
+		// existing ancestor — not the raw probe (review AO-8). The raw probe
+		// answers null for a workspace root that does not exist yet, which
+		// is every freshly enrolled node until its first provision: the beat
+		// then omitted `diskFreeBytes` while reporting `minFreeDiskBytes`
+		// beside it, so the drawer showed a floor with no reading to compare
+		// it against and could never say "below" — on exactly the machines
+		// whose lease gate was already enforcing against the parent volume.
+		telemetry.diskFreeBytes = () => measureWorkspaceFreeBytes(probe, path);
 	}
 	return telemetry;
 }
@@ -253,6 +261,15 @@ export interface NodeRuntime {
 	 * process is using right now (belt and braces over the on-disk lease).
 	 */
 	workspaceProvisioner?: FleetWorkspaceProvisionerLike;
+	/**
+	 * Node housekeeping reporting (EW-803), present with `worker`.
+	 *
+	 * Already wired into the heartbeat's `describe` closure. Exposed so
+	 * the shell can hand each completed reaper cycle to it — the reaper
+	 * timer is started out there, after this runtime exists, so the two
+	 * meet through this object rather than through a constructor.
+	 */
+	housekeeping?: NodeHousekeepingReporter;
 }
 
 /** The provisioner surface the runtime composes over; the real one and every test double satisfy it. */
@@ -442,6 +459,33 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 		// to report, and the platform shows "unknown" rather than a
 		// fabricated `idle`.
 		telemetry.workerHealth = () => describeWorkerHealth(worker.getState());
+		// Node housekeeping (EW-803), onto the SAME telemetry object and
+		// for the same reason. Only with a worker: a visibility-only node
+		// enforces no floor and runs no reaper, so it has nothing to say
+		// and must not claim otherwise.
+		//
+		// The floor here is `effectiveMinFreeDiskBytes(limits)` — the very
+		// value the lease gate and the provisioner were handed above — so
+		// what Fleet displays is what this machine actually enforces,
+		// rather than a second reading of the config that could drift.
+		//
+		// With one condition, and it is the whole point of the sentence
+		// above (review AO-9): BOTH gates switch themselves off when no
+		// `diskProbe` is wired — `wantsDisk` requires one, and
+		// `assertWorkspaceDiskHeadroom` returns before it measures. An
+		// embedder that builds a `NodeIo` without a probe therefore
+		// enforces nothing, and reporting a floor anyway would put a
+		// control on the operator's screen that does nothing. `null` on the
+		// wire is "no floor in force", which is exactly true here, and
+		// `hasFleetNodeHousekeeping` deliberately does not count a null
+		// floor as a report — so the drawer says "not reported" rather than
+		// "Above floor".
+		const housekeeping = new NodeHousekeepingReporter({
+			minFreeDiskBytes: io.diskProbe ? effectiveMinFreeDiskBytes(limits) : null,
+			...(io.now ? { now: io.now } : {})
+		});
+		telemetry.housekeeping = () => housekeeping.describe();
+		runtime.housekeeping = housekeeping;
 		const workspaceProvisioner: FleetWorkspaceProvisionerLike =
 			options.workspaceProvisioner ??
 			new FleetTaskWorkspaceProvisioner({
@@ -555,6 +599,18 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 							await jobClient.revokeMcpCredential(id);
 						}
 					},
+					// The disk floor on the OTHER workspace path (review
+					// AO-10). A payload that carries `workspacePath` — or
+					// neither field, which falls back to the node's own
+					// working directory — never reaches the provisioner, so
+					// neither of the slice's two gates looked at the volume
+					// it is about to run on. The lease gate had already
+					// passed, because it measures the FLEET root's volume,
+					// which in the installer's own recommended layout is a
+					// different drive. Same floor, same fail-closed rule,
+					// applied to the path the steps actually run in.
+					checkWorkspaceHeadroom: (path, signal) =>
+						assertWorkspaceDiskHeadroom(io.diskProbe, effectiveMinFreeDiskBytes(limits), path, signal),
 					...(options.agentTaskScratchRoot !== undefined
 						? { scratchRoot: options.agentTaskScratchRoot }
 						: {}),

--- a/apps/node/src/core/types.ts
+++ b/apps/node/src/core/types.ts
@@ -323,6 +323,24 @@ export interface NodeConfig {
 	 * byte-for-byte.
 	 */
 	workspaceGc?: NodeWorkspaceGcPolicy;
+	/**
+	 * The workspace root this node actually runs against, recorded by
+	 * `start --workspace-root` (node housekeeping, EW-803).
+	 *
+	 * Stored so that `doctor` and `gc` inspect the SAME tree the service
+	 * uses. They resolved it independently before — flag, else
+	 * `defaultFleetTaskWorkspaceRoot`, which falls back to `homedir()` —
+	 * and the Windows installer's preflight ERRORS unless the operator
+	 * passes `-WorkspaceRoot D:\...`, so `doctor` routinely reported
+	 * `0 worktree(s), 0 B` about an empty directory in the admin's own
+	 * profile while the node was refusing every job for want of space on
+	 * D:. Both disk-refusal messages send the operator to exactly those two
+	 * commands, so they have to land on the right tree.
+	 *
+	 * Absent means "never set on this machine" — the default applies, and
+	 * a config that never carried the key round-trips without it.
+	 */
+	workspaceRoot?: string;
 	/** Local display label; the authoritative name lives on the platform. */
 	name?: string;
 	heartbeatIntervalMs: number;
@@ -350,6 +368,8 @@ export interface RedactedNodeConfig {
 	capabilitySelection?: string[];
 	limits: NodeResourceLimits;
 	workspaceGc?: NodeWorkspaceGcPolicy;
+	/** Where this node keeps its worktrees; a path, never a credential. */
+	workspaceRoot?: string;
 	name?: string;
 	heartbeatIntervalMs: number;
 	enrolledAt: string;
@@ -382,6 +402,9 @@ export function redactConfig(config: NodeConfig): RedactedNodeConfig {
 	}
 	if (config.workspaceGc !== undefined) {
 		redacted.workspaceGc = clampWorkspaceGcPolicy(config.workspaceGc);
+	}
+	if (config.workspaceRoot !== undefined) {
+		redacted.workspaceRoot = config.workspaceRoot;
 	}
 	if (config.name !== undefined) {
 		redacted.name = config.name;

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -19,6 +19,7 @@ import {
 	admitByResourceLimits,
 	hasAdmissionCeilings,
 	hasDiskFloor,
+	judgeDiskFloor,
 	type AdmissionDecision,
 	type ResourceProbe,
 	type ResourceSample
@@ -937,12 +938,20 @@ export class WorkerLoop {
 		if (wantsDisk) {
 			// Measured on the nearest EXISTING ancestor of the root (a fresh
 			// node has not created it yet). A throwing / nonsense probe maps
-			// to null, and null admits: an unreadable volume is reported (the
-			// heartbeat carries no figure) rather than idling the node.
+			// to null, and null now REFUSES: the provisioner refuses the same
+			// unreadable reading, and a node that leases on it only defers the
+			// job later, burning its attempt budget (review AO-11).
 			sample.diskFreeBytes = await measureWorkspaceFreeBytes(this.diskProbe!, this.workspacePath!);
+		} else {
+			// Not sampled on this poll. Cleared explicitly so a host probe
+			// that happens to carry the field cannot make the floor speak.
+			delete sample.diskFreeBytes;
 		}
 		const decision = admitByResourceLimits(this.limits, sample);
-		this.noteDiskDecision(decision);
+		// Judged from the SAMPLE, not from `decision`: `admitByResourceLimits`
+		// reports only the first refusing dimension, so a disk refusal
+		// disappears from it the moment CPU or memory also trips.
+		this.noteDiskDecision(wantsDisk ? judgeDiskFloor(this.limits, sample) : null);
 		return decision;
 	}
 
@@ -950,18 +959,31 @@ export class WorkerLoop {
 	 * One warning when the floor starts refusing, one info line when it
 	 * clears — not a line per poll, which at the idle cadence would be a
 	 * log entry every five seconds for as long as the disk stays full.
+	 *
+	 * `refusal` is the DISK's own verdict (null = the volume is fine, or
+	 * the floor was not evaluated on this poll). It used to be the whole
+	 * admission decision, which meant a CPU refusal on the next poll
+	 * cleared the latch and logged "the volume is back above the disk floor
+	 * — leasing resumes" about a machine still sitting at 190 MB and still
+	 * leasing nothing (review AO-7). On a node with a CPU ceiling that
+	 * produced an alternating refuse/resume log — the exact signal an
+	 * operator is told to read to find out why the node went quiet.
 	 */
-	private noteDiskDecision(decision: AdmissionDecision): void {
-		if (!decision.admit && decision.dimension === 'disk') {
-			if (this.lastDiskRefusal !== decision.reason) {
-				this.lastDiskRefusal = decision.reason;
+	private noteDiskDecision(refusal: AdmissionDecision | null): void {
+		if (refusal) {
+			if (this.lastDiskRefusal !== refusal.reason) {
+				this.lastDiskRefusal = refusal.reason;
 				this.options.logger?.warn(
-					`Refusing to lease work: ${decision.reason}. Free space on the workspace volume (\`ever-works-node doctor\`, \`ever-works-node gc\`) or lower the floor with --min-free-disk.`
+					// Both remedies, because the refusal now has two causes:
+					// a volume that is genuinely full, and one whose free
+					// space cannot be read at all — where clearing space
+					// fixes nothing and only `--no-disk-floor` does.
+					`Refusing to lease work: ${refusal.reason}. Free space on the workspace volume (\`ever-works-node doctor\`, \`ever-works-node gc\`), lower the floor with --min-free-disk, or switch it off with --no-disk-floor.`
 				);
 			}
 			return;
 		}
-		if (this.lastDiskRefusal !== null && (decision.admit || decision.dimension !== 'disk')) {
+		if (this.lastDiskRefusal !== null) {
 			this.lastDiskRefusal = null;
 			this.options.logger?.info('Workspace volume is back above the disk floor — leasing resumes');
 		}

--- a/apps/node/src/core/workspaces/fleet-task-workspace-housekeeping.spec.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace-housekeeping.spec.ts
@@ -5,7 +5,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { admitByResourceLimits } from '../resource-limits';
 import {
+	acquireWorkspaceLease,
 	FleetTaskWorkspaceProvisioner,
 	readWorkspaceLease,
 	readWorkspaceUsage,
@@ -59,7 +61,9 @@ describe('FleetTaskWorkspaceProvisioner — disk floor re-check', () => {
 
 		const failure = await provisioner.provision('task-0001', valid).catch((error: unknown) => error);
 		expect(failure).toMatchObject({ code: 'disk-low' });
-		expect(String((failure as Error).message)).toContain('100 MB');
+		// `MiB`, not `MB`: both halves of this sentence are binary and both
+		// now say so (review AO-14).
+		expect(String((failure as Error).message)).toContain('100 MiB');
 		expect(String((failure as Error).message)).toContain('2.0 GiB');
 		expect(plugin.provision).not.toHaveBeenCalled();
 		// The root does not exist yet: the reading was taken on its nearest
@@ -88,15 +92,69 @@ describe('FleetTaskWorkspaceProvisioner — disk floor re-check', () => {
 		expect(off.provision).toHaveBeenCalledOnce();
 	});
 
-	it('admits when the reading is unknown — an unreadable volume must not fail every job', async () => {
+	// CONTRACT REVERSAL, stated so the next reader does not "fix" it back.
+	//
+	// This case used to assert the opposite — that an unknown reading
+	// ADMITS, on the argument that an unreadable volume must not fail every
+	// job. It was the wrong rule HERE: this is the last check before a
+	// clone, a fetch and a model's entire budget land on a volume whose free
+	// space nobody can name, and nothing checks again afterwards — the
+	// failure it used to allow was a run dying inside git or pnpm with the
+	// lease, the plan and part of the spend already gone. Controls fail
+	// closed: a limit that cannot be EVALUATED refuses. And refusing costs
+	// little, because `disk-low` is a deferral, not a verdict.
+	//
+	// A SECOND reversal followed (review AO-11), on the sibling case below:
+	// the LEASE gate now refuses the same unknown reading too. It was
+	// admitting, and the pair did not compose — the node leased every job
+	// and deferred it here, and each deferral silently spent one of the
+	// job's attempts (nothing is reported; the claim simply lapses) until
+	// the platform failed it for "attempt budget exhausted", a message that
+	// never mentions disk. The original concern — "a broken `statfs` must
+	// not idle a machine" — is answered by `--no-disk-floor`, an explicit
+	// decision, rather than by a silent one that costs jobs.
+	it('refuses when the reading is unknown — a floor it cannot evaluate fails closed', async () => {
 		const plugin = { provision: vi.fn(async () => null) } as unknown as FleetWorkspacePlugin;
 		const provisioner = new FleetTaskWorkspaceProvisioner({
 			rootPath,
 			plugin,
 			diskProbe: { freeBytes: () => null }
 		});
-		await expect(provisioner.provision('task-0001', valid)).rejects.toMatchObject({ code: 'provision-failed' });
-		expect(plugin.provision).toHaveBeenCalledOnce();
+
+		const failure = await provisioner.provision('task-0001', valid).catch((error: unknown) => error);
+		expect(failure).toMatchObject({ code: 'disk-low' });
+		// The message must say the reading FAILED, not that the disk is
+		// full: an operator sent to clear space on a half-empty volume
+		// never finds the real fault.
+		expect(String((failure as Error).message)).toContain('could not be measured');
+		expect(plugin.provision).not.toHaveBeenCalled();
+	});
+
+	it('refuses at the LEASE too, so the pair cannot loop (review AO-11)', () => {
+		// The other half, driven through the real admission function rather
+		// than restated: same floor, same unknown reading, and now the SAME
+		// answer one gate earlier — which is what makes the composition
+		// terminate. A gate that admits what the next gate refuses turns
+		// every won job into a deferral and burns its attempt budget.
+		const limits = { maxCpuPercent: null, maxMemoryMb: null };
+		const sample = { cpuPercent: 5, usedMemoryMb: 100, totalMemoryMb: 16_000 };
+		expect(admitByResourceLimits(limits, { ...sample, diskFreeBytes: null })).toMatchObject({
+			admit: false,
+			dimension: 'disk'
+		});
+		expect(admitByResourceLimits(limits, { ...sample, diskFreeBytes: Number.NaN })).toMatchObject({
+			admit: false,
+			dimension: 'disk'
+		});
+		// A dimension that was never SAMPLED still admits — that is the case
+		// the original rule was really protecting, and it is untouched.
+		expect(admitByResourceLimits(limits, sample)).toMatchObject({ admit: true });
+		// And a reading it CAN take is still refused on the same defaults,
+		// so the cases above are not passing merely because the floor is off.
+		expect(admitByResourceLimits(limits, { ...sample, diskFreeBytes: 100 * MIB })).toMatchObject({
+			admit: false,
+			dimension: 'disk'
+		});
 	});
 
 	it('keeps a pre-cancelled request from reading the disk or reaching Git', async () => {
@@ -249,6 +307,75 @@ describe.sequential('FleetTaskWorkspaceProvisioner — lease and usage files (re
 		expect(failure).toMatchObject({ code: 'workspace-busy' });
 		expect(String((failure as Error).message)).toContain('reaper');
 		expect(String((failure as Error).message)).toContain(String(process.pid));
+	});
+
+	it('treats a lease it cannot PARSE as held, and never takes the slot (review AO-3)', async () => {
+		// The lease is the only cross-process evidence that a job is running
+		// in a worktree, and `removeWorktree` takes it immediately before
+		// `git worktree remove --force`. It used to DELETE any lease it could
+		// not read and take the slot — so the single file gating an
+		// irreversible delete opened exactly when it became unknown. Two
+		// builds on one machine is the shipped pattern (the worker runs as a
+		// Windows service while an operator runs `gc` from a shell), so a
+		// lease this build does not recognise is a live job at least as often
+		// as it is litter.
+		const owner = new FleetTaskWorkspaceProvisioner({ rootPath: workspaceRoot });
+		const descriptor = await owner.provision('task-lease-6', workspace('task/lease-6'));
+		await owner.release('task-lease-6', descriptor);
+		const gitDir = gitDirOf(descriptor.path);
+		writeFileSync(join(descriptor.path, 'in-progress.txt'), 'the running job\n');
+
+		for (const content of [
+			// A future build's format.
+			JSON.stringify({ version: 2, purpose: 'job', pid: 4242, since: '2026-09-01T00:00:00.000Z' }),
+			// A purpose this build has never heard of.
+			JSON.stringify({ version: 1, purpose: 'audit', pid: 4242, since: '2026-09-01T00:00:00.000Z' }),
+			// Torn by a hard kill.
+			'{"version":1,"purpose":"jo'
+		]) {
+			await fs.writeFile(join(gitDir, 'ew-workspace-lease.json'), content);
+			// `isProcessAlive` says NOTHING is running: the old rule would
+			// have called this stale and reclaimed it on that basis.
+			const contended = new FleetTaskWorkspaceProvisioner({
+				rootPath: workspaceRoot,
+				isProcessAlive: () => false
+			});
+			const failure = await contended
+				.provision('task-lease-6', workspace('task/lease-6'))
+				.catch((error: unknown) => error);
+			expect(failure).toMatchObject({ code: 'path-collision' });
+			expect(String((failure as Error).message)).toContain('could not be read as a lease');
+			// Nothing was written through, and the file itself was preserved
+			// so an operator can see what it actually is.
+			expect(await fs.readFile(join(descriptor.path, 'in-progress.txt'), 'utf8')).toBe('the running job\n');
+			expect(await fs.readFile(join(gitDir, 'ew-workspace-lease.json'), 'utf8')).toBe(content);
+		}
+
+		// And `acquireWorkspaceLease` says so in its own words, so the reaper
+		// (which reads the acquisition, not the exception) sees it too.
+		const acquisition = await acquireWorkspaceLease(
+			gitDir,
+			{ version: 1, purpose: 'gc', pid: process.pid, since: new Date().toISOString() },
+			() => false
+		);
+		expect(acquisition).toMatchObject({ acquired: false });
+		expect('unreadable' in acquisition).toBe(true);
+
+		await fs.unlink(join(gitDir, 'ew-workspace-lease.json'));
+	});
+
+	it('writes the lease atomically, so a crash cannot leave a torn one', async () => {
+		// The complement of the rule above: because an unreadable lease is
+		// now a permanent keep, the node must never PRODUCE one. The usage
+		// file already wrote temp-then-rename for exactly this reason while
+		// the gating file did not.
+		const owner = new FleetTaskWorkspaceProvisioner({ rootPath: workspaceRoot });
+		const descriptor = await owner.provision('task-lease-7', workspace('task/lease-7'));
+		const gitDir = gitDirOf(descriptor.path);
+		expect(await readWorkspaceLease(gitDir)).toMatchObject({ pid: process.pid, purpose: 'job' });
+		// No temp file left behind by the atomic create.
+		expect((await fs.readdir(gitDir)).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+		await owner.release('task-lease-7', descriptor);
 	});
 
 	it('drops the lease again when the provision fails after taking it', async () => {

--- a/apps/node/src/core/workspaces/fleet-task-workspace.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.ts
@@ -27,7 +27,12 @@ export type FleetTaskWorkspaceErrorCode =
 	| 'provision-failed'
 	| 'path-collision'
 	| 'git-failed'
-	/** The workspace volume is below the node's disk floor; nothing was written. */
+	/**
+	 * The workspace volume is below the node's disk floor, OR its free
+	 * space could not be measured at all; nothing was written either way.
+	 * The floor fails closed at provision time — see `assertDiskHeadroom`
+	 * for why this gate is stricter than the one at the lease.
+	 */
 	| 'disk-low'
 	/**
 	 * The worktree is being reclaimed by the workspace reaper right now;
@@ -261,10 +266,20 @@ export async function readWorkspaceUsage(gitDir: string): Promise<FleetWorkspace
 	};
 }
 
-export type WorkspaceLeaseAcquisition = { acquired: true } | { acquired: false; heldBy: FleetWorkspaceLease };
+export type WorkspaceLeaseAcquisition =
+	| { acquired: true }
+	| { acquired: false; heldBy: FleetWorkspaceLease }
+	/**
+	 * A lease file is PRESENT and this build cannot read it as a lease — a
+	 * future `version`, an unknown `purpose`, a link where a file belongs,
+	 * or a torn write left by a hard kill. Nobody can be named, and nobody
+	 * may be evicted either: see the fail-closed note on
+	 * {@link acquireWorkspaceLease}.
+	 */
+	| { acquired: false; unreadable: string };
 
 /**
- * Take the lease on a worktree with O_EXCL.
+ * Take the lease on a worktree, exclusively.
  *
  * An existing lease is replaced only when it is provably not in use: held
  * by a pid that is no longer running, or by THIS process for the SAME
@@ -272,6 +287,27 @@ export type WorkspaceLeaseAcquisition = { acquired: true } | { acquired: false; 
  * held by a live pid — or by this process for the OTHER purpose, which is
  * the in-process reaper and a job meeting on one worktree — is reported,
  * never overwritten.
+ *
+ * ## An unreadable lease is HELD, never reclaimable (review AO-3)
+ *
+ * This file is the only cross-process evidence that a job is running in a
+ * worktree, and the reaper's `removeWorktree` takes it immediately before
+ * `git worktree remove --force`. It used to delete any lease it could not
+ * PARSE and take the slot — so the one file that gates an irreversible
+ * delete opened when it became unreadable, which is the wrong side of
+ * every other rule in this slice ("unknown state means keep"). Two builds
+ * on one machine is the shipped pattern (the worker runs as a Windows
+ * service while an operator runs `ever-works-node gc` from a shell), so a
+ * lease this build does not recognise is a live job at least as often as
+ * it is litter.
+ *
+ * The write is made atomic for the same reason: the temp file is written
+ * in full and then hard-linked into place, so a crash mid-write can no
+ * longer leave a torn lease that this rule would then treat as held
+ * forever. `link` is the atomic-AND-exclusive primitive (`rename`, which
+ * the usage file uses, would clobber a live lease); where the filesystem
+ * has no hard links the exclusive create is used directly, exactly as
+ * before.
  */
 export async function acquireWorkspaceLease(
 	gitDir: string,
@@ -282,19 +318,29 @@ export async function acquireWorkspaceLease(
 	const content = `${JSON.stringify(lease)}\n`;
 	for (let attempt = 0; attempt < 3; attempt += 1) {
 		try {
-			await fs.writeFile(path, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+			await createLeaseFileExclusive(path, content);
 			return { acquired: true };
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
 		}
 		const existing = await readWorkspaceLease(gitDir);
-		if (existing) {
-			const ours = existing.pid === lease.pid && existing.purpose === lease.purpose;
-			if (!ours && isProcessAlive(existing.pid)) {
-				return { acquired: false, heldBy: existing };
+		if (!existing) {
+			// Present but not a lease this build understands: fail closed.
+			// (Gone between the create and the read is a plain race — retry.)
+			const stats = await lstatOrNull(path);
+			if (stats) {
+				return {
+					acquired: false,
+					unreadable: `the lease file at '${path}' exists but could not be read as a lease of this version`
+				};
 			}
+			continue;
 		}
-		// Stale (dead pid), ours, or unreadable: replace it and try again.
+		const ours = existing.pid === lease.pid && existing.purpose === lease.purpose;
+		if (!ours && isProcessAlive(existing.pid)) {
+			return { acquired: false, heldBy: existing };
+		}
+		// Stale (dead pid) or ours: replace it and try again.
 		await fs.unlink(path).catch((error: NodeJS.ErrnoException) => {
 			if (error.code !== 'ENOENT') throw error;
 		});
@@ -302,6 +348,42 @@ export async function acquireWorkspaceLease(
 	const contended = await readWorkspaceLease(gitDir);
 	if (contended) return { acquired: false, heldBy: contended };
 	throw new Error(`workspace lease at '${path}' could not be taken`);
+}
+
+/**
+ * Create the lease file with its full content or fail with `EEXIST` —
+ * both properties at once. The content is written to a private temp file
+ * first, so the only thing that can appear at `path` is a complete lease.
+ */
+async function createLeaseFileExclusive(path: string, content: string): Promise<void> {
+	const temporary = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+	try {
+		await fs.writeFile(temporary, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+	} catch {
+		// No temp file (a read-only or exotic filesystem): the direct
+		// exclusive create is still correct, just not crash-atomic.
+		await fs.writeFile(path, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+		return;
+	}
+	try {
+		await fs.link(temporary, path);
+	} catch (error) {
+		// EEXIST is the contention this function exists to report; anything
+		// else means hard links are unavailable here, not that we may skip
+		// the exclusivity.
+		if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw error;
+		await fs.writeFile(path, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+	} finally {
+		await fs.unlink(temporary).catch(() => undefined);
+	}
+}
+
+async function lstatOrNull(path: string): Promise<Awaited<ReturnType<typeof fs.lstat>> | null> {
+	try {
+		return await fs.lstat(path);
+	} catch {
+		return null;
+	}
 }
 
 /** Drop a lease this process holds. A lease held by anyone else is left alone; a missing one is success. */
@@ -403,6 +485,60 @@ export function defaultFleetTaskWorkspaceRoot(
 ): string {
 	const configured = (env.EVER_WORKS_NODE_WORKSPACE_ROOT ?? env.EW_WORKSPACES_DIR ?? '').trim();
 	return configured || join(homePath, '.ever-works', 'fleet-workspaces');
+}
+
+/**
+ * Refuse to write into `targetPath`'s volume unless it can be PROVEN to
+ * have room. Fails closed: a floor that cannot be evaluated refuses.
+ *
+ * This is the LAST gate before a clone, a fetch and a model's whole
+ * budget go onto a volume, and there is no gate after it — so an
+ * unreadable reading refuses here, where a wrong guess costs a
+ * half-written worktree and the spend of a run that dies inside git or
+ * pnpm.
+ *
+ * That is no longer an asymmetry with the lease gate: `admitByResourceLimits`
+ * refuses the same unreadable reading (review AO-11). It had to. While it
+ * admitted, a host whose `statfs` cannot answer — a persistent condition,
+ * per `createDiskProbe` — leased every job it was offered and then
+ * deferred it here, burning one attempt per 300 s lapse until the platform
+ * failed the job with a message that never mentioned disk. Two gates only
+ * compose safely when the earlier one is at least as strict as the later.
+ *
+ * Refusing is cheap because it is a DEFERRAL, not a verdict: `disk-low`
+ * is in `DECLINED_PROVISION_CODES`, so the job goes back unsettled.
+ *
+ * The two early returns are not the same as an unknown reading. No probe
+ * wired, or a floor the operator explicitly switched off, means the
+ * control was never asked for — there is no limit to fail closed ON. An
+ * unknown reading means the control WAS asked for and could not be
+ * evaluated, which is exactly the case that must refuse.
+ */
+export async function assertWorkspaceDiskHeadroom(
+	diskProbe: DiskProbeIo | undefined,
+	minFreeDiskBytes: number | null,
+	targetPath: string,
+	signal?: AbortSignal
+): Promise<void> {
+	throwIfCancelled(signal);
+	if (!diskProbe || minFreeDiskBytes === null) return;
+	const free = await measureWorkspaceFreeBytes(diskProbe, targetPath);
+	throwIfCancelled(signal);
+	if (free === null) {
+		throw new FleetTaskWorkspaceError(
+			'disk-low',
+			`Refusing to provision: free space on the workspace volume (${targetPath}) could not be measured, so the ${formatBytes(
+				minFreeDiskBytes
+			)} floor cannot be checked. Run \`ever-works-node doctor\` on this node.`
+		);
+	}
+	if (free >= minFreeDiskBytes) return;
+	throw new FleetTaskWorkspaceError(
+		'disk-low',
+		`Refusing to provision: ${formatBytes(free)} free on the workspace volume (${targetPath}), below the ${formatBytes(
+			minFreeDiskBytes
+		)} floor. Run \`ever-works-node doctor\` on this node.`
+	);
 }
 
 /**
@@ -776,19 +912,10 @@ export class FleetTaskWorkspaceProvisioner {
 		}
 	}
 
-	/** Refuse to write when the workspace volume is below the floor; an unknown reading admits. */
+	/** @see assertWorkspaceDiskHeadroom — the shared gate, so every writer refuses on the same evidence. */
 	private async assertDiskHeadroom(signal?: AbortSignal): Promise<void> {
 		throwIfCancelled(signal);
-		if (!this.diskProbe || this.minFreeDiskBytes === null) return;
-		const free = await measureWorkspaceFreeBytes(this.diskProbe, this.rootPath);
-		throwIfCancelled(signal);
-		if (free === null || free >= this.minFreeDiskBytes) return;
-		throw new FleetTaskWorkspaceError(
-			'disk-low',
-			`Refusing to provision: ${formatBytes(free)} free on the workspace volume (${this.rootPath}), below the ${formatBytes(
-				this.minFreeDiskBytes
-			)} floor. Run \`ever-works-node doctor\` on this node.`
-		);
+		await assertWorkspaceDiskHeadroom(this.diskProbe, this.minFreeDiskBytes, this.rootPath, signal);
 	}
 
 	/**
@@ -822,6 +949,17 @@ export class FleetTaskWorkspaceProvisioner {
 			this.isProcessAlive
 		);
 		if (!acquisition.acquired) {
+			// An unreadable lease means a process this build cannot identify
+			// may be in this worktree right now. Refuse rather than write
+			// through it, and say exactly which file an operator must look
+			// at — this does not clear on its own and must not read as a
+			// transient the platform should retry forever.
+			if ('unreadable' in acquisition) {
+				throw new FleetTaskWorkspaceError(
+					'path-collision',
+					`Task workspace may be in use by another process: ${acquisition.unreadable}. The workspace was preserved; remove that file only once no job is running in it.`
+				);
+			}
 			// The reaper holding it is OUR housekeeping mid-removal: a transient
 			// the executor hands back rather than a verdict about the job. A
 			// live foreign job is an anomaly (two processes on one root) worth

--- a/apps/node/src/core/workspaces/workspace-inventory.ts
+++ b/apps/node/src/core/workspaces/workspace-inventory.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { promises as fs, type Dirent } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { FLEET_AGENT_TASK_META_DIR } from '@ever-works/contracts';
 import { execFileWithVerifiedCancellation } from '@ever-works/local-workspace-plugin';
 import {
 	defaultIsProcessAlive,
@@ -86,6 +87,17 @@ export interface WorkspaceRecord {
 	lease: WorkspaceLeaseEvidence | null;
 	/** `.mounts/*` entries that are links (junctions / symlinks). */
 	mountLinks: string[];
+	/**
+	 * What `.mounts` itself is. `'foreign'` (a link or a file) and
+	 * `'unknown'` are never removed: enumerating or deleting through it
+	 * would reach whatever it points at. See {@link inspectMountsDir}.
+	 */
+	mountsDir: MountsDirState;
+	/**
+	 * Output under the fleet's own exclude rules (`.ever-works/`), which
+	 * `git status` structurally cannot see. See {@link hasFleetExcludedOutput}.
+	 */
+	excludedOutput: Tristate;
 }
 
 /** One bare pool clone. */
@@ -357,10 +369,15 @@ async function scanWorktree(
 		mergedIntoDefault: 'unknown',
 		intentPending: false,
 		lease: null,
-		mountLinks: []
+		mountLinks: [],
+		mountsDir: 'absent',
+		excludedOutput: 'unknown'
 	};
 
-	record.mountLinks = await listMountLinks(worktreePath);
+	const mounts = await inspectMountsDir(worktreePath);
+	record.mountsDir = mounts.state;
+	record.mountLinks = mounts.links;
+	record.excludedOutput = await hasFleetExcludedOutput(worktreePath);
 	record.sizeBytes = context.measureSize ? await directorySize(worktreePath) : 0;
 
 	const ownership = await proveOwnership(worktreePath, pools, context);
@@ -570,13 +587,33 @@ async function refreshPoolRemote(
 }
 
 /**
- * Commits on the pool's LOCAL branches that no remote-tracking ref reaches,
+ * Everything the pool can still reach that no remote-tracking ref does,
  * judged after the refresh. This is what makes an emptied pool safe (or
- * not) to delete: the worktrees are gone, the branches are not.
+ * not) to delete: deleting it is the one irreversible `fs.rm` in the
+ * reaper, and it takes the object store with it.
+ *
+ * `--all --reflog`, not `--branches` (review AO-2). `--branches` sees only
+ * `refs/heads/*`, and the provider's own
+ * `worktree add -B <branch> <dir> <startPoint>` FORCE-RESETS an existing
+ * local branch — so a commit from a run whose publish was withheld can
+ * end up reachable from that branch's reflog alone, at which point
+ * `--branches` counts zero and the pool (its last copy) becomes
+ * removable. `--all` additionally covers `refs/stash` and tags. Counting
+ * more is always the safe direction here: it can only keep a pool, never
+ * delete one.
  */
+export const POOL_UNPUSHED_REVISION_ARGS: readonly string[] = [
+	'rev-list',
+	'--count',
+	'--all',
+	'--reflog',
+	'--not',
+	'--remotes'
+];
+
 async function judgePool(pool: WorkspacePoolRecord, context: ScanContext): Promise<void> {
 	if (!pool.owned) return;
-	const counted = await git(['rev-list', '--count', '--branches', '--not', '--remotes'], pool.path, context);
+	const counted = await git(POOL_UNPUSHED_REVISION_ARGS, pool.path, context);
 	if (counted.code === 0 && /^\d+$/.test(counted.stdout.trim())) {
 		pool.unpushedCount = Number(counted.stdout.trim());
 	}
@@ -701,13 +738,100 @@ export function intentPath(poolPath: string, bindingKey: string): string {
 	return join(poolPath, FLEET_WORKSPACE_INTENTS_DIR, `${key}.json`);
 }
 
+/**
+ * What `<worktree>/.mounts` is right now, and the links inside it.
+ *
+ * `.mounts` is the one path in a worktree that the MODEL can replace,
+ * running as the node service account, and the provisioner deliberately
+ * leaves a link there in place for a single-repository task
+ * (`reconcileMountsDir`) rather than deleting it. So it is untrusted
+ * input to the reaper as well, and it is `lstat`-ed here before anything
+ * is enumerated: a bare `readdir` RESOLVES a junction, so the reaper
+ * would have listed the entries of the junction's TARGET — another Task's
+ * live checkout — and then unlinked them there while reporting that it
+ * had only touched this worktree (review AO-1).
+ *
+ * Each entry is `lstat`-ed again for the same reason `reconcileMountsDir`
+ * does it: the `Dirent` type is a snapshot, the unlink happens later.
+ */
+export type MountsDirState = 'absent' | 'directory' | 'foreign' | 'unknown';
+
+export interface MountsDirInventory {
+	state: MountsDirState;
+	/** Links to unlink before Git removes the worktree; only ever non-empty for `'directory'`. */
+	links: string[];
+}
+
+export async function inspectMountsDir(worktreePath: string): Promise<MountsDirInventory> {
+	const mountsDir = join(worktreePath, FLEET_TASK_WORKSPACE_MOUNTS_DIR);
+	let stats: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		stats = await fs.lstat(mountsDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { state: 'absent', links: [] };
+		return { state: 'unknown', links: [] };
+	}
+	if (stats.isSymbolicLink() || !stats.isDirectory()) return { state: 'foreign', links: [] };
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(mountsDir, { withFileTypes: true });
+	} catch {
+		return { state: 'unknown', links: [] };
+	}
+	const links: string[] = [];
+	for (const entry of entries) {
+		const entryPath = join(mountsDir, entry.name);
+		const entryStats = await lstatOrNull(entryPath);
+		if (!entryStats) continue;
+		if (entryStats.isSymbolicLink()) links.push(entryPath);
+	}
+	return { state: 'directory', links };
+}
+
 /** `.mounts/*` entries that are links right now; the reaper unlinks these before Git removes the worktree. */
 export async function listMountLinks(worktreePath: string): Promise<string[]> {
-	const links: string[] = [];
-	for (const entry of await readdirSafe(join(worktreePath, FLEET_TASK_WORKSPACE_MOUNTS_DIR))) {
-		if (entry.isSymbolicLink()) links.push(join(worktreePath, FLEET_TASK_WORKSPACE_MOUNTS_DIR, entry.name));
+	return (await inspectMountsDir(worktreePath)).links;
+}
+
+/**
+ * Whether the worktree holds output under the fleet's OWN exclude rules
+ * — `.ever-works/`, the owner-question channel and the agent meta
+ * directory (review AO-4).
+ *
+ * `git status --porcelain --untracked-files=all`, which is the reaper's
+ * entire "no uncommitted work" proof, reports NOTHING for these paths:
+ * the node writes `/.ever-works` and `.ever-works` into the pool's shared
+ * `info/exclude` itself (`FLEET_TASK_WORKSPACE_EXCLUDE_RULES`). So the
+ * one directory the fleet designates for non-committed model output is
+ * structurally invisible to the rule that decides whether a worktree may
+ * be deleted, and a run interrupted between writing `QUESTION.md` and
+ * `collectOwnerQuestion` reading it looked perfectly clean.
+ *
+ * Scoped to the fleet's own rules on purpose. Consulting the OWNER's
+ * `.gitignore` (via `--ignored`) would make almost every worktree read as
+ * dirty — `node_modules`, `dist`, caches — and the reaper would never
+ * reclaim anything, which is the defect this slice exists to close.
+ * Anything found here is left for an operator, because the normal path
+ * REMOVES the question file (and its directory) as soon as it is
+ * collected: a `.ever-works` still on disk means nobody read it.
+ */
+export async function hasFleetExcludedOutput(worktreePath: string): Promise<Tristate> {
+	const metaDir = join(worktreePath, FLEET_AGENT_TASK_META_DIR);
+	let stats: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		stats = await fs.lstat(metaDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+		return 'unknown';
 	}
-	return links;
+	// A link or a file where the meta DIRECTORY belongs is not something
+	// this reaper is entitled to reason about, let alone delete through.
+	if (stats.isSymbolicLink() || !stats.isDirectory()) return 'unknown';
+	try {
+		return (await fs.readdir(metaDir)).length > 0;
+	} catch {
+		return 'unknown';
+	}
 }
 
 function normalizedPath(value: string): string {

--- a/apps/node/src/core/workspaces/workspace-reaper-safety.spec.ts
+++ b/apps/node/src/core/workspaces/workspace-reaper-safety.spec.ts
@@ -1,0 +1,302 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { FleetTaskWorkspaceProvisioner } from './fleet-task-workspace';
+import { listMountLinks, scanWorkspaceRoot, type WorkspacePoolRecord } from './workspace-inventory';
+import { planWorkspaceReap, policyFromConfig, runWorkspaceReap } from './workspace-reaper';
+
+/**
+ * Reaper safety, second pass (review AO-1, AO-2, AO-3, AO-4, AO-5).
+ *
+ * Every case here is an irreversible delete the reaper WOULD have
+ * performed on evidence that structurally could not see the thing it was
+ * about to destroy: content hidden from `git status` by the node's own
+ * exclude rules, a commit reachable only from a reflog, a `.mounts` that
+ * is itself a junction into another Task's checkout, a relocated
+ * repository cache behind a reparse point, and a lease file this build
+ * cannot parse.
+ *
+ * They live in their own file because each needs a hand-built anomaly on
+ * disk rather than the happy-path provision the main suite exercises.
+ */
+
+const git = (cwd: string, ...args: string[]): string =>
+	execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true }).trim();
+
+const DAY = 24 * 60 * 60_000;
+const NOW = Date.parse('2026-09-05T12:00:00.000Z');
+const OLD = NOW - 30 * DAY;
+const policy = policyFromConfig({ maxAgeDays: 14, maxCount: null });
+
+const testTemporaryDirectory = process.env.RUNNER_TEMP ?? tmpdir();
+const canonicalTemporaryDirectory = realpathSync.native(testTemporaryDirectory);
+
+/** Junction on Windows, directory symlink elsewhere — what the provisioner itself creates. */
+const linkDir = async (target: string, path: string): Promise<void> => {
+	await fs.symlink(target, path, process.platform === 'win32' ? 'junction' : 'dir');
+};
+
+describe.sequential('workspace reaper — evidence it could not see', { timeout: 90_000 }, () => {
+	let ownedRoot: string;
+	let seedDir: string;
+	let originDir: string;
+	let originUrl: string;
+	let gitConfigIndex: number;
+	let counter = 0;
+	const remoteUrl = 'https://fleet-reaper-safety.invalid/ever/repository.git';
+
+	const spec = (repositoryId: string, branch: string) => ({
+		repositoryId,
+		repoUrl: remoteUrl,
+		baseRef: 'main',
+		branch
+	});
+
+	const freshRoot = (): string => join(ownedRoot, `root-${(counter += 1)}`);
+
+	const provisionAt = async (rootPath: string, taskId: string, repositoryId: string, branch: string, at: number) => {
+		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath, now: () => at });
+		const descriptor = await provisioner.provision(taskId, spec(repositoryId, branch));
+		await provisioner.release(taskId, descriptor);
+		return descriptor;
+	};
+
+	const commitIn = (worktree: string, name: string): void => {
+		writeFileSync(join(worktree, name), `${name}\n`);
+		git(worktree, 'add', name);
+		git(worktree, '-c', 'user.name=Fleet Test', '-c', 'user.email=fleet@test.invalid', 'commit', '-m', name);
+	};
+
+	const scanAndPlan = async (rootPath: string) => {
+		const scanned = await scanWorkspaceRoot(rootPath, { refreshRemote: true, now: () => NOW });
+		return { scanned, plan: planWorkspaceReap(scanned, policy, NOW) };
+	};
+
+	beforeAll(() => {
+		ownedRoot = realpathSync.native(mkdtempSync(join(canonicalTemporaryDirectory, 'ew-reaper-safety-')));
+		seedDir = join(ownedRoot, 'seed');
+		originDir = join(ownedRoot, 'origin.git');
+		originUrl = pathToFileURL(originDir).toString();
+		mkdirSync(seedDir, { recursive: true });
+		mkdirSync(originDir, { recursive: true });
+		git(originDir, 'init', '--bare', '--initial-branch', 'main');
+		git(seedDir, 'init', '--initial-branch', 'main');
+		writeFileSync(join(seedDir, 'README.md'), 'fleet workspace\n');
+		git(seedDir, 'add', 'README.md');
+		git(seedDir, '-c', 'user.name=Fleet Test', '-c', 'user.email=fleet@test.invalid', 'commit', '-m', 'seed');
+		git(seedDir, 'push', originUrl, 'HEAD:refs/heads/main');
+
+		gitConfigIndex = Number(process.env.GIT_CONFIG_COUNT ?? '0');
+		process.env.GIT_CONFIG_COUNT = String(gitConfigIndex + 1);
+		process.env[`GIT_CONFIG_KEY_${gitConfigIndex}`] = `url.${originUrl}.insteadOf`;
+		process.env[`GIT_CONFIG_VALUE_${gitConfigIndex}`] = remoteUrl;
+	});
+
+	afterAll(async () => {
+		delete process.env[`GIT_CONFIG_KEY_${gitConfigIndex}`];
+		delete process.env[`GIT_CONFIG_VALUE_${gitConfigIndex}`];
+		if (gitConfigIndex === 0) delete process.env.GIT_CONFIG_COUNT;
+		else process.env.GIT_CONFIG_COUNT = String(gitConfigIndex);
+		await fs.rm(ownedRoot, { recursive: true, force: true, maxRetries: 3 });
+	});
+
+	it('never enumerates through a `.mounts` that is ITSELF a junction (review AO-1)', async () => {
+		// The model runs in the reused primary worktree as the node service
+		// account and can replace `.mounts` with a junction; for a
+		// single-repository task the provisioner deliberately LEAVES that
+		// link in place rather than deleting it, and `/.mounts` is in the
+		// pool's `info/exclude`, so `git status` reports nothing and the
+		// worktree reads clean. `listMountLinks` then did a bare `readdir`,
+		// which RESOLVES the junction — so the reaper listed the entries of
+		// the junction's target (another Task's live checkout) and unlinked
+		// them there, while reporting that it had removed only this
+		// worktree.
+		const rootPath = freshRoot();
+		const primary = await provisionAt(rootPath, 'task-m1', 'ever/repo-m1', 'task/m1', OLD);
+		const victim = await provisionAt(rootPath, 'task-m2', 'ever/repo-m2', 'task/m2', NOW - DAY);
+		// The victim's own `.mounts`, with a link inside it — the shape the
+		// reaper is entitled to unlink, planted where it must NOT reach.
+		mkdirSync(join(victim.path, '.mounts'));
+		await linkDir(seedDir, join(victim.path, '.mounts', 'seed'));
+		// ...and the primary's `.mounts` is a junction to it.
+		await linkDir(join(victim.path, '.mounts'), join(primary.path, '.mounts'));
+
+		// The enumerator itself refuses to look through it.
+		expect(await listMountLinks(primary.path)).toEqual([]);
+		expect(await listMountLinks(victim.path)).toEqual([join(victim.path, '.mounts', 'seed')]);
+
+		const { scanned, plan } = await scanAndPlan(rootPath);
+		const record = scanned.repositories
+			.flatMap((repository) => repository.worktrees)
+			.find((tree) => tree.path === primary.path)!;
+		expect(record.mountsDir).toBe('foreign');
+		expect(record.mountLinks).toEqual([]);
+		// Clean by `git status` — which is exactly why this needed its own rule.
+		expect(record.dirty).toBe(false);
+		expect(plan.remove.map((verdict) => verdict.record.path)).not.toContain(primary.path);
+		expect(plan.keep.find((verdict) => verdict.record.path === primary.path)?.reason).toContain('`.mounts`');
+
+		const result = await runWorkspaceReap(plan, { now: () => NOW });
+		expect(result.errors).toEqual([]);
+		expect(existsSync(primary.path)).toBe(true);
+		// Nothing was unlinked through the junction.
+		expect(existsSync(join(victim.path, '.mounts', 'seed'))).toBe(true);
+		expect(existsSync(join(seedDir, 'README.md'))).toBe(true);
+	});
+
+	it('keeps a worktree holding output the node`s own exclude rules hide (review AO-4)', async () => {
+		// `.ever-works/` is where the OUTPUT CONTRACT tells the model to
+		// write an owner question, and the node writes that very path into
+		// the pool's shared `info/exclude` — so the reaper's entire "no
+		// uncommitted work" proof (`git status --porcelain
+		// --untracked-files=all`) reports nothing for it. A run interrupted
+		// between the model writing QUESTION.md and `collectOwnerQuestion`
+		// reading it therefore looked perfectly clean, and the question the
+		// owner was supposed to answer was deleted with no trace in `errors`
+		// or `kept`.
+		const rootPath = freshRoot();
+		const descriptor = await provisionAt(rootPath, 'task-q', 'ever/repo-q', 'task/q', OLD);
+		mkdirSync(join(descriptor.path, '.ever-works'));
+		writeFileSync(join(descriptor.path, '.ever-works', 'QUESTION.md'), '# Which database?\n');
+
+		const { scanned, plan } = await scanAndPlan(rootPath);
+		const [record] = scanned.repositories[0].worktrees;
+		// Git genuinely cannot see it: that is the premise, asserted.
+		expect(git(descriptor.path, 'status', '--porcelain', '--untracked-files=all')).toBe('');
+		expect(record.dirty).toBe(false);
+		expect(record.excludedOutput).toBe(true);
+		expect(plan.remove).toHaveLength(0);
+		expect(plan.keep[0].reason).toContain('.ever-works');
+
+		const result = await runWorkspaceReap(plan, { now: () => NOW });
+		expect(result.removed).toHaveLength(0);
+		expect(existsSync(join(descriptor.path, '.ever-works', 'QUESTION.md'))).toBe(true);
+
+		// And once the question has been collected — the normal path removes
+		// the file AND the directory — the worktree is reclaimable again, so
+		// this rule does not simply switch the reaper off.
+		await fs.rm(join(descriptor.path, '.ever-works'), { recursive: true, force: true });
+		const after = await scanAndPlan(rootPath);
+		expect(after.scanned.repositories[0].worktrees[0].excludedOutput).toBe(false);
+		expect(after.plan.remove).toHaveLength(1);
+	});
+
+	it('keeps a pool whose only copy of a commit is in a branch reflog (review AO-2)', async () => {
+		// `rev-list --count --branches --not --remotes` sees only
+		// `refs/heads/*`. The provider's own `worktree add -B <branch> <dir>
+		// <startPoint>` force-resets an existing local branch, so a commit
+		// from a run whose publish was withheld ends up reachable from that
+		// branch's REFLOG alone — at which point `--branches` answers 0 and
+		// `fs.rm(pool.path, {recursive: true})` takes the object store, the
+		// commit and the reflog that was its last reference.
+		const rootPath = freshRoot();
+		const descriptor = await provisionAt(rootPath, 'task-r', 'ever/repo-r', 'task/r', OLD);
+		commitIn(descriptor.path, 'never-pushed.txt');
+		const lost = git(descriptor.path, 'rev-parse', 'HEAD');
+
+		const { scanned: before } = await scanAndPlan(rootPath);
+		const poolPath = before.repositories[0].pools[0].path;
+		// Remove the worktree, then re-cut the same branch onto the base —
+		// exactly what the provider does on a retry whose branch was never
+		// pushed. The commit is now reflog-only.
+		git(poolPath, 'worktree', 'remove', '--force', descriptor.path);
+		git(poolPath, 'branch', '--force', 'task/r', 'refs/remotes/origin/main');
+		expect(git(poolPath, 'rev-list', '--count', '--branches', '--not', '--remotes')).toBe('0');
+		expect(git(poolPath, 'reflog', 'show', 'task/r')).toContain(lost.slice(0, 7));
+
+		const { scanned, plan } = await scanAndPlan(rootPath);
+		expect(scanned.repositories[0].pools[0].unpushedCount).toBeGreaterThan(0);
+		expect(plan.removePools).toHaveLength(0);
+		expect(plan.keepPools[0].reason).toContain('not on any remote');
+
+		const result = await runWorkspaceReap(plan, { now: () => NOW });
+		expect(result.removedPools).toHaveLength(0);
+		expect(existsSync(poolPath)).toBe(true);
+		// The commit is still there to be recovered.
+		expect(git(poolPath, 'cat-file', '-t', lost)).toBe('commit');
+	});
+
+	it('never rmdir`s a relocated `worktrees` reparse point (review AO-5)', async () => {
+		// The scanner classifies a `repos`/`worktrees` that is not a plain
+		// directory as unrecognised and promises unrecognised entries are
+		// "reported, never touched". `removeEmptyRepositoryRoot` then
+		// `rmdir`-ed both by NAME, and on Windows removing a reparse point
+		// always succeeds regardless of what is behind it — so an operator
+		// who moved a repository cache onto a larger volume lost the only
+		// path to those checkouts while being told a pool was reclaimed.
+		const rootPath = freshRoot();
+		const repositoryRoot = join(rootPath, 'repositories', 'relocated');
+		const poolPath = join(repositoryRoot, 'repos', 'pool.git');
+		mkdirSync(poolPath, { recursive: true });
+		git(poolPath, 'init', '--bare', '--initial-branch', 'main');
+		// The relocated checkouts, on "another volume".
+		const elsewhere = join(ownedRoot, `elsewhere-${counter}`);
+		mkdirSync(elsewhere, { recursive: true });
+		writeFileSync(join(elsewhere, 'checkout.txt'), 'still on disk\n');
+		await linkDir(elsewhere, join(repositoryRoot, 'worktrees'));
+
+		const pool: WorkspacePoolRecord = {
+			path: poolPath,
+			repositoryRoot,
+			remoteUrl: null,
+			registeredWorktrees: 0,
+			pendingIntents: 0,
+			lastUsedAt: OLD,
+			sizeBytes: 0,
+			owned: true,
+			ownershipNote: null,
+			defaultBranch: 'main',
+			remoteRefreshed: true,
+			unpushedCount: 0
+		};
+		const result = await runWorkspaceReap(
+			{
+				policy,
+				plannedAt: NOW,
+				remove: [],
+				keep: [],
+				removePools: [{ pool, reason: 'no worktree registered; unused for 30 d' }],
+				keepPools: [],
+				reclaimableBytes: 0
+			},
+			{ now: () => NOW }
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.removedPools).toHaveLength(1);
+		expect(existsSync(poolPath)).toBe(false);
+		// The reparse point and everything behind it survived.
+		expect(existsSync(join(repositoryRoot, 'worktrees'))).toBe(true);
+		expect(existsSync(join(elsewhere, 'checkout.txt'))).toBe(true);
+	});
+
+	it('keeps a worktree whose lease this build cannot parse (review AO-3)', async () => {
+		// A staged CLI upgrade leaves two builds on one machine — the worker
+		// runs as a Windows service while an operator runs `gc` from a shell
+		// — so the running job's lease can be a `version` this build does not
+		// know, or a torn write from a hard kill. `acquireWorkspaceLease`
+		// used to delete anything it could not parse and take the slot, and
+		// the re-checks that follow catch nothing while the model is between
+		// commits, so `teardown` ran `git worktree remove --force` on a live
+		// job.
+		const rootPath = freshRoot();
+		const descriptor = await provisionAt(rootPath, 'task-l', 'ever/repo-l', 'task/l', OLD);
+		const { scanned, plan } = await scanAndPlan(rootPath);
+		expect(plan.remove).toHaveLength(1);
+		const gitDir = scanned.repositories[0].worktrees[0].gitDir!;
+		const torn = '{"version":1,"purpose":"jo';
+		await fs.writeFile(join(gitDir, 'ew-workspace-lease.json'), torn);
+
+		// The pid oracle says nothing is alive: the old rule reclaimed on
+		// exactly that basis.
+		const result = await runWorkspaceReap(plan, { now: () => NOW, isProcessAlive: () => false });
+		expect(result.removed).toHaveLength(0);
+		expect(result.kept[0].reason).toContain('unreadable');
+		expect(existsSync(descriptor.path)).toBe(true);
+		// The foreign lease was neither replaced nor deleted.
+		expect(await fs.readFile(join(gitDir, 'ew-workspace-lease.json'), 'utf8')).toBe(torn);
+	});
+});

--- a/apps/node/src/core/workspaces/workspace-reaper.spec.ts
+++ b/apps/node/src/core/workspaces/workspace-reaper.spec.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { LocalWorkspacePlugin } from '@ever-works/local-workspace-plugin';
 import type { Scheduler } from '../heartbeat';
 import { FleetTaskWorkspaceProvisioner, readWorkspaceLease } from './fleet-task-workspace';
 import {
@@ -61,6 +62,8 @@ function record(overrides: Partial<WorkspaceRecord> = {}): WorkspaceRecord {
 		intentPending: false,
 		lease: null,
 		mountLinks: [],
+		mountsDir: 'absent',
+		excludedOutput: false,
 		...overrides
 	};
 }
@@ -235,12 +238,14 @@ describe('planWorkspaceReap — pools', () => {
 		['it was used recently', { lastUsedAt: NOW - DAY }, 'within the max age'],
 		['its last use is unknown', { lastUsedAt: null }, 'last use unknown'],
 		['ownership is unproven', { owned: false, ownershipNote: 'no HEAD' }, 'no HEAD'],
-		// `git worktree remove` leaves the branch in the pool: an emptied pool
-		// can still hold the only copy of a commit.
+		// `git worktree remove` leaves the branch in the pool, and the
+		// provider's `worktree add -B` force-resets one into its reflog: an
+		// emptied pool can still hold the only copy of a commit. Counted
+		// with `--all --reflog`, hence "refs" rather than "branches".
 		[
-			'a local branch carries commits not on any remote',
+			'a local ref carries commits not on any remote',
 			{ unpushedCount: 2 },
-			'2 commit(s) on local branches not on any remote'
+			'2 commit(s) on local refs not on any remote'
 		],
 		['the local branch state is unknown', { unpushedCount: 'unknown' }, 'local branch state unknown'],
 		['the remote was not consulted', { remoteRefreshed: false }, 'remote state unknown']
@@ -374,6 +379,88 @@ describe('startWorkspaceReaperTimer', () => {
 		timer.stop();
 	});
 
+	it('hands every completed cycle to onResult, so the heartbeat can report it', async () => {
+		// Node housekeeping (EW-803). Without this the reaper's outcome
+		// reached the local log file and nowhere else, and Fleet could not
+		// tell a machine whose reaper is keeping up from one where it has
+		// not run in months.
+		const scheduler = controllableScheduler();
+		const seen: WorkspaceReapResult[] = [];
+		const result = { ...emptyResult(), freedBytes: 4_096 };
+		const timer = startWorkspaceReaperTimer({
+			rootPath: '/root',
+			policy,
+			scheduler,
+			scan: vi.fn(async () => inventory([])),
+			reap: vi.fn(async () => result),
+			onResult: (value) => seen.push(value)
+		});
+
+		await timer.runNow();
+
+		expect(seen).toEqual([result]);
+		timer.stop();
+	});
+
+	it('does not call onResult for a cycle that was skipped or that threw', async () => {
+		// A cycle that produced no result must not be reported as one: a
+		// stamp moved by a failed sweep would say "reclaimed just now" about
+		// a reaper that is broken.
+		const busy = controllableScheduler();
+		const skipped: WorkspaceReapResult[] = [];
+		const busyTimer = startWorkspaceReaperTimer({
+			rootPath: '/root',
+			policy,
+			scheduler: busy,
+			scan: vi.fn(async () => inventory([])),
+			reap: vi.fn(async () => emptyResult()),
+			isBusy: () => true,
+			onResult: (value) => skipped.push(value)
+		});
+		await busyTimer.runNow();
+		expect(skipped).toEqual([]);
+		busyTimer.stop();
+
+		const failing = controllableScheduler();
+		const thrown: WorkspaceReapResult[] = [];
+		const failingTimer = startWorkspaceReaperTimer({
+			rootPath: '/root',
+			policy,
+			scheduler: failing,
+			scan: vi.fn(async () => {
+				throw new Error('root vanished mid-scan');
+			}),
+			reap: vi.fn(async () => emptyResult()),
+			onResult: (value) => thrown.push(value)
+		});
+		expect(await failingTimer.runNow()).toBeNull();
+		expect(thrown).toEqual([]);
+		failingTimer.stop();
+	});
+
+	it('keeps reclaiming when the reporting hook throws', async () => {
+		// Reporting is a courtesy; reclaiming disk is the job. A reporter
+		// that throws must not stop the only thing that frees space.
+		const scheduler = controllableScheduler();
+		const reap = vi.fn(async () => emptyResult());
+		const timer = startWorkspaceReaperTimer({
+			rootPath: '/root',
+			policy,
+			scheduler,
+			scan: vi.fn(async () => inventory([])),
+			reap,
+			onResult: () => {
+				throw new Error('reporter is gone');
+			}
+		});
+
+		await expect(timer.runNow()).resolves.not.toBeNull();
+		// And the cycle still re-arms rather than dying here.
+		await timer.runNow();
+		expect(reap).toHaveBeenCalledTimes(2);
+		timer.stop();
+	});
+
 	it('stop() clears the pending timer, and runNow() runs a cycle on demand', async () => {
 		const scheduler = controllableScheduler();
 		const reap = vi.fn(async () => emptyResult());
@@ -495,6 +582,36 @@ describe.sequential('workspace reaper — real Git worktrees and a real remote',
 		expect(result.removedPools).toHaveLength(1);
 		expect(existsSync(scanned.repositories[0].pools[0].path)).toBe(false);
 		expect(existsSync(scanned.repositories[0].repositoryRoot)).toBe(false);
+	});
+
+	it('removes through teardown ONLY, never through the mtime-based gc on the same provider', async () => {
+		// REGRESSION GUARD on the most dangerous code path adjacent to this
+		// one. `LocalWorkspacePlugin.gc()` is a method on the very object
+		// `runWorkspaceReap` constructs by default, and it deletes any
+		// `worktrees/*` entry whose MTIME alone is past a cutoff, with a raw
+		// recursive delete: no ownership proof, no lease check, no test for
+		// unpushed commits. Pointed at a fleet root it would destroy a
+		// Task's only copy of work nobody has pushed.
+		//
+		// Removal must therefore go exclusively through `teardown`, which
+		// re-proves ownership and refuses if the path survives. Asserted
+		// rather than assumed, because the two are one autocomplete apart
+		// and the mistake is irreversible.
+		const rootPath = freshRoot();
+		const descriptor = await provisionAt(rootPath, 'task-gc', 'ever/repo-gc', 'task/gc', OLD);
+		const { plan } = await scanAndPlan(rootPath);
+		expect(plan.remove).toHaveLength(1);
+
+		const provider = new LocalWorkspacePlugin();
+		const gc = vi.spyOn(provider, 'gc');
+		const teardown = vi.spyOn(provider, 'teardown');
+
+		const result = await runWorkspaceReap(plan, { plugin: provider, now: () => NOW });
+
+		expect(result.errors).toEqual([]);
+		expect(teardown).toHaveBeenCalledOnce();
+		expect(gc).not.toHaveBeenCalled();
+		expect(existsSync(descriptor.path)).toBe(false);
 	});
 
 	it('keeps a worktree with a commit that is not on any remote', async () => {
@@ -641,7 +758,7 @@ describe.sequential('workspace reaper — real Git worktrees and a real remote',
 			unpushedCount: 1
 		});
 		expect(plan.removePools).toHaveLength(0);
-		expect(plan.keepPools[0].reason).toContain('1 commit(s) on local branches not on any remote');
+		expect(plan.keepPools[0].reason).toContain('1 commit(s) on local refs not on any remote');
 		const result = await runWorkspaceReap(plan, { now: () => NOW });
 		expect(result.removedPools).toHaveLength(0);
 		expect(existsSync(poolPath)).toBe(true);

--- a/apps/node/src/core/workspaces/workspace-reaper.ts
+++ b/apps/node/src/core/workspaces/workspace-reaper.ts
@@ -16,8 +16,10 @@ import {
 } from './fleet-task-workspace';
 import {
 	FLEET_WORKSPACE_INTENTS_DIR,
+	hasFleetExcludedOutput,
+	inspectMountsDir,
 	intentPath,
-	listMountLinks,
+	POOL_UNPUSHED_REVISION_ARGS,
 	scanWorkspaceRoot,
 	type WorkspaceInventory,
 	type WorkspacePoolRecord,
@@ -37,9 +39,13 @@ import {
  *
  *   1. ownership — the provider's stamp AND an exact Git registration;
  *   2. no provisioning intent pending (a provision may be mid-way);
- *   3. no live lease (a job is running in it — this process or another);
+ *   3. no live lease (a job is running in it — this process or another),
+ *      and none this build cannot READ, which is the same thing;
  *   4. not a binding this process is using right now;
  *   5. no uncommitted or untracked changes, no Git lock file;
+ *   5b. `.mounts` is a plain directory, and nothing is sitting in the
+ *      fleet's own excluded `.ever-works` — `git status` cannot see either
+ *      of those, so rule 5 is not a proof without them;
  *   6. no commit on HEAD that is not reachable from a remote ref;
  *   7. the remote was reachable, AND the branch is gone from it or merged
  *      into its default branch — a branch still open there stays;
@@ -57,9 +63,11 @@ import {
  * `.mounts/*` link has been unlinked, because a recursive delete that
  * followed a junction would empty ANOTHER Task's checkout. A bare pool is
  * deleted only once Git lists no worktree for it, no intent is pending, its
- * remote was refreshed by this scan, and no commit on any of its LOCAL
- * branches is missing from the remote — `git worktree remove` leaves the
- * branch behind, so an emptied pool can still hold unpushed work.
+ * remote was refreshed by this scan, and nothing it can still reach —
+ * branches, tags, the stash, the REFLOG — is missing from the remote.
+ * `git worktree remove` leaves the branch behind, and the provider's
+ * `worktree add -B` force-resets one, so an emptied pool can still hold
+ * the only copy of unpushed work (see `POOL_UNPUSHED_REVISION_ARGS`).
  */
 
 export interface WorkspaceReapPolicy {
@@ -199,7 +207,7 @@ export function planWorkspaceReap(
 			} else if (pool.unpushedCount > 0) {
 				plan.keepPools.push({
 					pool,
-					reason: `${pool.unpushedCount} commit(s) on local branches not on any remote`
+					reason: `${pool.unpushedCount} commit(s) on local refs not on any remote`
 				});
 			} else if (pool.lastUsedAt === null) {
 				plan.keepPools.push({ pool, reason: 'last use unknown' });
@@ -236,6 +244,15 @@ function whyUnsafe(
 	if (record.bindingKey !== null && activeBindings.has(record.bindingKey)) return 'in use by this process';
 	if (record.dirty === 'unknown') return 'working tree state unknown';
 	if (record.dirty) return 'uncommitted changes';
+	// `.mounts` is the model's to replace and the provisioner deliberately
+	// leaves a link there for a single-repository task. Removal enumerates
+	// and unlinks inside it, so anything but a plain directory is a keep.
+	if (record.mountsDir === 'foreign') return '`.mounts` is a link or a file, not a directory';
+	if (record.mountsDir === 'unknown') return '`.mounts` state unknown';
+	// `git status` cannot see these — the node excludes them itself — so
+	// they need their own rule or the "clean" above is not a proof.
+	if (record.excludedOutput === 'unknown') return 'fleet-excluded output state unknown';
+	if (record.excludedOutput) return 'unreported output in `.ever-works` (owner question or agent metadata)';
 	if (record.hasLocks) return 'git lock file present';
 	if (record.unpushedCount === 'unknown') return 'unpushed commit count unknown';
 	if (record.unpushedCount > 0) return `${record.unpushedCount} commit(s) not on any remote`;
@@ -409,6 +426,12 @@ async function removeWorktree(
 				reason: `leased by pid ${acquisition.heldBy.pid} (${acquisition.heldBy.purpose === 'gc' ? 'reaper' : 'running job'})`
 			};
 		}
+		// A lease that exists and cannot be read names no holder — and is
+		// therefore exactly the case where a worktree must be kept, not the
+		// case where the gate opens (review AO-3).
+		if ('unreadable' in acquisition) {
+			return { ok: false, reason: `lease present but unreadable: ${acquisition.unreadable}` };
+		}
 		return { ok: false, reason: `lease could not be taken: ${describeError(acquisition.failure)}`, error: true };
 	}
 	try {
@@ -421,7 +444,26 @@ async function removeWorktree(
 		const status = await gitOutput(['status', '--porcelain', '--untracked-files=all'], record.path, deps.signal);
 		if (status === null) return { ok: false, reason: 'working tree state could not be re-read' };
 		if (status.trim().length > 0) return { ok: false, reason: 'uncommitted changes appeared' };
-		for (const link of await listMountLinks(record.path)) {
+		// Neither of these is visible to `git status` — the node's own
+		// exclude rules hide them — so both are re-proven here, live.
+		const excluded = await hasFleetExcludedOutput(record.path);
+		if (excluded !== false) {
+			return {
+				ok: false,
+				reason:
+					excluded === 'unknown'
+						? '`.ever-works` state could not be re-read'
+						: 'unreported output appeared in `.ever-works`'
+			};
+		}
+		// `lstat`-ed, not enumerated blind: a `.mounts` that is itself a
+		// junction would otherwise have this loop unlink entries inside the
+		// junction's TARGET — another Task's live checkout (review AO-1).
+		const mounts = await inspectMountsDir(record.path);
+		if (mounts.state === 'foreign' || mounts.state === 'unknown') {
+			return { ok: false, reason: `'.mounts' is not a plain directory (${mounts.state})` };
+		}
+		for (const link of mounts.links) {
 			await removeMountLink(link);
 		}
 		await deps.plugin.teardown({
@@ -447,8 +489,9 @@ async function removeWorktree(
 
 /**
  * Delete a bare pool only when Git lists nothing for it, no intent is
- * pending and no local branch carries a commit missing from every
- * remote-tracking ref — all re-proven right now, not from the scan.
+ * pending and nothing it can still reach — branches, tags, stash, reflog —
+ * carries a commit missing from every remote-tracking ref. All re-proven
+ * right now, not from the scan: this is the one irreversible `fs.rm` here.
  */
 async function removePool(pool: WorkspacePoolRecord, signal: AbortSignal | undefined): Promise<RemovalOutcome> {
 	try {
@@ -475,12 +518,12 @@ async function removePool(pool: WorkspacePoolRecord, signal: AbortSignal | undef
 			intents = [];
 		}
 		if (intents.length > 0) return { ok: false, reason: `${intents.length} provisioning intent(s) pending` };
-		const counted = await gitOutput(['rev-list', '--count', '--branches', '--not', '--remotes'], pool.path, signal);
+		const counted = await gitOutput(POOL_UNPUSHED_REVISION_ARGS, pool.path, signal);
 		if (counted === null || !/^\d+$/.test(counted.trim())) {
 			return { ok: false, reason: 'local branch state could not be re-read' };
 		}
 		if (Number(counted.trim()) > 0) {
-			return { ok: false, reason: `${counted.trim()} commit(s) on local branches not on any remote` };
+			return { ok: false, reason: `${counted.trim()} commit(s) on local refs not on any remote` };
 		}
 		await fs.rm(pool.path, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 		return { ok: true };
@@ -489,12 +532,35 @@ async function removePool(pool: WorkspacePoolRecord, signal: AbortSignal | undef
 	}
 }
 
-/** Drop the `repos/`, `worktrees/` and repository directories once they are empty — non-recursive, so a surprise stays. */
+/**
+ * Drop the `repos/`, `worktrees/` and repository directories once they are
+ * empty — non-recursive, so a surprise stays.
+ *
+ * Each name is `lstat`-ed first (review AO-5). The scanner classifies a
+ * `repos`/`worktrees` that is NOT a plain directory as unrecognised and
+ * promises unrecognised entries are "reported, never touched"; on Windows
+ * `rmdir` on a junction succeeds unconditionally and removes the reparse
+ * point, so an operator who relocated a repository cache onto a larger
+ * volume would have had the only path to those checkouts deleted while
+ * being told a pool was reclaimed. `rmdir` still refuses a non-empty
+ * directory, which is what keeps this non-recursive.
+ */
 async function removeEmptyRepositoryRoot(repositoryRoot: string): Promise<void> {
 	for (const child of ['repos', 'worktrees']) {
-		await fs.rmdir(join(repositoryRoot, child)).catch(() => undefined);
+		if (await isPlainDirectory(join(repositoryRoot, child))) {
+			await fs.rmdir(join(repositoryRoot, child)).catch(() => undefined);
+		}
 	}
-	await fs.rmdir(repositoryRoot).catch(() => undefined);
+	if (await isPlainDirectory(repositoryRoot)) await fs.rmdir(repositoryRoot).catch(() => undefined);
+}
+
+async function isPlainDirectory(path: string): Promise<boolean> {
+	try {
+		const stats = await fs.lstat(path);
+		return stats.isDirectory() && !stats.isSymbolicLink();
+	} catch {
+		return false;
+	}
 }
 
 async function gitOutput(
@@ -556,6 +622,16 @@ export interface WorkspaceReaperTimerOptions {
 	scan?: typeof scanWorkspaceRoot;
 	reap?: typeof runWorkspaceReap;
 	now?: () => number;
+	/**
+	 * Called with the outcome of every completed cycle (node housekeeping,
+	 * EW-803) — how the heartbeat learns what this machine reclaimed.
+	 *
+	 * Best-effort and never allowed to break the cycle: a reporting hook
+	 * that throws must not stop the thing that reclaims disk, so it is
+	 * called inside its own try/catch. Not called for a cycle that was
+	 * skipped (busy) or that threw, because neither produced a result.
+	 */
+	onResult?: (result: WorkspaceReapResult) => void;
 }
 
 export interface WorkspaceReaperTimer {
@@ -596,6 +672,12 @@ export function startWorkspaceReaperTimer(options: WorkspaceReaperTimerOptions):
 				const inventory = await scan(options.rootPath, { refreshRemote: true, now });
 				const plan = planWorkspaceReap(inventory, options.policy, now(), options.activeBindings?.());
 				const result = await reap(plan, { logger: options.logger, now });
+				try {
+					options.onResult?.(result);
+				} catch (error) {
+					// Reporting is a courtesy; reclaiming disk is the job.
+					options.logger?.warn(`Workspace reaper could not report its result: ${describeError(error)}`);
+				}
 				options.logger?.info(
 					`Workspace reaper: removed ${result.removed.length} worktree(s) and ${result.removedPools.length} pool(s) (${formatBytes(
 						result.freedBytes

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3529,7 +3529,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -3570,7 +3570,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -3502,7 +3502,22 @@
                     "unknown": "Unknown"
                 },
                 "workerStateReason": "Reason: {reason}",
-                "workerStateSince": "Since {time}"
+                "workerStateSince": "Since {time}",
+                "housekeeping": {
+                    "title": "Disk & workspaces",
+                    "disk": {
+                        "ok": "Above floor",
+                        "below": "Below floor",
+                        "unknown": "Unknown"
+                    },
+                    "diskFigures": "{free} free, floor {floor}",
+                    "noFloor": "off",
+                    "unknownValue": "unknown",
+                    "workspaces": "{count} workspaces using {size}",
+                    "lastReclaim": "Last reclaimed {time}, freed {freed}",
+                    "neverReclaimed": "No reclaim reported yet — this node has never swept its workspaces.",
+                    "notReported": "Housekeeping not reported by this node."
+                }
             },
             "jobRuntime": {
                 "title": "Job Runtime",

--- a/apps/web/src/components/settings/FleetNodeDrawer.tsx
+++ b/apps/web/src/components/settings/FleetNodeDrawer.tsx
@@ -15,6 +15,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import type { FleetJobView, FleetNodeDetailView, FleetNodeView } from '@/lib/api/fleet';
+import { formatBytes } from '@/components/dashboard/runner-status.shared';
 import { centsToUsdInput, formatCeilingCents, usdInputToCents } from './fleet-cost-ceiling.shared';
 import {
     FLEET_JOB_FILTERS,
@@ -22,9 +23,12 @@ import {
     fleetJobDurationMs,
     fleetJobOutcomeKey,
     fleetJobOutcomeText,
+    fleetNodeDiskBadgeClass,
+    fleetNodeDiskState,
     fleetWorkerStateBadgeClass,
     fleetWorkerStateKey,
     formatFleetJobDuration,
+    hasFleetNodeHousekeeping,
     type FleetJobFilter,
 } from './fleet-node-drawer.shared';
 
@@ -171,6 +175,9 @@ export function FleetNodeDrawer({
     // reported — never `idle`, which would claim a readiness nobody has
     // told us about.
     const workerStateKey = fleetWorkerStateKey(node);
+    // Node housekeeping (EW-803).
+    const diskState = fleetNodeDiskState(node);
+    const hasHousekeeping = hasFleetNodeHousekeeping(node);
 
     const addTag = () => {
         const tag = draft.trim().slice(0, MAX_TAG_LENGTH);
@@ -273,6 +280,89 @@ export function FleetNodeDrawer({
                                         {t('workerStateSince', {
                                             time: formatMoment(node.workerStateChangedAt),
                                         })}
+                                    </span>
+                                ) : null}
+                            </dd>
+                        </div>
+                        {/* Node housekeeping (EW-803): the disk floor this
+                            machine enforces on ITSELF, read against the free
+                            space it reports, plus what its reaper last
+                            reclaimed. `online` + `below the floor` is the
+                            pair that used to be invisible — a node that
+                            looks healthy and quietly leases nothing. */}
+                        <div className="col-span-2 sm:col-span-4">
+                            <dt className="text-text-muted dark:text-text-muted-dark text-xs">
+                                {t('housekeeping.title')}
+                            </dt>
+                            <dd
+                                className="text-text dark:text-text-dark"
+                                data-testid="fleet-node-drawer-housekeeping"
+                            >
+                                <span
+                                    className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium ${fleetNodeDiskBadgeClass(diskState)}`}
+                                    data-testid="fleet-node-drawer-disk-state"
+                                >
+                                    {t(`housekeeping.disk.${diskState}` as never)}
+                                </span>{' '}
+                                <span data-testid="fleet-node-drawer-disk-figures">
+                                    {t('housekeeping.diskFigures', {
+                                        free:
+                                            formatBytes(node.diskFreeBytes) ??
+                                            t('housekeeping.unknownValue'),
+                                        floor:
+                                            typeof node.minFreeDiskBytes === 'number'
+                                                ? (formatBytes(node.minFreeDiskBytes) ??
+                                                  t('housekeeping.unknownValue'))
+                                                : t('housekeeping.noFloor'),
+                                    })}
+                                </span>
+                                {hasHousekeeping ? (
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark"
+                                        data-testid="fleet-node-drawer-workspaces"
+                                    >
+                                        {t('housekeeping.workspaces', {
+                                            count:
+                                                typeof node.workspaceCount === 'number'
+                                                    ? node.workspaceCount
+                                                    : t('housekeeping.unknownValue'),
+                                            size:
+                                                formatBytes(node.workspaceBytes) ??
+                                                t('housekeeping.unknownValue'),
+                                        })}
+                                    </span>
+                                ) : (
+                                    // Said ONCE. Four dashes would read as
+                                    // four separate faults rather than one
+                                    // daemon that predates the fields.
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark"
+                                        data-testid="fleet-node-drawer-housekeeping-unreported"
+                                    >
+                                        {t('housekeeping.notReported')}
+                                    </span>
+                                )}
+                                {node.lastReclaimAt ? (
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark"
+                                        data-testid="fleet-node-drawer-last-reclaim"
+                                    >
+                                        {t('housekeeping.lastReclaim', {
+                                            time: formatMoment(node.lastReclaimAt),
+                                            freed:
+                                                formatBytes(node.lastReclaimFreedBytes) ??
+                                                t('housekeeping.unknownValue'),
+                                        })}
+                                    </span>
+                                ) : hasHousekeeping ? (
+                                    // The finding this field exists for: a
+                                    // machine reporting workspaces but no
+                                    // sweep is one whose reaper has never run.
+                                    <span
+                                        className="block text-xs text-text-muted dark:text-text-muted-dark"
+                                        data-testid="fleet-node-drawer-never-reclaimed"
+                                    >
+                                        {t('housekeeping.neverReclaimed')}
                                     </span>
                                 ) : null}
                             </dd>

--- a/apps/web/src/components/settings/FleetNodeDrawer.unit.spec.tsx
+++ b/apps/web/src/components/settings/FleetNodeDrawer.unit.spec.tsx
@@ -439,6 +439,107 @@ describe('FleetNodeDrawer — worker state', () => {
     });
 });
 
+/**
+ * Node housekeeping (EW-803).
+ *
+ * The two facts that used to be invisible from Fleet: the floor a machine
+ * enforces on itself (without which a free-space figure means nothing),
+ * and whether its reaper has run at all.
+ */
+describe('FleetNodeDrawer — housekeeping', () => {
+    const GIB = 1024 ** 3;
+
+    it('shows a node below its own floor, with both figures', () => {
+        // "Online, no jobs, 200 MB free, floor 2 GiB" is the whole story
+        // in one line — previously the operator saw only "online".
+        const starved = node({
+            status: 'online',
+            diskFreeBytes: 200 * 1024 ** 2,
+            minFreeDiskBytes: 2 * GIB,
+        });
+        renderDrawer({ node: starved, detail: detail({ node: starved }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-disk-state')).toHaveTextContent(
+            'housekeeping.disk.below',
+        );
+        // Rendered through `formatBytes`, which is base-1000 SI on
+        // purpose: the node's owner compares this against what Explorer
+        // or Finder shows them, so 200 MiB reads as 210 MB.
+        const figures = screen.getByTestId('fleet-node-drawer-disk-figures');
+        expect(figures).toHaveTextContent('210 MB');
+        expect(figures).toHaveTextContent('2.1 GB');
+    });
+
+    it('shows the workspaces retained and the last reclaim', () => {
+        const swept = node({
+            diskFreeBytes: 40 * GIB,
+            minFreeDiskBytes: 2 * GIB,
+            workspaceCount: 12,
+            workspaceBytes: 30 * GIB,
+            lastReclaimAt: '2026-09-05T09:30:00.000Z',
+            lastReclaimFreedBytes: 3 * GIB,
+        });
+        renderDrawer({ node: swept, detail: detail({ node: swept }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-disk-state')).toHaveTextContent(
+            'housekeeping.disk.ok',
+        );
+        expect(screen.getByTestId('fleet-node-drawer-workspaces')).toHaveTextContent('12');
+        expect(screen.getByTestId('fleet-node-drawer-last-reclaim')).toHaveTextContent(
+            'housekeeping.lastReclaim',
+        );
+        expect(screen.queryByTestId('fleet-node-drawer-never-reclaimed')).toBeNull();
+    });
+
+    it('says a node holding workspaces has never reclaimed, which is the finding', () => {
+        // Workspaces reported, no sweep ever reported: the reaper is not
+        // running on this machine. That is exactly the state that took a
+        // PC to 38 MB free, and it must not read as an absence of data.
+        const hoarding = node({
+            diskFreeBytes: 3 * GIB,
+            minFreeDiskBytes: 2 * GIB,
+            workspaceCount: 210,
+            workspaceBytes: 180 * GIB,
+            lastReclaimAt: null,
+        });
+        renderDrawer({ node: hoarding, detail: detail({ node: hoarding }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-never-reclaimed')).toBeInTheDocument();
+        expect(screen.queryByTestId('fleet-node-drawer-last-reclaim')).toBeNull();
+        expect(screen.queryByTestId('fleet-node-drawer-housekeeping-unreported')).toBeNull();
+    });
+
+    it('says "not reported" ONCE for a node that has never told us anything', () => {
+        // An older daemon, or a visibility-only node. Four dashes would
+        // read as four separate faults instead of one silent machine.
+        renderDrawer();
+
+        expect(screen.getByTestId('fleet-node-drawer-disk-state')).toHaveTextContent(
+            'housekeeping.disk.unknown',
+        );
+        expect(screen.getByTestId('fleet-node-drawer-housekeeping-unreported')).toBeInTheDocument();
+        expect(screen.queryByTestId('fleet-node-drawer-workspaces')).toBeNull();
+        expect(screen.queryByTestId('fleet-node-drawer-never-reclaimed')).toBeNull();
+    });
+
+    it('never claims a verdict for a node with free space but no floor', () => {
+        // The floor is off, or the daemon predates the field. Plenty of
+        // space is not the same as "above the line", because there is no
+        // line — and saying so would be a reassurance nobody earned.
+        const noFloor = node({ diskFreeBytes: 400_000_000_000, minFreeDiskBytes: null });
+        renderDrawer({ node: noFloor, detail: detail({ node: noFloor }) });
+
+        expect(screen.getByTestId('fleet-node-drawer-disk-state')).toHaveTextContent(
+            'housekeeping.disk.unknown',
+        );
+        const figures = screen.getByTestId('fleet-node-drawer-disk-figures');
+        expect(figures).toHaveTextContent('400 GB');
+        // …and says the floor is OFF rather than printing a bare dash,
+        // which would look like a missing reading.
+        expect(figures).toHaveTextContent('housekeeping.noFloor');
+    });
+});
+
 describe('FleetNodeDrawer — reconciled job outcome', () => {
     const historyRow = (over: Partial<FleetNodeJobHistoryEntry>): FleetNodeJobHistoryEntry => ({
         ...job(),

--- a/apps/web/src/components/settings/fleet-node-drawer.shared.ts
+++ b/apps/web/src/components/settings/fleet-node-drawer.shared.ts
@@ -235,3 +235,73 @@ export function fleetJobOutcomeText(job: FleetNodeJobHistoryEntry, maxLength = 2
     if (!trimmed) return null;
     return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed;
 }
+
+// ---------------------------------------------------------------------------
+// Node housekeeping (EW-803)
+// ---------------------------------------------------------------------------
+
+/**
+ * How the node's free disk stands against the floor it enforces on
+ * itself.
+ *
+ * `unknown` covers three different silences that all render the same way
+ * — no reading, no floor reported, or an older daemon that reports
+ * neither — because the operator's next step is identical in all three:
+ * there is nothing here to act on.
+ *
+ * `below` is the one that matters. It is the machine-side explanation for
+ * a node that reads online, holds no jobs and quietly leases nothing, and
+ * it is deliberately derived from the two REPORTED numbers rather than
+ * from `workerState`: a node that has fallen under its floor since its
+ * last state transition is already refusing work before the throttle is
+ * reported, and the numbers say so first.
+ */
+export type FleetNodeDiskState = 'unknown' | 'ok' | 'below';
+
+export function fleetNodeDiskState(
+    node: Pick<FleetNodeView, 'diskFreeBytes' | 'minFreeDiskBytes'>,
+): FleetNodeDiskState {
+    const free = node.diskFreeBytes;
+    const floor = node.minFreeDiskBytes;
+    if (typeof free !== 'number' || !Number.isFinite(free)) return 'unknown';
+    // A null floor is "the operator switched it off", which is a real
+    // answer — but not one that makes a free-space figure a pass or a
+    // fail. There is no line to be under.
+    if (typeof floor !== 'number' || !Number.isFinite(floor)) return 'unknown';
+    return free < floor ? 'below' : 'ok';
+}
+
+/** Badge classes for the disk state. Only `below` is an event worth colouring. */
+export function fleetNodeDiskBadgeClass(state: FleetNodeDiskState): string {
+    return state === 'below'
+        ? 'bg-danger/10 text-danger'
+        : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark';
+}
+
+/**
+ * Has this node ever told us anything about its housekeeping?
+ *
+ * False for an older daemon and for a visibility-only node, and the
+ * drawer uses it to say "not reported" ONCE rather than printing four
+ * dashes — four unknowns read as four separate faults.
+ *
+ * A `null` floor deliberately does NOT count. On the wire it collapses
+ * two different facts — "never reported" and "the operator switched the
+ * floor off" — and the storage layer says so explicitly: the column
+ * cannot tell them apart, so neither can this. Treating null as evidence
+ * would make every node ever enrolled claim to have reported, since
+ * `toView` emits null for an unset column.
+ */
+export function hasFleetNodeHousekeeping(
+    node: Pick<
+        FleetNodeView,
+        'minFreeDiskBytes' | 'workspaceCount' | 'workspaceBytes' | 'lastReclaimAt'
+    >,
+): boolean {
+    return (
+        typeof node.minFreeDiskBytes === 'number' ||
+        typeof node.workspaceCount === 'number' ||
+        typeof node.workspaceBytes === 'number' ||
+        typeof node.lastReclaimAt === 'string'
+    );
+}

--- a/apps/web/src/components/settings/fleet-node-drawer.shared.unit.spec.ts
+++ b/apps/web/src/components/settings/fleet-node-drawer.shared.unit.spec.ts
@@ -6,9 +6,12 @@ import {
     fleetJobDurationMs,
     fleetJobOutcomeKey,
     fleetJobOutcomeText,
+    fleetNodeDiskBadgeClass,
+    fleetNodeDiskState,
     fleetWorkerStateBadgeClass,
     fleetWorkerStateKey,
     formatFleetJobDuration,
+    hasFleetNodeHousekeeping,
 } from './fleet-node-drawer.shared';
 
 function job(over: Partial<FleetJobView> = {}): FleetJobView {
@@ -271,5 +274,81 @@ describe('fleetJobOutcomeText', () => {
         const text = fleetJobOutcomeText(historyJob({ error: 'x'.repeat(400) }), 240);
         expect(text).toHaveLength(241);
         expect(text?.endsWith('…')).toBe(true);
+    });
+});
+
+/**
+ * Node housekeeping (EW-803) — the derivations behind the drawer's disk
+ * and workspace block.
+ *
+ * The property that matters is that UNKNOWN never renders as a verdict.
+ * A node we have not heard from about its floor must not read "above
+ * floor" (a reassurance nobody earned) and must not read "below floor"
+ * (an alarm nobody raised).
+ */
+describe('fleetNodeDiskState', () => {
+    const GIB = 1024 ** 3;
+
+    it('reads a node under its own floor as below', () => {
+        // The state this whole slice exists to surface: online, idle, and
+        // refusing every job because the volume filled up.
+        expect(
+            fleetNodeDiskState({ diskFreeBytes: 200 * 1024 ** 2, minFreeDiskBytes: 2 * GIB }),
+        ).toBe('below');
+    });
+
+    it('reads a node with room as ok, including exactly at the floor', () => {
+        expect(fleetNodeDiskState({ diskFreeBytes: 9 * GIB, minFreeDiskBytes: 2 * GIB })).toBe(
+            'ok',
+        );
+        // The node admits at `free >= floor`, so the boundary must agree
+        // with the gate rather than being off by one machine's worth of
+        // confusion.
+        expect(fleetNodeDiskState({ diskFreeBytes: 2 * GIB, minFreeDiskBytes: 2 * GIB })).toBe(
+            'ok',
+        );
+    });
+
+    it.each([
+        ['no reading at all', { diskFreeBytes: null, minFreeDiskBytes: 2 * GIB }],
+        ['no floor reported', { diskFreeBytes: 9 * GIB, minFreeDiskBytes: undefined }],
+        ['the floor switched off', { diskFreeBytes: 9 * GIB, minFreeDiskBytes: null }],
+        ['an older daemon reporting neither', {}],
+        ['a non-finite reading', { diskFreeBytes: Number.NaN, minFreeDiskBytes: 2 * GIB }],
+    ])('reads %s as unknown rather than as a verdict', (_label, node) => {
+        expect(fleetNodeDiskState(node)).toBe('unknown');
+    });
+
+    it('colours only the below state, since neither ok nor unknown is an event', () => {
+        expect(fleetNodeDiskBadgeClass('below')).toContain('danger');
+        expect(fleetNodeDiskBadgeClass('ok')).not.toContain('danger');
+        expect(fleetNodeDiskBadgeClass('unknown')).not.toContain('danger');
+    });
+});
+
+describe('hasFleetNodeHousekeeping', () => {
+    it('is true once the node has reported any housekeeping figure', () => {
+        expect(hasFleetNodeHousekeeping({ minFreeDiskBytes: 2 * 1024 ** 3 })).toBe(true);
+        expect(hasFleetNodeHousekeeping({ workspaceCount: 0 })).toBe(true);
+        expect(hasFleetNodeHousekeeping({ workspaceBytes: 0 })).toBe(true);
+        expect(hasFleetNodeHousekeeping({ lastReclaimAt: '2026-09-05T09:30:00.000Z' })).toBe(true);
+    });
+
+    it('does NOT count a null floor, which every stored row carries', () => {
+        // `toView` emits null for an unset column, so treating null as
+        // evidence would make every node ever enrolled claim to have
+        // reported — and the "not reported yet" line would never show.
+        expect(
+            hasFleetNodeHousekeeping({
+                minFreeDiskBytes: null,
+                workspaceCount: null,
+                workspaceBytes: null,
+                lastReclaimAt: null,
+            }),
+        ).toBe(false);
+    });
+
+    it('is false for a node that has reported nothing at all', () => {
+        expect(hasFleetNodeHousekeeping({})).toBe(false);
     });
 });

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -417,7 +417,35 @@ node apps/node/dist/cli.js start --work
 
 `start` alone only heartbeats; **`--work`** is the separate consent that lets the machine lease and execute platform jobs. `pause` / `resume` drain and undrain it, `unenroll` retires it, `status` and `capabilities` inspect it. Until the package is published, the binary is `apps/node/dist/cli.js` — the unattended-install scripts (systemd unit, Windows service, container image, in `apps/node/packaging/README.md`) expect a command named `ever-works-node` on `PATH`. The full command reference, the config-file and keychain layout, and the capability tags a node reports are in `apps/node/README.md`.
 
-A node also looks after its own disk. It refuses to lease (and to provision) while the volume holding its workspace root has less than a **disk floor** free — 2 GiB by default, `--min-free-disk <mb>` to change it — and shows up as `throttled` with the reason, so a full machine stops taking work before a job fails halfway through a fetch. With `--work` it also runs a **workspace reaper** that removes Task worktrees it can prove are safe to remove (owned, not in use, clean, fully pushed, and with a branch that is gone from the remote or merged) once they are older than `--workspace-max-age` (14 days by default); anything it cannot prove stays. `ever-works-node doctor` prints the free space against the floor and what the reaper would do, `ever-works-node gc [--dry-run]` runs it by hand. Details and the exact rules: `apps/node/README.md`, "Disk floor and workspace GC".
+A node also looks after its own disk. It refuses to lease (and to provision) while the volume holding its workspace root has less than a **disk floor** free — 2 GiB by default, `--min-free-disk <mib>` (mebibytes) to change it — and shows up as `throttled` with the reason, so a full machine stops taking work before a job fails halfway through a fetch. With `--work` it also runs a **workspace reaper** that removes Task worktrees it can prove are safe to remove (owned, not in use, clean, fully pushed, and with a branch that is gone from the remote or merged) once they are older than `--workspace-max-age` (14 days by default); anything it cannot prove stays. `ever-works-node doctor` prints the free space against the floor and what the reaper would do, `ever-works-node gc [--dry-run]` runs it by hand. Details and the exact rules: `apps/node/README.md`, "Disk floor and workspace GC".
+
+The two gates around the floor are deliberately **asymmetric**, and an operator will notice the difference:
+
+- At the **lease**, a free-space reading the node cannot take never blocks. Refusing there would idle a whole machine indefinitely because of a broken `statfs`, and nothing has been spent yet.
+- Before **provisioning** — re-checked there because minutes can pass since the lease and that is where the space is actually consumed — the floor **fails closed**: if free space cannot be measured, the node refuses. That is the last check before a clone, a fetch and a model's whole budget land on a volume nobody can size, and there is no gate after it. The refusal is a _deferral_, not a failure: the job goes back unsettled and the platform re-offers it to a machine that can answer. `ever-works-node doctor` says so explicitly when the reading is unavailable.
+
+### What the platform can see about a node's disk
+
+The heartbeat carries the node's **housekeeping** alongside its free-space reading, so the Fleet node drawer can answer questions the free-space figure alone cannot:
+
+| Field                   | What it says                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `minFreeDiskBytes`      | the floor this machine enforces on itself; `null` = the operator switched it off |
+| `workspaceCount`        | Task worktrees it was holding when its last sweep finished                       |
+| `workspaceBytes`        | what those worktrees occupy                                                      |
+| `lastReclaimAt`         | when its last sweep completed — **the node's own clock**                         |
+| `lastReclaimFreedBytes` | what that sweep freed (`0` is a real answer: it ran and found nothing)           |
+
+The drawer shows **Above floor** / **Below floor** / **Unknown** with both figures, the workspaces retained, and the last reclaim. Two readings worth knowing how to interpret:
+
+- **Below floor** on a node that reads `online` and holds no jobs is the explanation for a machine that has gone quiet. It is derived from the two reported numbers, so it can be visible before the node's `throttled` worker state catches up.
+- **"No reclaim reported yet"** on a node that _is_ reporting workspaces means its reaper has never completed a sweep on that machine — the state that ends with a full disk. A node running without `--work` has no reaper at all and reports no housekeeping; the drawer says "not reported" once rather than showing four blanks.
+
+**Unknown is never a verdict.** A node with plenty of space but no floor reported reads _Unknown_, not _Above floor_: with the floor off, or on a daemon older than these fields, there is no line to be above, and saying otherwise would be a reassurance nobody earned. Likewise `null` and "never reported" are indistinguishable for the floor by design — both mean there is nothing to compare the free-space figure against.
+
+These figures travel **upward only**. The limit is still evaluated entirely on the machine; the platform neither sets it, routes on it, nor assumes a node respects it. There is no path for pushing a floor, a workspace budget or a reclaim policy down to a node — those are set at that keyboard, with `--min-free-disk`, `--workspace-max-age` and `--workspace-max-count`. The CPU and memory ceilings are **not** reported at all: they have no companion reading on the wire, so a ceiling on its own would be a number with nothing to compare it against.
+
+`lastReclaimAt` is the one instant on a node row the platform does not stamp itself, so it is treated as untrusted: an unparseable value, or one implausibly far in the future, is recorded as unknown rather than rejected — rejecting it would fail the heartbeat, and a failed heartbeat is a live node swept `offline`. A node that has never reported a figure shows **unknown**, never `0`: "no workspaces" and "we have never been told" are different facts, and only the first is reassuring.
 
 #### Pinning the control plane
 

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -349,6 +349,57 @@ export class FleetNode {
     @PortableDateColumn({ nullable: true })
     quarantineNoticedAt?: Date | null;
 
+    /**
+     * Node housekeeping (EW-803) — the free-space FLOOR the node enforces
+     * on itself, in bytes, as last reported. NULL means either "never
+     * reported" or "the operator switched the floor off"; the two are
+     * indistinguishable here on purpose, because both answer the
+     * operator's question the same way: there is no floor to compare
+     * {@link diskFreeBytes} against.
+     *
+     * Stored for DISPLAY. Nothing on the platform routes on it, and no
+     * path exists to push a value back down — the limit stays enforced on
+     * the machine, which is the invariant the node's `types.ts` states.
+     *
+     * `bigint` for the same reason as {@link diskFreeBytes}, and with the
+     * same warning: a STRING on Postgres, a number on sqlite, normalized
+     * only in `FleetService.toView`.
+     * Migration: `1789500000000-AddFleetNodeHousekeeping`.
+     */
+    @Column({ type: 'bigint', nullable: true })
+    minFreeDiskBytes?: string | number | null;
+
+    /**
+     * Task worktrees the node was holding when its last reclaim sweep
+     * finished. NULL = never reported, which is NOT the same as 0 and must
+     * never be rendered as it: "no workspaces" is reassuring, "we have
+     * never been told" is not.
+     */
+    @Column({ type: 'int', nullable: true })
+    workspaceCount?: number | null;
+
+    /** Bytes those retained workspaces occupy. `bigint`; see {@link diskFreeBytes}. */
+    @Column({ type: 'bigint', nullable: true })
+    workspaceBytes?: string | number | null;
+
+    /**
+     * When the node's last reclaim sweep completed, on the NODE's clock.
+     *
+     * The only node-supplied instant on this row — everything else
+     * temporal here is server-stamped — because the platform cannot
+     * derive it: it learns a sweep happened only when a beat says so. A
+     * machine with a stepped clock therefore reports a wrong instant and
+     * we cannot tell. Kept anyway: "last reclaimed three weeks ago" is
+     * the fact that explains a full disk, and `FleetService` refuses a
+     * value that does not parse or lands implausibly in the future.
+     */
+    @PortableDateColumn({ nullable: true })
+    lastReclaimAt?: Date | null;
+
+    /** Bytes that sweep freed. 0 is a real answer — it ran and found nothing to take. */
+    @Column({ type: 'bigint', nullable: true })
+    lastReclaimFreedBytes?: string | number | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/fleet/__tests__/fleet-node-telemetry.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet-node-telemetry.spec.ts
@@ -598,4 +598,230 @@ describe('FleetService node telemetry', () => {
             expect(patch.workerStateReason).toBeNull();
         });
     });
+
+    /**
+     * Node housekeeping (EW-803) — the disk floor a node enforces on
+     * itself, and what its reaper last reclaimed.
+     *
+     * Same additive contract as the telemetry above, with ONE deliberate
+     * exception that most of these cases exist to pin: an explicit `null`
+     * floor CLEARS the column, because "the operator switched the floor
+     * off" has no other way to be said, and a stale floor shown beside a
+     * node that no longer has one is worse than showing nothing.
+     *
+     * `lastReclaimAt` is the only instant on this row the NODE supplies
+     * rather than the server stamping, so it is handled as untrusted
+     * input rather than as data.
+     */
+    describe('housekeeping (EW-803)', () => {
+        const enrolling = (token: string) =>
+            repository.findByCredentialHash.mockResolvedValue(
+                node({
+                    status: 'enrolling',
+                    enrollmentTokenHash: sha256(token),
+                    credentialIssuedAt: new Date(),
+                }),
+            );
+
+        it('stores the floor and the last sweep from a heartbeat', async () => {
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                minFreeDiskBytes: 2 * 1024 ** 3,
+                workspaceCount: 12,
+                workspaceBytes: 40 * 1024 ** 3,
+                lastReclaimAt: '2026-09-05T09:30:00.000Z',
+                lastReclaimFreedBytes: 3 * 1024 ** 3,
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch.minFreeDiskBytes).toBe(2 * 1024 ** 3);
+            expect(patch.workspaceCount).toBe(12);
+            expect(patch.workspaceBytes).toBe(40 * 1024 ** 3);
+            expect(patch.lastReclaimAt).toEqual(new Date('2026-09-05T09:30:00.000Z'));
+            expect(patch.lastReclaimFreedBytes).toBe(3 * 1024 ** 3);
+        });
+
+        it('leaves every housekeeping column alone when the beat says nothing', async () => {
+            // The whole backward-compatibility story: a daemon older than
+            // this slice sends none of these and must not blank them.
+            repository.findById.mockResolvedValue(
+                node({ minFreeDiskBytes: '2147483648', workspaceCount: 9 }),
+            );
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, { platform: 'linux/x64' });
+
+            const patch = repository.update.mock.calls[0][1];
+            for (const field of [
+                'minFreeDiskBytes',
+                'workspaceCount',
+                'workspaceBytes',
+                'lastReclaimAt',
+                'lastReclaimFreedBytes',
+            ]) {
+                expect(patch).not.toHaveProperty(field);
+            }
+            expect(result?.node.minFreeDiskBytes).toBe(2147483648);
+            expect(result?.node.workspaceCount).toBe(9);
+        });
+
+        it('CLEARS the floor on an explicit null — the one field where null differs from absent', async () => {
+            repository.findById.mockResolvedValue(node({ minFreeDiskBytes: '2147483648' }));
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, { minFreeDiskBytes: null });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch).toHaveProperty('minFreeDiskBytes');
+            expect(patch.minFreeDiskBytes).toBeNull();
+        });
+
+        it('drops a nonsense count or byte figure rather than clamping it', async () => {
+            // A clamped figure is a plausible number an operator would act
+            // on; "unknown" is the honest rendering of a broken probe.
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                workspaceCount: 999_999_999,
+                workspaceBytes: -1,
+                minFreeDiskBytes: Number.POSITIVE_INFINITY,
+            });
+
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch).not.toHaveProperty('workspaceCount');
+            expect(patch).not.toHaveProperty('workspaceBytes');
+            // A refused FLOOR is dropped too. Only an EXPLICIT null clears
+            // it, so a broken probe can never read as "the floor is off".
+            expect(patch).not.toHaveProperty('minFreeDiskBytes');
+        });
+
+        it('refuses a fractional workspace count', async () => {
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, { workspaceCount: 3.5 });
+
+            expect(repository.update.mock.calls[0][1]).not.toHaveProperty('workspaceCount');
+        });
+
+        it('refuses an unparseable reclaim instant without failing the beat', async () => {
+            // Rejecting it at the DTO would fail the whole request, and a
+            // failed heartbeat is a live node swept offline. Losing one
+            // cosmetic figure is the correct price.
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, {
+                platform: 'linux/x64',
+                lastReclaimAt: 'last Tuesday',
+                lastReclaimFreedBytes: 3 * 1024 ** 3,
+            });
+
+            expect(result).not.toBeNull();
+            const patch = repository.update.mock.calls[0][1];
+            expect(patch).not.toHaveProperty('lastReclaimAt');
+            // The bytes go with it: a freed figure written against the
+            // PREVIOUS sweep's timestamp would misdate a real reclaim.
+            expect(patch).not.toHaveProperty('lastReclaimFreedBytes');
+            expect(patch.platform).toBe('linux/x64');
+        });
+
+        it('refuses an instant implausibly far in the future, and accepts one far in the past', async () => {
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                lastReclaimAt: new Date(Date.now() + 6 * 60 * 60_000).toISOString(),
+            });
+            expect(repository.update.mock.calls[0][1]).not.toHaveProperty('lastReclaimAt');
+
+            // "Last reclaimed in March" is not implausible — it is the exact
+            // finding this field exists to surface, so it is accepted.
+            repository.update.mockClear();
+            await service.heartbeat(NODE_ID, SECRET, {
+                lastReclaimAt: '2026-03-01T00:00:00.000Z',
+            });
+            expect(repository.update.mock.calls[0][1].lastReclaimAt).toEqual(
+                new Date('2026-03-01T00:00:00.000Z'),
+            );
+        });
+
+        it('writes a zero-byte reclaim, because a sweep that took nothing is a real outcome', async () => {
+            const service = build();
+
+            await service.heartbeat(NODE_ID, SECRET, {
+                lastReclaimAt: '2026-09-05T09:30:00.000Z',
+                lastReclaimFreedBytes: 0,
+            });
+
+            expect(repository.update.mock.calls[0][1].lastReclaimFreedBytes).toBe(0);
+        });
+
+        it('stamps every housekeeping column on enroll, since the row is new', async () => {
+            const token = 'd'.repeat(43);
+            enrolling(token);
+            const service = build();
+
+            await service.enroll(token, {
+                minFreeDiskBytes: 2 * 1024 ** 3,
+                workspaceCount: 4,
+                workspaceBytes: 1024 ** 3,
+                lastReclaimAt: '2026-09-05T09:30:00.000Z',
+                lastReclaimFreedBytes: 0,
+            });
+
+            const patch = repository.consumeEnrollment.mock.calls[0][2];
+            expect(patch.minFreeDiskBytes).toBe(2 * 1024 ** 3);
+            expect(patch.workspaceCount).toBe(4);
+            expect(patch.workspaceBytes).toBe(1024 ** 3);
+            expect(patch.lastReclaimAt).toEqual(new Date('2026-09-05T09:30:00.000Z'));
+            expect(patch.lastReclaimFreedBytes).toBe(0);
+        });
+
+        it('nulls housekeeping an enrolling node does not report', async () => {
+            const token = 'e'.repeat(43);
+            enrolling(token);
+            const service = build();
+
+            await service.enroll(token, {});
+
+            const patch = repository.consumeEnrollment.mock.calls[0][2];
+            expect(patch.minFreeDiskBytes).toBeNull();
+            expect(patch.workspaceCount).toBeNull();
+            expect(patch.lastReclaimAt).toBeNull();
+        });
+
+        it('normalizes bigint columns onto the view the way each driver hands them back', async () => {
+            // Postgres returns `bigint` as a STRING, sqlite as a number.
+            // `toView` is the one place that difference is resolved.
+            repository.findById.mockResolvedValue(
+                node({
+                    minFreeDiskBytes: '2147483648',
+                    workspaceBytes: '42949672960',
+                    lastReclaimFreedBytes: 0,
+                    lastReclaimAt: new Date('2026-09-05T09:30:00.000Z'),
+                }),
+            );
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, {});
+
+            expect(result?.node.minFreeDiskBytes).toBe(2147483648);
+            expect(result?.node.workspaceBytes).toBe(42949672960);
+            expect(result?.node.lastReclaimFreedBytes).toBe(0);
+            expect(result?.node.lastReclaimAt).toBe('2026-09-05T09:30:00.000Z');
+        });
+
+        it('reports never-populated columns as null, never as zero', async () => {
+            // "0 workspaces" reads as a tidy machine; the truth is that we
+            // have never been told. The UI must be able to tell them apart.
+            const service = build();
+
+            const result = await service.heartbeat(NODE_ID, SECRET, {});
+
+            expect(result?.node.minFreeDiskBytes).toBeNull();
+            expect(result?.node.workspaceCount).toBeNull();
+            expect(result?.node.workspaceBytes).toBeNull();
+            expect(result?.node.lastReclaimAt).toBeNull();
+            expect(result?.node.lastReclaimFreedBytes).toBeNull();
+        });
+    });
 });

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -21,6 +21,7 @@ import {
     FLEET_MAX_PLATFORM_LENGTH,
     FLEET_MAX_VERSION_LENGTH,
     FLEET_MAX_WORKER_STATE_REASON_LENGTH,
+    FLEET_MAX_WORKSPACE_COUNT,
     FLEET_MIN_NODE_NAME_LENGTH,
     normalizeFleetNodeWorkerState,
 } from '@ever-works/contracts';
@@ -166,6 +167,26 @@ export interface EnrollInput {
     workerState?: string;
     /** Why — quarantine message, throttle reason. Sanitized and capped. */
     workerStateReason?: string;
+    /**
+     * Node housekeeping (EW-803) — the free-space floor the node enforces
+     * on ITSELF, in bytes.
+     *
+     * The one field on this input where `undefined` and `null` mean
+     * different things. `undefined` is the usual "said nothing, leave the
+     * stored value alone"; an explicit `null` means "this machine has no
+     * floor" and DOES clear the column, because an operator switching the
+     * floor off is a change they need to see reflected rather than a
+     * silence that preserves a stale number.
+     */
+    minFreeDiskBytes?: number | null;
+    /** Workspaces retained by the node's last reclaim sweep. Same additive contract as {@link cliVersion}. */
+    workspaceCount?: number;
+    /** Bytes those workspaces occupy. */
+    workspaceBytes?: number;
+    /** ISO-8601 instant of that sweep, on the NODE's clock. Parsed and refused here if implausible. */
+    lastReclaimAt?: string;
+    /** Bytes that sweep freed. */
+    lastReclaimFreedBytes?: number;
 }
 
 export interface EnrollResult {
@@ -394,6 +415,14 @@ export class FleetService {
             // credential from a previous life still authenticating.
             previousCredentialHash: null,
             previousCredentialExpiresAt: null,
+            // Node housekeeping (EW-803). Set (possibly to null) for the
+            // same reason as the telemetry above: the row is brand new, so
+            // there is no earlier reading that "leave alone" could protect.
+            minFreeDiskBytes: sanitizeByteCount(input.minFreeDiskBytes),
+            workspaceCount: sanitizeCount(input.workspaceCount, FLEET_MAX_WORKSPACE_COUNT),
+            workspaceBytes: sanitizeByteCount(input.workspaceBytes),
+            lastReclaimAt: sanitizeReportedInstant(input.lastReclaimAt, now),
+            lastReclaimFreedBytes: sanitizeByteCount(input.lastReclaimFreedBytes),
         };
         // CAS: single-use by construction — a raced duplicate enroll
         // matches zero rows and gets the same null as a bad token.
@@ -499,6 +528,7 @@ export class FleetService {
         // the telemetry above — and is distinct from a REPORTED value this
         // build does not recognise, which is stored as null / "unknown".
         const workerState = this.applyWorkerState(node, refresh, patch);
+        this.applyHousekeeping(refresh, patch);
         // Re-arm the offline notice markers on EVERY accepted beat, not
         // only on beats that happened to report a worker state. The beat
         // itself is the proof the machine is reachable, and the daemons
@@ -521,6 +551,48 @@ export class FleetService {
             node: this.toView({ ...node, ...patch }),
             rotationRequested: Boolean(node.rotationRequestedAt),
         };
+    }
+
+    /**
+     * Fold a heartbeat's housekeeping report into the update patch
+     * (EW-803).
+     *
+     * Every field follows the additive contract the telemetry above
+     * follows — absent leaves the stored value alone — with ONE deliberate
+     * exception, `minFreeDiskBytes`, where an explicit `null` clears the
+     * column. That asymmetry exists because "the operator switched the
+     * floor off" is a real state with no other way to say it, and a stale
+     * "2.0 GiB floor" shown next to a node that no longer has one would be
+     * worse than showing nothing.
+     *
+     * A figure the sanitizers refuse is dropped, not written as null: a
+     * broken probe must not wipe the last good reading an operator is
+     * looking at. The one exception is the pairing rule at the bottom —
+     * see there.
+     */
+    private applyHousekeeping(refresh: EnrollInput, patch: Partial<FleetNode>): void {
+        if (refresh.minFreeDiskBytes === null) {
+            patch.minFreeDiskBytes = null;
+        } else if (refresh.minFreeDiskBytes !== undefined) {
+            const floor = sanitizeByteCount(refresh.minFreeDiskBytes);
+            if (floor !== null) patch.minFreeDiskBytes = floor;
+        }
+        const workspaceCount = sanitizeCount(refresh.workspaceCount, FLEET_MAX_WORKSPACE_COUNT);
+        if (workspaceCount !== null) patch.workspaceCount = workspaceCount;
+        const workspaceBytes = sanitizeByteCount(refresh.workspaceBytes);
+        if (workspaceBytes !== null) patch.workspaceBytes = workspaceBytes;
+        // The instant and the bytes it describes move TOGETHER. "4.1 GB
+        // freed" is reassuring or alarming entirely depending on when, so a
+        // freed-bytes figure is never written against the previous sweep's
+        // timestamp: if the instant is refused, the bytes are dropped with
+        // it, and if the instant is accepted the bytes are written even
+        // when the node reported none (a sweep that freed nothing is a
+        // real, and reassuring, outcome).
+        const lastReclaimAt = sanitizeReportedInstant(refresh.lastReclaimAt, new Date());
+        if (lastReclaimAt !== null) {
+            patch.lastReclaimAt = lastReclaimAt;
+            patch.lastReclaimFreedBytes = sanitizeByteCount(refresh.lastReclaimFreedBytes);
+        }
     }
 
     /**
@@ -1499,6 +1571,14 @@ export class FleetService {
             // window expiry stay OUT of the view: a wire shape that can
             // carry a credential artefact eventually does.
             rotationRequestedAt: node.rotationRequestedAt ? toIso(node.rotationRequestedAt) : null,
+            // Node housekeeping (EW-803). Three of these are `bigint`
+            // columns and go through the same driver normalization as
+            // `diskFreeBytes` — this method is the one place that happens.
+            minFreeDiskBytes: toOptionalNumber(node.minFreeDiskBytes),
+            workspaceCount: toOptionalNumber(node.workspaceCount),
+            workspaceBytes: toOptionalNumber(node.workspaceBytes),
+            lastReclaimAt: node.lastReclaimAt ? toIso(node.lastReclaimAt) : null,
+            lastReclaimFreedBytes: toOptionalNumber(node.lastReclaimFreedBytes),
         };
     }
 }
@@ -1551,6 +1631,59 @@ function sanitizeByteCount(value: unknown): number | null {
     if (value < 0 || value > FLEET_MAX_DISK_FREE_BYTES) return null;
     return Math.floor(value);
 }
+
+/**
+ * Accept a node-reported COUNT, or refuse it.
+ *
+ * Same doctrine as {@link sanitizeByteCount}, and the same reason: a
+ * clamped count is one an operator would believe. A machine reporting
+ * 4 billion workspaces has a broken probe, and "unknown" is the honest
+ * rendering of that — not `FLEET_MAX_WORKSPACE_COUNT`.
+ */
+function sanitizeCount(value: unknown, max: number): number | null {
+    if (typeof value !== 'number' || !Number.isInteger(value)) return null;
+    if (value < 0 || value > max) return null;
+    return value;
+}
+
+/**
+ * Accept an instant a NODE reported, or refuse it.
+ *
+ * Unlike every other timestamp on `fleet_nodes`, this one is not
+ * server-stamped — the platform learns a reclaim sweep happened only
+ * because a beat said so, and cannot derive the time itself. So it is
+ * treated as untrusted input:
+ *
+ *  - anything that is not a parseable date is refused, which is also why
+ *    the DTO admits it as a plain string: rejecting it at the pipe would
+ *    fail the whole beat and sweep a live node offline over a cosmetic
+ *    field;
+ *  - anything more than {@link REPORTED_INSTANT_FUTURE_SKEW_MS} ahead of
+ *    the server is refused. A little skew is ordinary on an unattended
+ *    PC; hours of it means the clock is wrong, and "last reclaimed in
+ *    four hours" is worse than no answer at all.
+ *
+ * A far-PAST instant is accepted deliberately. "Last reclaimed in March"
+ * is not implausible, it is the exact finding this field exists to
+ * surface.
+ */
+function sanitizeReportedInstant(value: unknown, now: Date): Date | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = new Date(trimmed);
+    const ms = parsed.getTime();
+    if (Number.isNaN(ms)) return null;
+    if (ms > now.getTime() + REPORTED_INSTANT_FUTURE_SKEW_MS) return null;
+    return parsed;
+}
+
+/**
+ * How far ahead of the server a node-reported instant may sit before it
+ * is refused: five minutes, comfortably more than the clock drift of an
+ * unattended machine and comfortably less than a timezone mistake.
+ */
+const REPORTED_INSTANT_FUTURE_SKEW_MS = 5 * 60_000;
 
 function sanitizeText(value: unknown, maxLength: number): string | null {
     if (typeof value !== 'string') return null;

--- a/packages/contracts/fixtures/fleet-node-contract.v1.json
+++ b/packages/contracts/fixtures/fleet-node-contract.v1.json
@@ -512,10 +512,23 @@
 			"diskFreeBytes",
 			"modelIdentity",
 			"workerState",
-			"workerStateReason"
+			"workerStateReason",
+			"minFreeDiskBytes",
+			"workspaceCount",
+			"workspaceBytes",
+			"lastReclaimAt",
+			"lastReclaimFreedBytes"
 		],
 		"nodeEmits": ["platform", "version", "capabilities", "cliVersion", "diskFreeBytes", "modelIdentity"],
-		"nodeEmitsOptional": ["workerState", "workerStateReason"],
+		"nodeEmitsOptional": [
+			"workerState",
+			"workerStateReason",
+			"minFreeDiskBytes",
+			"workspaceCount",
+			"workspaceBytes",
+			"lastReclaimAt",
+			"lastReclaimFreedBytes"
+		],
 		"controllerForwards": {
 			"enroll": [
 				"platform",
@@ -525,7 +538,12 @@
 				"diskFreeBytes",
 				"modelIdentity",
 				"workerState",
-				"workerStateReason"
+				"workerStateReason",
+				"minFreeDiskBytes",
+				"workspaceCount",
+				"workspaceBytes",
+				"lastReclaimAt",
+				"lastReclaimFreedBytes"
 			],
 			"heartbeat": [
 				"platform",
@@ -535,7 +553,12 @@
 				"diskFreeBytes",
 				"modelIdentity",
 				"workerState",
-				"workerStateReason"
+				"workerStateReason",
+				"minFreeDiskBytes",
+				"workspaceCount",
+				"workspaceBytes",
+				"lastReclaimAt",
+				"lastReclaimFreedBytes"
 			]
 		}
 	},

--- a/packages/contracts/src/fleet/__tests__/fleet-node.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-node.spec.ts
@@ -15,6 +15,7 @@ import {
 	FLEET_MAX_CREDENTIAL_ROTATION_OVERLAP_MS,
 	FLEET_MAX_DAILY_COST_CEILING_CENTS,
 	FLEET_MAX_DISK_FREE_BYTES,
+	FLEET_MAX_WORKSPACE_COUNT,
 	FLEET_MAX_MODEL_IDENTITY_LENGTH,
 	FLEET_MAX_NODE_NAME_LENGTH,
 	FLEET_MAX_PLATFORM_LENGTH,
@@ -50,6 +51,7 @@ function BOUNDS_AND_TUNABLES(): Array<[string, number]> {
 		['FLEET_MAX_MODEL_IDENTITY_LENGTH', FLEET_MAX_MODEL_IDENTITY_LENGTH],
 		['FLEET_MAX_DAILY_COST_CEILING_CENTS', FLEET_MAX_DAILY_COST_CEILING_CENTS],
 		['FLEET_MAX_DISK_FREE_BYTES', FLEET_MAX_DISK_FREE_BYTES],
+		['FLEET_MAX_WORKSPACE_COUNT', FLEET_MAX_WORKSPACE_COUNT],
 		['FLEET_MIN_NODE_NAME_LENGTH', FLEET_MIN_NODE_NAME_LENGTH],
 		['FLEET_MAX_NODE_NAME_LENGTH', FLEET_MAX_NODE_NAME_LENGTH],
 		['FLEET_CREDENTIAL_MIN_LENGTH', FLEET_CREDENTIAL_MIN_LENGTH],
@@ -441,5 +443,25 @@ describe('FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS', () => {
 
 	it('defaults to 30 minutes', () => {
 		expect(FLEET_DEFAULT_NODE_OFFLINE_NOTICE_AFTER_MS).toBe(30 * 60_000);
+	});
+});
+
+describe('FLEET_MAX_WORKSPACE_COUNT', () => {
+	it('is the "certainly nonsense" line, not a policy on how many workspaces a node may hold', () => {
+		// A real machine that has gone unreaped for months holds hundreds,
+		// maybe a few thousand, Task worktrees. The cap has to sit far above
+		// anything legitimate, because a count at or under it is STORED and
+		// shown verbatim — the platform must never quietly turn a broken
+		// probe's figure into a plausible one.
+		expect(FLEET_MAX_WORKSPACE_COUNT).toBe(100_000);
+		expect(FLEET_MAX_WORKSPACE_COUNT).toBeGreaterThan(10_000);
+	});
+
+	it('stays a safe integer, unlike the byte ceiling beside it', () => {
+		// `FLEET_MAX_DISK_FREE_BYTES` is deliberately past MAX_SAFE_INTEGER;
+		// a COUNT has no such excuse, and an unsafe one would make `<=`
+		// comparisons in the DTO silently approximate.
+		expect(Number.isSafeInteger(FLEET_MAX_WORKSPACE_COUNT)).toBe(true);
+		expect(FLEET_MAX_WORKSPACE_COUNT).toBeLessThan(FLEET_MAX_DISK_FREE_BYTES);
 	});
 });

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -109,7 +109,10 @@ const NODE_EXPORTS = [
 	// Covered in `fleet-node.spec.ts`.
 	'FLEET_DEFAULT_CREDENTIAL_ROTATION_OVERLAP_MS',
 	'FLEET_MIN_CREDENTIAL_ROTATION_OVERLAP_MS',
-	'FLEET_MAX_CREDENTIAL_ROTATION_OVERLAP_MS'
+	'FLEET_MAX_CREDENTIAL_ROTATION_OVERLAP_MS',
+	// Node housekeeping visibility (EW-803): the cap on a reported
+	// workspace count. Covered in `fleet-node.spec.ts`.
+	'FLEET_MAX_WORKSPACE_COUNT'
 ] as const;
 
 /** Agent execution v2 — model CLIs on the node (`fleet-jobs.types.js`). */
@@ -286,7 +289,7 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 148 runtime symbols', () => {
+	it('exposes exactly these 149 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
@@ -301,8 +304,10 @@ describe('fleet barrel', () => {
 		// helpers of `fleet-run-secrets.types.ts`.
 		// → 148 with the node MCP bridge (EW-782): the run-credential
 		// symbols, pinned in `fleet-run-credential.spec.ts`.
+		// → 149 with node housekeeping visibility (EW-803): the cap on a
+		// reported workspace count, in an existing module.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(148);
+		expect(Object.keys(fleet)).toHaveLength(149);
 	});
 
 	it.each([

--- a/packages/contracts/src/fleet/fleet-node.types.ts
+++ b/packages/contracts/src/fleet/fleet-node.types.ts
@@ -234,6 +234,50 @@ export interface FleetNodeSelfDescription {
 	 * sanitizes and caps it at {@link FLEET_MAX_WORKER_STATE_REASON_LENGTH}.
 	 */
 	workerStateReason?: string;
+	/**
+	 * Node housekeeping (EW-803) — the disk FLOOR this machine enforces on
+	 * itself, in bytes. `null` means the operator switched the floor off.
+	 *
+	 * Reported for VISIBILITY only, and that distinction is the whole
+	 * reason it is allowed to exist. The limit is still evaluated entirely
+	 * on the node; the platform neither sets it, nor consults it when
+	 * routing, nor may assume a node respects it — a lent machine stays
+	 * bounded from its own side. What the figure closes is an operator
+	 * question that {@link FleetNodeSelfDescription.diskFreeBytes} alone
+	 * cannot answer: "1.2 GB free" says nothing about whether that is
+	 * above or below the line at which this node stops taking work.
+	 *
+	 * Additive like {@link FleetNodeSelfDescription.cliVersion}, with ONE
+	 * difference: an explicit `null` is not the same as absent. Absent
+	 * means "this daemon said nothing" and leaves the stored value alone;
+	 * `null` means "there is no floor on this machine" and does overwrite,
+	 * because a floor that was switched off is a fact an operator needs.
+	 */
+	minFreeDiskBytes?: number | null;
+	/**
+	 * How many workspaces (Task worktrees) the node was holding when its
+	 * reclaim sweep last finished. Capped at {@link FLEET_MAX_WORKSPACE_COUNT}.
+	 *
+	 * The number that answers "is this machine accumulating?" — bytes
+	 * alone cannot tell one enormous checkout from four hundred small
+	 * ones, and only the second means the reaper is falling behind.
+	 */
+	workspaceCount?: number;
+	/** Bytes those retained workspaces occupy, as last measured by the sweep. */
+	workspaceBytes?: number;
+	/**
+	 * ISO-8601 instant at which the node's last reclaim sweep COMPLETED.
+	 *
+	 * The NODE's own clock, and therefore the one field here the platform
+	 * cannot corroborate — a machine with a stepped clock reports a wrong
+	 * instant and the server has no way to know. Stored anyway, because
+	 * "the reaper last ran three weeks ago" is exactly the fact that
+	 * explains a full disk; refused outright when it does not parse or
+	 * lands implausibly far in the future.
+	 */
+	lastReclaimAt?: string;
+	/** Bytes that sweep reclaimed. Zero is a real answer: it ran and found nothing to take. */
+	lastReclaimFreedBytes?: number;
 }
 
 /** Wire view of one fleet node — never carries credentials or hashes. */
@@ -316,6 +360,20 @@ export interface FleetNodeView {
 	 * Cleared by the rotation that satisfies it.
 	 */
 	rotationRequestedAt?: string | null;
+
+	/**
+	 * Node housekeeping (EW-803), as last reported. Every one of these is
+	 * null for a node that has never reported it — an older daemon, a
+	 * visibility-only node with no worker, or a worker whose first reclaim
+	 * sweep has not run yet. Null renders as "unknown", never as zero:
+	 * "0 workspaces" and "we have never been told" are different facts,
+	 * and only the first would be reassuring.
+	 */
+	minFreeDiskBytes?: number | null;
+	workspaceCount?: number | null;
+	workspaceBytes?: number | null;
+	lastReclaimAt?: string | null;
+	lastReclaimFreedBytes?: number | null;
 }
 
 /**
@@ -433,6 +491,18 @@ export const FLEET_MAX_DAILY_COST_CEILING_CENTS = 100_000 * 100;
  * make the runner widget render a machine with an exabyte free.
  */
 export const FLEET_MAX_DISK_FREE_BYTES = 2 ** 60;
+
+/**
+ * Ceiling on a node's reported workspace COUNT (EW-803).
+ *
+ * 100,000 Task worktrees is not a machine that needs a bigger reaper — a
+ * single checkout of the monorepo is tens of megabytes, so a hundred
+ * thousand of them cannot fit on any volume a node runs on. Like
+ * {@link FLEET_MAX_DISK_FREE_BYTES} this is the "certainly nonsense"
+ * line, not a policy: a count outside `[0, this]` is dropped rather than
+ * clamped, because a clamped figure is one an operator would believe.
+ */
+export const FLEET_MAX_WORKSPACE_COUNT = 100_000;
 
 /** Node display-name bounds, enforced by the DTO and re-checked in the service. */
 export const FLEET_MIN_NODE_NAME_LENGTH = 1;


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AO**. Refs **EW-803**, and it builds directly on **EW-793**.

**Scope note first, because it changes how to read this PR.** The slice as briefed was already merged: `ab00c3fbb` (EW-793) landed `minFreeDiskBytes`, the admission gate, the pre-provision re-check, the age/LRU reaper, `--workspace-max-age` and the `doctor`/`gc` verbs — about 5,000 lines. Re-implementing it would have been duplicate work. This PR is the **two things that were still missing from it**.

### 1. The gate failed open, and a test said that was the contract

`assertDiskHeadroom` admitted when the free-space reading was unavailable, and a spec pinned it: *"admits when the reading is unknown — an unreadable volume must not fail every job."*

That is the wrong rule at provision time. It is the last check before a clone, a fetch and a model's whole budget land on a volume nobody can size, and **nothing checks again afterwards** — so the failure it allowed was a run dying inside git or pnpm with the lease, the plan and part of the spend already gone.

**Both gates now refuse an unknown reading.** Review caught that fixing only the provision gate composed badly: the node leased every job and deferred it at provisioning, and **each deferral silently spent one of the job's attempts** until the platform failed it for "attempt budget exhausted" — a message that never mentions disk.

The original concern, that a broken `statfs` must not idle a machine, is answered by `--no-disk-floor`: an explicit decision rather than a silent one that costs jobs. It ships with a contradiction guard against `--min-free-disk`, a latched operator warning that fires once per episode rather than every five seconds, a recovery message, and `doctor` output that names the state.

The refusal says **"could not be measured"**, not "below the floor" — sending someone to clear space on a half-empty volume hides the real fault.

The reversed test carries a `CONTRACT REVERSAL` comment explaining both reversals, so the next reader does not "fix" it back.

### 2. Housekeeping was invisible from the platform

The floor was node-local and the reaper's outcome went only to the local log file. Five optional heartbeat fields now travel **upward only** and render in the node drawer as above/below floor with figures, workspaces retained, and last reclaim.

They are optional in both directions and listed in `OPTIONAL_DESCRIPTION_FIELDS` — the list that lets a beat retry without new fields after a 400. **Omitting that would have swept every node offline**, which is the global-validation-pipe failure mode this program has hit before; two tests pin it and go red if the list is reverted.

The CPU and memory ceilings are deliberately **not** reported: that would contradict a documented invariant, and they have no companion reading to compare against.

### Two defects the slice's own tests caught

- A `gc --dry-run` in a second process overwrote the reclaimed byte count while leaving the older instant, so a real 4 GB sweep would have displayed as **"0 bytes freed"**.
- The reaper could reach `LocalWorkspacePlugin.gc()` — a method on the same object it constructs by default, which deletes on mtime alone with a raw recursive `fs.rm` and no ownership, lease or unpushed-work check. A regression guard now pins that removal happens **only** through `teardown`.

### Verified locally

| Check | Result |
| --- | --- |
| `packages/contracts` whole suite | 32 files / 1638 tests, no type errors |
| `apps/api` migrations + fleet DTO | 46 suites / 250 tests |
| `apps/node` `src/core` + `src/cli` | 922 passed |
| `packages/agent` fleet, database, events, entities | 102 suites / 1395 tests |
| `apps/web` dashboard + settings | 20 files / 233 tests |
| 21 locale files | valid JSON, all 13 new keys present in every one |
| `prettier --check` over all 64 changed files | clean |

`fleet.controller.ts` gains **no constructor parameter** — only the two field-by-field mappings, both of them.

### Not verified locally

- **`apps/api/src/fleet/fleet.controller.spec.ts` does not compile here.** `apps/api` resolves `@ever-works/agent` through a workspace `dist` that predates EW-776, and rebuilding it needs an install this environment does not run. The cases added there verify in CI only. This is the exact suite that caught a real defect on an earlier slice, so it is worth watching.
- Three `apps/node` failures are environmental and untouched by this branch: the Windows trust spec needs a Rust binary that is not built here, and `acceptance-checks` and `model-process` are the known load-sensitivity family — both pass in isolation, and this branch changes neither file.
- A pre-existing locale drift is visible but **not** from this change: `dashboard.newPage.hints.pickChip` is in 14 locales and absent from `en.json` on `develop` already.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet node details now show disk status, free space, workspace usage, and reclaim history.
  * Node heartbeats report housekeeping metrics, including workspace counts, storage, and cleanup results.
  * Workspace roots can be configured and identified in diagnostic and cleanup commands.

* **Bug Fixes**
  * Disk checks now fail safely when available space cannot be measured.
  * Workspace cleanup better protects active mounts, hidden output, reflog-reachable changes, and unreadable leases.
  * Task execution checks disk headroom before starting.

* **Documentation**
  * Disk thresholds now use MiB units, with updated housekeeping and safety guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->