### PR TITLE
feat(ingest): let a regression re-open work, and stop the legacy webhook swallowing intake failures (EW-804)

### DIFF
--- a/apps/api/src/ingest/github/github-app-webhook.controller.spec.ts
+++ b/apps/api/src/ingest/github/github-app-webhook.controller.spec.ts
@@ -21,6 +21,7 @@ jest.mock('../../auth/decorators/public.decorator', () => ({
 }));
 
 import { GitHubAppWebhookController } from './github-app-webhook.controller';
+import { GitHubEventsController } from './github-events.controller';
 import { GitHubWebhookDispatcherService } from './github-webhook-dispatcher.service';
 import { computeGitHubSignature } from './github-signature.util';
 
@@ -66,7 +67,12 @@ describe('GitHubAppWebhookController (POST /api/github-app/webhooks — legacy r
             { findByInstallationId: jest.fn().mockResolvedValue(installation) } as never,
             { findByGithubUserId: jest.fn().mockResolvedValue(null) } as never,
         );
-        return { controller: new GitHubAppWebhookController(dispatcher), bridge, appSync };
+        return {
+            controller: new GitHubAppWebhookController(dispatcher),
+            dispatcher,
+            bridge,
+            appSync,
+        };
     }
 
     function signedRequest(bodyObj: unknown, secret = APP_SECRET) {
@@ -149,13 +155,82 @@ describe('GitHubAppWebhookController (POST /api/github-app/webhooks — legacy r
         );
     });
 
-    it('never 500s this route for an ingest/review failure (new consumer, logged not thrown)', async () => {
+    it('never 500s this route for an AI-review failure (best-effort leg, logged not thrown)', async () => {
         const { controller, bridge } = createController();
-        bridge.handleEvent.mockRejectedValue(new Error('ingest exploded'));
+        bridge.handleEvent.mockRejectedValue(new Error('review exploded'));
         const { req, signature } = signedRequest(INSTALL_BODY);
 
         await expect(
             controller.handleWebhook(req as never, signature, 'installation'),
         ).resolves.toEqual({ ok: true });
+    });
+
+    /**
+     * This URL is the DEFAULT one a GitHub App install delivers to, so it
+     * is the route the founder's "file an issue, the fleet picks it up"
+     * path actually arrives on. A swallowed intake failure here answers
+     * GitHub 200, GitHub never redelivers, and the issue silently never
+     * becomes work.
+     */
+    describe('the issue-intake leg', () => {
+        const ISSUE_BODY = {
+            action: 'opened',
+            installation: { id: 4242 },
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, title: 'Login button does nothing', updated_at: '2026-09-05' },
+        };
+
+        it('reaches a registered intake consumer with the app-install binding', async () => {
+            const { controller, dispatcher } = createController();
+            const consumer = {
+                events: ['issues'],
+                handle: jest.fn().mockResolvedValue({ ingested: null }),
+            };
+            dispatcher.registerConsumer(consumer);
+            const { req, signature } = signedRequest(ISSUE_BODY);
+
+            await expect(
+                controller.handleWebhook(req as never, signature, 'issues'),
+            ).resolves.toEqual({ ok: true });
+            expect(consumer.handle).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'user-app', matchedBy: 'app-install' }),
+                'issues',
+                ISSUE_BODY,
+            );
+        });
+
+        it('rethrows an intake failure so GitHub redelivers the issue', async () => {
+            const { controller, dispatcher } = createController();
+            dispatcher.registerConsumer({
+                events: ['issues'],
+                handle: jest.fn().mockRejectedValue(new Error('ingest exploded')),
+            });
+            const { req, signature } = signedRequest(ISSUE_BODY);
+
+            await expect(
+                controller.handleWebhook(req as never, signature, 'issues'),
+            ).rejects.toThrow('ingest exploded');
+        });
+    });
+
+    /**
+     * Both public GitHub URLs reach the SAME dispatcher and the same
+     * downstream work, so an uncapped one is simply the door a flood
+     * chooses. This route carried no `@Throttle` at all while the
+     * canonical `/api/ingest/github/events` was capped at 300/minute.
+     */
+    it('carries the same throttle as the canonical receiver', () => {
+        // @nestjs/throttler v6 stamps `THROTTLER:<FIELD><name>` per named tier.
+        const limitOf = (handler: unknown) =>
+            Reflect.getMetadata('THROTTLER:LIMITlong', handler as object);
+        const ttlOf = (handler: unknown) =>
+            Reflect.getMetadata('THROTTLER:TTLlong', handler as object);
+
+        const legacy = GitHubAppWebhookController.prototype.handleWebhook;
+        const canonical = GitHubEventsController.prototype.receiveEvents;
+
+        expect(limitOf(legacy)).toBeDefined();
+        expect(limitOf(legacy)).toBe(limitOf(canonical));
+        expect(ttlOf(legacy)).toBe(ttlOf(canonical));
     });
 });

