### PR TITLE
fix(agent,web): two review findings — env isolation and a pointer invariant

### DIFF
--- a/apps/web/src/lib/api/bff-scope.navigation.unit.spec.ts
+++ b/apps/web/src/lib/api/bff-scope.navigation.unit.spec.ts
@@ -27,10 +27,16 @@ const base = { Authorization: 'Bearer fake-jwt' };
 
 describe('applyBffWorkspaceScopeFromNavigation', () => {
     beforeEach(() => {
+        // BOTH, because `trustedBrowserOrigin()` prefers
+        // NEXT_PUBLIC_WEB_URL. A test environment that sets it to another
+        // origin would otherwise make every matching-Referer case fail as
+        // cross-origin — the assertion would be measuring the environment.
         process.env.WEB_URL = 'http://web.example';
+        process.env.NEXT_PUBLIC_WEB_URL = 'http://web.example';
     });
     afterEach(() => {
         delete process.env.WEB_URL;
+        delete process.env.NEXT_PUBLIC_WEB_URL;
     });
 
     it('reads the Organization selector from ?scope= and forwards it as x-scope-slug', () => {
@@ -144,10 +150,16 @@ describe('applyBffWorkspaceScopeFromNavigation', () => {
 
 describe('applyBffWorkspaceScope (header variant) is unchanged', () => {
     beforeEach(() => {
+        // BOTH, because `trustedBrowserOrigin()` prefers
+        // NEXT_PUBLIC_WEB_URL. A test environment that sets it to another
+        // origin would otherwise make every matching-Referer case fail as
+        // cross-origin — the assertion would be measuring the environment.
         process.env.WEB_URL = 'http://web.example';
+        process.env.NEXT_PUBLIC_WEB_URL = 'http://web.example';
     });
     afterEach(() => {
         delete process.env.WEB_URL;
+        delete process.env.NEXT_PUBLIC_WEB_URL;
     });
 
     /**

--- a/packages/agent/src/mcp/__tests__/mcp-stdio-launcher.spec.ts
+++ b/packages/agent/src/mcp/__tests__/mcp-stdio-launcher.spec.ts
@@ -26,6 +26,17 @@ describe('stdio connection pseudo-URL', () => {
         });
     });
 
+    /**
+     * The MCP schema does not constrain `mcpServers` keys, so `a/b` is a
+     * schema-valid server name. It cannot reach here — the reconciler refuses
+     * any server whose `toolNamespace` is null, well before the pointer is
+     * built — but the pointer's grammar depends on that, and a silent
+     * mis-parse would lose an agent's tools rather than announce itself.
+     */
+    it('refuses a server name containing "/" instead of building an ambiguous pointer', () => {
+        expect(() => stdioConnectionUrl('acme-tools', 'a/b')).toThrow('must not contain');
+    });
+
     it.each([
         'https://example.test/mcp',
         'stdio:',

--- a/packages/agent/src/mcp/mcp-stdio-launcher.ts
+++ b/packages/agent/src/mcp/mcp-stdio-launcher.ts
@@ -51,6 +51,21 @@ export interface McpStdioLauncher {
 const STDIO_URL_PREFIX = 'stdio:';
 
 export function stdioConnectionUrl(packageName: string, serverName: string): string {
+    // The invariant this pointer's grammar rests on, asserted rather than
+    // assumed. `parseStdioConnectionUrl` splits on the LAST `/`, so a server
+    // name containing one would parse back as a different (package, server)
+    // pair and silently resolve to nothing.
+    //
+    // Nothing can reach here with such a name today: the MCP schema does NOT
+    // constrain `mcpServers` keys, but `PackageMcpReconcilerService` refuses
+    // any server whose `toolNamespace` is null — `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`
+    // — and that guard runs well before this is called, from the only
+    // production call site. The check is here so that relaxing the name gate
+    // later fails loudly at the boundary instead of quietly losing an agent's
+    // tools.
+    if (serverName.includes('/')) {
+        throw new Error(`MCP server name must not contain "/": ${serverName}`);
+    }
     return `${STDIO_URL_PREFIX}${packageName}/${serverName}`;
 }
 


### PR DESCRIPTION
Triage of the CodeRabbit review left on #2357 and #2366 after both merged. Each finding was checked against live code before acting.

## 1. Valid — fixed

`bff-scope.navigation.unit.spec.ts` set only `WEB_URL`, but `trustedBrowserOrigin()` prefers `NEXT_PUBLIC_WEB_URL`. A test environment that set it to another origin would make every matching-Referer case fail as cross-origin — the assertion would be measuring the environment rather than the code. Both are now set and cleared together, in both blocks.

## 2. Premise wrong — but the invariant is worth asserting

The finding said the MCP schemas accept server names containing `/` and that *"reconciliation does not reject them"*, so the stdio pointer would mis-parse.

**First half true:** neither `1.0.0` nor `1.1.0` constrains `mcpServers` keys — no `propertyNames`, no `patternProperties`. My earlier PR comment was loose about that.

**Second half false.** `PackageMcpReconcilerService.reconcileOne` refuses any server whose `toolNamespace` is null — `isToolNamespaceSafeServerName`, `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` — at line 215. The pointer is built at line 249, from the **only** production call site. Such a name never becomes a connection row, so no mis-parse is reachable and encoding the segments would be dead code.

What *is* worth having is the invariant stated where it is relied on: `stdioConnectionUrl` now throws on a server name containing `/`. If someone relaxes the name gate later, it fails loudly at the boundary instead of quietly losing an agent's tools.

## 3. Declined, with a reason

A suggestion to rebuild three specs on `Test.createTestingModule`. Every sibling spec in those directories constructs the service directly (`new McpToolSource(...)`, `new AgentRunService(...)`, and the pre-existing `stdio-server.service.spec.ts`), and these follow that convention. The one spec that actually tests dependency injection — `mcp-stdio-launcher-wiring.spec.ts` — *does* use `Test.createTestingModule`, because there the module graph is the thing under test. Converting pure unit tests would make ~50 tests slower for no behavioural coverage.

## Verification

`mcp-stdio-launcher.spec.ts` 10 green (1 new), `bff-scope.navigation.unit.spec.ts` 21 green, root `format:check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid MCP server names containing `/` are now rejected, preventing ambiguous connection references.

- **Tests**
  - Added regression coverage for invalid MCP server names.
  - Improved navigation tests to consistently validate trusted browser-origin handling across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->