### PR TITLE
test(e2e): pin the last GoalDto key, verified against the whole projection

### DIFF
--- a/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
+++ b/apps/web/e2e/flow-mission-goals-evaluation-chain.spec.ts
@@ -130,6 +130,9 @@ const GOAL_DTO_KEYS = [
     // existed — which is why it belongs in this exact-shape list rather
     // than being tolerated as optional.
     'goalKind',
+    // Goal loop-control knob (EW-796 self-build orchestration). Like
+    // `goalKind`, `toGoalDto` emits it unconditionally.
+    'maxConcurrentIterations',
     // Ownership scope: the DTO deliberately surfaces the tenant/Organization
     // pair a Goal is stamped with (e49936d8 "fix(api): expose and enforce
     // organization ownership"), so a client can tell a personal Goal from an


### PR DESCRIPTION
Stage run [33989749596](https://github.com/ever-works/ever-works/actions/runs/33989749596), shard 13.

My previous fix for this spec added `goalKind` and **worked** — this run reports a different missing key, `maxConcurrentIterations`, added by `5000c3a21` (EW-801) after that fix landed.

Two changes to one exact-shape list, each costing a full cascade cycle, because I fixed the key the error named instead of fixing the list. So this time I diffed every key `toGoalDto` emits against every key the spec pins:

```
emitted 43, pinned 43, missing none, extra none
```

Verified mechanically rather than by reading the failure. The exactness is the point of the assertion — it is what would catch a Goal DTO quietly gaining an owning `userId` — so the list is completed, never loosened.

With this, shard 10 (EW-802, fleet runner pill) is the only remaining stage e2e failure: that run was 31 green / 2 red, down from 9 red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation to account for the `maxConcurrentIterations` field in goal data.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->