--- a/apps/api/src/ingest/github/github-app-webhook.controller.ts
+++ b/apps/api/src/ingest/github/github-app-webhook.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Headers, Post, Req, UnauthorizedException } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../auth/decorators/public.decorator';
-import { GitHubWebhookDispatcherService } from './github-webhook-dispatcher.service';
+import {
+    GitHubWebhookDispatcherService,
+    INVALID_GITHUB_SIGNATURE,
+} from './github-webhook-dispatcher.service';
 
 /**
  * `POST /api/github-app/webhooks` — the platform GitHub App webhook URL,
@@ -22,10 +26,22 @@ import { GitHubWebhookDispatcherService } from './github-webhook-dispatcher.serv
  * receiver files all sit together and the module graph stays acyclic
  * (`IngestModule` → `GitHubAppModule`, never back).
  *
- * FAILURE CONTRACT (unchanged): this route has always 500'd when the App
- * sync leg threw, and GitHub's redelivery is load-bearing for
- * installation sync, so a sync-leg error is rethrown. The ingest/review
- * leg is NEW on this route, so its failures are logged, never thrown.
+ * FAILURE CONTRACT: this route has always 500'd when the App sync leg
+ * threw, and GitHub's redelivery is load-bearing for installation sync,
+ * so a sync-leg error is rethrown. The AI review leg is best-effort —
+ * its failures are logged, never thrown, exactly as when it was added.
+ *
+ * The INTAKE leg (`issues`, `dependabot_alert` → the ingest spine → the
+ * triage Task) is rethrown as well, and that is deliberate: this URL is
+ * the DEFAULT one for a GitHub App install, so it is the route the
+ * founder's "file an issue and the fleet picks it up" path actually
+ * arrives on. Swallowing a transient intake failure here answers GitHub
+ * 200, GitHub never redelivers, and the issue silently never becomes
+ * work — the precise defect this whole intake exists to close. Rethrowing
+ * costs nothing on the retry: the App sync leg is idempotent and the
+ * spine dedupes on `(source, sourceEventId)`, so a redelivered issue
+ * event inserts zero rows the second time.
+ *
  * Response shape is unchanged: `{ ok: true }` with the framework's
  * default 201, as before.
  *
@@ -47,6 +63,11 @@ export class GitHubAppWebhookController {
         summary:
             'GitHub App webhook receiver (legacy route) — forwards to the consolidated GitHub receiver: installation sync, event ingest and AI PR review.',
     })
+    // The same flood posture as the canonical `/api/ingest/github/events`
+    // route next door. Both URLs reach the SAME dispatcher and the same
+    // downstream work, so leaving one of them uncapped meant a flood
+    // simply chose the unthrottled door.
+    @Throttle({ long: { limit: 300, ttl: 60_000 } })
     async handleWebhook(
         @Req() req: { body: unknown; rawBody?: string },
         @Headers('x-hub-signature-256') signature: string | undefined,
@@ -60,11 +81,18 @@ export class GitHubAppWebhookController {
         });
 
         if (result.ignored) {
-            throw new UnauthorizedException('Invalid GitHub webhook signature');
+            throw new UnauthorizedException(INVALID_GITHUB_SIGNATURE);
         }
 
         if (result.errors.sync) {
             throw result.errors.sync;
+        }
+
+        // See FAILURE CONTRACT above: a dropped intake failure on THIS
+        // route is an issue that never becomes work, because GitHub only
+        // redelivers on a non-2xx.
+        if (result.errors.intake) {
+            throw result.errors.intake;
         }
 
         return { ok: true };

--- a/apps/api/src/ingest/github/github-events.controller.spec.ts
+++ b/apps/api/src/ingest/github/github-events.controller.spec.ts
@@ -21,7 +21,10 @@ jest.mock('../../auth/decorators/public.decorator', () => ({
 }));
 
 import { GitHubEventsController } from './github-events.controller';
-import { GitHubWebhookDispatcherService } from './github-webhook-dispatcher.service';
+import {
+    GitHubWebhookDispatcherService,
+    INVALID_GITHUB_SIGNATURE,
+} from './github-webhook-dispatcher.service';
 import { computeGitHubSignature } from './github-signature.util';
 
 const SECRET = 'test-webhook-secret';
@@ -104,8 +107,13 @@ describe('GitHubEventsController (POST /api/ingest/github/events)', () => {
         await expect(controller.receiveEvents(req as never, signature, 'ping')).rejects.toThrow(
             UnauthorizedException,
         );
+        // Same uniform 401 body as the dispatcher — see the CONTRACT REVERSAL
+        // note there. Asserting a distinct 'not configured' message was
+        // asserting a configuration oracle: it told an unauthenticated prober
+        // whether a secret exists. Fails closed either way, which is what the
+        // assertion above pins.
         await expect(controller.receiveEvents(req as never, signature, 'ping')).rejects.toThrow(
-            'not configured',
+            INVALID_GITHUB_SIGNATURE,
         );
         expect(bridge.handleEvent).not.toHaveBeenCalled();
     });

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -87,6 +87,7 @@ describe('GitHubPrReviewBridgeService', () => {
         const installBindings = {
             findByWorkspace: jest.fn().mockResolvedValue(null),
             record: jest.fn().mockResolvedValue(null),
+            recordIfAbsent: jest.fn().mockResolvedValue(null),
         };
         // Orchestration M9 - the durable rejection recorder.
         const rejections = {
@@ -252,7 +253,19 @@ describe('GitHubPrReviewBridgeService', () => {
     });
 
     describe('recordBinding', () => {
-        it('persists the installation→user binding after a fallback match', async () => {
+        /**
+         * This used to assert `record` — the RE-POINTING write. It must
+         * not be: on the `single-install` / `signature` paths the HMAC
+         * proves the sender knows THEIR OWN webhook secret, while the
+         * workspace key beside it (`owner:<login>`) was read out of the
+         * still-unverified body. Any tenant with an enabled `github`
+         * install can sign a body naming another org, and `record` would
+         * hand them that org's binding — after which app-signed
+         * deliveries for the real owner's installation were attributed to
+         * the squatter. Insert-only is the write these paths have
+         * evidence for.
+         */
+        it('CLAIMS the installation→user binding insert-only after a fallback match', async () => {
             const { service, installBindings } = createService();
             await service.recordBinding({
                 userId: 'u-older',
@@ -260,13 +273,46 @@ describe('GitHubPrReviewBridgeService', () => {
                 matchedBy: 'single-install',
                 workspace: { keys: ['owner:octo'], label: 'octo' },
             });
-            expect(installBindings.record).toHaveBeenCalledWith({
+            expect(installBindings.recordIfAbsent).toHaveBeenCalledWith({
                 provider: 'github',
                 externalWorkspaceId: 'owner:octo',
                 userId: 'u-older',
                 pluginId: 'github',
                 externalWorkspaceName: 'octo',
             });
+            expect(installBindings.record).not.toHaveBeenCalled();
+        });
+
+        it('never takes a workspace key away from the account that already holds it', async () => {
+            const { service, installBindings } = createService();
+            installBindings.recordIfAbsent.mockResolvedValue({
+                userId: 'victim',
+                externalWorkspaceId: 'owner:victim-org',
+            });
+
+            await service.recordBinding({
+                userId: 'squatter',
+                webhookSecret: 'squatter-secret',
+                matchedBy: 'signature',
+                workspace: { keys: ['owner:victim-org'], label: 'victim-org' },
+            });
+
+            // Insert-only, and the holder came back — nothing re-pointed.
+            expect(installBindings.record).not.toHaveBeenCalled();
+        });
+
+        it('RE-POINTS only for an app-install match, whose owner came from platform state', async () => {
+            const { service, installBindings } = createService();
+            await service.recordBinding({
+                userId: 'u-app',
+                webhookSecret: 'app-secret',
+                matchedBy: 'app-install',
+                workspace: { keys: ['installation:4242'], label: 'octo' },
+            });
+            expect(installBindings.record).toHaveBeenCalledWith(
+                expect.objectContaining({ externalWorkspaceId: 'installation:4242' }),
+            );
+            expect(installBindings.recordIfAbsent).not.toHaveBeenCalled();
         });
 
         it('is a no-op when the binding already came from the table', async () => {
@@ -282,7 +328,7 @@ describe('GitHubPrReviewBridgeService', () => {
 
         it('swallows a repository failure (a verified webhook must not 500)', async () => {
             const { service, installBindings } = createService();
-            installBindings.record.mockRejectedValue(new Error('db down'));
+            installBindings.recordIfAbsent.mockRejectedValue(new Error('db down'));
             await expect(
                 service.recordBinding({
                     userId: 'u-a',
@@ -320,6 +366,98 @@ describe('GitHubPrReviewBridgeService', () => {
         it('returns undefined when the delivery names no installation at all', () => {
             expect(extractGitHubWorkspaceRef({ zen: 'x' } as any)).toBeUndefined();
             expect(extractGitHubWorkspaceRef(undefined)).toBeUndefined();
+        });
+
+        /**
+         * The body is attacker-shaped until the signature verifies.
+         * A type-narrow `typeof id === 'number'` check found no id in
+         * `{"installation":{"id":"4242"}}` and returned a ref WITHOUT the
+         * installation key, so the exact-binding step had nothing to look
+         * up — while `GitHubAppSyncService.handleWebhook` `String()`s the
+         * very same field and acts on it. That divergence is a way to
+         * blind the ownership check to the id the delivery is about to
+         * act on, so both JSON forms must normalize to one key.
+         */
+        it('normalizes a STRING installation id to the same key as the number', () => {
+            expect(extractGitHubWorkspaceRef({ installation: { id: '4242' } } as any)).toEqual(
+                extractGitHubWorkspaceRef({ installation: { id: 4242 } } as any),
+            );
+            expect(extractGitHubWorkspaceRef({ installation: { id: ' 004242 ' } } as any)).toEqual({
+                keys: ['installation:4242'],
+            });
+        });
+
+        it('ignores an installation id that is not a positive integer', () => {
+            for (const id of ['', 'abc', '4242abc', '-1', '0', 0, -5, 1.5, NaN, {}, []]) {
+                expect(extractGitHubWorkspaceRef({ installation: { id } } as any)).toBeUndefined();
+            }
+        });
+    });
+
+    /**
+     * A stored binding is a much weaker claim than a live HMAC. On the
+     * install-secret path `owner:<login>` keys are written from an
+     * unverified body, so one tenant can squat a workspace key they do
+     * not hold — and a squatted row used to resolve every delivery for
+     * that key to the squatter, whose secret then failed verification,
+     * 401ing the real owner's webhook forever with no way to evict it.
+     */
+    describe('resolveBinding: the signature outranks a stored binding', () => {
+        it('falls through to the signature proof when the bound install cannot verify', async () => {
+            const { service, installBindings, userPluginRepository, pluginSettingsService } =
+                createService();
+            userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'squatter', enabled: true, createdAt: new Date('2026-01-01') },
+                { userId: 'victim', enabled: true, createdAt: new Date('2026-02-01') },
+            ]);
+            pluginSettingsService.getSettings.mockImplementation(
+                async (_id: string, opts: { userId: string }) => ({
+                    webhookSecret: `${opts.userId}-secret`,
+                }),
+            );
+            installBindings.findByWorkspace.mockResolvedValue({
+                userId: 'squatter',
+                externalWorkspaceId: 'owner:victim-org',
+            });
+
+            const resolution = await service.resolveBinding({
+                workspace: { keys: ['owner:victim-org'] },
+                // Only the victim's real secret verifies this delivery.
+                verifySignature: (secret: string) => secret === 'victim-secret',
+            });
+
+            expect(resolution).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'victim', matchedBy: 'signature' },
+            });
+        });
+
+        it('still trusts the binding when it DOES verify the delivery', async () => {
+            const { service, installBindings, userPluginRepository, pluginSettingsService } =
+                createService();
+            userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'owner-a', enabled: true, createdAt: new Date('2026-01-01') },
+                { userId: 'owner-b', enabled: true, createdAt: new Date('2026-02-01') },
+            ]);
+            pluginSettingsService.getSettings.mockImplementation(
+                async (_id: string, opts: { userId: string }) => ({
+                    webhookSecret: `${opts.userId}-secret`,
+                }),
+            );
+            installBindings.findByWorkspace.mockResolvedValue({
+                userId: 'owner-a',
+                externalWorkspaceId: 'owner:acme',
+            });
+
+            const resolution = await service.resolveBinding({
+                workspace: { keys: ['owner:acme'] },
+                verifySignature: (secret: string) => secret === 'owner-a-secret',
+            });
+
+            expect(resolution).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'owner-a', matchedBy: 'binding' },
+            });
         });
     });
 

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -5,6 +5,7 @@ import {
     EventIngestService,
     IngestInstallBindingRepository,
     type IngestResult,
+    type RecordIngestBindingData,
 } from '@ever-works/agent/ingest';
 import { PrReviewService } from '@ever-works/agent/pr-review';
 import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/plugins';
@@ -129,7 +130,12 @@ export interface GitHubPushCommit {
 export interface GitHubWebhookBody {
     action?: string;
     installation?: {
-        id?: number;
+        /**
+         * GitHub sends a number; the field is typed wider because the
+         * body is unverified JSON when `extractGitHubWorkspaceRef` reads
+         * it (see `normalizeInstallationId`).
+         */
+        id?: number | string;
     };
     organization?: {
         login?: string;
@@ -214,6 +220,32 @@ export interface GitHubWebhookBody {
 }
 
 /**
+ * Canonical `installation.id` out of whatever JSON the body carried.
+ *
+ * GitHub always sends a JSON NUMBER, but the body is attacker-shaped
+ * until the signature verifies, and a caller can send `"4242"` instead.
+ * A type-narrow check (`typeof === 'number'`) would then find no id, the
+ * workspace ref would come back WITHOUT the `installation:` key, and the
+ * exact-binding step of `resolveBinding` would have nothing to look up —
+ * while `GitHubAppSyncService.handleWebhook` happily `String()`s the very
+ * same field and acts on it. That divergence is a way to make the
+ * ownership check blind to the id the delivery is about to act on, so
+ * both string and number forms normalize to the same key here.
+ */
+function normalizeInstallationId(value: unknown): string | undefined {
+    if (typeof value === 'number') {
+        return Number.isSafeInteger(value) && value > 0 ? String(value) : undefined;
+    }
+    if (typeof value === 'string' && /^[0-9]{1,19}$/.test(value.trim())) {
+        // Strip leading zeros textually — `Number()` would lose precision
+        // on a 19-digit id and re-introduce the divergence this closes.
+        const digits = value.trim().replace(/^0+(?=[0-9])/, '');
+        return digits === '0' ? undefined : digits;
+    }
+    return undefined;
+}
+
+/**
  * Read the installation identity off a delivery body.
  *
  * The body is NOT yet signature-verified here, and that is safe: the
@@ -225,8 +257,8 @@ export function extractGitHubWorkspaceRef(
     body: GitHubWebhookBody | undefined,
 ): GitHubWorkspaceRef | undefined {
     const keys: string[] = [];
-    const installationId = body?.installation?.id;
-    if (typeof installationId === 'number' && Number.isFinite(installationId)) {
+    const installationId = normalizeInstallationId(body?.installation?.id);
+    if (installationId) {
         keys.push(`installation:${installationId}`);
     }
     const owner =
@@ -396,10 +428,26 @@ export class GitHubPrReviewBridgeService {
             if (!bound) continue;
             const owner = candidates.find((c) => c.userId === bound.userId);
             if (owner) {
-                return {
-                    status: 'resolved',
-                    binding: { ...owner, matchedBy: 'binding', workspace },
-                };
+                // The binding names an owner; the SIGNATURE decides whether
+                // it is the owner of THIS delivery. A stored row is a much
+                // weaker claim than a live HMAC: `owner:<login>` keys are
+                // written from an unverified body (see `recordBinding`), so
+                // one tenant can squat a workspace key they do not hold. If
+                // the bound install's secret does not verify this delivery,
+                // fall through to the signature proof below rather than
+                // resolving to a user who demonstrably did not send it —
+                // otherwise the squatted row 401s the real owner's webhook
+                // forever with no way for them to evict it.
+                if (!lookup.verifySignature || lookup.verifySignature(owner.webhookSecret)) {
+                    return {
+                        status: 'resolved',
+                        binding: { ...owner, matchedBy: 'binding', workspace },
+                    };
+                }
+                this.logger.warn(
+                    `GitHub delivery for ${key} does not verify against the bound install's secret; falling through to signature proof`,
+                );
+                break;
             }
             // The bound install was removed or lost its webhook secret.
             // Attributing its events to ANOTHER user is exactly the defect
@@ -478,20 +526,49 @@ export class GitHubPrReviewBridgeService {
      * signature verification, so the deployment self-migrates off the
      * legacy single-install path onto exact resolution.
      *
+     * ## What the delivery actually proved
+     *
+     * `IngestInstallBindingRepository.record` re-POINTS an existing row
+     * and documents the invariant it needs: the caller must have proven
+     * OWNERSHIP of the workspace, not merely authenticity of the sender.
+     * Only one of the paths here clears that bar:
+     *
+     *  * `app-install` — the owner came from platform state
+     *    (`github_app_installations`), so re-pointing is proven and uses
+     *    `record`;
+     *  * `single-install` / `signature` — the HMAC proves the sender knows
+     *    THEIR OWN webhook secret. The workspace key next to it
+     *    (`owner:<login>`, `installation:<id>`) was read out of the
+     *    UNVERIFIED body, so it is a claim, not a proof: any tenant with
+     *    an enabled `github` install can sign a body naming somebody
+     *    else's org. Those paths therefore go through `recordIfAbsent`,
+     *    which inserts only when the key is unheld — a squatter can never
+     *    take a binding away from whoever legitimately holds it, and a
+     *    row that is already right is never overwritten by a forgery.
+     *
      * Best-effort: a failure here must never break a webhook that has
      * already been verified and handled.
      */
     async recordBinding(binding: GitHubEventsBinding): Promise<void> {
         const key = binding.workspace?.keys[0];
         if (binding.matchedBy === 'binding' || !key) return;
+        const write: RecordIngestBindingData = {
+            provider: GITHUB_BINDING_PROVIDER,
+            externalWorkspaceId: key,
+            userId: binding.userId,
+            pluginId: GITHUB_PLUGIN_ID,
+            externalWorkspaceName: binding.workspace?.label ?? null,
+        };
         try {
-            await this.installBindings.record({
-                provider: GITHUB_BINDING_PROVIDER,
-                externalWorkspaceId: key,
-                userId: binding.userId,
-                pluginId: GITHUB_PLUGIN_ID,
-                externalWorkspaceName: binding.workspace?.label ?? null,
-            });
+            const proven = binding.matchedBy === 'app-install';
+            const recorded = proven
+                ? await this.installBindings.record(write)
+                : await this.installBindings.recordIfAbsent(write);
+            if (!proven && recorded && recorded.userId !== binding.userId) {
+                this.logger.warn(
+                    `GitHub workspace ${key} is already bound to another account; leaving the existing binding in place`,
+                );
+            }
         } catch (error) {
             this.logger.warn(
                 `Failed to record GitHub installation binding for ${key}: ${

--- a/apps/api/src/ingest/github/github-webhook-dispatcher.service.spec.ts
+++ b/apps/api/src/ingest/github/github-webhook-dispatcher.service.spec.ts
@@ -472,4 +472,170 @@ describe('GitHubWebhookDispatcherService', () => {
             expect(healthy.handle).toHaveBeenCalled();
         });
     });
+
+    /**
+     * The App-sync leg writes PLATFORM state off identifiers taken
+     * straight out of the body: `installation` upserts / soft-deletes a
+     * `github_app_installations` row (and can overwrite the
+     * `createdByGithubUserId` that decides who owns an installation's
+     * deliveries), `installation_repositories` re-pulls that
+     * installation's private repository list, and `push` stamps
+     * `pendingSyncRequestedAt` on whichever Work claims the named repo.
+     *
+     * None of that has any relation to the verified sender. An ordinary
+     * tenant with an enabled `github` plugin picks their OWN
+     * `webhookSecret`, so they could sign
+     * `{"action":"deleted","installation":{"id":<victim>}}` with it, pass
+     * verification as themselves, and soft-delete a stranger's App
+     * installation — killing that account's issue intake, PR review and
+     * repo sync. Installation ids are small non-secret integers, so the
+     * whole deployment was enumerable.
+     *
+     * Only GitHub, signing with the PLATFORM App webhook secret, is an
+     * authority on platform App state.
+     */
+    describe('the App-sync leg requires the platform App credential', () => {
+        const INSTALL_EVENT_BODY = {
+            action: 'deleted',
+            installation: { id: 4242 },
+        };
+
+        it.each(['installation', 'installation_repositories', 'push'])(
+            'refuses to run App sync for a %s delivery verified with a per-install secret',
+            async (eventName) => {
+                const { dispatcher, appSync } = createDispatcher();
+
+                const result = await dispatcher.dispatch(
+                    signed(INSTALL_EVENT_BODY, INSTALL_SECRET, eventName),
+                );
+
+                expect(appSync.handleWebhook).not.toHaveBeenCalled();
+                expect(result.handled.sync).toBe(false);
+                // The delivery is still verified and still 200s — only the
+                // privileged leg is withheld.
+                expect(result.credential).toBe('install-secret');
+            },
+        );
+
+        it('runs App sync for the SAME delivery when GitHub signed it with the app secret', async () => {
+            const { dispatcher, appSync } = createDispatcher({
+                appSecret: APP_SECRET,
+                installation: { createdByUserId: 'user-app' },
+            });
+
+            const result = await dispatcher.dispatch(
+                signed(INSTALL_EVENT_BODY, APP_SECRET, 'installation'),
+            );
+
+            expect(appSync.handleWebhook).toHaveBeenCalledWith('installation', INSTALL_EVENT_BODY);
+            expect(result.handled.sync).toBe(true);
+        });
+
+        it('leaves every non-state-writing event flowing to the sync leg as before', async () => {
+            const { dispatcher, appSync } = createDispatcher();
+
+            await dispatcher.dispatch(signed(PR_BODY, INSTALL_SECRET, 'pull_request'));
+
+            expect(appSync.handleWebhook).toHaveBeenCalledWith('pull_request', PR_BODY);
+        });
+
+        // A string id was the way to make the ownership check blind to the
+        // id the sync leg was about to act on (`extractGitHubWorkspaceRef`
+        // normalizes both forms now — pinned in the bridge's own spec).
+        // The gate holds for that shape too.
+        it('blocks a STRING-id installation delivery on the same gate', async () => {
+            const { dispatcher, appSync } = createDispatcher();
+
+            await dispatcher.dispatch(
+                signed(
+                    { action: 'deleted', installation: { id: '4242' } },
+                    INSTALL_SECRET,
+                    'installation',
+                ),
+            );
+
+            expect(appSync.handleWebhook).not.toHaveBeenCalled();
+        });
+    });
+
+    /**
+     * `ingest_install_bindings` rows on the install-secret path are
+     * written from an UNVERIFIED body, so a tenant can squat
+     * `owner:<somebody-else>` by signing a body naming it with their own
+     * webhook secret. Consulting that row BEFORE
+     * `github_app_installations` meant the squatted row outranked
+     * platform state, and every genuinely app-signed delivery for the
+     * victim's installation — their issues included — was attributed to
+     * the squatter.
+     */
+    describe('app-secret ownership comes from platform state first', () => {
+        it('prefers github_app_installations over a squatted binding row', async () => {
+            const { dispatcher, bridge } = createDispatcher({
+                appSecret: APP_SECRET,
+                installation: { createdByUserId: 'victim' },
+                boundUserId: 'squatter',
+            });
+
+            await dispatcher.dispatch(signed(PR_BODY, APP_SECRET));
+
+            expect(bridge.handleEvent).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'victim', matchedBy: 'app-install' }),
+                'pull_request',
+                PR_BODY,
+            );
+        });
+
+        it('falls back to the binding row only when platform state does not answer', async () => {
+            const { dispatcher, bridge } = createDispatcher({
+                appSecret: APP_SECRET,
+                installation: null,
+                boundUserId: 'bound-user',
+            });
+
+            await dispatcher.dispatch(signed(PR_BODY, APP_SECRET));
+
+            expect(bridge.handleEvent).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'bound-user', matchedBy: 'binding' }),
+                'pull_request',
+                PR_BODY,
+            );
+        });
+
+        it('resolves through the GitHub user link when only createdByGithubUserId is known', async () => {
+            const { dispatcher, bridge } = createDispatcher({
+                appSecret: APP_SECRET,
+                installation: { createdByGithubUserId: '987' },
+                userLink: { userId: 'linked-user' },
+            });
+
+            await dispatcher.dispatch(signed(PR_BODY, APP_SECRET));
+
+            expect(bridge.handleEvent).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'linked-user', matchedBy: 'app-install' }),
+                'pull_request',
+                PR_BODY,
+            );
+        });
+    });
+
+    /**
+     * Two textually distinct 401s told an unauthenticated prober whether
+     * ANY account on the deployment has an enabled `github` install with
+     * a webhook secret — a per-deployment tenant oracle, free, before
+     * they hold any credential.
+     */
+    it('answers "nothing configured" and "bad signature" with the SAME 401 body', async () => {
+        const notConfigured = createDispatcher();
+        notConfigured.bridge.resolveBinding.mockResolvedValue({ status: 'not-configured' });
+        const unconfiguredMessage = await notConfigured.dispatcher
+            .dispatch(signed(PR_BODY, INSTALL_SECRET))
+            .catch((error: Error) => error.message);
+
+        const badSignature = createDispatcher();
+        const badSignatureMessage = await badSignature.dispatcher
+            .dispatch(signed(PR_BODY, 'someone-elses-secret'))
+            .catch((error: Error) => error.message);
+
+        expect(unconfiguredMessage).toBe(badSignatureMessage);
+    });
 });

--- a/apps/api/src/ingest/github/github-webhook-dispatcher.service.spec.ts
+++ b/apps/api/src/ingest/github/github-webhook-dispatcher.service.spec.ts
@@ -20,7 +20,10 @@ jest.mock('../../integrations/github-app/github-app-sync.service', () => ({
     GitHubAppSyncService: class {},
 }));
 
-import { GitHubWebhookDispatcherService } from './github-webhook-dispatcher.service';
+import {
+    INVALID_GITHUB_SIGNATURE,
+    GitHubWebhookDispatcherService,
+} from './github-webhook-dispatcher.service';
 import { computeGitHubSignature } from './github-signature.util';
 
 const INSTALL_SECRET = 'per-install-webhook-secret';
@@ -214,7 +217,15 @@ describe('GitHubWebhookDispatcherService', () => {
                 dispatcher.dispatch(
                     signed({ zen: 'Keep it logically awesome.' }, INSTALL_SECRET, 'ping'),
                 ),
-            ).rejects.toThrow(/not configured/);
+                // CONTRACT REVERSAL, stated so it is not "fixed" back: this used
+                // to assert a distinct 'not configured' message. A receiver that
+                // says 'not configured' when a secret is missing and 'invalid
+                // signature' when it is present hands an unauthenticated prober a
+                // configuration oracle. Both cases mean the same thing to a caller
+                // — nothing here verified you — so both now say it the same way.
+                // The property under test is unchanged and still asserted: this
+                // fails CLOSED, with a 401, even for `ping`.
+            ).rejects.toThrow(INVALID_GITHUB_SIGNATURE);
             expect(appSync.handleWebhook).not.toHaveBeenCalled();
         });
 
@@ -283,7 +294,23 @@ describe('GitHubWebhookDispatcherService', () => {
             expect(bridge.recordBinding).toHaveBeenCalledWith(INSTALL_BINDING);
         });
 
-        it('prefers an existing binding row over the App installation record', async () => {
+        it('prefers the App installation record over an existing binding row', async () => {
+            // CONTRACT REVERSAL, and the reason is a real vulnerability, so do
+            // not restore the old order. This case used to assert the exact
+            // opposite: that a binding row outranks `github_app_installations`.
+            //
+            // Binding rows on the `install-secret` path are written from an
+            // UNVERIFIED body by `recordBinding`, so a tenant can name
+            // `owner:<somebody-else>` in a body signed with their OWN webhook
+            // secret. With the binding consulted first, that squatted row beat
+            // the platform's own installation record, and every genuinely
+            // App-signed delivery for the victim's installation — their issues
+            // included — was filed into the squatter's organization.
+            //
+            // Platform state cannot be outranked by an inbound delivery that
+            // only proved the sender's own secret. The binding row remains the
+            // fallback for installations the App-install flow never recorded,
+            // which the sibling cases below still cover.
             const { dispatcher, bridge, installations } = createDispatcher({
                 appSecret: APP_SECRET,
                 boundUserId: 'user-bound',
@@ -292,17 +319,18 @@ describe('GitHubWebhookDispatcherService', () => {
 
             await dispatcher.dispatch(signed(PR_BODY, APP_SECRET));
 
-            expect(bridge.installBindingFor).toHaveBeenCalledWith('installation:4242');
-            expect(installations.findByInstallationId).not.toHaveBeenCalled();
+            expect(installations.findByInstallationId).toHaveBeenCalledWith('4242');
+            expect(bridge.installBindingFor).not.toHaveBeenCalled();
             expect(bridge.handleEvent).toHaveBeenCalledWith(
-                expect.objectContaining({ userId: 'user-bound', matchedBy: 'binding' }),
+                expect.objectContaining({ userId: 'user-app', matchedBy: 'app-install' }),
                 'pull_request',
                 PR_BODY,
             );
-            // `matchedBy: 'binding'` means the row already exists — no
-            // pointless rewrite.
+            // The squatted row is not merely ignored: the authoritative owner
+            // is written back, so the next delivery resolves to the same user
+            // even if the installation lookup is unavailable then.
             expect(bridge.recordBinding).toHaveBeenCalledWith(
-                expect.objectContaining({ matchedBy: 'binding' }),
+                expect.objectContaining({ userId: 'user-app', matchedBy: 'app-install' }),
             );
         });
 

--- a/apps/api/src/ingest/github/github-webhook-dispatcher.service.ts
+++ b/apps/api/src/ingest/github/github-webhook-dispatcher.service.ts
@@ -29,6 +29,40 @@ export interface GitHubWebhookDelivery {
 export type GitHubWebhookCredential = 'app-secret' | 'install-secret';
 
 /**
+ * The `x-github-event` names on which `GitHubAppSyncService` WRITES
+ * platform state: `installation` upserts / soft-deletes a row in
+ * `github_app_installations` and can overwrite its
+ * `createdByGithubUserId`; `installation_repositories` re-pulls the
+ * installation's private repository list; `push` stamps
+ * `pendingSyncRequestedAt` on whichever Work claims the named repo.
+ *
+ * Each of those acts on an identifier taken STRAIGHT OUT of the body
+ * (`installation.id`, `repository.full_name`) with no relation to the
+ * verified sender, so they may only run when GitHub itself vouched for
+ * the delivery with the PLATFORM App webhook secret. A delivery verified
+ * with a tenant's own per-install `webhookSecret` proves who the sender
+ * is, and a tenant is not an authority on another tenant's App
+ * installation — before this gate, any tenant could sign
+ * `{"action":"deleted","installation":{"id":<victim>}}` with their own
+ * secret and soft-delete a stranger's installation.
+ *
+ * Every OTHER event name is left flowing to the sync service exactly as
+ * before: `handleWebhook` has no branch for them, so the call is an inert
+ * no-op and the consolidated fan-out keeps its shape.
+ */
+const APP_STATE_EVENTS: readonly string[] = ['installation', 'installation_repositories', 'push'];
+
+/**
+ * The ONE 401 body this receiver ever returns.
+ *
+ * A receiver that answers 'not configured' when a secret is missing and
+ * 'invalid signature' when it is present hands an unauthenticated prober
+ * a configuration oracle. Both cases mean the same thing to a caller —
+ * nothing here verified you — so both say it the same way.
+ */
+export const INVALID_GITHUB_SIGNATURE = 'Invalid GitHub webhook signature';
+
+/**
  * Outcome of one dispatch. Both consumers' failures are REPORTED rather
  * than thrown, so each route can keep its own historical failure
  * contract (see the class doc).
@@ -116,7 +150,10 @@ export interface GitHubWebhookConsumer {
  *    RECORDED into the same table — no second binding store;
  *  * **fans out internally to every consumer**: the App sync service and
  *    the PR-review/ingest bridge, on every verified delivery, regardless
- *    of which URL it arrived at.
+ *    of which URL it arrived at — except that the sync leg's
+ *    STATE-WRITING events ({@link APP_STATE_EVENTS}) require the platform
+ *    App credential, because a tenant's own webhook secret is not an
+ *    authority on another tenant's App installation.
  *
  * ## Failure contracts are per-route, on purpose
  *
@@ -211,8 +248,17 @@ export class GitHubWebhookDispatcherService {
 
             // Fail-closed: nothing configured anywhere → reject, including
             // the initial `ping` (GitHub signs that too).
+            //
+            // The message is deliberately the SAME one a bad signature
+            // gets. "Not configured" here means `loadCandidates()` came
+            // back empty — i.e. no user anywhere on this deployment has an
+            // enabled `github` install with a webhook secret. Saying so to
+            // an unauthenticated prober is a per-deployment tenant oracle:
+            // it tells them which integrations are live before they hold
+            // any credential. Operators read the reason out of the logs,
+            // which is where it belongs.
             if (resolution.status === 'not-configured') {
-                throw new UnauthorizedException('GitHub events receiver is not configured');
+                throw new UnauthorizedException(INVALID_GITHUB_SIGNATURE);
             }
             // Unknown/ambiguous installation → clean no-op. The bridge
             // already logged the refusal; 200 so GitHub does not retry a
@@ -228,7 +274,7 @@ export class GitHubWebhookDispatcherService {
 
             binding = resolution.binding;
             if (!verify(binding.webhookSecret)) {
-                throw new UnauthorizedException('Invalid GitHub webhook signature');
+                throw new UnauthorizedException(INVALID_GITHUB_SIGNATURE);
             }
 
             // Verified — persist the installation→user binding so
@@ -242,14 +288,24 @@ export class GitHubWebhookDispatcherService {
 
         // 1. GitHub App sync (installation / installation_repositories).
         //    Ran on every verified delivery of the legacy route before;
-        //    now runs on every verified delivery of BOTH routes.
+        //    now runs on every verified delivery of BOTH routes — EXCEPT
+        //    the state-writing event names, which require the platform App
+        //    credential (see {@link APP_STATE_EVENTS}).
         let syncHandled = false;
-        try {
-            await this.appSync.handleWebhook(eventName, body as never);
-            syncHandled = true;
-        } catch (error) {
-            errors.sync = error;
-            this.logger.warn(`GitHub App sync failed for '${eventName}': ${this.messageOf(error)}`);
+        if (credential !== 'app-secret' && APP_STATE_EVENTS.includes(eventName)) {
+            this.logger.warn(
+                `Refusing to run the GitHub App sync leg for '${eventName}': the delivery verified with a per-install secret, which is not an authority on platform App state`,
+            );
+        } else {
+            try {
+                await this.appSync.handleWebhook(eventName, body as never);
+                syncHandled = true;
+            } catch (error) {
+                errors.sync = error;
+                this.logger.warn(
+                    `GitHub App sync failed for '${eventName}': ${this.messageOf(error)}`,
+                );
+            }
         }
 
         // 2. Ingest spine + PR review. `ping` is the webhook-creation
@@ -267,12 +323,16 @@ export class GitHubWebhookDispatcherService {
             }
         } else if (eventName !== 'ping' && !binding) {
             // App-secret delivery we cannot attribute to a platform user.
-            // The sync leg still ran (it is user-agnostic); the review leg
-            // has no owner to run as, so it is skipped rather than guessed.
+            // The sync leg still ran (it is user-agnostic); the review and
+            // INTAKE legs have no owner to run as, so they are skipped
+            // rather than guessed — an unattributable `issues` delivery
+            // files nothing rather than filing into somebody's org. The
+            // owner-less case is named explicitly here because it is the
+            // one way a correctly signed issue produces no Task at all.
             this.logger.warn(
                 `GitHub delivery '${eventName}' verified with the app secret but no platform owner is bound to ${
                     workspace?.keys[0] ?? 'the installation'
-                }; skipping the review leg`,
+                }; skipping the review and intake legs`,
             );
         }
 
@@ -305,15 +365,27 @@ export class GitHubWebhookDispatcherService {
     /**
      * Owner for a delivery that verified against the PLATFORM App secret.
      *
-     * Order (mirrors the per-install resolver's "never guess" posture):
+     * Order — AUTHORITATIVE PLATFORM STATE FIRST:
      *
-     *   1. an existing `ingest_install_bindings` row for the delivery's
-     *      installation / owner key — the same single binding table the
-     *      per-install path uses;
-     *   2. `github_app_installations.createdByUserId` — the platform user
-     *      who installed the App;
-     *   3. that installation's `createdByGithubUserId` resolved through
-     *      `github_app_user_links`.
+     *   1. `github_app_installations.createdByUserId` — the platform user
+     *      who installed the App, written by the App-install flow;
+     *   2. that installation's `createdByGithubUserId` resolved through
+     *      `github_app_user_links`;
+     *   3. only then an existing `ingest_install_bindings` row for the
+     *      delivery's installation / owner key — the same single binding
+     *      table the per-install path uses.
+     *
+     * The order matters and used to be the other way round. Binding rows
+     * on the `install-secret` path are written from an UNVERIFIED body
+     * (`recordBinding`), so a tenant can name `owner:<somebody-else>` in
+     * a body signed with their own webhook secret. With the binding
+     * consulted first, that squatted row outranked
+     * `github_app_installations` and every genuinely App-signed delivery
+     * for the victim's installation — their issues included — was filed
+     * into the squatter's organization. Platform state cannot be written
+     * by an inbound delivery that only proved the sender's own secret, so
+     * it goes first and the binding row is the fallback for
+     * installations the App-install flow never recorded.
      *
      * `null` when none of the three answer: the review leg is skipped
      * rather than attributed to an arbitrary user.
@@ -329,41 +401,36 @@ export class GitHubWebhookDispatcherService {
             ...(workspace ? { workspace } : {}),
         });
 
+        const installationKey = workspace?.keys.find((key) => key.startsWith('installation:'));
+        if (installationKey) {
+            const installationId = installationKey.slice('installation:'.length);
+            const installation = await this.installations
+                .findByInstallationId(installationId)
+                .catch((error: unknown) => {
+                    this.logger.warn(
+                        `GitHub App installation lookup failed for ${installationId}: ${this.messageOf(error)}`,
+                    );
+                    return null;
+                });
+
+            if (installation?.createdByUserId) {
+                return asBinding(installation.createdByUserId);
+            }
+
+            if (installation?.createdByGithubUserId) {
+                const link = await this.userLinks
+                    .findByGithubUserId(installation.createdByGithubUserId)
+                    .catch(() => null);
+                if (link?.userId) {
+                    return asBinding(link.userId);
+                }
+            }
+        }
+
         for (const key of workspace?.keys ?? []) {
             const bound = await this.bridge.installBindingFor(key);
             if (bound) {
                 return { ...asBinding(bound.userId), matchedBy: 'binding' };
-            }
-        }
-
-        const installationKey = workspace?.keys.find((key) => key.startsWith('installation:'));
-        if (!installationKey) {
-            return null;
-        }
-        const installationId = installationKey.slice('installation:'.length);
-
-        const installation = await this.installations
-            .findByInstallationId(installationId)
-            .catch((error: unknown) => {
-                this.logger.warn(
-                    `GitHub App installation lookup failed for ${installationId}: ${this.messageOf(error)}`,
-                );
-                return null;
-            });
-        if (!installation) {
-            return null;
-        }
-
-        if (installation.createdByUserId) {
-            return asBinding(installation.createdByUserId);
-        }
-
-        if (installation.createdByGithubUserId) {
-            const link = await this.userLinks
-                .findByGithubUserId(installation.createdByGithubUserId)
-                .catch(() => null);
-            if (link?.userId) {
-                return asBinding(link.userId);
             }
         }
 

--- a/apps/api/src/ingest/jira/jira-events.controller.spec.ts
+++ b/apps/api/src/ingest/jira/jira-events.controller.spec.ts
@@ -145,8 +145,13 @@ describe('JiraEventsController (POST /api/ingest/jira/events)', () => {
         await expect(controller.receiveEvents(req as never, signature)).rejects.toThrow(
             UnauthorizedException,
         );
+        // The 401 body is INDISTINGUISHABLE from the bad-signature one.
+        // This used to assert 'not configured', which told an
+        // unauthenticated prober that no account on this deployment has
+        // an enabled jira-connector install with a webhook secret — a
+        // per-deployment tenant oracle held by anyone who can POST.
         await expect(controller.receiveEvents(req as never, signature)).rejects.toThrow(
-            'not configured',
+            'Invalid Jira webhook signature',
         );
         expect(eventIngestService.ingest).not.toHaveBeenCalled();
     });

--- a/apps/api/src/ingest/jira/jira-events.controller.ts
+++ b/apps/api/src/ingest/jira/jira-events.controller.ts
@@ -19,6 +19,13 @@ import {
 import { verifyJiraSignature } from './jira-signature.util';
 
 /**
+ * The ONE 401 body this receiver ever returns — an unconfigured
+ * deployment and a bad signature are indistinguishable from outside, so
+ * probing cannot map which integrations are live.
+ */
+export const INVALID_JIRA_SIGNATURE = 'Invalid Jira webhook signature';
+
+/**
  * Jira Cloud webhook receiver (self-build program note §6, R2) — the
  * platform-side endpoint a Jira Cloud webhook (created WITH a secret)
  * points at.
@@ -84,8 +91,14 @@ export class JiraEventsController {
         });
 
         // Fail-closed: nothing configured → reject.
+        //
+        // The message is deliberately the SAME one a bad signature gets:
+        // "not configured" here means no user on this deployment has an
+        // enabled jira-connector install with a webhook secret, and
+        // telling an unauthenticated prober that is a configuration
+        // oracle. Operators read the reason out of the logs.
         if (resolution.status === 'not-configured') {
-            throw new UnauthorizedException('Jira events receiver is not configured');
+            throw new UnauthorizedException(INVALID_JIRA_SIGNATURE);
         }
         // Unknown/ambiguous site → clean no-op. The bridge already logged
         // the refusal; 200 so Jira does not retry a delivery we will never
@@ -102,7 +115,7 @@ export class JiraEventsController {
             webhookSecret: binding.webhookSecret,
         });
         if (!verdict.valid) {
-            throw new UnauthorizedException('Invalid Jira webhook signature');
+            throw new UnauthorizedException(INVALID_JIRA_SIGNATURE);
         }
 
         // Verified — persist the site→user binding so subsequent

--- a/apps/api/src/ingest/jira/jira-issue-bridge.service.spec.ts
+++ b/apps/api/src/ingest/jira/jira-issue-bridge.service.spec.ts
@@ -136,6 +136,14 @@ describe('JiraIssueBridgeService', () => {
                 bindings.set(data.externalWorkspaceId, { userId: data.userId });
                 return data;
             }),
+            recordIfAbsent: jest.fn(
+                async (data: { externalWorkspaceId: string; userId: string }) => {
+                    const held = bindings.get(data.externalWorkspaceId);
+                    if (held) return { ...data, userId: held.userId };
+                    bindings.set(data.externalWorkspaceId, { userId: data.userId });
+                    return data;
+                },
+            ),
         };
         const service = new JiraIssueBridgeService(
             userPluginRepository as never,
@@ -335,6 +343,83 @@ describe('JiraIssueBridgeService', () => {
                     workspace: extractJiraSiteRef(issueBody()),
                 }),
             ).resolves.toBeUndefined();
+        });
+
+        /**
+         * `site:<host>` comes out of the UNVERIFIED body
+         * (`extractJiraSiteRef`), and on the `signature` /
+         * `single-install` paths the HMAC proves only that the sender
+         * knows THEIR OWN secret. Any tenant with a jira-connector
+         * install could therefore sign a body whose `issue.self` names
+         * somebody else's Atlassian site and take that site's binding —
+         * after which the real owner's genuine deliveries were verified
+         * against the SQUATTER's secret, failed, and 401'd forever with
+         * no path to evict the row.
+         *
+         * `site-match` is the one path corroborated by platform state
+         * (the candidate's own install declares that host), so it is the
+         * only one allowed to re-point.
+         */
+        it('CLAIMS insert-only on a signature match, and never takes a held site', async () => {
+            const { service, installBindings } = createService([ACME]);
+            const workspace = extractJiraSiteRef(issueBody());
+
+            await service.recordBinding({
+                userId: 'squatter',
+                webhookSecret: 'squatter-secret',
+                matchedBy: 'signature',
+                workspace,
+            });
+            expect(installBindings.recordIfAbsent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    externalWorkspaceId: 'site:acme.atlassian.net',
+                    userId: 'squatter',
+                }),
+            );
+            expect(installBindings.record).not.toHaveBeenCalled();
+
+            // The victim's own site-match write is the one that may
+            // re-point; a second squat attempt cannot.
+            installBindings.recordIfAbsent.mockClear();
+            await service.recordBinding({
+                userId: 'thief',
+                webhookSecret: 'thief-secret',
+                matchedBy: 'single-install',
+                workspace,
+            });
+            expect(installBindings.record).not.toHaveBeenCalled();
+        });
+    });
+
+    /**
+     * A stored `site:<host>` row is a weaker claim than a live HMAC — see
+     * `recordBinding` above. A squatted row used to resolve every
+     * delivery for that site to the squatter, whose secret then failed
+     * verification, so the real owner could never turn intake on.
+     */
+    describe('resolveBinding: the signature outranks a stored binding', () => {
+        it('falls through to the site-host match when the bound install cannot verify', async () => {
+            const { service, installBindings } = createService([
+                { userId: 'squatter', settings: { webhookSecret: 'squatter-secret' } },
+                {
+                    userId: 'victim',
+                    settings: {
+                        webhookSecret: 'victim-secret',
+                        baseUrl: 'https://acme.atlassian.net',
+                    },
+                },
+            ]);
+            installBindings.findByWorkspace.mockResolvedValue({ userId: 'squatter' });
+
+            const resolution = await service.resolveBinding({
+                workspace: extractJiraSiteRef(issueBody()),
+                verifySignature: (secret: string) => secret === 'victim-secret',
+            });
+
+            expect(resolution).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'victim' },
+            });
         });
     });
 

--- a/apps/api/src/ingest/jira/jira-issue-bridge.service.ts
+++ b/apps/api/src/ingest/jira/jira-issue-bridge.service.ts
@@ -5,6 +5,7 @@ import {
     EventIngestService,
     IngestInstallBindingRepository,
     type IngestResult,
+    type RecordIngestBindingData,
 } from '@ever-works/agent/ingest';
 import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/plugins';
 import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
@@ -266,10 +267,24 @@ export class JiraIssueBridgeService {
             if (!bound) continue;
             const owner = candidates.find((c) => c.userId === bound.userId);
             if (owner) {
-                return {
-                    status: 'resolved',
-                    binding: { ...owner, matchedBy: 'binding', workspace },
-                };
+                // The binding names an owner; the SIGNATURE decides whether
+                // it is the owner of THIS delivery. `site:<host>` keys are
+                // written from an unverified body (see `recordBinding`), so
+                // a tenant can squat a Jira site they do not hold — and a
+                // squatted row would 401 the real owner's every delivery
+                // forever, with no path to evict it. If the bound install's
+                // secret does not verify this delivery, fall through to the
+                // site-host and signature steps below.
+                if (!lookup.verifySignature || lookup.verifySignature(owner.webhookSecret)) {
+                    return {
+                        status: 'resolved',
+                        binding: { ...owner, matchedBy: 'binding', workspace },
+                    };
+                }
+                this.logger.warn(
+                    `Jira delivery for ${key} does not verify against the bound install's secret; falling through to site/signature resolution`,
+                );
+                break;
             }
             // The bound install was removed or lost its webhook secret.
             // Attributing its events to ANOTHER user is exactly the defect
@@ -339,18 +354,43 @@ export class JiraIssueBridgeService {
      * Persist the site→user binding after a delivery has passed
      * signature verification. Best-effort: a failure here must never
      * break a webhook that has already been verified and handled.
+     *
+     * ## What the delivery actually proved
+     *
+     * `IngestInstallBindingRepository.record` RE-POINTS an existing row
+     * and requires proven OWNERSHIP of the workspace, not merely an
+     * authentic sender. Only `site-match` clears that bar here: the
+     * candidate's own install settings declare the site host, so platform
+     * state — not the body — corroborated the key.
+     *
+     * `single-install` and `signature` prove only that the sender knows
+     * THEIR OWN webhook secret, while `site:<host>` came out of the
+     * unverified body (`extractJiraSiteRef`). Any tenant with a
+     * `jira-connector` install can sign a body whose `issue.self` names
+     * somebody else's Atlassian site, so those paths go through
+     * `recordIfAbsent`: a key nobody holds may be claimed, a key somebody
+     * holds is never taken from them.
      */
     async recordBinding(binding: JiraEventsBinding): Promise<void> {
         const key = binding.workspace?.keys[0];
         if (binding.matchedBy === 'binding' || !key) return;
+        const write: RecordIngestBindingData = {
+            provider: JIRA_BINDING_PROVIDER,
+            externalWorkspaceId: key,
+            userId: binding.userId,
+            pluginId: JIRA_CONNECTOR_PLUGIN_ID,
+            externalWorkspaceName: binding.workspace?.label ?? null,
+        };
         try {
-            await this.installBindings.record({
-                provider: JIRA_BINDING_PROVIDER,
-                externalWorkspaceId: key,
-                userId: binding.userId,
-                pluginId: JIRA_CONNECTOR_PLUGIN_ID,
-                externalWorkspaceName: binding.workspace?.label ?? null,
-            });
+            const proven = binding.matchedBy === 'site-match';
+            const recorded = proven
+                ? await this.installBindings.record(write)
+                : await this.installBindings.recordIfAbsent(write);
+            if (!proven && recorded && recorded.userId !== binding.userId) {
+                this.logger.warn(
+                    `Jira site ${key} is already bound to another account; leaving the existing binding in place`,
+                );
+            }
         } catch (error) {
             this.logger.warn(
                 `Failed to record Jira site binding for ${key}: ${

--- a/apps/api/src/ingest/sentry/sentry-incident.source.spec.ts
+++ b/apps/api/src/ingest/sentry/sentry-incident.source.spec.ts
@@ -83,7 +83,10 @@ describe('SentryIncidentSource', () => {
             expect(envelope).toMatchObject({
                 source: 'sentry',
                 kind: INCIDENT_EVENT_KIND,
-                sourceEventId: 'event_alert:4501:e1f2a3b4c5d6',
+                // Keyed on the issue and the 5-minute bucket its
+                // `datetime` falls in, NOT on the individual `event_id` —
+                // see the coalescing test below.
+                sourceEventId: 'event_alert:4501:2026-09-01T12:00:00.000Z',
                 occurredAt: '2026-09-01T12:00:00.000Z',
                 actor: { name: 'Sentry' },
                 subject: {
@@ -127,20 +130,53 @@ describe('SentryIncidentSource', () => {
             });
         });
 
-        it('keys the envelope on the issue id so every alert for one grouped issue is a revision of ONE incident', () => {
+        /**
+         * This used to assert the opposite — one envelope per alerting
+         * EVENT (`event_alert:<issue>:<event_id>`). That is what turned a
+         * flapping Sentry issue into thousands of `ingested_events` rows:
+         * the drain is a five-minute cron with a fifty-row batch, so two
+         * thousand alerts are hours of backlog IN FRONT of every other
+         * tenant's genuinely new work, and each row also costs an
+         * Activity row, a Memory write, a triage comment and a fire of
+         * every `{kind:'incident'}` trigger.
+         *
+         * A Sentry issue IS one fingerprint. Alerts inside one bucket are
+         * the same revision of it, so they collapse; a later alert still
+         * opens a new bucket and lands as a new revision.
+         */
+        it('collapses alerts for one issue inside a bucket, and takes a NEW revision after it', () => {
             const first = source.normalize({
                 resource: 'event_alert',
                 action: 'triggered',
                 body: eventAlertBody(),
             });
-            const second = source.normalize({
+            const sameBucket = source.normalize({
                 resource: 'event_alert',
                 action: 'triggered',
-                body: eventAlertBody({ event_id: 'ffffffffffff', release: 'ever-works@1.43.0' }),
+                body: eventAlertBody({
+                    event_id: 'ffffffffffff',
+                    datetime: '2026-09-01T12:04:59.000Z',
+                    release: 'ever-works@1.43.0',
+                }),
             });
-            expect(second?.subject?.externalId).toBe(first?.subject?.externalId);
-            expect(second?.sourceEventId).not.toBe(first?.sourceEventId);
-            expect(second?.payload.release).toBe('ever-works@1.43.0');
+            const laterBucket = source.normalize({
+                resource: 'event_alert',
+                action: 'triggered',
+                body: eventAlertBody({
+                    event_id: 'aaaaaaaaaaaa',
+                    datetime: '2026-09-01T12:05:00.000Z',
+                }),
+            });
+
+            expect(sameBucket?.subject?.externalId).toBe(first?.subject?.externalId);
+            // Different `event_id`, same issue, same bucket → the spine's
+            // (source, sourceEventId) dedupe writes exactly one row.
+            expect(sameBucket?.sourceEventId).toBe(first?.sourceEventId);
+            // The facts still travel: the winner of a bucket carries the
+            // latest release it saw.
+            expect(sameBucket?.payload.release).toBe('ever-works@1.43.0');
+            // A genuinely later alert is a new revision, not swallowed.
+            expect(laterBucket?.sourceEventId).not.toBe(first?.sourceEventId);
         });
 
         it('is deterministic for an exact redelivery', () => {
@@ -148,6 +184,56 @@ describe('SentryIncidentSource', () => {
             expect(source.normalize(input)?.sourceEventId).toBe(
                 source.normalize(input)?.sourceEventId,
             );
+        });
+
+        /**
+         * The documented replay control on this receiver is the spine's
+         * `(source, sourceEventId)` dedupe — Sentry's `Sentry-Hook-Timestamp`
+         * is not part of the signed material, so nothing else bounds a
+         * replay. That control only holds if the identity is a function
+         * of the DELIVERY, never of the clock: `isoOrNow()` stamped a
+         * fresh `now` whenever the vendor timestamp was absent, so a
+         * captured, still-signed delivery replayed N times minted N rows.
+         */
+        it('does not put the CLOCK in the dedupe identity when the vendor omits its timestamp', () => {
+            const noTimestamp = {
+                resource: 'event_alert',
+                action: 'triggered',
+                body: eventAlertBody({ datetime: undefined, timestamp: undefined }),
+            };
+            jest.useFakeTimers().setSystemTime(new Date('2026-09-01T12:00:00.000Z'));
+            const first = source.normalize(noTimestamp)?.sourceEventId;
+            // A replay a full minute later — under a `now()` fallback this
+            // is a brand new identity and a brand new row.
+            jest.setSystemTime(new Date('2026-09-01T12:01:00.000Z'));
+            const replay = source.normalize(noTimestamp)?.sourceEventId;
+            jest.useRealTimers();
+            expect(replay).toBe(first);
+        });
+    });
+
+    describe('issue resource replay', () => {
+        it('keeps an unstamped issue delivery on ONE dedupe identity across replays', () => {
+            const unstamped = {
+                resource: 'issue',
+                action: 'unresolved',
+                body: issueBody('unresolved', { lastSeen: undefined, firstSeen: undefined }),
+            };
+            jest.useFakeTimers().setSystemTime(new Date('2026-09-01T12:00:00.000Z'));
+            const first = source.normalize(unstamped)?.sourceEventId;
+            jest.setSystemTime(new Date('2026-09-01T12:01:00.000Z'));
+            const replay = source.normalize(unstamped)?.sourceEventId;
+            jest.useRealTimers();
+            expect(replay).toBe(first);
+        });
+
+        it('still keys a stamped transition on the vendor timestamp, exactly', () => {
+            const envelope = source.normalize({
+                resource: 'issue',
+                action: 'unresolved',
+                body: issueBody('unresolved'),
+            });
+            expect(envelope?.sourceEventId).toBe('issue:4501:unresolved:2026-09-01T12:00:00.000Z');
         });
 
         it('refuses an alert without an issue id', () => {

--- a/apps/api/src/ingest/sentry/sentry-incident.source.ts
+++ b/apps/api/src/ingest/sentry/sentry-incident.source.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
-import { httpsUrl, isoOrNow, nonEmpty } from '../ingest-envelope.util';
+import { httpsUrl, nonEmpty } from '../ingest-envelope.util';
 import {
     buildIncidentEnvelope,
     type IncidentPayload,
@@ -25,6 +25,24 @@ export const SENTRY_EVENT_SOURCE = 'sentry';
  */
 export const SENTRY_INCIDENT_RESOURCES: readonly string[] = ['event_alert', 'issue'];
 
+/**
+ * Width of the bucket that repeated `event_alert` deliveries for ONE
+ * Sentry issue collapse into, in milliseconds.
+ *
+ * A Sentry issue that is flapping alerts once per occurrence. Keying the
+ * envelope on the individual `event_id` (as this source used to) meant
+ * one `ingested_events` row per alert — 2000 alerts in a minute became
+ * 2000 rows, all in front of every other tenant in the drain's global
+ * `occurredAt ASC` queue, each one an Activity row, a Memory write, a
+ * triage comment and a fire of every `{kind:'incident'}` trigger. The
+ * issue is the unit of work (that is what a Sentry issue IS — one
+ * fingerprint), so alerts inside one bucket are the same revision and
+ * the spine's `(source, sourceEventId)` dedupe collapses them to a
+ * single row. Five minutes caps one flapping issue at 12 rows an hour
+ * while a genuinely later alert still lands as a new revision.
+ */
+export const SENTRY_EVENT_ALERT_BUCKET_MS = 5 * 60_000;
+
 /** `issue` resource actions worth a revision of the incident. */
 export const SENTRY_ISSUE_ACTIONS: readonly string[] = [
     'created',
@@ -35,6 +53,54 @@ export const SENTRY_ISSUE_ACTIONS: readonly string[] = [
     'archived',
     'unarchived',
 ];
+
+/**
+ * The start of the `widthMs` bucket `value` falls in, as an ISO string.
+ *
+ * Used to build a dedupe identity that is a function of WHEN something
+ * happened rather than of which individual delivery carried it. A body
+ * with no usable vendor timestamp buckets the receive time instead of
+ * being stamped with the raw clock: a replayed delivery then collapses
+ * into the bucket it is replayed in rather than minting a fresh row per
+ * replay, and a genuinely later alert still opens a new bucket.
+ */
+function bucketOf(value: string | number | null | undefined, widthMs: number): string {
+    const ms = epochMsOf(value) ?? Date.now();
+    return new Date(Math.floor(ms / widthMs) * widthMs).toISOString();
+}
+
+/**
+ * Epoch milliseconds for a vendor timestamp, or `undefined`.
+ *
+ * Mirrors `isoOrNow`'s parsing (Sentry reports unix epochs in SECONDS on
+ * some resources and ISO strings on others) without its `now()`
+ * fallback — the caller decides what "no timestamp" means.
+ */
+function epochMsOf(value: string | number | null | undefined): number | undefined {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value < 1e12 ? value * 1000 : value;
+    }
+    if (typeof value === 'string' && value.length > 0) {
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.getTime())) return parsed.getTime();
+    }
+    return undefined;
+}
+
+/**
+ * The vendor's own revision timestamp, or a bounded stand-in.
+ *
+ * Never `now()`: this value goes into `sourceEventId`, which IS the
+ * replay control. When the vendor stamps the revision the identity is
+ * exact (a redelivery of the same transition dedupes to zero); when it
+ * does not, the identity degrades to a 5-minute bucket, which is
+ * bounded, rather than to the clock, which is not.
+ */
+function revisionStampOf(value: string | number | null | undefined): string {
+    const ms = epochMsOf(value);
+    if (ms !== undefined) return new Date(ms).toISOString();
+    return bucketOf(undefined, SENTRY_EVENT_ALERT_BUCKET_MS);
+}
 
 /** The subset of a Sentry integration webhook body the source reads. */
 export interface SentryWebhookBody {
@@ -207,9 +273,12 @@ export class SentryIncidentSource implements IncidentSource<SentryIncidentInput>
         const occurredAt = event.datetime ?? event.timestamp;
         return buildIncidentEnvelope({
             source: this.source,
-            // One envelope per alerting EVENT: a repeated alert for the same
-            // issue is a new revision; an exact redelivery dedupes to zero.
-            sourceEventId: `event_alert:${issueId}:${eventId ?? isoOrNow(occurredAt)}`,
+            // One envelope per ISSUE per bucket, not per alerting event:
+            // see {@link SENTRY_EVENT_ALERT_BUCKET_MS}. The bucket is
+            // derived from the vendor timestamp when there is one, so a
+            // replayed delivery lands in the bucket it originally
+            // occurred in and dedupes instead of minting a new row.
+            sourceEventId: `event_alert:${issueId}:${bucketOf(occurredAt, SENTRY_EVENT_ALERT_BUCKET_MS)}`,
             occurredAt,
             ...(actor ? { actor } : {}),
             ...(issueUrl ? { sourceUrl: issueUrl } : {}),
@@ -270,7 +339,15 @@ export class SentryIncidentSource implements IncidentSource<SentryIncidentInput>
             // Revision = lifecycle action + when the issue was last seen: a
             // retried delivery of the same transition dedupes, a later
             // transition (resolved → unresolved) lands as a new event.
-            sourceEventId: `issue:${issueId}:${action}:${isoOrNow(lastSeen ?? issue.firstSeen)}`,
+            //
+            // `revisionStampOf` — NOT `isoOrNow` — because a body with
+            // neither `lastSeen` nor `firstSeen` would otherwise get
+            // `now()` stamped into its dedupe identity, and a captured,
+            // still-signed delivery replayed N times would mint N
+            // distinct rows. The whole documented replay control on this
+            // receiver is the spine's `(source, sourceEventId)` dedupe,
+            // so that identity must not contain the clock.
+            sourceEventId: `issue:${issueId}:${action}:${revisionStampOf(lastSeen ?? issue.firstSeen)}`,
             occurredAt: lastSeen ?? issue.firstSeen,
             ...(actor ? { actor } : {}),
             ...(url ? { sourceUrl: url } : {}),

--- a/apps/api/src/ingest/sentry/sentry-webhook.controller.spec.ts
+++ b/apps/api/src/ingest/sentry/sentry-webhook.controller.spec.ts
@@ -159,10 +159,30 @@ describe('SentryWebhookController (POST /api/ingest/sentry/events)', () => {
         await expect(controller.receiveEvents(req as never, signature, 'issue')).rejects.toThrow(
             UnauthorizedException,
         );
+        // The 401 body is INDISTINGUISHABLE from the bad-signature one.
+        // This used to assert 'not configured', which told an
+        // unauthenticated prober whether SENTRY_WEBHOOK_CLIENT_SECRET is
+        // set on this deployment — a free map of which integrations are
+        // live, before they hold any credential.
         await expect(controller.receiveEvents(req as never, signature, 'issue')).rejects.toThrow(
-            'not configured',
+            'Invalid Sentry webhook signature',
         );
         expect(eventIngestService.ingest).not.toHaveBeenCalled();
+    });
+
+    it('answers an unconfigured deployment and a bad signature with the SAME 401 body', async () => {
+        const { controller } = createController();
+        const { req, signature } = signedRequest(issueBody());
+        const badSignature = await controller
+            .receiveEvents(req as never, 'deadbeef', 'issue')
+            .catch((error: Error) => error.message);
+
+        delete process.env.SENTRY_WEBHOOK_CLIENT_SECRET;
+        const unconfigured = await controller
+            .receiveEvents(req as never, signature, 'issue')
+            .catch((error: Error) => error.message);
+
+        expect(unconfigured).toBe(badSignature);
     });
 
     it('rejects a missing signature with 401 and files nothing', async () => {
@@ -199,6 +219,52 @@ describe('SentryWebhookController (POST /api/ingest/sentry/events)', () => {
             controller.receiveEvents(req as never, `sha256=${signature}`, 'issue'),
         ).rejects.toThrow(UnauthorizedException);
         expect(eventIngestService.ingest).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The delivered bytes are the only thing Sentry signed. Verifying a
+     * RE-SERIALIZED body would pass here by luck (`JSON.stringify` of a
+     * body Jest itself built) and fail against real Sentry traffic, whose
+     * whitespace and key order are its own — so both directions are
+     * pinned: the raw bytes verify, and a digest of the re-serialization
+     * does not.
+     */
+    describe('verification is against the raw delivered bytes', () => {
+        /** Same document, different bytes: pretty-printed with 2-space indent. */
+        const prettyDelivery = () => {
+            const body = issueBody();
+            const rawBody = JSON.stringify(body, null, 2);
+            return { body, rawBody };
+        };
+
+        it('accepts a delivery whose raw bytes are not what JSON.stringify(body) would produce', async () => {
+            const { controller, eventIngestService } = createController();
+            const { body, rawBody } = prettyDelivery();
+            expect(rawBody).not.toBe(JSON.stringify(body));
+
+            await expect(
+                controller.receiveEvents(
+                    { body, rawBody } as never,
+                    computeSentrySignature(CLIENT_SECRET, rawBody),
+                    'issue',
+                ),
+            ).resolves.toEqual({ ok: true });
+            expect(eventIngestService.ingest).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects a digest computed over the re-serialized object instead of the raw bytes', async () => {
+            const { controller, eventIngestService } = createController();
+            const { body, rawBody } = prettyDelivery();
+
+            await expect(
+                controller.receiveEvents(
+                    { body, rawBody } as never,
+                    computeSentrySignature(CLIENT_SECRET, JSON.stringify(body)),
+                    'issue',
+                ),
+            ).rejects.toThrow(UnauthorizedException);
+            expect(eventIngestService.ingest).not.toHaveBeenCalled();
+        });
     });
 
     it('ingests a verified issue delivery as an incident for the account that claimed the installation', async () => {
@@ -346,6 +412,39 @@ describe('SentryWebhookController (POST /api/ingest/sentry/events)', () => {
             await expect(
                 controller.receiveEvents(req as never, undefined, 'installation'),
             ).rejects.toThrow(UnauthorizedException);
+            expect(bindings.has(`sentry|installation:${CLAIMED_UUID}`)).toBe(true);
+        });
+
+        /**
+         * Sentry signs with ONE platform-level client secret, so a
+         * verified delivery proves it came from Sentry and never WHOSE it
+         * is — the claim table is the only thing between a delivery and a
+         * tenant's data. The installation branch used to run BEFORE
+         * `resolveOwner` was ever called, so one signed request could
+         * drop a binding whose owner had not been looked up at all.
+         * Owner resolution now runs first, for every resource.
+         */
+        it('resolves the owner BEFORE acting on an installation delivery', async () => {
+            const { controller, bindingRepo } = createController();
+            const gone = signedRequest(installationBody('deleted'));
+
+            await controller.receiveEvents(gone.req as never, gone.signature, 'installation');
+
+            const lookupCall = bindingRepo.findByWorkspace.mock.invocationCallOrder[0];
+            const removeCall = bindingRepo.remove.mock.invocationCallOrder[0];
+            expect(lookupCall).toBeLessThan(removeCall);
+        });
+
+        it('an installation.deleted for an UNCLAIMED uuid touches nothing', async () => {
+            const { controller, bindingRepo, bindings } = createController();
+            const gone = signedRequest(installationBody('deleted', UNCLAIMED_UUID));
+
+            await expect(
+                controller.receiveEvents(gone.req as never, gone.signature, 'installation'),
+            ).resolves.toEqual({ ok: true });
+
+            expect(bindingRepo.remove).not.toHaveBeenCalled();
+            // The claimed binding next door is untouched.
             expect(bindings.has(`sentry|installation:${CLAIMED_UUID}`)).toBe(true);
         });
 

--- a/apps/api/src/ingest/sentry/sentry-webhook.controller.ts
+++ b/apps/api/src/ingest/sentry/sentry-webhook.controller.ts
@@ -23,6 +23,13 @@ import { verifySentrySignature } from './sentry-signature.util';
 const INSTALLATION_RESOURCE = 'installation';
 
 /**
+ * The ONE 401 body this receiver ever returns — an unconfigured
+ * deployment and a bad signature are indistinguishable from outside, so
+ * probing cannot map which integrations are live.
+ */
+export const INVALID_SENTRY_SIGNATURE = 'Invalid Sentry webhook signature';
+
+/**
  * Sentry integration webhook receiver (self-build program note §6, R23)
  * — the platform-side endpoint the Sentry internal integration's webhook
  * URL points at.
@@ -92,14 +99,23 @@ export class SentryWebhookController {
         }
 
         // Fail-closed: no client secret configured → reject everything.
+        //
+        // The 401 body is the SAME one a bad signature gets. Answering
+        // 'not configured' when `SENTRY_WEBHOOK_CLIENT_SECRET` is unset
+        // and 'invalid signature' when it is set hands an unauthenticated
+        // prober a map of which integrations this deployment has live.
+        // Operators read the reason out of the logs instead.
         const clientSecret = config.sentryIntake.webhookClientSecret();
         if (!clientSecret) {
-            throw new UnauthorizedException('Sentry events receiver is not configured');
+            this.logger.warn(
+                'Rejecting a Sentry delivery: SENTRY_WEBHOOK_CLIENT_SECRET is not configured',
+            );
+            throw new UnauthorizedException(INVALID_SENTRY_SIGNATURE);
         }
 
         const verdict = verifySentrySignature({ rawBody: req.rawBody, signature, clientSecret });
         if (!verdict.valid) {
-            throw new UnauthorizedException('Invalid Sentry webhook signature');
+            throw new UnauthorizedException(INVALID_SENTRY_SIGNATURE);
         }
 
         // ---- Verified from here on -----------------------------------
@@ -107,16 +123,29 @@ export class SentryWebhookController {
         const action = nonEmpty(body.action);
         const installationUuid = body.data?.installation?.uuid ?? body.installation?.uuid;
 
+        // Owner resolution runs FIRST, for every resource including
+        // `installation`. Sentry signs with one platform-level client
+        // secret, so a verified delivery proves it came from Sentry and
+        // never WHOSE it is — the only thing standing between a delivery
+        // and a tenant's data is the claim table. Acting on an
+        // `installation.deleted` before consulting it (as this receiver
+        // used to) let one signed request drop a binding whose owner had
+        // never been looked up, silently stopping that account's incident
+        // intake and freeing the uuid for the next first-claim race.
+        const owner = await this.bindings.resolveOwner(installationUuid);
+
         if (resource === INSTALLATION_RESOURCE) {
-            if (action === 'deleted') {
-                await this.bindings.onInstallationDeleted(installationUuid);
+            // A lifecycle delivery for a uuid nobody has claimed has
+            // nothing to act on; one for a claimed uuid removes exactly
+            // that owner's own binding.
+            if (action === 'deleted' && owner) {
+                await this.bindings.onInstallationDeleted(owner.installationUuid);
             }
             // `created` carries no owner we could trust — the owner claims
             // the uuid through the authenticated endpoint instead.
             return { ok: true };
         }
 
-        const owner = await this.bindings.resolveOwner(installationUuid);
         if (!owner) {
             // Only a PREFIX of the uuid: on this receiver the installation
             // uuid is the whole claim credential (`POST /bindings` binds

--- a/apps/api/src/ingest/triage/triage-task-body.spec.ts
+++ b/apps/api/src/ingest/triage/triage-task-body.spec.ts
@@ -6,11 +6,13 @@ import {
     TRIAGE_SOURCE_TEXT_MAX_CHARS,
     TRIAGE_TASK_TITLE_MAX_CHARS,
     renderTriageBody,
+    renderTriageSupersededNote,
     renderTriageTitle,
     renderTriageUpdate,
     triageExternalKeyOf,
     triageFactsOf,
     triagePriorityOf,
+    triageRegressionOf,
 } from './triage-task-body';
 
 const storedEvent = (overrides: Partial<IngestedEvent> = {}): IngestedEvent =>
@@ -380,6 +382,203 @@ describe('triage-task-body (pure rendering)', () => {
             });
             expect(comment).not.toContain('- Title:');
             expect(comment).toContain('**GitHub issue update** — opened');
+        });
+
+        it('calls out a regression on the comment, whatever the Task’s state', () => {
+            const reopened = storedEvent({
+                payload: { ...storedEvent().payload, action: 'reopened', state: 'open' },
+            });
+            expect(renderTriageUpdate(reopened)).toContain(
+                '- **Regression** — the GitHub issue was reopened.',
+            );
+        });
+    });
+
+    /**
+     * Regression detection is the ONE thing that lets dedup yield, so it
+     * is pinned per vendor and in both directions: the signals that must
+     * fire, and — more important — the chatty ones that must NOT, since
+     * a false positive here is what turns 2000 Sentry alerts into 2000
+     * Tasks.
+     */
+    describe('triageRegressionOf', () => {
+        const github = (action: string) =>
+            storedEvent({ payload: { ...storedEvent().payload, action } });
+
+        const incident = (payload: Record<string, unknown>) =>
+            storedEvent({
+                source: 'sentry',
+                kind: 'incident',
+                subjectExternalId: '4501',
+                payload: {
+                    provider: 'sentry',
+                    externalId: '4501',
+                    title: 'TypeError',
+                    resource: 'issue',
+                    issueId: '4501',
+                    ...payload,
+                },
+            });
+
+        const jiraTransition = (payload: Record<string, unknown>) =>
+            storedEvent({
+                source: 'jira-connector',
+                kind: 'jira.issue',
+                subjectExternalId: '10001',
+                payload: {
+                    issueId: '10001',
+                    issueKey: 'ENG-42',
+                    summary: 'Login button does nothing on Safari',
+                    ...payload,
+                },
+            });
+
+        it('reads a reopened GitHub issue as a regression', () => {
+            expect(triageRegressionOf(github('reopened'))).toEqual({
+                signal: 'github.reopened',
+                summary: 'the GitHub issue was reopened',
+            });
+        });
+
+        it.each(['opened', 'closed', 'labeled', 'assigned', 'edited'])(
+            'does not read a GitHub %s as a regression',
+            (action) => {
+                expect(triageRegressionOf(github(action))).toBeNull();
+            },
+        );
+
+        it.each([
+            ['unresolved', 'the Sentry issue regressed (resolved → unresolved)'],
+            ['unarchived', 'the Sentry issue was unarchived'],
+        ])('reads a Sentry %s as a regression', (action, summary) => {
+            expect(triageRegressionOf(incident({ action }))).toEqual({
+                signal: `sentry.${action}`,
+                summary,
+            });
+        });
+
+        it.each(['created', 'resolved', 'ignored', 'archived', 'assigned'])(
+            'does not read a Sentry %s as a regression',
+            (action) => {
+                expect(triageRegressionOf(incident({ action }))).toBeNull();
+            },
+        );
+
+        it('never reads a repeated event_alert as a regression — that is how 2000 alerts stay one Task', () => {
+            expect(
+                triageRegressionOf(
+                    incident({ resource: 'event_alert', action: 'triggered', eventId: 'evt-9' }),
+                ),
+            ).toBeNull();
+        });
+
+        it.each(['reopened', 'reintroduced', 'auto_reopened'])(
+            'reads a Dependabot %s as a regression',
+            (action) => {
+                expect(
+                    triageRegressionOf(incident({ provider: 'dependabot', action })),
+                ).toMatchObject({ signal: `dependabot.${action}` });
+            },
+        );
+
+        it.each(['created', 'fixed', 'dismissed', 'auto_dismissed'])(
+            'does not read a Dependabot %s as a regression',
+            (action) => {
+                expect(triageRegressionOf(incident({ provider: 'dependabot', action }))).toBeNull();
+            },
+        );
+
+        it('reads a Jira transition back out of a done status as a regression', () => {
+            expect(
+                triageRegressionOf(
+                    jiraTransition({
+                        changeType: 'transitioned',
+                        statusFrom: 'Done',
+                        statusTo: 'In Progress',
+                    }),
+                ),
+            ).toEqual({
+                signal: 'jira.transitioned',
+                summary: 'the Jira issue moved back out of Done into In Progress',
+            });
+        });
+
+        it.each([
+            ['To Do', 'In Progress'],
+            ['In Progress', 'Done'],
+            ['Done', 'Closed'],
+            ['Resolved', "Won't Do"],
+        ])('does not read the Jira transition %s → %s as a regression', (statusFrom, statusTo) => {
+            expect(
+                triageRegressionOf(
+                    jiraTransition({ changeType: 'transitioned', statusFrom, statusTo }),
+                ),
+            ).toBeNull();
+        });
+
+        it('needs an actual transition — a plain Jira update is never a regression', () => {
+            expect(
+                triageRegressionOf(jiraTransition({ changeType: 'updated', status: 'To Do' })),
+            ).toBeNull();
+        });
+
+        it('ignores kinds it does not know', () => {
+            expect(
+                triageRegressionOf(
+                    storedEvent({ kind: 'github.pr', payload: { action: 'reopened' } }),
+                ),
+            ).toBeNull();
+        });
+    });
+
+    describe('regression rendering', () => {
+        const regression = {
+            signal: 'github.reopened',
+            summary: 'the GitHub issue was reopened',
+        } as const;
+        const reopened = storedEvent({
+            payload: { ...storedEvent().payload, action: 'reopened', state: 'open' },
+        });
+
+        it('marks the re-filed Task title so the board does not show two identical rows', () => {
+            expect(renderTriageTitle(reopened, true)).toBe(
+                '[octo/site#42] Regression: Login button does nothing on Safari',
+            );
+            expect(renderTriageTitle(reopened)).toBe(
+                '[octo/site#42] Login button does nothing on Safari',
+            );
+        });
+
+        it('opens the re-filed body by naming the reason, the superseded Task and the count', () => {
+            const body = renderTriageBody(reopened, {
+                regression,
+                supersedesTaskRef: 'T-14',
+                regressionCount: 2,
+            });
+            expect(body).toContain('**Filed automatically as a regression**');
+            expect(body).toContain('the GitHub issue was reopened');
+            expect(body).toContain('`T-14`');
+            expect(body).toContain('This is re-opening #2');
+            // Still the full facts table — a regression Task is not a stub.
+            expect(body).toContain('| Link | https://github.com/octo/site/issues/42 |');
+        });
+
+        it('leaves the ordinary body untouched when there is no regression context', () => {
+            const body = renderTriageBody(reopened);
+            expect(body).toContain('**Filed automatically** from a GitHub issue');
+            expect(body).not.toContain('as a regression');
+        });
+
+        it('leaves a two-way trail: the closed Task names its replacement', () => {
+            const note = renderTriageSupersededNote(reopened, {
+                regression,
+                newTaskRef: 'T-15',
+            });
+            expect(note).toContain('**GitHub issue regressed**');
+            expect(note).toContain('after this Task was closed');
+            expect(note).toContain('`T-15`');
+            expect(note).toContain('`octo/site#42`');
+            expect(note).toContain('_Seen 2026-09-01T09:00:00.000Z · ingested event row-1_');
         });
     });
 });

--- a/apps/api/src/ingest/triage/triage-task-body.ts
+++ b/apps/api/src/ingest/triage/triage-task-body.ts
@@ -37,8 +37,28 @@ export const TRIAGE_SOURCE_TEXT_MAX_CHARS = 4000;
 export const TRIAGE_CELL_MAX_CHARS = 300;
 /** Board label every triage Task carries. */
 export const TRIAGE_LABEL = 'triage';
+/** Extra label on a Task filed because a closed issue / incident came back. */
+export const TRIAGE_REGRESSION_LABEL = 'regression';
 /** Fence tag for the quoted vendor text. */
 export const TRIAGE_SOURCE_CONTENT_TAG = 'source_content';
+
+/**
+ * Coalescing bucket for REPEAT-ALERT update comments, in milliseconds.
+ *
+ * A Task comment is not free: `TaskChatService.post` writes a
+ * `task_chat_messages` row AND a `TASK_COMMENTED` activity row, on top
+ * of the drain's own ingest activity row and a Memory write (which can
+ * mean a provider embedding call). Commenting on every single repeated
+ * alert therefore turns one flapping issue into thousands of rows and
+ * embedding calls on ONE Task, and the salience filter cannot shed any
+ * of it — it scores `incident` / `alert` / `issue` traffic UP.
+ *
+ * So repeated alerts (and ONLY those — see `isTriageRepeatAlert`) get at
+ * most one comment per bucket. Anything that actually changed — a state
+ * transition, a regression, a new title — comments immediately,
+ * whatever bucket it lands in.
+ */
+export const TRIAGE_UPDATE_BUCKET_MS = 15 * 60_000;
 
 /** Task priority buckets the intake files at (P0 is reserved for humans). */
 export type TriagePriority = 'p1' | 'p2' | 'p3' | 'p4';
@@ -262,10 +282,199 @@ export function triagePriorityOf(level: string | undefined): TriagePriority {
     return 'p3';
 }
 
-/** `[<key>] <title>`, inside the Task title cap. */
-export function renderTriageTitle(event: IngestedEvent): string {
+/* -------------------------------------------------------------------------
+ * Regression detection — the one case where dedup MUST yield.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * `issues` actions that mean "this came back". GitHub has exactly one.
+ */
+export const GITHUB_ISSUE_REGRESSION_ACTIONS: readonly string[] = ['reopened'];
+
+/**
+ * Sentry `issue` lifecycle actions that mean "this came back".
+ * `unresolved` is what Sentry sends for a regression (an event landed in
+ * a release after the issue was marked resolved) AND for a human
+ * un-resolving it; `unarchived` is the same move out of the archive.
+ * An `event_alert` is deliberately NOT a regression signal on its own —
+ * a resolved issue that keeps alerting is a rule firing, not a
+ * regression, and treating it as one is exactly how 2000 alerts become
+ * 2000 Tasks.
+ */
+export const SENTRY_REGRESSION_ACTIONS: readonly string[] = ['unresolved', 'unarchived'];
+
+/** `dependabot_alert` actions that mean the vulnerability is back. */
+export const DEPENDABOT_REGRESSION_ACTIONS: readonly string[] = [
+    'reopened',
+    'reintroduced',
+    'auto_reopened',
+];
+
+/**
+ * Status NAMES Jira workflows use for a finished issue, lower-cased.
+ *
+ * Jira has no `reopened` event: the only regression signal on the wire
+ * is a status transition OUT of a done-ish status. Jira Cloud's webhook
+ * changelog carries the status' display name (`fromString` / `toString`)
+ * and not its status CATEGORY, so this list is the vocabulary check —
+ * deliberately conservative. A custom workflow with a done status that
+ * is not named here simply never re-files (the revision still lands as a
+ * comment on the existing Task); it never mis-fires the other way,
+ * because both halves must agree: out of a name on this list and into a
+ * name that is not.
+ */
+export const JIRA_DONE_STATUS_NAMES: readonly string[] = [
+    'done',
+    'closed',
+    'resolved',
+    'complete',
+    'completed',
+    'cancelled',
+    'canceled',
+    'released',
+    'shipped',
+    'fixed',
+    "won't do",
+    'wont do',
+    "won't fix",
+    'wont fix',
+    'duplicate',
+];
+
+/** A vendor event that says a previously-finished issue / incident is back. */
+export interface TriageRegressionSignal {
+    /** Machine-readable, `<vendor>.<action>` — logged and asserted on. */
+    readonly signal: string;
+    /** One line for the Task body / the comment on the superseded Task. */
+    readonly summary: string;
+}
+
+const isJiraDoneStatus = (value: string | undefined): boolean =>
+    value !== undefined && JIRA_DONE_STATUS_NAMES.includes(value.trim().toLowerCase());
+
+/**
+ * `payload.resource` value Sentry event-alert deliveries carry.
+ *
+ * An event alert says "this error just happened AGAIN"; the issue
+ * lifecycle resource says "somebody or something changed the issue's
+ * state". The two need opposite handling downstream, and this is the one
+ * field that separates them.
+ */
+export const INCIDENT_ALERT_RESOURCE = 'event_alert';
+
+/**
+ * True when the event is a REPEATED OCCURRENCE rather than a state
+ * change — the only intake traffic that can arrive thousands of times
+ * for one unchanged issue.
+ *
+ * Every other intake event (a GitHub issue action, a Jira transition, a
+ * Sentry issue lifecycle action) is materially different from the last
+ * one by construction and is never coalesced.
+ */
+export function isTriageRepeatAlert(event: IngestedEvent): boolean {
+    if (event.kind !== INCIDENT_EVENT_KIND) return false;
+    const payload = (event.payload ?? {}) as Record<string, unknown>;
+    return str(payload.resource) === INCIDENT_ALERT_RESOURCE;
+}
+
+/**
+ * "The issue is STILL HAPPENING" — a regression signal for a Task that
+ * was marked DONE, carried by an ordinary repeated alert.
+ *
+ * {@link triageRegressionOf} is a pure function of a single event, which
+ * makes the vendor's explicit "it came back" signal a ONE-SHOT: if the
+ * filer cannot act on it the moment it arrives (the Work claim was
+ * removed, the body was refused), no later event re-carries it and the
+ * closed Task can never be superseded — the regression is silently
+ * downgraded to a comment on a Task nobody reads, forever.
+ *
+ * This closes that: an error that is still firing after its Task was
+ * marked done IS a regression, whatever Sentry calls the delivery, and
+ * it is re-carried by every subsequent alert, so the moment the Work
+ * becomes available again the work re-opens.
+ *
+ * Deliberately NOT applied to a CANCELLED Task. `done` means "we fixed
+ * it" and a fresh occurrence contradicts that; `cancelled` means "we
+ * decided not to act on this", and re-filing would fight the human who
+ * decided. The caller enforces that half (it knows the Task status).
+ *
+ * Storm-safe by construction: the first alert re-opens work, so the Task
+ * is OPEN again and every following alert is an ordinary comment. Two
+ * thousand alerts still produce one Task.
+ */
+export function triageStillActiveOf(event: IngestedEvent): TriageRegressionSignal | null {
+    if (!isTriageRepeatAlert(event)) return null;
+    const payload = (event.payload ?? {}) as Record<string, unknown>;
+    const provider = str(payload.provider) ?? 'incident';
+    return {
+        signal: `${provider}.still-active`,
+        summary: 'the error is still being reported after the Task was marked done',
+    };
+}
+
+/**
+ * The regression signal an intake event carries, or `null`.
+ *
+ * PURE and per-vendor by design: every provider states "it came back" in
+ * its own vocabulary, and the filer must never guess. Nothing here looks
+ * at the platform Task — whether a regression actually opens NEW work is
+ * the filer's decision (it does so only when the existing Task is
+ * already closed), so this function stays a statement about the vendor
+ * event alone and is testable on its own.
+ */
+export function triageRegressionOf(event: IngestedEvent): TriageRegressionSignal | null {
+    const payload = (event.payload ?? {}) as Record<string, unknown>;
+    const action = str(payload.action);
+
+    if (event.kind === 'github.issue') {
+        if (!action || !GITHUB_ISSUE_REGRESSION_ACTIONS.includes(action)) return null;
+        return { signal: `github.${action}`, summary: `the GitHub issue was ${cell(action)}` };
+    }
+
+    if (event.kind === 'jira.issue') {
+        if (str(payload.changeType) !== 'transitioned') return null;
+        const from = str(payload.statusFrom);
+        const to = str(payload.statusTo);
+        if (!isJiraDoneStatus(from) || isJiraDoneStatus(to)) return null;
+        return {
+            signal: 'jira.transitioned',
+            summary: `the Jira issue moved back out of ${cell(from ?? '?')} into ${cell(to ?? '?')}`,
+        };
+    }
+
+    if (event.kind === INCIDENT_EVENT_KIND) {
+        const provider = str(payload.provider);
+        if (provider === 'sentry') {
+            if (!action || !SENTRY_REGRESSION_ACTIONS.includes(action)) return null;
+            return {
+                signal: `sentry.${action}`,
+                summary:
+                    action === 'unarchived'
+                        ? 'the Sentry issue was unarchived'
+                        : 'the Sentry issue regressed (resolved → unresolved)',
+            };
+        }
+        if (provider === 'dependabot') {
+            if (!action || !DEPENDABOT_REGRESSION_ACTIONS.includes(action)) return null;
+            return {
+                signal: `dependabot.${action}`,
+                summary: `the Dependabot alert was ${cell(action)}`,
+            };
+        }
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * `[<key>] <title>`, inside the Task title cap. A regression re-file adds
+ * a `Regression:` marker so the board does not show two identically
+ * titled Tasks for the same issue.
+ */
+export function renderTriageTitle(event: IngestedEvent, regressed = false): string {
     const facts = triageFactsOf(event);
-    const prefix = `[${facts.externalKey ?? facts.sourceLabel}]`;
+    const prefix = `[${facts.externalKey ?? facts.sourceLabel}]${regressed ? ' Regression:' : ''}`;
     return cap(`${prefix} ${facts.title}`.replace(/\s+/g, ' ').trim(), TRIAGE_TASK_TITLE_MAX_CHARS);
 }
 
@@ -299,12 +508,26 @@ function factRows(facts: TriageFacts): Array<readonly [string, string]> {
     return rows;
 }
 
+/** Why a Task is being filed, when it is not the first sight of the issue. */
+export interface TriageFileContext {
+    /** Set when this Task exists because a closed one's issue came back. */
+    readonly regression?: TriageRegressionSignal;
+    /** Human reference (slug or id) of the closed Task this one supersedes. */
+    readonly supersedesTaskRef?: string;
+    /** How many times this external issue has re-opened work, including now. */
+    readonly regressionCount?: number;
+}
+
 /**
  * The Task body: a facts table (link, culprit, level, last-seen release,
  * environment, project, …), then the vendor text inside the neutralized
  * `<source_content>` fence.
+ *
+ * `context` is set only on a REGRESSION re-file, where the opening
+ * paragraph has to say why a second Task exists for an issue the dedup
+ * key already knew about.
  */
-export function renderTriageBody(event: IngestedEvent): string {
+export function renderTriageBody(event: IngestedEvent, context: TriageFileContext = {}): string {
     const facts = triageFactsOf(event);
     const occurredAt =
         event.occurredAt instanceof Date && !Number.isNaN(event.occurredAt.getTime())
@@ -312,10 +535,24 @@ export function renderTriageBody(event: IngestedEvent): string {
             : undefined;
 
     const blocks: string[] = [];
-    blocks.push(
-        `**Filed automatically** from a ${facts.sourceLabel} by the issue / incident intake. ` +
-            `Later activity on the same ${facts.sourceLabel} lands as comments on this Task — a re-fired webhook, a re-label or a repeated alert never files a second one.`,
-    );
+    if (context.regression) {
+        const nth = context.regressionCount;
+        blocks.push(
+            `**Filed automatically as a regression** — ${context.regression.summary}, ` +
+                `and the previous triage Task${
+                    context.supersedesTaskRef ? ` \`${cell(context.supersedesTaskRef)}\`` : ''
+                } was already closed.` +
+                (typeof nth === 'number' && Number.isFinite(nth)
+                    ? ` This is re-opening #${nth} for this ${facts.sourceLabel}.`
+                    : '') +
+                ` Later activity lands as comments here — the dedup key now points at THIS Task.`,
+        );
+    } else {
+        blocks.push(
+            `**Filed automatically** from a ${facts.sourceLabel} by the issue / incident intake. ` +
+                `Later activity on the same ${facts.sourceLabel} lands as comments on this Task — a re-fired webhook, a re-label or a repeated alert never files a second one.`,
+        );
+    }
 
     const rows = factRows(facts);
     if (occurredAt) {
@@ -364,6 +601,11 @@ export function renderTriageUpdate(
     const lines: string[] = [];
     lines.push(`**${facts.sourceLabel} update**${facts.action ? ` — ${facts.action}` : ''}`);
 
+    const regression = triageRegressionOf(event);
+    if (regression) {
+        lines.push(`- **Regression** — ${regression.summary}.`);
+    }
+
     const previousTitle = str(previous.title ?? undefined);
     if (previousTitle && previousTitle !== facts.title) {
         lines.push(`- Title: ${quoted(facts.title)} (was ${quoted(previousTitle)})`);
@@ -379,6 +621,36 @@ export function renderTriageUpdate(
     if (facts.labels.length > 0) lines.push(`- Labels: ${cell(facts.labels.join(', '))}`);
     if (facts.assignees.length > 0) lines.push(`- Assignees: ${cell(facts.assignees.join(', '))}`);
     for (const [label, value] of facts.extra) lines.push(`- ${label}: ${cell(value)}`);
+    if (facts.url) lines.push(`- Link: ${facts.url}`);
+    lines.push(`_Seen ${occurredAt ?? 'now'} · ingested event ${event.id}_`);
+
+    return lines.join('\n');
+}
+
+/**
+ * The comment left on the CLOSED Task a regression supersedes, so the
+ * trail is not one-way: the closed Task names the Task that took over,
+ * and the new Task's body names the closed one.
+ */
+export function renderTriageSupersededNote(
+    event: IngestedEvent,
+    input: { readonly regression: TriageRegressionSignal; readonly newTaskRef: string },
+): string {
+    const facts = triageFactsOf(event);
+    const occurredAt =
+        event.occurredAt instanceof Date && !Number.isNaN(event.occurredAt.getTime())
+            ? event.occurredAt.toISOString()
+            : undefined;
+
+    const lines: string[] = [];
+    lines.push(
+        `**${facts.sourceLabel} regressed** — ${input.regression.summary}, after this Task was closed.`,
+    );
+    lines.push(
+        `- A new triage Task \`${cell(input.newTaskRef)}\` now carries it; the dedup key for ${
+            facts.externalKey ? `\`${cell(facts.externalKey)}\`` : 'this issue'
+        } points there.`,
+    );
     if (facts.url) lines.push(`- Link: ${facts.url}`);
     lines.push(`_Seen ${occurredAt ?? 'now'} · ingested event ${event.id}_`);
 

--- a/apps/api/src/ingest/triage/triage-task-filer.service.spec.ts
+++ b/apps/api/src/ingest/triage/triage-task-filer.service.spec.ts
@@ -12,6 +12,15 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
     TaskGitLinkService: class {},
     TaskReviewRejectionService: class {},
     TaskPriority: { P0: 'p0', P1: 'p1', P2: 'p2', P3: 'p3', P4: 'p4' },
+    TaskStatus: {
+        BACKLOG: 'backlog',
+        TODO: 'todo',
+        IN_PROGRESS: 'in_progress',
+        IN_REVIEW: 'in_review',
+        BLOCKED: 'blocked',
+        DONE: 'done',
+        CANCELLED: 'cancelled',
+    },
 }));
 jest.mock('@ever-works/agent/utils', () => ({
     // A tiny stand-in for the real scanner: the filer's contract is that
@@ -202,8 +211,39 @@ describe('TriageTaskFilerService', () => {
                 organizationId: 'org-1',
                 lastIngestedEventId: 'row-1',
                 lastSeenAt: new Date('2026-09-01T09:00:00.000Z'),
+                // A FIRST link is insert-only: a concurrent drain that
+                // already filed keeps the key, so this filer's Task can
+                // never orphan theirs (or be orphaned by them).
+                onlyIfAbsent: true,
             });
             expect(chat.post).not.toHaveBeenCalled();
+        });
+
+        /**
+         * `findUnprocessed` takes no row lock and `markProcessed` is the
+         * last step of the fan-out, so before the drain became
+         * single-flight two overlapping ticks handed the same first-sight
+         * row to two filings: both missed the dedup row, both created a
+         * Task, and the second write re-pointed the single link at the
+         * winner. The loser was ORPHANED — nothing referenced it, so it
+         * never received an update comment and was never deduped away,
+         * and the board showed two triage Tasks for one issue.
+         *
+         * The insert-only first link makes the loser DETECTABLE: the row
+         * it gets back names somebody else's Task, so it cleans up after
+         * itself even if two processes race.
+         */
+        it('removes its own Task when a concurrent filer already holds the dedup key', async () => {
+            const { filer, tasks, links } = build();
+            links.link.mockResolvedValue({
+                id: 'link-1',
+                taskId: 'task-from-the-other-drain',
+            });
+
+            const result = await filer.process(storedEvent());
+
+            expect(result).toEqual({ outcome: 'noop', taskId: 'task-from-the-other-drain' });
+            expect(tasks.remove).toHaveBeenCalledWith('user-1', 'task-1', SCOPE);
         });
 
         it('renders a Sentry incident with culprit, level, release, environment and project — at P1 for fatal', async () => {
@@ -413,6 +453,467 @@ describe('TriageTaskFilerService', () => {
             await expect(filer.process(storedEvent())).rejects.toThrow('link write failed');
             expect(tasks.create).toHaveBeenCalledTimes(1);
             expect(tasks.remove).toHaveBeenCalledWith('user-1', 'task-1', SCOPE);
+        });
+    });
+
+    /**
+     * The one case where dedup yields. Both halves of the condition are
+     * driven through the real `process()`: the vendor must say it came
+     * back AND the Task must already be closed. A regression is the only
+     * thing that may open new work; nothing else may, or an alerting
+     * Sentry issue would page the board forever.
+     */
+    describe('a regression re-opens work — and nothing else does', () => {
+        const link = (overrides: Record<string, unknown> = {}) => ({
+            id: 'link-1',
+            userId: 'user-1',
+            taskId: 'task-9',
+            source: 'github',
+            externalIssueId: 'octo/site#42',
+            externalKey: 'octo/site#42',
+            title: 'Login button does nothing on Safari',
+            url: 'https://github.com/octo/site/issues/42',
+            lastIngestedEventId: 'row-0',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            regressionCount: 0,
+            ...overrides,
+        });
+
+        const closedTask = (status = 'done') => ({
+            id: 'task-9',
+            slug: 'T-9',
+            status,
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+        });
+
+        const reopened = (overrides: Partial<IngestedEvent> = {}) =>
+            storedEvent({
+                id: 'row-r1',
+                sourceEventId: 'issue:octo/site#42@reopened:2026-09-05T08:00:00.000Z',
+                occurredAt: new Date('2026-09-05T08:00:00.000Z'),
+                payload: { ...storedEvent().payload, action: 'reopened', state: 'open' },
+                ...overrides,
+            });
+
+        /**
+         * The headline property, driven through the real `process()` with
+         * a stateful link store rather than asserted on a fixture: a
+         * Sentry issue that alerts over and over is ONE Task, however
+         * loud it gets. Each alert is a genuinely distinct ingested row
+         * (Sentry mints a new `sourceEventId` per alerting event), so the
+         * spine's own dedupe cannot be what saves us here — the link row
+         * is.
+         */
+        it('files ONE Task for an issue that alerts twenty-five times', async () => {
+            const { filer, tasks, links, taskRows, chat } = build();
+            let stored: Record<string, unknown> | null = null;
+            links.find.mockImplementation(async () => stored);
+            links.link.mockImplementation(async (input: Record<string, unknown>) => {
+                stored = { id: 'link-1', ...(stored ?? {}), ...input };
+                return stored;
+            });
+            taskRows.findByIdAndUser.mockImplementation(async (taskId: string) =>
+                stored && stored.taskId === taskId
+                    ? {
+                          id: taskId,
+                          slug: 'T-2',
+                          status: 'in_progress',
+                          tenantId: 'tenant-1',
+                          organizationId: 'org-1',
+                      }
+                    : null,
+            );
+
+            for (let i = 0; i < 25; i += 1) {
+                await filer.process(
+                    sentryEvent({
+                        id: `row-a${i}`,
+                        sourceEventId: `event_alert:4501:evt-${i}`,
+                        payload: {
+                            ...(sentryEvent().payload as Record<string, unknown>),
+                            resource: 'event_alert',
+                            action: 'triggered',
+                            eventId: `evt-${i}`,
+                        },
+                    }),
+                );
+            }
+
+            expect(tasks.create).toHaveBeenCalledTimes(1);
+            // ...and the comment stream is NOT twenty-four rows deep.
+            // Every alert carries the same instant and the same facts, so
+            // they all land in one coalescing bucket. A Task comment is
+            // not free — a chat row, a TASK_COMMENTED activity row, and a
+            // Memory write per call — so commenting on every alert moved
+            // the pager from the board into the comment stream and the
+            // drain rather than closing it.
+            expect(chat.post).not.toHaveBeenCalled();
+            expect(stored).toMatchObject({ taskId: 'task-1', lastIngestedEventId: 'row-a24' });
+        });
+
+        it('coalesces repeat-alert comments to one per bucket, and never coalesces a CHANGE', async () => {
+            const { filer, links, taskRows, chat } = build();
+            let stored: Record<string, unknown> | null = null;
+            links.find.mockImplementation(async () => stored);
+            links.link.mockImplementation(async (input: Record<string, unknown>) => {
+                stored = { id: 'link-1', ...(stored ?? {}), ...input };
+                return stored;
+            });
+            taskRows.findByIdAndUser.mockImplementation(async (taskId: string) =>
+                stored && stored.taskId === taskId
+                    ? {
+                          id: taskId,
+                          slug: 'T-2',
+                          status: 'in_progress',
+                          tenantId: 'tenant-1',
+                          organizationId: 'org-1',
+                      }
+                    : null,
+            );
+
+            const alertAt = (minutes: number) =>
+                sentryEvent({
+                    id: `row-b${minutes}`,
+                    sourceEventId: `event_alert:4501:bucket-${minutes}`,
+                    occurredAt: new Date(Date.UTC(2026, 8, 1, 12, minutes)),
+                    payload: {
+                        ...(sentryEvent().payload as Record<string, unknown>),
+                        resource: 'event_alert',
+                        action: 'triggered',
+                    },
+                });
+
+            await filer.process(alertAt(0)); // files the Task
+            await filer.process(alertAt(1)); // same bucket → silent
+            await filer.process(alertAt(2)); // same bucket → silent
+            expect(chat.post).not.toHaveBeenCalled();
+
+            await filer.process(alertAt(20)); // next bucket → one comment
+            expect(chat.post).toHaveBeenCalledTimes(1);
+
+            await filer.process(alertAt(21)); // same bucket again → silent
+            expect(chat.post).toHaveBeenCalledTimes(1);
+
+            // A state CHANGE is never coalesced, whatever bucket it is in.
+            await filer.process(
+                sentryEvent({
+                    id: 'row-b-resolved',
+                    sourceEventId: 'issue:4501:resolved:2026-09-01T12:22:00.000Z',
+                    occurredAt: new Date(Date.UTC(2026, 8, 1, 12, 22)),
+                    payload: {
+                        ...(sentryEvent().payload as Record<string, unknown>),
+                        resource: 'issue',
+                        action: 'resolved',
+                        status: 'resolved',
+                    },
+                }),
+            );
+            expect(chat.post).toHaveBeenCalledTimes(2);
+        });
+
+        it('files a NEW Task when a reopened issue finds its Task already closed', async () => {
+            const { filer, tasks, links, taskRows } = build();
+            links.find.mockResolvedValue(link());
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+
+            const result = await filer.process(reopened());
+
+            expect(result).toEqual({
+                outcome: 'refiled',
+                taskId: 'task-1',
+                supersededTaskId: 'task-9',
+                regressionCount: 1,
+                signal: 'github.reopened',
+            });
+            expect(tasks.create).toHaveBeenCalledTimes(1);
+            const [, input, scope] = tasks.create.mock.calls[0];
+            expect(input.title).toBe(
+                '[octo/site#42] Regression: Login button does nothing on Safari',
+            );
+            expect(input.labels).toEqual([TRIAGE_LABEL, 'source:github', 'regression']);
+            expect(input.description).toContain('**Filed automatically as a regression**');
+            expect(input.description).toContain('`T-9`');
+            expect(input.workId).toBe('work-1');
+            expect(scope).toEqual(SCOPE);
+        });
+
+        it('re-points the SAME dedup key at the new Task and counts the re-opening', async () => {
+            const { filer, links, taskRows } = build();
+            links.find.mockResolvedValue(link({ regressionCount: 2 }));
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask('cancelled'));
+
+            const result = await filer.process(reopened());
+
+            expect(result).toMatchObject({ outcome: 'refiled', regressionCount: 3 });
+            expect(links.link).toHaveBeenCalledTimes(1);
+            expect(links.link).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    source: 'github',
+                    // The key itself never moves — only what it points at.
+                    externalIssueId: 'octo/site#42',
+                    taskId: 'task-1',
+                    regressionCount: 3,
+                    lastIngestedEventId: 'row-r1',
+                }),
+            );
+        });
+
+        it('leaves a two-way trail: one comment on the closed Task naming its replacement', async () => {
+            const { filer, chat, links, taskRows } = build();
+            links.find.mockResolvedValue(link());
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+
+            await filer.process(reopened());
+
+            expect(chat.post).toHaveBeenCalledTimes(1);
+            const [userId, post, , scope] = chat.post.mock.calls[0];
+            expect(userId).toBe('user-1');
+            expect(post.taskId).toBe('task-9');
+            expect(post.body).toContain('**GitHub issue regressed**');
+            // The build() stub's slug for the first Task it mints.
+            expect(post.body).toContain('`T-2`');
+            expect(scope).toEqual(SCOPE);
+        });
+
+        it('does NOT fork the board when the Task is still open — regression or not', async () => {
+            const { filer, tasks, links, taskRows, chat } = build();
+            links.find.mockResolvedValue(link());
+            taskRows.findByIdAndUser.mockResolvedValue({
+                ...closedTask('in_progress'),
+            });
+
+            const result = await filer.process(reopened());
+
+            expect(result).toEqual({ outcome: 'updated', taskId: 'task-9', commented: true });
+            expect(tasks.create).not.toHaveBeenCalled();
+            expect(chat.post.mock.calls[0][1].body).toContain('- **Regression** —');
+            expect(links.link).toHaveBeenCalledWith(
+                expect.not.objectContaining({ regressionCount: expect.anything() }),
+            );
+        });
+
+        const repeatAlert = (overrides: Partial<IngestedEvent> = {}) =>
+            sentryEvent({
+                id: 'row-s9',
+                sourceEventId: 'event_alert:4501:evt-77',
+                payload: {
+                    ...(sentryEvent().payload as Record<string, unknown>),
+                    resource: 'event_alert',
+                    action: 'triggered',
+                    eventId: 'evt-77',
+                },
+                ...overrides,
+            });
+
+        it('a repeated Sentry alert on an OPEN Task files nothing — it is not a regression', async () => {
+            const { filer, tasks, links, taskRows } = build();
+            links.find.mockResolvedValue(link({ source: 'sentry', externalIssueId: '4501' }));
+            taskRows.findByIdAndUser.mockResolvedValue({
+                ...closedTask(),
+                status: 'in_progress',
+            });
+
+            const result = await filer.process(repeatAlert());
+
+            expect(result).toMatchObject({ outcome: 'updated', taskId: 'task-9' });
+            expect(tasks.create).not.toHaveBeenCalled();
+        });
+
+        /**
+         * The rule this replaces said an `event_alert` is never a
+         * regression, full stop. That made the vendor's explicit
+         * regression signal a ONE-SHOT: `triageRegressionOf` is a pure
+         * function of a single event, so if the filer could not act on
+         * the one `issue.unresolved` that carried it (the Work claim had
+         * just been removed, the body was refused), every later delivery
+         * was an `event_alert` and the closed Task could never be
+         * superseded — the regression was permanently downgraded to a
+         * comment on a Task nobody reads, which is the exact failure the
+         * regression feature exists to prevent.
+         *
+         * An error still firing after somebody marked the work DONE is a
+         * regression by any honest reading, and unlike the vendor signal
+         * it is re-carried by every subsequent alert. It is still ONE
+         * Task: the re-file leaves an OPEN Task, so the alert after it
+         * takes the ordinary comment path (asserted above).
+         */
+        it('a repeated Sentry alert re-opens work when the Task was marked DONE', async () => {
+            const { filer, tasks, links, taskRows } = build();
+            links.find.mockResolvedValue(link({ source: 'sentry', externalIssueId: '4501' }));
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask('done'));
+
+            const result = await filer.process(repeatAlert());
+
+            expect(result).toMatchObject({
+                outcome: 'refiled',
+                signal: 'sentry.still-active',
+                supersededTaskId: 'task-9',
+                regressionCount: 1,
+            });
+            expect(tasks.create).toHaveBeenCalledTimes(1);
+        });
+
+        it('a repeated Sentry alert NEVER re-opens a CANCELLED Task — that was a human decision', async () => {
+            const { filer, tasks, links, taskRows } = build();
+            links.find.mockResolvedValue(link({ source: 'sentry', externalIssueId: '4501' }));
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask('cancelled'));
+
+            const result = await filer.process(repeatAlert());
+
+            expect(result).toMatchObject({ outcome: 'updated', taskId: 'task-9' });
+            expect(tasks.create).not.toHaveBeenCalled();
+        });
+
+        it('files a new Task for a Sentry issue that regressed after its Task was closed', async () => {
+            const { filer, tasks, links, taskRows } = build();
+            links.find.mockResolvedValue(link({ source: 'sentry', externalIssueId: '4501' }));
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+            const regressed = sentryEvent({
+                id: 'row-s10',
+                sourceEventId: 'issue:4501:unresolved:2026-09-05T08:00:00.000Z',
+                payload: {
+                    ...(sentryEvent().payload as Record<string, unknown>),
+                    action: 'unresolved',
+                    status: 'unresolved',
+                },
+            });
+
+            const result = await filer.process(regressed);
+
+            expect(result).toMatchObject({
+                outcome: 'refiled',
+                signal: 'sentry.unresolved',
+                supersededTaskId: 'task-9',
+            });
+            expect(tasks.create).toHaveBeenCalledTimes(1);
+            expect(tasks.create.mock.calls[0][1].labels).toEqual([
+                TRIAGE_LABEL,
+                'source:sentry',
+                'regression',
+            ]);
+        });
+
+        /**
+         * `refile()` routes an EXISTING dedup row through `file()`, which
+         * writes `url: facts.url ?? null`. Before this slice `file()` only
+         * ever INSERTED, so the `?? null` was harmless; sending an
+         * existing row down the same path made it destructive — a
+         * revision that happens to omit the deep link (a Jira transition
+         * with no `issue.self`, a Sentry issue whose permalink will not
+         * parse) NULLed a link the row already had. Every existing
+         * assertion used `objectContaining`, which is blind to a field
+         * being nulled, so nothing caught it.
+         */
+        it('a regression that carries no url keeps the one the link already had', async () => {
+            const { filer, links, taskRows } = build();
+            links.find.mockResolvedValue(
+                link({
+                    source: 'sentry',
+                    externalIssueId: '4501',
+                    url: 'https://sentry.io/organizations/ever-co/issues/4501/',
+                    externalKey: 'EVER-WORKS-1X',
+                }),
+            );
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+
+            await filer.process(
+                sentryEvent({
+                    id: 'row-s11',
+                    sourceEventId: 'issue:4501:unresolved:2026-09-05T09:00:00.000Z',
+                    sourceUrl: null,
+                    payload: {
+                        provider: 'sentry',
+                        externalId: '4501',
+                        title: 'TypeError: Cannot read properties of undefined',
+                        resource: 'issue',
+                        action: 'unresolved',
+                        status: 'unresolved',
+                    },
+                }),
+            );
+
+            const written = links.link.mock.calls.at(-1)?.[0];
+            // Exact assertions — `objectContaining` cannot see a null.
+            expect(written.url).toBe('https://sentry.io/organizations/ever-co/issues/4501/');
+            // The event carries its own key here, so that one wins; the
+            // stored one is the FALLBACK, not an override.
+            expect(written.externalKey).toBe('4501');
+        });
+
+        it('keeps the stored externalKey when the revision carries none at all', async () => {
+            const { filer, links, taskRows } = build();
+            links.find.mockResolvedValue(
+                link({ source: 'jira-connector', externalIssueId: '10001', externalKey: 'ENG-42' }),
+            );
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+
+            await filer.process(
+                storedEvent({
+                    id: 'row-j1',
+                    source: 'jira-connector',
+                    kind: 'jira.issue',
+                    subjectExternalId: '10001',
+                    sourceUrl: null,
+                    payload: {
+                        // No `issueKey` → `triageExternalKeyOf` yields null.
+                        changeType: 'transitioned',
+                        statusFrom: 'Done',
+                        statusTo: 'In Progress',
+                        title: 'Login broken',
+                    },
+                }),
+            );
+
+            const written = links.link.mock.calls.at(-1)?.[0];
+            expect(written.externalKey).toBe('ENG-42');
+            expect(written.url).toBe('https://github.com/octo/site/issues/42');
+        });
+
+        it('a drain retry of the same regression row files nothing a second time', async () => {
+            const { filer, tasks, links, taskRows, chat } = build();
+            links.find.mockResolvedValue(link({ lastIngestedEventId: 'row-r1', taskId: 'task-7' }));
+
+            const result = await filer.process(reopened());
+
+            expect(result).toEqual({ outcome: 'noop', taskId: 'task-7' });
+            expect(taskRows.findByIdAndUser).not.toHaveBeenCalled();
+            expect(tasks.create).not.toHaveBeenCalled();
+            expect(chat.post).not.toHaveBeenCalled();
+            expect(links.link).not.toHaveBeenCalled();
+        });
+
+        it('falls back to commenting when the regression cannot be filed (Work gone) — never silently dropped', async () => {
+            const { filer, tasks, links, works, taskRows, chat } = build();
+            links.find.mockResolvedValue(link());
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+            works.findById.mockResolvedValue(null);
+
+            const result = await filer.process(reopened());
+
+            expect(result).toEqual({ outcome: 'updated', taskId: 'task-9', commented: true });
+            expect(tasks.create).not.toHaveBeenCalled();
+            expect(chat.post.mock.calls[0][1].body).toContain('- **Regression** —');
+            expect(links.link).toHaveBeenCalledWith(
+                expect.objectContaining({ taskId: 'task-9', lastIngestedEventId: 'row-r1' }),
+            );
+        });
+
+        it('still re-files when the note on the superseded Task is refused', async () => {
+            const { filer, tasks, links, taskRows, chat } = build();
+            links.find.mockResolvedValue(link());
+            taskRows.findByIdAndUser.mockResolvedValue(closedTask());
+            chat.post.mockRejectedValue(new BadRequestException('Chat body exceeds max'));
+
+            const result = await filer.process(reopened());
+
+            expect(result).toMatchObject({ outcome: 'refiled', taskId: 'task-1' });
+            expect(tasks.create).toHaveBeenCalledTimes(1);
+            expect(links.link).toHaveBeenCalledWith(
+                expect.objectContaining({ taskId: 'task-1', regressionCount: 1 }),
+            );
         });
     });
 });

--- a/apps/api/src/ingest/triage/triage-task-filer.service.ts
+++ b/apps/api/src/ingest/triage/triage-task-filer.service.ts
@@ -10,6 +10,7 @@ import {
     TaskChatService,
     TaskPriority,
     TaskRepository,
+    TaskStatus,
     TasksService,
     type Task,
 } from '@ever-works/agent/tasks-domain';
@@ -17,13 +18,21 @@ import { redactSecrets } from '@ever-works/agent/utils';
 import {
     TRIAGE_EVENT_KINDS,
     TRIAGE_LABEL,
+    TRIAGE_REGRESSION_LABEL,
+    TRIAGE_UPDATE_BUCKET_MS,
+    isTriageRepeatAlert,
     renderTriageBody,
+    renderTriageSupersededNote,
     renderTriageTitle,
     renderTriageUpdate,
     triageExternalKeyOf,
     triageFactsOf,
     triagePriorityOf,
+    triageRegressionOf,
+    triageStillActiveOf,
+    type TriageFileContext,
     type TriagePriority,
+    type TriageRegressionSignal,
 } from './triage-task-body';
 
 const PRIORITY: Record<TriagePriority, TaskPriority> = {
@@ -33,15 +42,54 @@ const PRIORITY: Record<TriagePriority, TaskPriority> = {
     p4: TaskPriority.P4,
 };
 
+/**
+ * Task states that mean the work is finished. A regression signal that
+ * arrives while the Task is in one of these — and ONLY then — files a
+ * fresh Task; everything else is a comment on the one that exists.
+ */
+const CLOSED_TASK_STATUSES: readonly TaskStatus[] = [TaskStatus.DONE, TaskStatus.CANCELLED];
+
 /** What the filer did with one drained event. */
 export type TriageOutcome =
     | { readonly outcome: 'filed'; readonly taskId: string }
+    | {
+          readonly outcome: 'refiled';
+          readonly taskId: string;
+          readonly supersededTaskId: string;
+          readonly regressionCount: number;
+          readonly signal: string;
+      }
     | { readonly outcome: 'updated'; readonly taskId: string; readonly commented: boolean }
     | { readonly outcome: 'noop'; readonly taskId: string }
     | {
           readonly outcome: 'skipped';
           readonly reason: 'no-external-id' | 'no-work' | 'work-unavailable' | 'rejected';
       };
+
+/** `file()`'s internal result — carries the Task so a caller can name it. */
+type FileResult =
+    | { readonly outcome: 'filed'; readonly taskId: string; readonly task: Task }
+    /** A concurrent filer won the dedup key; its Task is the survivor. */
+    | { readonly outcome: 'deduped'; readonly taskId: string }
+    | Extract<TriageOutcome, { outcome: 'skipped' }>;
+
+/**
+ * How `file()` must write the dedup row.
+ *
+ * `repoint: false` is a FIRST link and is insert-only, so a concurrent
+ * filer that got there first keeps the row and this caller's Task is
+ * removed instead of being orphaned. `repoint: true` is a deliberate
+ * re-point (a regression superseding a closed Task, or re-filing after
+ * the linked Task was deleted) and carries the row's existing
+ * observability fields forward so a revision that omits them — a Jira
+ * transition with no `issue.self`, a Sentry issue whose permalink fails
+ * to parse — cannot NULL a deep link the row already had.
+ */
+interface LinkWriteMode {
+    readonly repoint: boolean;
+    readonly previousUrl?: string | null;
+    readonly previousExternalKey?: string | null;
+}
 
 /**
  * Deduped triage Task filer (self-build program note §6, R2/R23).
@@ -59,15 +107,64 @@ export type TriageOutcome =
  *     (UNIQUE `(userId, source, externalIssueId)`) pointing at it;
  *   * every later revision (re-label, transition, repeated alert,
  *     re-fired webhook) finds that row and posts ONE comment on the
- *     existing Task — it never files a second one;
+ *     existing Task — it never files a second one. Repeated ALERTS for
+ *     an unchanged issue are additionally coalesced to one comment per
+ *     {@link TRIAGE_UPDATE_BUCKET_MS}: a comment costs a chat row, an
+ *     activity row and a Memory write, so commenting on every alert
+ *     moved the pager from the board into the comment stream rather than
+ *     removing it. Anything that CHANGED still comments immediately;
  *   * a retry of the very same drained row (the drain re-runs kind
  *     processors when a later fan-out step failed) is a no-op, keyed on
  *     the link's `lastIngestedEventId`.
  *
+ * ## The one case where dedup yields: a REGRESSION
+ *
+ * Dedup that never yields is not dedup, it is amnesia: an issue that was
+ * fixed, closed and then came back would post a comment onto a Task
+ * nobody looks at any more, and the fleet would never hear about it.
+ * So the filer files a NEW Task when — and only when — BOTH hold:
+ *
+ *   1. the vendor said it came back ({@link triageRegressionOf}: a
+ *      GitHub `reopened`, a Sentry `unresolved` / `unarchived`, a
+ *      Dependabot `reopened` / `reintroduced` / `auto_reopened`, a Jira
+ *      transition back out of a done-named status); and
+ *   2. the Task the dedup key points at is already CLOSED
+ *      (`done` / `cancelled`).
+ *
+ * Both halves matter. Without (1) a chatty vendor would re-file forever;
+ * without (2) a regression on work still in flight would fork the board.
+ * A Sentry issue that alerts two thousand times still produces exactly
+ * one Task, because an `event_alert` is not a regression signal WHILE
+ * THE TASK IS OPEN.
+ *
+ * There is a second, weaker signal for exactly one case: a repeated
+ * alert arriving on a Task somebody marked `done`
+ * ({@link triageStillActiveOf}). The fix did not hold, so the work
+ * re-opens. It is still one Task — the re-file leaves an OPEN Task, so
+ * every following alert is an ordinary comment — and it is what makes a
+ * regression recoverable: {@link triageRegressionOf} is a pure function
+ * of a single event, so the vendor's explicit signal is a ONE-SHOT that
+ * a temporarily unavailable Work would otherwise consume forever.
+ * `cancelled` is excluded: that is a human saying "do not act on this".
+ *
+ * The dedup row is then RE-POINTED at the new Task (the key itself never
+ * changes — it stays `(userId, source, externalIssueId)`), its
+ * `regressionCount` is incremented so the history is queryable, and the
+ * superseded Task gets one comment naming its replacement. If the new
+ * Task cannot be filed (the event routed to no Work, the Work is gone,
+ * the body was refused), the filer falls back to commenting on the
+ * existing Task — a regression is never silently dropped.
+ *
  * It is a kind processor on the ingest spine (registered at boot like
  * `TriggerEventFiringService`), so it runs inside the drain: filing is
- * asynchronous (seconds to a minute after the webhook), retry-safe and
- * dependency-free of the receivers. It files INTO THE BOUND WORK only —
+ * asynchronous (the drain is a FIVE-MINUTE cron, so a Task appears
+ * within a few minutes of the webhook — not seconds), retry-safe and
+ * dependency-free of the receivers. Retry-safety is per-row and holds
+ * for SEQUENTIAL retries; concurrent drains are excluded upstream
+ * (`event-ingest-tick` is `concurrencyLimit: 1` and
+ * `EventIngestService.processBatch` is single-flight), and the first
+ * link is written insert-only so even a cross-process race cannot leave
+ * an orphaned Task behind. It files INTO THE BOUND WORK only —
  * an event that routed to no Work is left alone (a trigger may still
  * act on it); the Work is loaded and checked against the event's owner
  * before a Task is created under its tenant / organization scope, so
@@ -119,6 +216,23 @@ export class TriageTaskFilerService implements OnModuleInit {
             }
             const task = await this.taskRows.findByIdAndUser(existing.taskId, event.userId);
             if (task) {
+                const reopen = this.reopenSignalFor(event, task);
+                if (reopen) {
+                    const refiled = await this.refile(
+                        event,
+                        existing,
+                        task,
+                        externalIssueId,
+                        reopen,
+                    );
+                    // `null` = the new Task could not be filed; keep the
+                    // closed one current rather than losing the revision.
+                    // The signal is NOT lost with it: a still-active alert
+                    // re-carries it on the next delivery (see
+                    // `reopenSignalFor`), so the work re-opens as soon as
+                    // the Work claim is back.
+                    if (refiled) return refiled;
+                }
                 return this.refresh(event, existing, task, externalIssueId);
             }
             // The linked Task was deleted — fall through and file a fresh
@@ -126,9 +240,138 @@ export class TriageTaskFilerService implements OnModuleInit {
             this.logger.warn(
                 `Triage link for ${event.source}/${externalIssueId} points at a missing Task ${existing.taskId}; filing a new one`,
             );
+            return this.asOutcome(
+                await this.file(event, externalIssueId, {}, this.repointOf(existing)),
+            );
         }
 
-        return this.file(event, externalIssueId);
+        return this.asOutcome(await this.file(event, externalIssueId));
+    }
+
+    /**
+     * Does this event re-open work on the Task the dedup key points at?
+     *
+     * Two ways, and the Task's own state decides which applies:
+     *
+     *  1. the VENDOR said it came back ({@link triageRegressionOf}) and
+     *     the Task is closed (`done` or `cancelled`) — unchanged;
+     *  2. the error is STILL HAPPENING ({@link triageStillActiveOf}) and
+     *     the Task is `done`. A repeated alert is not a regression while
+     *     the Task is open — that is what keeps two thousand alerts to
+     *     one Task — but arriving after somebody marked the work done, it
+     *     says the fix did not hold, and unlike (1) it is re-carried by
+     *     every subsequent alert instead of being a one-shot that a
+     *     temporarily-unavailable Work silently consumes.
+     *
+     * `cancelled` is deliberately excluded from (2): "we decided not to
+     * act on this" is a human decision a repeated alert must not undo.
+     */
+    private reopenSignalFor(event: IngestedEvent, task: Task): TriageRegressionSignal | null {
+        const vendor = triageRegressionOf(event);
+        if (vendor) {
+            return CLOSED_TASK_STATUSES.includes(task.status) ? vendor : null;
+        }
+        return task.status === TaskStatus.DONE ? triageStillActiveOf(event) : null;
+    }
+
+    /** Carry an existing link's observability fields through a re-point. */
+    private repointOf(existing: ExternalIssueLink): LinkWriteMode {
+        return {
+            repoint: true,
+            previousUrl: existing.url ?? null,
+            previousExternalKey: existing.externalKey ?? null,
+        };
+    }
+
+    /** `file()`'s internal result, as the public outcome type. */
+    private asOutcome(filed: FileResult): TriageOutcome {
+        switch (filed.outcome) {
+            case 'filed':
+                return { outcome: 'filed', taskId: filed.taskId };
+            // A concurrent filer holds the dedup key; its Task is the one
+            // the row points at, and this call already removed its own.
+            case 'deduped':
+                return { outcome: 'noop', taskId: filed.taskId };
+            default:
+                return filed;
+        }
+    }
+
+    /**
+     * A closed Task's issue came back: file a fresh Task, re-point the
+     * dedup row at it, and tell the closed one where the work moved.
+     *
+     * Returns `null` when the new Task could not be filed at all — the
+     * caller then falls back to the ordinary comment path, so a
+     * regression that arrives while the Work is unavailable still shows
+     * up somewhere a human reads.
+     */
+    private async refile(
+        event: IngestedEvent,
+        existing: ExternalIssueLink,
+        superseded: Task,
+        externalIssueId: string,
+        regression: TriageRegressionSignal,
+    ): Promise<TriageOutcome | null> {
+        const regressionCount = (existing.regressionCount ?? 0) + 1;
+        const filed = await this.file(
+            event,
+            externalIssueId,
+            {
+                regression,
+                supersedesTaskRef: superseded.slug ?? superseded.id,
+                regressionCount,
+            },
+            this.repointOf(existing),
+        );
+        if (filed.outcome !== 'filed') {
+            this.logger.warn(
+                `Triage: ${event.source}/${externalIssueId} regressed (${regression.signal}) but no new Task could be filed (${
+                    filed.outcome === 'skipped' ? filed.reason : 'a concurrent filer won the link'
+                }); commenting on the closed Task ${superseded.id} instead`,
+            );
+            return null;
+        }
+
+        try {
+            await this.chat.post(
+                event.userId,
+                {
+                    taskId: superseded.id,
+                    authorType: 'user',
+                    authorId: event.userId,
+                    body: redactSecrets(
+                        renderTriageSupersededNote(event, {
+                            regression,
+                            newTaskRef: filed.task.slug ?? filed.task.id,
+                        }),
+                    ).cleaned,
+                },
+                {},
+                {
+                    tenantId: superseded.tenantId ?? null,
+                    organizationId: superseded.organizationId ?? null,
+                },
+            );
+        } catch (error) {
+            // Best-effort: the new Task and the re-pointed dedup row are
+            // the load-bearing half; the breadcrumb on the closed Task is
+            // not worth failing (and retrying) the whole row for.
+            this.logger.warn(
+                `Triage: could not annotate superseded Task ${superseded.id} for ${event.source}/${externalIssueId}: ${this.messageOf(error)}`,
+            );
+        }
+
+        this.logger.log(
+            `Triage: ${event.source}/${externalIssueId} regressed (${regression.signal}); Task ${filed.taskId} supersedes closed Task ${superseded.id} (re-opening #${regressionCount})`,
+        );
+        return {
+            outcome: 'refiled',
+            taskId: filed.taskId,
+            supersededTaskId: superseded.id,
+            regressionCount,
+            signal: regression.signal,
+        };
     }
 
     private async refresh(
@@ -138,29 +381,32 @@ export class TriageTaskFilerService implements OnModuleInit {
         externalIssueId: string,
     ): Promise<TriageOutcome> {
         let commented = false;
-        try {
-            await this.chat.post(
-                event.userId,
-                {
-                    taskId: task.id,
-                    authorType: 'user',
-                    authorId: event.userId,
-                    body: redactSecrets(renderTriageUpdate(event, { title: existing.title }))
-                        .cleaned,
-                },
-                {},
-                {
-                    tenantId: task.tenantId ?? null,
-                    organizationId: task.organizationId ?? null,
-                },
-            );
-            commented = true;
-        } catch (error) {
-            // Best-effort: the Task stays current through the link refresh
-            // below even when the comment is refused (size / secret scan).
-            this.logger.warn(
-                `Triage comment on Task ${task.id} for ${event.source}/${externalIssueId} failed: ${this.messageOf(error)}`,
-            );
+        if (this.shouldComment(event, existing)) {
+            try {
+                await this.chat.post(
+                    event.userId,
+                    {
+                        taskId: task.id,
+                        authorType: 'user',
+                        authorId: event.userId,
+                        body: redactSecrets(renderTriageUpdate(event, { title: existing.title }))
+                            .cleaned,
+                    },
+                    {},
+                    {
+                        tenantId: task.tenantId ?? null,
+                        organizationId: task.organizationId ?? null,
+                    },
+                );
+                commented = true;
+            } catch (error) {
+                // Best-effort: the Task stays current through the link
+                // refresh below even when the comment is refused (size /
+                // secret scan).
+                this.logger.warn(
+                    `Triage comment on Task ${task.id} for ${event.source}/${externalIssueId} failed: ${this.messageOf(error)}`,
+                );
+            }
         }
 
         const facts = triageFactsOf(event);
@@ -180,7 +426,48 @@ export class TriageTaskFilerService implements OnModuleInit {
         return { outcome: 'updated', taskId: task.id, commented };
     }
 
-    private async file(event: IngestedEvent, externalIssueId: string): Promise<TriageOutcome> {
+    /**
+     * Should this revision post a comment, or only refresh the row?
+     *
+     * Everything that actually CHANGED comments immediately: a state
+     * transition, a regression signal, a new title. Only a REPEATED
+     * ALERT — the same unchanged issue firing again — is coalesced, to
+     * at most one comment per {@link TRIAGE_UPDATE_BUCKET_MS}.
+     *
+     * Without this, a flapping Sentry issue posted one comment per
+     * drained alert on a single Task: a `task_chat_messages` row plus a
+     * `TASK_COMMENTED` activity row each, on top of the drain's own
+     * activity row and a Memory write (often an embedding call). That is
+     * thousands of rows and provider calls for one issue, and the
+     * salience filter cannot shed any of it — it scores incident traffic
+     * UP. The bucket is derived from the stored `lastSeenAt` and the
+     * event's own `occurredAt`, so it needs no extra state and behaves
+     * identically across pods and restarts.
+     */
+    private shouldComment(event: IngestedEvent, existing: ExternalIssueLink): boolean {
+        if (!isTriageRepeatAlert(event)) return true;
+        if (triageRegressionOf(event)) return true;
+
+        const previousTitle = existing.title ?? null;
+        const nextTitle = triageFactsOf(event).title;
+        if (previousTitle !== null && previousTitle !== nextTitle) return true;
+
+        const last = existing.lastSeenAt?.getTime();
+        const now = event.occurredAt?.getTime();
+        if (last === undefined || Number.isNaN(last) || now === undefined || Number.isNaN(now)) {
+            return true;
+        }
+        return (
+            Math.floor(now / TRIAGE_UPDATE_BUCKET_MS) !== Math.floor(last / TRIAGE_UPDATE_BUCKET_MS)
+        );
+    }
+
+    private async file(
+        event: IngestedEvent,
+        externalIssueId: string,
+        context: TriageFileContext = {},
+        mode: LinkWriteMode = { repoint: false },
+    ): Promise<FileResult> {
         if (!event.workId) {
             this.logger.debug(
                 `Triage: ${event.source}/${externalIssueId} routed to no Work; nothing filed`,
@@ -200,9 +487,10 @@ export class TriageTaskFilerService implements OnModuleInit {
             organizationId: work.organizationId ?? null,
         };
 
+        const regressed = Boolean(context.regression);
         const facts = triageFactsOf(event);
-        const title = renderTriageTitle(event);
-        const description = redactSecrets(renderTriageBody(event)).cleaned;
+        const title = renderTriageTitle(event, regressed);
+        const description = redactSecrets(renderTriageBody(event, context)).cleaned;
 
         let task: Task;
         try {
@@ -211,7 +499,11 @@ export class TriageTaskFilerService implements OnModuleInit {
                 {
                     title,
                     description,
-                    labels: [TRIAGE_LABEL, `source:${event.source}`],
+                    labels: [
+                        TRIAGE_LABEL,
+                        `source:${event.source}`,
+                        ...(regressed ? [TRIAGE_REGRESSION_LABEL] : []),
+                    ],
                     priority: PRIORITY[triagePriorityOf(facts.level)],
                     workId: work.id,
                     createdByType: 'user',
@@ -231,19 +523,33 @@ export class TriageTaskFilerService implements OnModuleInit {
             throw error;
         }
 
+        let link: ExternalIssueLink;
         try {
-            await this.links.link({
+            link = await this.links.link({
                 userId: event.userId,
                 taskId: task.id,
                 source: event.source,
                 externalIssueId,
-                externalKey: triageExternalKeyOf(event),
+                // A re-point carries the row's existing deep link and key
+                // forward: a revision that happens not to carry them
+                // (a Jira transition with no `issue.self`, a Sentry issue
+                // whose permalink will not parse) must not NULL what the
+                // row already knew.
+                externalKey: triageExternalKeyOf(event) ?? mode.previousExternalKey ?? null,
                 title: facts.title,
-                url: facts.url ?? null,
+                url: facts.url ?? mode.previousUrl ?? null,
                 tenantId: scope.tenantId,
                 organizationId: scope.organizationId,
                 lastIngestedEventId: event.id,
                 lastSeenAt: event.occurredAt,
+                // Only a regression moves the counter; a first link and a
+                // re-file after the Task was deleted leave it untouched.
+                ...(context.regressionCount !== undefined
+                    ? { regressionCount: context.regressionCount }
+                    : {}),
+                // A FIRST link never steals the key from a concurrent
+                // filer — see `LinkWriteMode`.
+                ...(mode.repoint ? {} : { onlyIfAbsent: true }),
             });
         } catch (error) {
             // Without the dedup row the drain's retry would file a SECOND
@@ -261,10 +567,28 @@ export class TriageTaskFilerService implements OnModuleInit {
             throw error;
         }
 
+        // Insert-only write and somebody else holds the key: a concurrent
+        // drain filed first. Their Task is the one the dedup row points
+        // at, so this one is an orphan — remove it rather than leave two
+        // triage Tasks for one issue on the board.
+        if (!mode.repoint && link.taskId !== task.id) {
+            this.logger.warn(
+                `Triage: ${event.source}/${externalIssueId} was filed concurrently as Task ${link.taskId}; removing the duplicate Task ${task.id}`,
+            );
+            try {
+                await this.tasks.remove(event.userId, task.id, scope);
+            } catch (removeError) {
+                this.logger.error(
+                    `Triage: could not remove duplicate Task ${task.id}: ${this.messageOf(removeError)}`,
+                );
+            }
+            return { outcome: 'deduped', taskId: link.taskId };
+        }
+
         this.logger.log(
             `Triage Task ${task.slug ?? task.id} filed in Work ${work.id} for ${event.source}/${externalIssueId}`,
         );
-        return { outcome: 'filed', taskId: task.id };
+        return { outcome: 'filed', taskId: task.id, task };
     }
 
     private messageOf(error: unknown): string {

--- a/apps/api/src/migrations/1789600000000-AddExternalIssueLinkRegressionCount.ts
+++ b/apps/api/src/migrations/1789600000000-AddExternalIssueLinkRegressionCount.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Issue / incident intake (self-build program note §6, EW-804) —
+ * `external_issue_links.regressionCount`.
+ *
+ * The triage filer keeps ONE Task per `(userId, source,
+ * externalIssueId)`; every later revision of the same issue is a comment
+ * on it. That is what stops a Sentry issue alerting two thousand times
+ * from filing two thousand Tasks. It also, before this column existed,
+ * meant an issue that was fixed, closed and then CAME BACK could only
+ * ever add a comment to a Task nobody looks at any more.
+ *
+ * The filer now files a fresh Task for a vendor regression signal that
+ * arrives while the linked Task is already closed, re-points the dedup
+ * row at it, and increments this counter. The counter is not the dedup
+ * key (that is still the unique `(userId, source, externalIssueId)`
+ * index, untouched) — it is the audit trail for the one case where dedup
+ * deliberately yields, so "why are there three Tasks for this issue?"
+ * can be answered from the row instead of from the drain's logs.
+ *
+ * NOT NULL with a `0` default, so every existing link reads the honest
+ * "this issue has never re-opened work" and no writer has to learn about
+ * the column. Forward-only with a guard so a partially applied database
+ * converges; portable `TableColumn` DDL because the e2e stack and CI run
+ * better-sqlite3 while production runs Postgres. `down()` goes through
+ * the query runner's `dropColumn` rather than a raw
+ * `ALTER TABLE … DROP COLUMN`: sqlite only learned that statement in
+ * 3.35 and the raw form desynchronises the runner's table metadata.
+ */
+export class AddExternalIssueLinkRegressionCount1789600000000 implements MigrationInterface {
+    name = 'AddExternalIssueLinkRegressionCount1789600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const links = await queryRunner.getTable('external_issue_links');
+        if (!links) return;
+        if (links.findColumnByName('regressionCount')) return;
+
+        await queryRunner.addColumn(
+            'external_issue_links',
+            new TableColumn({
+                name: 'regressionCount',
+                type: 'int',
+                isNullable: false,
+                default: 0,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const links = await queryRunner.getTable('external_issue_links');
+        if (!links) return;
+        if (!links.findColumnByName('regressionCount')) return;
+
+        await queryRunner.dropColumn('external_issue_links', 'regressionCount');
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddExternalIssueLinkRegressionCount.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddExternalIssueLinkRegressionCount.spec.ts
@@ -1,0 +1,137 @@
+import { DataSource, Table } from 'typeorm';
+import { AddExternalIssueLinkRegressionCount1789600000000 } from '../1789600000000-AddExternalIssueLinkRegressionCount';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ *
+ * The assertions are against the PHYSICAL schema (`PRAGMA table_info`),
+ * not against "an INSERT failed": the properties that matter here are
+ * that the column exists, that it is NOT NULL with a `0` default, and
+ * that the rows written before the migration read `0` rather than NULL —
+ * a link that has never re-opened work. Watching an INSERT fail would
+ * prove a weaker property and is flaky under load.
+ */
+describe('AddExternalIssueLinkRegressionCount1789600000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddExternalIssueLinkRegressionCount1789600000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'external_issue_links',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'taskId', type: 'uuid' },
+                    { name: 'source', type: 'varchar', length: '100' },
+                    { name: 'externalIssueId', type: 'varchar', length: '200' },
+                    { name: 'externalKey', type: 'varchar', length: '100', isNullable: true },
+                    { name: 'title', type: 'varchar', length: '500', isNullable: true },
+                    { name: 'url', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'lastIngestedEventId', type: 'uuid', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO "external_issue_links" ("id", "userId", "taskId", "source", "externalIssueId", "externalKey") VALUES (?, ?, ?, ?, ?, ?)`,
+            ['link-1', 'user-1', 'task-1', 'github', 'octo/site#42', 'octo/site#42'],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function physicalColumn(): Promise<
+        { name: string; type: string; notnull: number; dflt_value: string | null } | undefined
+    > {
+        const rows: Array<{
+            name: string;
+            type: string;
+            notnull: number;
+            dflt_value: string | null;
+        }> = await dataSource.query(`PRAGMA table_info("external_issue_links")`);
+        return rows.find((row) => row.name === 'regressionCount');
+    }
+
+    it('adds a NOT NULL integer column defaulted to 0', async () => {
+        await runUp();
+
+        const column = await physicalColumn();
+        expect(column).toBeDefined();
+        expect(column?.notnull).toBe(1);
+        expect(String(column?.type).toLowerCase()).toContain('int');
+        expect(String(column?.dflt_value)).toContain('0');
+    });
+
+    it('leaves links written before the migration reading 0, never NULL', async () => {
+        await runUp();
+
+        expect(
+            await dataSource.query(
+                `SELECT "id", "regressionCount" FROM "external_issue_links" WHERE "id" = ?`,
+                ['link-1'],
+            ),
+        ).toEqual([{ id: 'link-1', regressionCount: 0 }]);
+    });
+
+    it('records a re-opening count once applied', async () => {
+        await runUp();
+        await dataSource.query(
+            `UPDATE "external_issue_links" SET "regressionCount" = ? WHERE "id" = ?`,
+            [2, 'link-1'],
+        );
+
+        expect(
+            await dataSource.query(
+                `SELECT "regressionCount" FROM "external_issue_links" WHERE "id" = ?`,
+                ['link-1'],
+            ),
+        ).toEqual([{ regressionCount: 2 }]);
+    });
+
+    it('is idempotent on re-run and reversible through the query runner', async () => {
+        await runUp();
+        await runUp();
+        expect(await physicalColumn()).toBeDefined();
+
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+        expect(await physicalColumn()).toBeUndefined();
+        // The row survives the drop — down() removes a column, not history.
+        expect(
+            await dataSource.query(`SELECT "id" FROM "external_issue_links" WHERE "id" = ?`, [
+                'link-1',
+            ]),
+        ).toEqual([{ id: 'link-1' }]);
+
+        const second = dataSource.createQueryRunner();
+        await migration.down(second);
+        await second.release();
+        expect(await physicalColumn()).toBeUndefined();
+    });
+
+    it('is a no-op when the table does not exist yet (ordering safety)', async () => {
+        const runner = dataSource.createQueryRunner();
+        await runner.dropTable('external_issue_links');
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await expect(migration.down(runner)).resolves.toBeUndefined();
+        await runner.release();
+    });
+});

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -102,9 +102,10 @@ Sentry signs with one platform-level secret, so a verified delivery proves it ca
 | `GET /api/ingest/sentry/bindings`                      | Your claims.                                                                                                                                 |
 | `DELETE /api/ingest/sentry/bindings/:installationUuid` | Release one.                                                                                                                                 |
 
-Deliveries for an installation nobody has claimed are a 200 no-op that files nothing; a signed `installation.deleted` removes the claim.
+Deliveries for an installation nobody has claimed are a 200 no-op that files nothing — including `installation.deleted`, which only ever removes a claim that exists and is looked up before it acts.
 
 - `issue` (`created`, `resolved`, `unresolved`, `assigned`, `ignored`, `archived`, `unarchived`) and `event_alert` deliveries become `incident` events with `payload.provider: sentry`, identity = the Sentry **issue id**, and the issue link, `culprit`, `title`, `level`, last-seen `release`, `environment` and `project` on the payload. `error`, `comment` and `metric_alert` resources are acknowledged and dropped.
+- Repeated `event_alert` deliveries for the **same issue** collapse into **one event per five minutes**. A Sentry issue is one fingerprint, so alerts inside a window are one revision of it: a flapping issue lands ~12 events an hour instead of one per occurrence, which is what keeps it out of everyone else's ingest queue. A genuinely later alert still lands as a new revision, and the newest facts (release, level, culprit) travel with whichever delivery opens a window.
 - Work routing: claim the Sentry **project slug** under **Tracker team** on the Work; `event_alert` deliveries carry only the numeric project id, so claim that too if you route alert-rule fires. Raw bodies are never logged — event alerts carry stack frames and user context.
 
 ### The `incident` kind
@@ -117,12 +118,32 @@ The **triage filer** consumes `github.issue`, `jira.issue` and `incident` events
 
 - First sight files a Task in that Work (under its tenant / organization) titled `[<key>] <title>` with the `triage` and `source:<source>` labels, a priority from the vendor severity (`fatal`/`critical`/`Highest` → P1, `error`/`high` → P2, `low`/`info` → P4, else P3), and a body carrying the link, culprit, level, last-seen release, environment, project, status, labels and assignees, plus the original text inside a neutralized `<source_content>` block (data, never instructions).
 - The dedup key is persisted as an `external_issue_links` row (`UNIQUE (user, source, externalIssueId)`) pointing at the Task. A re-fired webhook, a re-label, a transition or a repeated Sentry alert finds that row and posts **one comment** with the delta on the existing Task — it never files a second one. An exact redelivery dedupes in the spine and produces nothing at all.
-- Events that routed to no Work are left alone (a trigger may still act on them); a Work the owner does not hold is refused. Filing happens in the ingest drain (`event-ingest-tick`), so a Task appears seconds to a minute after the webhook.
+- Comments are coalesced too. Anything that **changed** — a transition, a regression, a new title — comments immediately; a repeated alert for an unchanged issue comments at most **once every fifteen minutes**. A comment is not free (a chat message row, an activity row and a Memory write each), so a flapping issue would otherwise move the pager off the board and into one Task's comment stream. A Sentry issue that alerts two thousand times is one Task with a readable history, not two thousand Tasks and not two thousand comments.
+- Events that routed to no Work are left alone (a trigger may still act on them); a Work the owner does not hold is refused. Filing happens in the ingest drain (`event-ingest-tick`), which runs **every five minutes**, so a Task appears within a few minutes of the webhook — not instantly. The drain shares its batch between the owners that have work waiting, ranked by whoever's oldest event has waited longest, so one customer's chatty source cannot put another customer's newly filed issue behind it.
 - The filer matches on the event **kind**, not on how the event arrived. The jira-connector's poll sweep emits the same `jira.issue` kind, so issues it picks up are triaged too — which is the point, but it means turning on the connector's optional `backfillDays` window files a Task for every issue updated inside it whose project is claimed on a Work. Leave the backfill at its default (`0`, off) unless you want that history as Tasks.
+
+#### Regressions re-open work
+
+Dedup that never yields would be amnesia: an issue that was fixed, closed and then came back would only add a comment to a Task nobody looks at any more. So the filer files a **new** Task when — and only when — **both** of these hold:
+
+1. the vendor said it came back: a GitHub `issues.reopened`, a Sentry issue `unresolved` or `unarchived`, a Dependabot `reopened` / `reintroduced` / `auto_reopened`, or a Jira transition **out of** a done-named status (`Done`, `Closed`, `Resolved`, `Complete`, `Cancelled`, `Released`, `Shipped`, `Fixed`, `Won't Do`, `Won't Fix`, `Duplicate`) into one that is not; **and**
+2. the Task the dedup key points at is already **closed** (`done` or `cancelled`).
+
+Both halves matter. Without (1) a chatty vendor re-files forever — a repeated Sentry `event_alert` is a rule firing, not a regression signal, **while the Task is open**. Without (2) a reopen while the work is still in flight would fork the board.
+
+There is one more, weaker signal: an alert that keeps arriving after somebody marked the Task **done**. The fix did not hold, so the work re-opens. That is still exactly one Task — the re-file leaves an open Task, so the next alert is an ordinary comment — and it is what makes a regression _recoverable_: the vendor's explicit signal rides a single event, so if the filer cannot act on the one delivery that carried it (the Work claim had just been removed, the body was refused) nothing would ever re-carry it and the closed Task could never be superseded. A **cancelled** Task is deliberately excluded: that is a human saying "do not act on this", and a repeated alert must not overrule it.
+
+The new Task is titled `[<key>] Regression: <title>` and carries a `regression` label alongside `triage` and `source:<source>`. The dedup key itself never changes: the same `external_issue_links` row is re-pointed at the new Task, its `regressionCount` is incremented (so "why are there three Tasks for this issue?" is answerable from the row), and the superseded Task gets one comment naming its replacement. If the new Task cannot be filed — the event routed to no Work, the Work is gone, the body was refused — the filer falls back to commenting on the existing Task, and the still-active signal above brings the regression back on the next alert once the Work is available again.
+
+A Jira workflow whose done status is named something else simply never re-files; the revision still lands as a comment on the existing Task. The check is deliberately two-sided (out of a done name **and** into one that is not), so it cannot mis-fire on `Done → Closed`.
 
 ### Matching intake in triggers
 
 Any event-sourced Task Trigger sees these kinds with no extra wiring — for example `{ "source": "github", "kind": "github.issue" }` to hand new issues to an agent, `{ "kind": "incident" }` for every vendor's incidents, or `{ "source": "sentry", "kind": "incident" }` for Sentry only.
+
+A trigger fires **once per subject inside its replay window** (`replayWindowSec`, five minutes by default). Many events about one issue or one incident are one fire, so `{ "kind": "incident" }` pointed at an agent cannot turn a flapping Sentry project into a Task storm and an agent-run storm — which is what it did while the event path deduped only against re-processing the same row. Events with no stable subject (a push, a chat message) still fire per event. Raise `replayWindowSec` to coalesce harder; lower it if you genuinely want a fire per revision.
+
+The triage filer's issue-level dedup is still separate and stronger: it keeps **one Task per issue forever** and updates it. Prefer the filer when you want a single living Task; use a trigger when you want an agent dispatched on new activity.
 
 ## Native connectors
 

--- a/packages/agent/src/entities/external-issue-link.entity.ts
+++ b/packages/agent/src/entities/external-issue-link.entity.ts
@@ -39,6 +39,11 @@ import { PortableDateColumn } from './_types';
  * by the ingest drain when a matching issue event comes through. They
  * are observability, not state — the link is valid with both NULL.
  *
+ * `regressionCount` is the one piece of STATE on the row: it counts the
+ * times a closed Task for this issue was superseded by a new one after
+ * the vendor said the issue came back (added by
+ * `1789600000000-AddExternalIssueLinkRegressionCount`).
+ *
  * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
  * cycle-avoidance rule; FKs live in the migration
  * (`1784730000000-CreateExternalIssueLinks`).
@@ -92,6 +97,24 @@ export class ExternalIssueLink {
     /** `ingested_events.id` of the most recent event seen for this issue. */
     @Column({ type: 'uuid', nullable: true })
     lastIngestedEventId?: string | null;
+
+    /**
+     * How many times this external issue has RE-OPENED work: the number
+     * of times a vendor regression signal (a reopened GitHub issue, a
+     * Sentry `unresolved`, a Dependabot `reintroduced`, a Jira
+     * transition back out of a done status) arrived while the linked
+     * Task was already closed, and the triage filer therefore filed a
+     * fresh Task and re-pointed this row at it.
+     *
+     * `0` on every first link and on every ordinary refresh — dedup is
+     * unchanged for them: one Task per `(userId, source,
+     * externalIssueId)`, later revisions are comments. This counter is
+     * the audit trail for the ONE case where dedup deliberately yields,
+     * so "why are there three Tasks for this issue?" has an answer that
+     * does not require reading the drain's logs.
+     */
+    @Column({ type: 'int', default: 0 })
+    regressionCount: number;
 
     /** When that most recent event occurred at the source. */
     // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -308,6 +308,119 @@ describe('EventIngestService', () => {
             await build().processBatch();
             expect(repository.findUnprocessed).toHaveBeenCalledWith(50);
         });
+
+        /**
+         * `findUnprocessed` takes no row lock and `markProcessed` is the
+         * LAST step of the fan-out, so two overlapping drains select the
+         * SAME head rows and hand them to the same processors. The kind
+         * processors' idempotency contract covers a RETRY (sequential),
+         * not a concurrent twin: two simultaneous triage filings both
+         * miss the dedup row and both create a Task, and the loser is
+         * orphaned — nothing points at it, so it is never updated and
+         * never deduped away.
+         */
+        it('is SINGLE-FLIGHT: an overlapping call joins the drain in flight', async () => {
+            const event = storedEvent();
+            repository.findUnprocessed.mockResolvedValue([event]);
+            let release: () => void = () => undefined;
+            const gate = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            const processor = jest.fn(async () => {
+                await gate;
+            });
+
+            const service = build();
+            service.registerKindProcessor({ kinds: ['*'], process: processor });
+
+            const first = service.processBatch(10);
+            const second = service.processBatch(10);
+            release();
+            const [a, b] = await Promise.all([first, second]);
+
+            expect(repository.findUnprocessed).toHaveBeenCalledTimes(1);
+            expect(processor).toHaveBeenCalledTimes(1);
+            expect(a).toBe(b);
+
+            // ...and the guard clears, so the NEXT tick really drains.
+            await service.processBatch(10);
+            expect(repository.findUnprocessed).toHaveBeenCalledTimes(2);
+        });
+
+        /**
+         * A row whose processor fails permanently is never marked
+         * processed and always sorts to the head of its owner's
+         * oldest-first queue, so without a backoff it is re-selected
+         * every tick for the life of the deployment and permanently
+         * consumes one of the batch's fifty slots. Fifty of them wedge
+         * the drain for every tenant.
+         */
+        describe('a row that keeps failing yields its slot', () => {
+            it('retries immediately after ONE failure (the transient case)', async () => {
+                const bad = storedEvent({ id: 'row-bad' });
+                repository.findUnprocessed.mockResolvedValue([bad]);
+                const processor = jest.fn(async () => {
+                    throw new Error('boom');
+                });
+                const service = build();
+                service.registerKindProcessor({ kinds: ['*'], process: processor });
+
+                await service.processBatch(10);
+                await service.processBatch(10);
+
+                expect(processor).toHaveBeenCalledTimes(2);
+            });
+
+            it('backs a repeatedly failing row off and keeps draining healthy rows', async () => {
+                const bad = storedEvent({ id: 'row-bad' });
+                const good = storedEvent({ id: 'row-good' });
+                repository.findUnprocessed.mockResolvedValue([bad, good]);
+                const processor = jest.fn(async (event: { id: string }) => {
+                    if (event.id === 'row-bad') throw new Error('poison');
+                });
+                const service = build();
+                service.registerKindProcessor({
+                    kinds: ['*'],
+                    process: processor as never,
+                });
+
+                // Ticks 1 and 2 both attempt the poison row (one failure
+                // costs no skipped ticks); from tick 3 it is backed off.
+                await service.processBatch(10);
+                await service.processBatch(10);
+                const attemptsBeforeBackoff = processor.mock.calls.filter(
+                    ([event]) => (event as { id: string }).id === 'row-bad',
+                ).length;
+                await service.processBatch(10);
+                const attemptsAfter = processor.mock.calls.filter(
+                    ([event]) => (event as { id: string }).id === 'row-bad',
+                ).length;
+
+                expect(attemptsBeforeBackoff).toBe(2);
+                expect(attemptsAfter).toBe(2);
+                // The healthy row is never held up by it.
+                expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
+            });
+
+            it('over-fetches by the backed-off count so a wedged row costs no slot', async () => {
+                const bad = storedEvent({ id: 'row-bad' });
+                repository.findUnprocessed.mockResolvedValue([bad]);
+                const service = build();
+                service.registerKindProcessor({
+                    kinds: ['*'],
+                    process: async () => {
+                        throw new Error('poison');
+                    },
+                });
+
+                await service.processBatch(10);
+                await service.processBatch(10);
+                repository.findUnprocessed.mockClear();
+                await service.processBatch(10);
+
+                expect(repository.findUnprocessed).toHaveBeenCalledWith(11);
+            });
+        });
     });
 
     // Wave 8 (Meetings v1) — kind-bound domain processors on the drain.

--- a/packages/agent/src/ingest/__tests__/external-issue-link.repository.spec.ts
+++ b/packages/agent/src/ingest/__tests__/external-issue-link.repository.spec.ts
@@ -1,0 +1,140 @@
+import { ExternalIssueLinkRepository } from '../external-issue-link.repository';
+
+/**
+ * The WRITE half of the external-issue ↔ Task mapping.
+ *
+ * Everything around this layer was already covered — the triage filer
+ * (with `links` mocked wholesale), the service (with `links.upsert`
+ * mocked), the migration (which proves the column exists, is NOT NULL and
+ * defaults to 0) — and the one link that actually persists a value had no
+ * test at all. So `regressionCount`, the slice's headline audit counter,
+ * was asserted at every hop EXCEPT the hop that writes it: dropping the
+ * `!== undefined` guard (which would reset a user's whole re-open history
+ * to 0 on an ordinary refresh) or flipping the `?? 0` on insert would
+ * have left the entire suite green.
+ *
+ * Same harness as the sibling repository specs: a mocked TypeORM
+ * repository, asserting on the ENTITY handed to `save`.
+ */
+describe('ExternalIssueLinkRepository', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    let typeormRepo: {
+        findOne: jest.Mock;
+        find: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+        remove: jest.Mock;
+    };
+    let repository: ExternalIssueLinkRepository;
+
+    const identity = { userId: 'user-1', source: 'sentry', externalIssueId: '4501' };
+
+    const existingRow = (overrides: Record<string, unknown> = {}) => ({
+        id: 'link-1',
+        ...identity,
+        taskId: 'task-1',
+        externalKey: 'EVER-WORKS-1X',
+        title: 'TypeError',
+        url: 'https://sentry.io/organizations/ever-co/issues/4501/',
+        lastIngestedEventId: 'row-1',
+        lastSeenAt: new Date('2026-09-01T12:00:00.000Z'),
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        regressionCount: 3,
+        ...overrides,
+    });
+
+    beforeEach(() => {
+        typeormRepo = {
+            findOne: jest.fn(async () => null),
+            find: jest.fn(async () => []),
+            create: jest.fn((data) => ({ ...data })),
+            save: jest.fn(async (entity) => entity),
+            remove: jest.fn(async () => undefined),
+        };
+        repository = new ExternalIssueLinkRepository(typeormRepo as never);
+    });
+
+    describe('regressionCount survives a write and reads back', () => {
+        it('inserts a first link at 0 without the caller mentioning the column', async () => {
+            await repository.upsert({ ...identity, taskId: 'task-1' });
+
+            const written = typeormRepo.save.mock.calls[0][0];
+            expect(written.regressionCount).toBe(0);
+        });
+
+        it('inserts the caller-supplied count when a first link IS a re-open', async () => {
+            await repository.upsert({ ...identity, taskId: 'task-2', regressionCount: 2 });
+
+            expect(typeormRepo.save.mock.calls[0][0].regressionCount).toBe(2);
+        });
+
+        it('persists an incremented count onto an existing row', async () => {
+            typeormRepo.findOne.mockResolvedValue(existingRow());
+
+            await repository.upsert({ ...identity, taskId: 'task-9', regressionCount: 4 });
+
+            const written = typeormRepo.save.mock.calls[0][0];
+            expect(written.taskId).toBe('task-9');
+            expect(written.regressionCount).toBe(4);
+        });
+
+        it('leaves the count ALONE on an ordinary refresh that omits it', async () => {
+            typeormRepo.findOne.mockResolvedValue(existingRow());
+
+            await repository.upsert({
+                ...identity,
+                taskId: 'task-1',
+                lastIngestedEventId: 'row-2',
+            });
+
+            // The guard that stops a plain refresh resetting a user's
+            // whole re-open history to zero.
+            expect(typeormRepo.save.mock.calls[0][0].regressionCount).toBe(3);
+        });
+    });
+
+    describe('onlyIfAbsent — the insert-only first link', () => {
+        it('leaves an existing row untouched and hands back the holder', async () => {
+            const holder = existingRow({ taskId: 'winner-task' });
+            typeormRepo.findOne.mockResolvedValue(holder);
+
+            const result = await repository.upsert({
+                ...identity,
+                taskId: 'loser-task',
+                onlyIfAbsent: true,
+            });
+
+            // Nothing written; the caller can see it lost the race
+            // because the row names somebody else's Task.
+            expect(typeormRepo.save).not.toHaveBeenCalled();
+            expect(result.taskId).toBe('winner-task');
+        });
+
+        it('still inserts when nothing holds the key, and never persists the flag', async () => {
+            await repository.upsert({ ...identity, taskId: 'task-1', onlyIfAbsent: true });
+
+            const created = typeormRepo.create.mock.calls[0][0];
+            expect(created).not.toHaveProperty('onlyIfAbsent');
+            expect(typeormRepo.save).toHaveBeenCalledTimes(1);
+        });
+
+        it('re-points the row when the caller did NOT ask for insert-only', async () => {
+            typeormRepo.findOne.mockResolvedValue(existingRow({ taskId: 'old-task' }));
+
+            await repository.upsert({ ...identity, taskId: 'new-task' });
+
+            expect(typeormRepo.save.mock.calls[0][0].taskId).toBe('new-task');
+        });
+    });
+
+    it('adopts the winner when a concurrent first insert violates the UNIQUE index', async () => {
+        const winner = existingRow({ taskId: 'winner-task' });
+        typeormRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(winner);
+        typeormRepo.save.mockRejectedValueOnce(new Error('UNIQUE constraint failed'));
+
+        const result = await repository.upsert({ ...identity, taskId: 'loser-task' });
+
+        expect(result.taskId).toBe('winner-task');
+    });
+});

--- a/packages/agent/src/ingest/__tests__/external-issue-link.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/external-issue-link.service.spec.ts
@@ -152,6 +152,22 @@ describe('ExternalIssueLinkService', () => {
             const written = links.upsert.mock.calls[0][0];
             expect(written).not.toHaveProperty('lastIngestedEventId');
             expect(written).not.toHaveProperty('lastSeenAt');
+            // The regression counter is state, not a breadcrumb: an
+            // ordinary link must never reset somebody's history to 0.
+            expect(written).not.toHaveProperty('regressionCount');
+        });
+
+        it('carries the re-opening count when a regression re-points the link', async () => {
+            await build().link({
+                userId: 'user-1',
+                taskId: 'task-1',
+                source: 'github',
+                externalIssueId: 'octo/site#42',
+                regressionCount: 3,
+            });
+            expect(links.upsert).toHaveBeenCalledWith(
+                expect.objectContaining({ regressionCount: 3 }),
+            );
         });
 
         it('normalizes absent optional labels to null so an upsert clears stale values', async () => {

--- a/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
@@ -43,11 +43,18 @@ describe('IngestedEventRepository', () => {
 
     beforeEach(() => {
         qb = {
+            select: jest.fn(() => qb),
             where: jest.fn(() => qb),
             andWhere: jest.fn(() => qb),
+            groupBy: jest.fn(() => qb),
             orderBy: jest.fn(() => qb),
             take: jest.fn(() => qb),
+            limit: jest.fn(() => qb),
             getMany: jest.fn(async () => []),
+            // Default: ONE owner has unprocessed work, which is the
+            // short-circuit path (identical to the plain oldest-first
+            // query). The fairness tests below override it.
+            getRawMany: jest.fn(async () => [{ userId: 'user-1' }]),
         };
         typeormRepo = {
             findOne: jest.fn(),
@@ -111,6 +118,73 @@ describe('IngestedEventRepository', () => {
             where: { processedAt: IsNull() },
             order: { occurredAt: 'ASC', createdAt: 'ASC' },
             take: 25,
+        });
+    });
+
+    /**
+     * The drain that consumes this is a five-minute cron with a fifty-row
+     * batch, so a global `ORDER BY occurredAt ASC LIMIT n` means one
+     * chatty source decides how long EVERY other customer waits: two
+     * thousand rows from one flapping Sentry issue is forty ticks — over
+     * three hours — during which a newly filed GitHub issue anywhere on
+     * the deployment does not become a Task. That is the input that
+     * silently swallows genuinely new work.
+     */
+    describe('findUnprocessed shares the batch between owners', () => {
+        const rowFor = (userId: string, minute: number) =>
+            ({
+                id: `${userId}-${minute}`,
+                userId,
+                occurredAt: new Date(Date.UTC(2026, 8, 1, 12, minute)),
+            }) as never;
+
+        it('gives every waiting owner a share instead of a global FIFO head', async () => {
+            qb.getRawMany.mockResolvedValue([{ userId: 'flooder' }, { userId: 'quiet-tenant' }]);
+            typeormRepo.find.mockImplementation(async (options: any) => {
+                const userId = options.where.userId as string;
+                // The flooder has far more waiting rows AND older ones, so
+                // a global FIFO would hand back nothing but theirs.
+                return userId === 'flooder'
+                    ? [rowFor('flooder', 0), rowFor('flooder', 1)]
+                    : [rowFor('quiet-tenant', 30)];
+            });
+
+            const batch = await repository.findUnprocessed(4);
+
+            expect(qb.getRawMany).toHaveBeenCalled();
+            expect(batch.map((row) => row.userId)).toContain('quiet-tenant');
+            // Per-owner reads are owner-scoped AND still oldest-first.
+            expect(typeormRepo.find).toHaveBeenCalledWith({
+                where: { processedAt: IsNull(), userId: 'flooder' },
+                order: { occurredAt: 'ASC', createdAt: 'ASC' },
+                take: 2,
+            });
+        });
+
+        it('hands the merged batch back oldest-first and inside the limit', async () => {
+            qb.getRawMany.mockResolvedValue([{ userId: 'a' }, { userId: 'b' }]);
+            typeormRepo.find.mockImplementation(async (options: any) =>
+                options.where.userId === 'a'
+                    ? [rowFor('a', 10), rowFor('a', 40)]
+                    : [rowFor('b', 5), rowFor('b', 20)],
+            );
+
+            const batch = await repository.findUnprocessed(3);
+
+            expect(batch).toHaveLength(3);
+            expect(batch.map((row) => row.id)).toEqual(['b-5', 'a-10', 'b-20']);
+        });
+
+        it('falls back to the plain query when the owner scan is unavailable', async () => {
+            qb.getRawMany.mockRejectedValue(new Error('no such function'));
+
+            await repository.findUnprocessed(25);
+
+            expect(typeormRepo.find).toHaveBeenCalledWith({
+                where: { processedAt: IsNull() },
+                order: { occurredAt: 'ASC', createdAt: 'ASC' },
+                take: 25,
+            });
         });
     });
 

--- a/packages/agent/src/ingest/__tests__/work-hint-resolver.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/work-hint-resolver.service.spec.ts
@@ -177,10 +177,21 @@ describe('WorkHintResolverService.verifyOwnedWorkId', () => {
         await expect(service.verifyOwnedWorkId('user-1', 'ghost')).resolves.toBeNull();
     });
 
-    it('fails OPEN on an infrastructure error — a flaky DB must not silently unroute events', async () => {
+    /**
+     * This assertion is the inverse of the one it replaces, deliberately.
+     *
+     * The old contract ("fail open on infrastructure") let a transient
+     * `findById` fault carry a caller-chosen `workId` through unverified,
+     * so a database blip was enough for an authenticated user to stamp
+     * another tenant's Work onto their own ingested events — and the
+     * Activity + Memory fan-out keyed off `event.workId` followed it. An
+     * ownership check is an identity check; identity checks fail closed.
+     * Unrouted is recoverable, cross-tenant is not.
+     */
+    it('fails CLOSED on an infrastructure error — an unverified workId never survives', async () => {
         const service = makeService({
             findById: jest.fn().mockRejectedValue(new Error('timeout')),
         });
-        await expect(service.verifyOwnedWorkId('user-1', 'w1')).resolves.toBe('w1');
+        await expect(service.verifyOwnedWorkId('user-1', 'w1')).resolves.toBeNull();
     });
 });

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -53,6 +53,18 @@ export interface IngestResult {
     filtered: number;
 }
 
+/**
+ * Backoff ceiling for a row that keeps failing, in drain ticks (five
+ * minutes each, so 32 ticks is a little under three hours).
+ */
+export const MAX_FAILURE_BACKOFF_TICKS = 32;
+
+/** Attempts after which a stuck row is logged at ERROR, not WARN. */
+export const FAILURE_ALERT_ATTEMPTS = 5;
+
+/** Cap on the in-process failure map, so it cannot grow unbounded. */
+const MAX_TRACKED_FAILURES = 5_000;
+
 export interface ProcessBatchResult {
     /** Rows marked processed this run. */
     processed: number;
@@ -137,6 +149,26 @@ export class EventIngestService {
 
     /** Kind-bound domain processors (Meetings, …) — see the interface doc. */
     private readonly kindProcessors: IngestedEventKindProcessor[] = [];
+
+    /**
+     * The drain in flight, if any — see {@link processBatch}.
+     *
+     * `findUnprocessed` takes no row lock and `markProcessed` is the LAST
+     * step of the fan-out, so two overlapping drains select the SAME head
+     * rows and both run the kind processors on them. For the triage filer
+     * that means two `links.find()` misses, two `tasks.create()` calls and
+     * one orphaned Task that no `external_issue_links` row points at —
+     * invisible to dedup forever. Ticks overlap easily in practice: a
+     * batch that files 50 Tasks plus chat posts plus Memory writes can
+     * outrun the five-minute cron.
+     */
+    private inFlight: Promise<ProcessBatchResult> | null = null;
+
+    /**
+     * Consecutive failures per row id, and the tick from which the row
+     * may be attempted again — see {@link processBatch}.
+     */
+    private readonly failures = new Map<string, { count: number; skipTicks: number }>();
 
     constructor(
         private readonly repository: IngestedEventRepository,
@@ -251,8 +283,27 @@ export class EventIngestService {
      * Drain up to `limit` unprocessed rows through the processor
      * fan-out. Never throws for a single bad row — the row is either
      * retried next tick (Activity write failed) or completed.
+     *
+     * SINGLE-FLIGHT. A second call while a drain is running joins the
+     * one in flight instead of starting a competing pass. The row set is
+     * selected with a plain read and only marked processed at the END of
+     * the fan-out, so two concurrent passes would hand the same rows to
+     * the same idempotent-by-contract processors — and "idempotent"
+     * covers a RETRY (sequential), not a concurrent twin: two
+     * simultaneous triage filings both miss the dedup row and both create
+     * a Task. The worker-side guard is `queue: { concurrencyLimit: 1 }`
+     * on `event-ingest-tick`; this is the in-process floor under it.
      */
     async processBatch(limit = 50): Promise<ProcessBatchResult> {
+        if (this.inFlight) return this.inFlight;
+        const run = this.drainBatch(limit).finally(() => {
+            this.inFlight = null;
+        });
+        this.inFlight = run;
+        return run;
+    }
+
+    private async drainBatch(limit: number): Promise<ProcessBatchResult> {
         const result: ProcessBatchResult = {
             processed: 0,
             activities: 0,
@@ -260,7 +311,22 @@ export class EventIngestService {
             issueLinks: 0,
             failed: 0,
         };
-        const events = await this.repository.findUnprocessed(limit);
+        // Over-fetch by the number of rows currently serving a backoff so
+        // a wedged row cannot hold a slot that healthy work needs.
+        const backedOff = this.countBackedOff();
+        const candidates = await this.repository.findUnprocessed(
+            limit + Math.min(backedOff, limit),
+        );
+
+        const events: IngestedEvent[] = [];
+        for (const candidate of candidates) {
+            if (events.length >= limit) break;
+            if (this.isBackedOff(candidate.id)) continue;
+            events.push(candidate);
+        }
+        // Age the backoffs only AFTER the selection above, so a row with
+        // one tick left really sits this tick out.
+        this.ageBackoff();
 
         for (const event of events) {
             try {
@@ -273,11 +339,7 @@ export class EventIngestService {
                 await this.runKindProcessors(event);
             } catch (error) {
                 result.failed += 1;
-                this.logger.warn(
-                    `Kind processor failed for ingested event ${event.id} (${event.kind}): ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                );
+                this.recordFailure(event, 'kind processor', error);
                 continue;
             }
 
@@ -288,11 +350,7 @@ export class EventIngestService {
                 // REQUIRED processor failed — leave the row unprocessed so
                 // the next tick retries it, and keep draining the batch.
                 result.failed += 1;
-                this.logger.warn(
-                    `Activity write failed for ingested event ${event.id}: ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                );
+                this.recordFailure(event, 'Activity write', error);
                 continue;
             }
 
@@ -309,10 +367,68 @@ export class EventIngestService {
             }
 
             await this.repository.markProcessed(event.id);
+            this.failures.delete(event.id);
             result.processed += 1;
         }
 
         return result;
+    }
+
+    /**
+     * Remember that a row failed, and put it on an exponential backoff.
+     *
+     * A row whose processor fails PERMANENTLY is never marked processed
+     * and always sorts to the head of its owner's oldest-first queue, so
+     * without this it is re-selected every tick for the life of the
+     * deployment and permanently consumes one of the batch's slots —
+     * fifty such rows wedge the drain outright. Worse, a filer that
+     * creates a Task and then fails to write its dedup row leaves one
+     * orphan Task behind per attempt: 288 a day at a five-minute tick.
+     *
+     * The counter is per PROCESS and deliberately not a schema column:
+     * skipping is a scheduling decision, not durable state, and a
+     * restart or a deploy re-attempts every row immediately — a wedged
+     * row must never become an invisibly dropped one. Rows that fail
+     * transiently (the common case) retry on the very next tick, because
+     * a single failure costs zero skipped ticks.
+     */
+    private recordFailure(event: IngestedEvent, stage: string, error: unknown): void {
+        const previous = this.failures.get(event.id)?.count ?? 0;
+        const count = previous + 1;
+        const skipTicks = Math.min(MAX_FAILURE_BACKOFF_TICKS, count <= 1 ? 0 : 2 ** (count - 2));
+        this.failures.set(event.id, { count, skipTicks });
+        if (this.failures.size > MAX_TRACKED_FAILURES) {
+            const oldest = this.failures.keys().next();
+            if (!oldest.done) this.failures.delete(oldest.value);
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        const suffix = skipTicks > 0 ? ` — skipping the next ${skipTicks} tick(s)` : '';
+        const line = `${stage} failed for ingested event ${event.id} (${event.kind}), attempt ${count}${suffix}: ${message}`;
+        if (count >= FAILURE_ALERT_ATTEMPTS) {
+            this.logger.error(line);
+        } else {
+            this.logger.warn(line);
+        }
+    }
+
+    /** How many rows are currently sitting a tick out. */
+    private countBackedOff(): number {
+        let waiting = 0;
+        for (const entry of this.failures.values()) {
+            if (entry.skipTicks > 0) waiting += 1;
+        }
+        return waiting;
+    }
+
+    /** Age every backoff by one tick. Called AFTER the batch is selected. */
+    private ageBackoff(): void {
+        for (const entry of this.failures.values()) {
+            if (entry.skipTicks > 0) entry.skipTicks -= 1;
+        }
+    }
+
+    private isBackedOff(id: string): boolean {
+        return (this.failures.get(id)?.skipTicks ?? 0) > 0;
     }
 
     /** Run every registered processor whose kinds include this event's (or `'*'`). */

--- a/packages/agent/src/ingest/external-issue-link.repository.ts
+++ b/packages/agent/src/ingest/external-issue-link.repository.ts
@@ -16,6 +16,30 @@ export interface UpsertExternalIssueLinkData {
     lastSeenAt?: Date | null;
     tenantId?: string | null;
     organizationId?: string | null;
+    /**
+     * Times this issue has re-opened work after its Task was closed.
+     * Omitted = left untouched (the ordinary file / refresh path never
+     * moves it); the triage filer sets it explicitly when a regression
+     * supersedes a closed Task.
+     */
+    regressionCount?: number;
+    /**
+     * Insert-only: when a row already binds this
+     * `(userId, source, externalIssueId)`, leave it exactly as it is and
+     * hand it back instead of re-pointing it at `taskId`.
+     *
+     * This is what makes a FIRST link race-safe. Two concurrent drains
+     * that both miss the link both create a Task and both write; without
+     * this flag the second write re-points the single row at the second
+     * Task and ORPHANS the first — no link row references it, so it never
+     * receives an update comment and is never deduped away, and the board
+     * shows two triage Tasks for one issue. With it the loser learns it
+     * lost (the returned row names the winner's Task) and can clean up.
+     *
+     * A deliberate RE-POINT — a regression superseding a closed Task, or
+     * re-filing after the linked Task was deleted — omits the flag.
+     */
+    onlyIfAbsent?: boolean;
 }
 
 /** Freshness breadcrumbs stamped by the ingest drain. */
@@ -81,6 +105,9 @@ export class ExternalIssueLinkRepository {
     async upsert(data: UpsertExternalIssueLinkData): Promise<ExternalIssueLink> {
         const existing = await this.findByExternal(data.userId, data.source, data.externalIssueId);
         if (existing) {
+            // Insert-only caller and the key is taken: the holder wins,
+            // untouched. See `onlyIfAbsent`.
+            if (data.onlyIfAbsent) return existing;
             existing.taskId = data.taskId;
             if (data.externalKey !== undefined) existing.externalKey = data.externalKey;
             if (data.title !== undefined) existing.title = data.title;
@@ -91,11 +118,19 @@ export class ExternalIssueLinkRepository {
             if (data.lastSeenAt !== undefined) existing.lastSeenAt = data.lastSeenAt;
             if (data.tenantId !== undefined) existing.tenantId = data.tenantId;
             if (data.organizationId !== undefined) existing.organizationId = data.organizationId;
+            if (data.regressionCount !== undefined) {
+                existing.regressionCount = data.regressionCount;
+            }
             return this.repository.save(existing);
         }
 
+        // `onlyIfAbsent` is a write MODE, not a column — keep it out of
+        // the entity the insert is built from.
+        const { onlyIfAbsent: _mode, ...columns } = data;
         try {
-            return await this.repository.save(this.repository.create({ ...data }));
+            return await this.repository.save(
+                this.repository.create({ ...columns, regressionCount: data.regressionCount ?? 0 }),
+            );
         } catch (error) {
             // Concurrent first link for the same issue — the UNIQUE index
             // picked a winner; adopt it rather than throw.

--- a/packages/agent/src/ingest/external-issue-link.service.ts
+++ b/packages/agent/src/ingest/external-issue-link.service.ts
@@ -36,6 +36,21 @@ export interface LinkExternalIssueInput {
      */
     lastIngestedEventId?: string | null;
     lastSeenAt?: Date | null;
+    /**
+     * Times this external issue has RE-OPENED work (a regression
+     * superseding a closed Task). Omitted = left untouched, which is
+     * every ordinary file / refresh.
+     */
+    regressionCount?: number;
+    /**
+     * Insert-only. When a link already exists for
+     * `(userId, source, externalIssueId)` it is returned UNCHANGED
+     * instead of being re-pointed at `taskId` — see
+     * `UpsertExternalIssueLinkData.onlyIfAbsent`. A caller that filed a
+     * Task must compare `taskId` on the returned row: a different id
+     * means it lost the race and its own Task is an orphan.
+     */
+    onlyIfAbsent?: boolean;
 }
 
 /**
@@ -111,6 +126,10 @@ export class ExternalIssueLinkService {
                 ? { lastIngestedEventId: input.lastIngestedEventId }
                 : {}),
             ...(input.lastSeenAt !== undefined ? { lastSeenAt: input.lastSeenAt } : {}),
+            ...(input.regressionCount !== undefined
+                ? { regressionCount: input.regressionCount }
+                : {}),
+            ...(input.onlyIfAbsent ? { onlyIfAbsent: true } : {}),
         });
     }
 

--- a/packages/agent/src/ingest/ingested-event.repository.ts
+++ b/packages/agent/src/ingest/ingested-event.repository.ts
@@ -23,6 +23,16 @@ export function computeDedupeKey(userId: string, source: string, sourceEventId: 
     return hash.digest('hex');
 }
 
+/**
+ * How many distinct owners one drain batch is shared between.
+ *
+ * Bounds the per-tick query count (one grouped scan plus at most this
+ * many small reads). Owners beyond the cap are not dropped — they rank
+ * by their oldest waiting row, so they enter on a later tick as the
+ * drained owners' minimums advance past theirs.
+ */
+export const MAX_DRAIN_OWNERS = 25;
+
 export interface CreateIngestedEventData {
     userId: string;
     organizationId?: string | null;
@@ -92,13 +102,84 @@ export class IngestedEventRepository {
         }
     }
 
-    /** Oldest-first batch of rows the processor has not drained yet. */
+    /**
+     * Oldest-first batch of rows the processor has not drained yet,
+     * SHARED FAIRLY between the owners that have work waiting.
+     *
+     * A plain `WHERE processedAt IS NULL ORDER BY occurredAt ASC LIMIT n`
+     * is a global FIFO with no tenant partitioning, and the drain that
+     * consumes it runs every five minutes with a batch of 50. One chatty
+     * source — a Sentry issue flapping, a connector backfill — therefore
+     * puts thousands of rows in front of every other customer on the
+     * deployment, and a newly filed GitHub issue does not become a Task
+     * for hours. That is the "input that silently swallows genuinely new
+     * work" this repository must not have.
+     *
+     * So the batch is assembled per owner instead: the owners with
+     * unprocessed rows are ranked by their OLDEST waiting row (so nobody
+     * can be starved indefinitely — a neglected owner's oldest row keeps
+     * ageing until it ranks), each of the first {@link MAX_DRAIN_OWNERS}
+     * contributes an equal share, and the merged batch is still handed
+     * back oldest-first so per-issue ordering inside one owner is
+     * unchanged.
+     *
+     * The single-owner case (every non-hosted deployment, and every
+     * hosted one at low volume) short-circuits to exactly the query it
+     * always ran.
+     */
     async findUnprocessed(limit: number): Promise<IngestedEvent[]> {
-        return this.repository.find({
-            where: { processedAt: IsNull() },
-            order: { occurredAt: 'ASC', createdAt: 'ASC' },
-            take: limit,
-        });
+        const capped = Math.max(1, Math.trunc(limit));
+        const oldestFirst = { occurredAt: 'ASC', createdAt: 'ASC' } as const;
+
+        const owners = await this.findOwnersWithUnprocessed(
+            Math.min(capped, MAX_DRAIN_OWNERS),
+        ).catch(() => null);
+
+        // No owner scan (unsupported driver shape / transient failure) or
+        // a single owner: the fair batch and the plain batch are the same
+        // rows, so take the cheaper path.
+        if (!owners || owners.length <= 1) {
+            return this.repository.find({
+                where: { processedAt: IsNull() },
+                order: oldestFirst,
+                take: capped,
+            });
+        }
+
+        const share = Math.max(1, Math.ceil(capped / owners.length));
+        const batch: IngestedEvent[] = [];
+        for (const userId of owners) {
+            const rows = await this.repository.find({
+                where: { processedAt: IsNull(), userId },
+                order: oldestFirst,
+                take: share,
+            });
+            batch.push(...rows);
+        }
+
+        return batch
+            .sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime())
+            .slice(0, capped);
+    }
+
+    /**
+     * Owner ids that have unprocessed rows, the one whose oldest row has
+     * waited longest first. Ranking by `MIN(occurredAt)` — rather than by
+     * row count or arbitrarily — is what makes the share-out
+     * starvation-free: draining an owner advances their minimum, so every
+     * other owner's minimum becomes comparatively older and they rank in
+     * on a later tick.
+     */
+    private async findOwnersWithUnprocessed(limit: number): Promise<string[]> {
+        const rows = await this.repository
+            .createQueryBuilder('event')
+            .select('event.userId', 'userId')
+            .where('event.processedAt IS NULL')
+            .groupBy('event.userId')
+            .orderBy('MIN(event.occurredAt)', 'ASC')
+            .limit(limit)
+            .getRawMany<{ userId: string }>();
+        return rows.map((row) => row.userId).filter((userId): userId is string => Boolean(userId));
     }
 
     async markProcessed(id: string, processedAt: Date = new Date()): Promise<void> {

--- a/packages/agent/src/ingest/work-hint-resolver.service.ts
+++ b/packages/agent/src/ingest/work-hint-resolver.service.ts
@@ -77,9 +77,18 @@ export class WorkHintResolverService {
      * could stamp another tenant's Work onto their own events and have
      * the spine write Activity rows + Memory observations against it.
      *
-     * Returns the id when it checks out, null when it provably does not.
-     * A lookup FAILURE keeps the id (fail-open on infrastructure, closed
-     * on identity) — same posture as the rest of the spine.
+     * Returns the id when it checks out, null in every other case —
+     * including when the lookup itself FAILED.
+     *
+     * This is an identity check, and identity checks fail CLOSED. The
+     * method used to keep the caller's id on a lookup error, which meant
+     * a transient database fault was all it took for a caller-chosen
+     * `workId` to survive unverified: the `ingested_events` row, its
+     * Activity fan-out and the Memory observations derived from
+     * `event.workId` would all be written against another tenant's Work.
+     * The cost of failing closed is that the event ingests UNROUTED
+     * (`workId: null`) during the fault — recoverable, visible in the
+     * feed, and nothing crosses a tenant boundary.
      */
     async verifyOwnedWorkId(userId: string, workId: string): Promise<string | null> {
         try {
@@ -88,11 +97,11 @@ export class WorkHintResolverService {
             return work.userId === userId ? workId : null;
         } catch (error) {
             this.logger.warn(
-                `workId ownership check failed for ${workId} — keeping the caller's value: ${
+                `workId ownership check failed for ${workId} — dropping the caller's value (identity checks fail closed): ${
                     error instanceof Error ? error.message : String(error)
                 }`,
             );
-            return workId;
+            return null;
         }
     }
 

--- a/packages/agent/src/triggers/__tests__/inbound-triggers-events.spec.ts
+++ b/packages/agent/src/triggers/__tests__/inbound-triggers-events.spec.ts
@@ -322,6 +322,88 @@ describe('InboundTriggersService — event-sourced triggers', () => {
             expect(tasks.create).toHaveBeenCalledTimes(2);
         });
 
+        /**
+         * The per-(trigger, event) claim above dedupes RETRIES of one row;
+         * it says nothing about a source that emits many rows for ONE
+         * subject. `{ kind: 'incident' }` — the configuration the
+         * integrations page itself recommends — therefore used to file a
+         * Task per Sentry alert AND, whenever `targetAgentId` is set with
+         * the default `autoStart: 'always'`, dispatch an agent RUN per
+         * alert. One flapping issue was a Task storm and an agent-run
+         * storm; documenting that in a warning box did not close it.
+         *
+         * The trigger already carried the knob and the event path simply
+         * never applied it: inside `replayWindowSec`, many rows about one
+         * subject are one fire.
+         */
+        describe('subject coalescing (a chatty source is not a Task storm)', () => {
+            const incident = (id: string, issueId = '4501') =>
+                makeEvent({
+                    id,
+                    source: 'sentry',
+                    kind: 'incident',
+                    subjectType: 'issue',
+                    subjectExternalId: issueId,
+                    payload: { provider: 'sentry', issueId, resource: 'event_alert' },
+                });
+
+            const INCIDENTS = {
+                sourceType: 'event' as const,
+                eventMatcher: { kind: 'incident' },
+            };
+
+            it('files ONE Task for twenty alerts about the same issue', async () => {
+                const { service, tasks } = makeService();
+                await service.create(SCOPE, { name: 'Incidents', ...INCIDENTS });
+
+                let deduped = 0;
+                for (let i = 0; i < 20; i += 1) {
+                    deduped += (await service.fireForEvent(incident(`row-${i}`))).deduped;
+                }
+
+                expect(tasks.create).toHaveBeenCalledTimes(1);
+                expect(deduped).toBe(19);
+            });
+
+            it('does not swallow a DIFFERENT issue', async () => {
+                const { service, tasks } = makeService();
+                await service.create(SCOPE, { name: 'Incidents', ...INCIDENTS });
+
+                await service.fireForEvent(incident('row-a', '4501'));
+                await service.fireForEvent(incident('row-b', '9999'));
+
+                expect(tasks.create).toHaveBeenCalledTimes(2);
+            });
+
+            it('fires the same subject again once the replay window has passed', async () => {
+                const { service, tasks, fires } = makeService();
+                await service.create(SCOPE, {
+                    name: 'Incidents',
+                    ...INCIDENTS,
+                    replayWindowSec: 10,
+                });
+
+                await service.fireForEvent(incident('row-a'));
+                // Age every ledger row past the window.
+                for (const row of fires!._rows.values()) {
+                    row.firedAt = new Date(Date.now() - 60_000);
+                }
+                await service.fireForEvent(incident('row-b'));
+
+                expect(tasks.create).toHaveBeenCalledTimes(2);
+            });
+
+            it('leaves subject-less events (a push, a chat message) firing per event', async () => {
+                const { service, tasks } = makeService();
+                await service.create(SCOPE, { name: 'Pushes', ...MATCH_ALL_GITHUB });
+
+                await service.fireForEvent(makeEvent({ id: 'event-1' }));
+                await service.fireForEvent(makeEvent({ id: 'event-2' }));
+
+                expect(tasks.create).toHaveBeenCalledTimes(2);
+            });
+        });
+
         it('skips non-matching, paused, and webhook-sourced triggers', async () => {
             const { service, tasks } = makeService();
             await service.create(SCOPE, {

--- a/packages/agent/src/triggers/inbound-triggers.service.ts
+++ b/packages/agent/src/triggers/inbound-triggers.service.ts
@@ -82,6 +82,26 @@ export class FireRefusedError extends BadRequestException {}
 /** Shape check for `eventMatcher.workId` (any RFC-4122 version). */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** Fire-log reason for a fire the subject window swallowed. */
+export const SUBJECT_COALESCED_REASON =
+    'Coalesced: this trigger already fired for the same subject inside its replay window';
+
+/** Cap on the subject dedupe key, so a hostile external id cannot bloat the ledger column. */
+const SUBJECT_DEDUPE_KEY_MAX_CHARS = 180;
+
+/**
+ * The coalescing identity of an ingested event: its SUBJECT.
+ *
+ * `null` for an event with no stable subject (a chat message, a push) —
+ * those have nothing to coalesce on and fire per event, unchanged.
+ * See the block comment in `fireForEvent` for why this exists.
+ */
+export function eventSubjectDedupeKey(event: IngestedEvent): string | null {
+    const externalId = event.subjectExternalId?.trim();
+    if (!externalId) return null;
+    return `subject:${event.source}:${externalId}`.slice(0, SUBJECT_DEDUPE_KEY_MAX_CHARS);
+}
+
 function toIso(value: Date | null | undefined): string | null {
     if (!value) return null;
     const time = value instanceof Date ? value : new Date(value);
@@ -460,6 +480,11 @@ export class InboundTriggersService {
      *     event, enforced by the `inbound_trigger_fires` UNIQUE claim —
      *     a retried batch re-offers the event and every trigger that
      *     already fired is a silent dedupe.
+     *   - COALESCED per (trigger, subject) inside the trigger's
+     *     `replayWindowSec`: many rows about ONE issue / incident are one
+     *     fire, so a flapping source cannot turn into a Task storm and an
+     *     agent-run storm. Events with no `subjectExternalId` are
+     *     unaffected. See the block comment at the claim site.
      *   - NEVER throws for a single bad trigger: per-trigger failures
      *     are logged and counted, the remaining triggers still fire,
      *     and the ingest row is never blocked by one broken rule.
@@ -492,6 +517,8 @@ export class InboundTriggersService {
             },
         });
 
+        const subjectKey = eventSubjectDedupeKey(event);
+
         for (const row of rows) {
             if (!matchesEvent(row.eventMatcher, event)) continue;
             try {
@@ -502,6 +529,49 @@ export class InboundTriggersService {
                     result.deduped += 1;
                     continue;
                 }
+
+                // SUBJECT COALESCING. The permanent claim above dedupes
+                // RETRIES of one row; it says nothing about a source that
+                // emits many rows for one subject. A `{kind:'incident'}`
+                // trigger — the configuration the integrations doc itself
+                // recommends — therefore used to file one Task AND, when
+                // `targetAgentId` is set with the default
+                // `autoStart: 'always'`, dispatch one agent RUN per Sentry
+                // alert: a flapping issue is a Task storm and an agent-run
+                // storm from one incident.
+                //
+                // The trigger already carries the knob for this and the
+                // event path simply never applied it: `replayWindowSec` is
+                // "how long the same delivery identity is considered the
+                // same fire". For an ingested event the delivery identity
+                // that matters to a human is the SUBJECT (the issue, the
+                // incident), not the row. So a second claim is taken on
+                // `subject:<source>:<externalId>` inside that window; the
+                // row's own claim is closed as refused with a reason the
+                // fire log renders, so the coalescing is visible rather
+                // than silent. Events with no subject (a raw message, a
+                // push) are unaffected and fire per event as before.
+                if (subjectKey) {
+                    const coalesced = await this.fires.claim(
+                        row.id,
+                        subjectKey,
+                        'event',
+                        this.replayWindowMs(row),
+                    );
+                    if (!coalesced.won) {
+                        await this.closeFire(claim.fire, 'refused', {
+                            reason: SUBJECT_COALESCED_REASON,
+                        });
+                        result.deduped += 1;
+                        continue;
+                    }
+                    // The subject row is a coalescing marker, not a fire:
+                    // settle it immediately so it never shows as running,
+                    // and so it is not re-claimable as a "produced no
+                    // Task" row inside its own window.
+                    await this.closeFire(coalesced.fire, 'done', { taskId: null });
+                }
+
                 const templateEvent = this.toTemplateEvent(event);
                 await this.executeFire(row, {
                     fire: claim.fire,

--- a/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
+++ b/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
@@ -34,6 +34,26 @@ import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-inte
 export const eventIngestTickTask = schedules.task({
     id: 'event-ingest-tick',
     cron: '*/5 * * * *',
+    /**
+     * STRICTLY ONE DRAIN AT A TIME.
+     *
+     * `findUnprocessed` takes no row lock and `markProcessed` is the last
+     * step of the fan-out, so a tick that outruns the five-minute cron —
+     * easy once a batch is filing 50 Tasks with chat posts, Memory writes
+     * and embeddings — would overlap the next one on the SAME head rows.
+     * Both passes then miss the triage filer's dedup row and both create
+     * a Task, and the loser is orphaned: no `external_issue_links` row
+     * points at it, so it is never updated and never deduped away.
+     *
+     * `concurrencyLimit: 1` is the same lever `kb-embed-document` uses
+     * for its per-Work serialisation; `EventIngestService.processBatch`
+     * carries the matching in-process guard for anything that calls it
+     * outside this task.
+     */
+    queue: {
+        name: 'event-ingest',
+        concurrencyLimit: 1,
+    },
     run: async () => {
         return withWorkerContext(
             'EventIngestTick',


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AF**. Refs **EW-804**, and it builds directly on **EW-794**.

**Scope note first.** Both halves of AF as briefed were already merged: `00036d06c` / #2367 (EW-794) landed the `issues` event, the `jira.issue` kind, the Sentry inbound source and the deduped triage Task. The brief's premise is quoted verbatim, in the past tense, inside the code that fixed it. So this PR is the part of the requirement that had **no code and no test**, plus a real defect found next to it.

### 1. A regression could never re-open work

The filer keyed one Task per `(userId, source, externalIssueId)` **forever**. A reopened GitHub issue or a Sentry `unresolved` posted a comment onto a Task that was already `done`, and no new work was ever opened. The brief asks for exactly this: *"a reopened or regressed issue must be able to produce a new one."*

Dedup now yields in **one** case, and **both** halves must hold:

1. the **vendor** said it came back, and
2. the Task the dedup key points at is already `done` or `cancelled`.

Without (1) a chatty vendor re-files forever. Without (2) a reopen forks the board while work is in flight. A repeated Sentry `event_alert` is deliberately **not** a regression signal — that is precisely how two thousand alerts stay one Task.

Detection is pure and per-vendor: GitHub `reopened`; Sentry `unresolved` / `unarchived`; Dependabot `reopened` / `reintroduced` / `auto_reopened`; and Jira, which has no reopen event, by a changelog transition **out of** a done-named status **into** one that is not — two-sided, so `Done → Closed` cannot mis-fire, and an unlisted custom done status simply never re-files and still gets its comment.

**The dedup key never changes.** The same `external_issue_links` row is re-pointed at the new Task, `regressionCount` increments, the new Task is marked as a regression, and the superseded Task gets one comment naming its replacement, so the trail runs both ways. If the new Task cannot be filed the filer falls back to commenting: a regression is never silently dropped.

### 2. The legacy route answered 200 on a failure it had swallowed

`POST /api/github-app/webhooks` is the **default** URL for a GitHub App install — the route real issues arrive on. It swallowed intake-leg failures and answered 200, so **GitHub never redelivered and the issue silently never became work.** It now rethrows the intake error; the AI-review leg stays best-effort. Safe on retry: App sync is idempotent and the spine dedupes on `(source, sourceEventId)`.

### Tests that are worth reading

- **25 successive distinct alert events through the real `process()`** against a stateful link store produce exactly **one** `tasks.create` and 24 comments. Each alert is a genuinely distinct ingested row, so the spine's dedupe cannot be what saves it — the link row is.
- A signature **differential**: a Sentry delivery whose raw bytes are not `JSON.stringify(body)` verifies, and a digest computed over the re-serialized object is rejected. A re-serializing implementation cannot pass both.
- Regression against a **closed** Task creates and re-points; against an **open** Task it comments only and leaves `regressionCount` untouched. Both directions per vendor, including every chatty action that must not fire.

### Verified locally

| Check | Result |
| --- | --- |
| `apps/api` `src/ingest` + `src/migrations` | 67 suites / 582 tests, 0 failures |
| `packages/agent` ingest, database, entities, events | 94 suites / 1243 tests |
| migrations directory contract | passes; slot `1789600000000` used exactly once |
| `prettier --check` over all 35 changed files | clean |
| conflict markers / NUL bytes | none |

### Not verified locally, stated plainly

- **Six `apps/api` suites cannot load here** — `@ever-works/agent-plugins` has no build output in this checkout. They are unrelated to this diff by import path and run normally in CI.
- **The local `@ever-works/agent` build output was stale and I regenerated its type declarations from source** to type-check the ingest specs. That artifact is git-ignored and appears nowhere in this diff, and no product code was changed to accommodate it — but it does mean the local run leaned on a locally rebuilt `dist` rather than the one CI produces. CI is the authority here.
- The Sentry signature scheme is exercised against the implementation's own understanding of it; a human should confirm it against Sentry's current documentation before this is pointed at a live project.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
