### PR TITLE
feat(merge): a human can finally approve an agent's merge, and nothing else can (EW-805)

### DIFF
--- a/apps/api/src/agent-approvals/agent-approvals.controller.ts
+++ b/apps/api/src/agent-approvals/agent-approvals.controller.ts
@@ -78,14 +78,19 @@ export class AgentApprovalsController {
     @Post('approve-all')
     @ApiOperation({
         summary:
-            'Bulk-approve my pending proposals in one call (optional ids subset; already-decided rows are skipped)',
+            'Bulk-approve my pending proposals in one call (optional ids subset; already-decided rows are skipped, merge approvals are excluded and stay pending)',
     })
     @HttpCode(HttpStatus.OK)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     async approveAll(
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: ApproveAllAgentApprovalsDto,
-    ): Promise<{ approved: number; skipped: number }> {
+    ): Promise<{ approved: number; skipped: number; excluded: number }> {
+        // `skipped` and `excluded` are deliberately separate counters:
+        // skipped means "somebody already decided this", excluded means
+        // "bulk approve refused to decide it and it is STILL PENDING"
+        // (merge approval, slice AE). A client that collapses them tells
+        // the user their merge was handled when it was not.
         return this.service.approveAll(auth.userId, body.ids);
     }
 

--- a/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-reconciler.service.ts
@@ -225,8 +225,8 @@ export class FleetAgentTaskReconcilerService {
         // the event arrives as an ordinary `node-report`.
         //
         // Falling through from there ran the whole success path:
-        // `finalizeRemotePush` OPENED A PULL REQUEST — and can auto-merge it
-        // — for a Task the user had explicitly cancelled, then posted a
+        // `finalizeRemotePush` OPENED A PULL REQUEST for a Task the user had
+        // explicitly cancelled, then posted a
         // "run finished" chat message contradicting the cancellation.
         //
         // The terminal write itself was always safe: `markCompleted` CASes

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -98,6 +98,11 @@ describe('GitHubPrReviewBridgeService', () => {
             findByBranch: jest.fn().mockResolvedValue(null),
             findByPullRequest: jest.fn().mockResolvedValue(null),
         };
+        // Merge approval (slice AE) - the durable HUMAN approval recorder.
+        const approvals = {
+            recordPullRequestApproval: jest.fn().mockResolvedValue(true),
+            clearPullRequestApproval: jest.fn().mockResolvedValue(true),
+        };
         const service = new GitHubPrReviewBridgeService(
             userPluginRepository as any,
             pluginSettingsService as any,
@@ -106,6 +111,7 @@ describe('GitHubPrReviewBridgeService', () => {
             installBindings as any,
             rejections as any,
             taskLinks as any,
+            approvals as any,
         );
         return {
             service,
@@ -116,6 +122,7 @@ describe('GitHubPrReviewBridgeService', () => {
             installBindings,
             rejections,
             taskLinks,
+            approvals,
         };
     }
 
@@ -929,12 +936,30 @@ describe('GitHubPrReviewBridgeService', () => {
             expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
         });
 
-        it('ignores an approval - only a rejection carries feedback for the next run', async () => {
+        // CONTRACT NARROWED (merge approval, slice AE). This used to read
+        // "ignores an approval - only a rejection carries feedback for the
+        // next run" and assert that nothing at all happened. The claim
+        // about REJECTION FEEDBACK is still exactly right and is still
+        // pinned here; what was wrong was the consequence, because
+        // dropping the delivery entirely left the platform unable to
+        // answer "has a person read this pull request?" - the first thing
+        // somebody authorising a merge wants to know. An approval is now
+        // recorded on its own path, and still never becomes rejection
+        // feedback for the next run.
+        it('does not turn an approval into rejection feedback for the next run', async () => {
             const { service, rejections } = createService();
             await service.handleEvent(
                 BINDING,
                 'pull_request_review',
-                reviewBody({ review: { id: 1, state: 'approved', body: 'ship it' } }),
+                reviewBody({
+                    review: {
+                        id: 1,
+                        state: 'approved',
+                        body: 'ship it',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'octocat', type: 'User' },
+                    },
+                }),
             );
             expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
         });
@@ -973,6 +998,260 @@ describe('GitHubPrReviewBridgeService', () => {
             rejections.recordPullRequestRejection.mockRejectedValue(new Error('db down'));
             await expect(
                 service.handleEvent(BINDING, 'pull_request_review', reviewBody()),
+            ).resolves.toEqual({ ingested: null });
+        });
+    });
+
+    describe('pull_request_review -> human review approval (merge approval, slice AE)', () => {
+        function approvalBody(over: Record<string, unknown> = {}) {
+            return {
+                action: 'submitted',
+                repository: { full_name: 'octo/site' },
+                pull_request: {
+                    number: 9,
+                    html_url: 'https://github.com/octo/site/pull/9',
+                    head: { sha: 'b'.repeat(40) },
+                },
+                review: {
+                    id: 1,
+                    state: 'approved',
+                    body: 'looks right',
+                    commit_id: 'a'.repeat(40),
+                    submitted_at: '2026-09-01T10:00:00Z',
+                    user: { login: 'octocat', type: 'User' },
+                },
+                ...over,
+            };
+        }
+
+        it('records a human approval against the commit the reviewer actually saw', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(BINDING, 'pull_request_review', approvalBody());
+            expect(approvals.recordPullRequestApproval).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: BINDING.userId,
+                    owner: 'octo',
+                    repo: 'site',
+                    prNumber: 9,
+                    // review.commit_id, NOT pull_request.head.sha - recording
+                    // the branch head "now" would launder a review of an old
+                    // diff into a review of whatever was pushed since.
+                    headSha: 'a'.repeat(40),
+                    reviewerLabel: 'octocat',
+                    approvedAt: new Date('2026-09-01T10:00:00Z'),
+                }),
+            );
+        });
+
+        // CONTRACT REVERSAL (AE review). This used to be "falls back to
+        // the pull request head only when the review names no commit", and
+        // it pinned exactly the laundering the two docblocks either side
+        // of it forbid: `TaskReviewApprovalService` says headSha "is the
+        // review's own commit_id - the commit the reviewer actually looked
+        // at, not the branch head now. Storing the branch head instead
+        // would silently launder an approval of an old diff into an
+        // approval of whatever was pushed since." `pull_request.head.sha`
+        // IS the branch head now, and on a redelivered, trimmed or GHES
+        // payload it can be several commits past what the reviewer read.
+        //
+        // An unattributable approval is dropped instead - which is what
+        // the consuming service's own no-commit-id branch already did, so
+        // the fallback was only ever producing a WRONG record where the
+        // alternative was no record.
+        it('records NOTHING when the review names no commit — it never guesses the head', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    review: {
+                        id: 1,
+                        state: 'approved',
+                        user: { login: 'octocat', type: 'User' },
+                    },
+                }),
+            );
+            expect(approvals.recordPullRequestApproval).toHaveBeenCalledWith(
+                expect.objectContaining({ headSha: null }),
+            );
+            // Emphatically not the branch head, which is what the Inbox
+            // would otherwise show as "octocat reviewed this commit".
+            expect(approvals.recordPullRequestApproval).not.toHaveBeenCalledWith(
+                expect.objectContaining({ headSha: 'b'.repeat(40) }),
+            );
+        });
+
+        it('IGNORES the platform own bot approving its own pull request', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    review: {
+                        id: 1,
+                        state: 'approved',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'ever-works[bot]', type: 'Bot' },
+                    },
+                }),
+            );
+            expect(approvals.recordPullRequestApproval).not.toHaveBeenCalled();
+        });
+
+        it('IGNORES an allow-listed reviewer bot approving - its rejections count, its blessings do not', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    review: {
+                        id: 1,
+                        state: 'approved',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'coderabbitai[bot]', type: 'Bot' },
+                    },
+                }),
+            );
+            expect(approvals.recordPullRequestApproval).not.toHaveBeenCalled();
+        });
+
+        it.each(['commented', 'dismissed'])(
+            'records no APPROVAL for a %s review',
+            async (state) => {
+                const { service, approvals, rejections } = createService();
+                await service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    approvalBody({
+                        review: {
+                            id: 1,
+                            state,
+                            commit_id: 'a'.repeat(40),
+                            user: { login: 'octocat', type: 'User' },
+                        },
+                    }),
+                );
+                expect(approvals.recordPullRequestApproval).not.toHaveBeenCalled();
+                expect(rejections.recordPullRequestRejection).not.toHaveBeenCalled();
+            },
+        );
+
+        // A recorded approval that is never revoked (AE review). The
+        // head-SHA binding answers "did the code change under the
+        // approval?"; it says nothing about the reviewer changing their
+        // mind about the SAME commit — which is precisely the case where
+        // a person read the diff again and decided against it. Without
+        // this, the merge proposal goes on telling whoever is authorising
+        // it that "alice reviewed this" after alice explicitly withdrew.
+
+        it('WITHDRAWS the recorded approval when its author dismisses the review', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    action: 'dismissed',
+                    review: {
+                        id: 1,
+                        state: 'dismissed',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'octocat', type: 'User' },
+                    },
+                }),
+            );
+            expect(approvals.clearPullRequestApproval).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: BINDING.userId,
+                    owner: 'octo',
+                    repo: 'site',
+                    prNumber: 9,
+                    reviewerLabel: 'octocat',
+                }),
+            );
+        });
+
+        it('WITHDRAWS it when the same person replaces their approval with changes_requested', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    review: {
+                        id: 2,
+                        state: 'changes_requested',
+                        body: 'actually, no',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'octocat', type: 'User' },
+                    },
+                }),
+            );
+            expect(approvals.clearPullRequestApproval).toHaveBeenCalledWith(
+                expect.objectContaining({ reviewerLabel: 'octocat' }),
+            );
+        });
+
+        it('does not attempt a withdrawal for a BOT review', async () => {
+            // A bot never wrote one of these records, so it can never
+            // clear one — the same rule as the writer, from the other side.
+            const { service, approvals } = createService();
+            await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody({
+                    review: {
+                        id: 1,
+                        state: 'dismissed',
+                        commit_id: 'a'.repeat(40),
+                        user: { login: 'coderabbitai[bot]', type: 'Bot' },
+                    },
+                }),
+            );
+            expect(approvals.clearPullRequestApproval).not.toHaveBeenCalled();
+        });
+
+        it('does not attempt a withdrawal on an APPROVED review', async () => {
+            const { service, approvals } = createService();
+            await service.handleEvent(BINDING, 'pull_request_review', approvalBody());
+            expect(approvals.clearPullRequestApproval).not.toHaveBeenCalled();
+        });
+
+        it('a withdrawal failure never fails the delivery', async () => {
+            const { service, approvals } = createService();
+            approvals.clearPullRequestApproval.mockRejectedValue(new Error('db down'));
+            await expect(
+                service.handleEvent(
+                    BINDING,
+                    'pull_request_review',
+                    approvalBody({
+                        review: {
+                            id: 1,
+                            state: 'dismissed',
+                            commit_id: 'a'.repeat(40),
+                            user: { login: 'octocat', type: 'User' },
+                        },
+                    }),
+                ),
+            ).resolves.toEqual({ ingested: null });
+        });
+
+        it('never enters the review loop', async () => {
+            const { service, prReviewService, eventIngestService } = createService();
+            const result = await service.handleEvent(
+                BINDING,
+                'pull_request_review',
+                approvalBody(),
+            );
+            expect(result.ingested).toBeNull();
+            expect(eventIngestService.ingest).not.toHaveBeenCalled();
+            await flush();
+            expect(prReviewService.reviewPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('a recorder failure never fails the delivery', async () => {
+            const { service, approvals } = createService();
+            approvals.recordPullRequestApproval.mockRejectedValue(new Error('db down'));
+            await expect(
+                service.handleEvent(BINDING, 'pull_request_review', approvalBody()),
             ).resolves.toEqual({ ingested: null });
         });
     });

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -9,7 +9,11 @@ import {
 } from '@ever-works/agent/ingest';
 import { PrReviewService } from '@ever-works/agent/pr-review';
 import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/plugins';
-import { TaskGitLinkService, TaskReviewRejectionService } from '@ever-works/agent/tasks-domain';
+import {
+    TaskGitLinkService,
+    TaskReviewApprovalService,
+    TaskReviewRejectionService,
+} from '@ever-works/agent/tasks-domain';
 import type { TaskGitLink } from '@ever-works/agent/tasks-domain';
 import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
 import { config } from '../../config/constants';
@@ -215,7 +219,16 @@ export interface GitHubWebhookBody {
         state?: string;
         body?: string;
         html_url?: string;
+        /**
+         * The commit the reviewer actually looked at. Load-bearing for
+         * merge approval (slice AE): an approval recorded against the
+         * branch head "now" rather than against this would silently
+         * launder a review of an old diff into a review of whatever has
+         * been pushed since.
+         */
+        commit_id?: string;
         user?: { login?: string; type?: string };
+        submitted_at?: string;
     };
 }
 
@@ -396,6 +409,13 @@ export class GitHubPrReviewBridgeService {
         // and, like `rejections`, deliberately NOT @Optional(): the same
         // TasksDomainModule provides it.
         private readonly taskLinks: TaskGitLinkService,
+        // Merge approval (self-build slice AE, EW-805) - persist a HUMAN
+        // `approved` review against the commit it was given for. Appended
+        // LAST and, like the two above, deliberately NOT @Optional(): the
+        // same TasksDomainModule provides it, and an approval recorder
+        // that silently did nothing would leave the merge approval UI
+        // saying "nobody has reviewed this" forever.
+        private readonly approvals: TaskReviewApprovalService,
     ) {}
 
     /**
@@ -620,7 +640,29 @@ export class GitHubPrReviewBridgeService {
         // react to being reviewed), so it is handled and returned before
         // normalize() is consulted.
         if (eventName === 'pull_request_review') {
-            await this.recordReviewRejection(binding, body);
+            // Merge approval (slice AE): an `approved` review used to be
+            // dropped on the floor here - `recordReviewRejection` returns
+            // immediately for any state other than `changes_requested`,
+            // and its spec pinned that ("ignores an approval - only a
+            // rejection carries feedback for the next run"). That was
+            // right about the FEEDBACK loop and it left the platform
+            // unable to answer "has a person read this pull request?",
+            // which is the first thing somebody authorising a merge wants
+            // to know. Both states are now recorded, on separate paths,
+            // and neither enters the review loop.
+            const reviewState = body.review?.state?.toLowerCase();
+            if (reviewState === 'approved') {
+                await this.recordReviewApproval(binding, body);
+            } else {
+                // A reviewer who DISMISSES their approval, or replaces it
+                // with `changes_requested`, has withdrawn the one signal
+                // the merge Inbox offers about whether a person read the
+                // diff. The head-SHA binding covers a new commit; it does
+                // not cover the reviewer changing their mind about the
+                // same one, which is precisely this case.
+                await this.withdrawReviewApproval(binding, body);
+                await this.recordReviewRejection(binding, body);
+            }
             return { ingested: null };
         }
 
@@ -723,6 +765,122 @@ export class GitHubPrReviewBridgeService {
         } catch (error) {
             this.logger.warn(
                 `PR rejection record failed for ${fullName}#${prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Merge approval (self-build slice AE, EW-805) — persist an
+     * `approved` PR review as provider-side review context for the Task.
+     *
+     * HUMANS ONLY, and that is the security property. `classifyReviewer`
+     * checks the platform's own `<slug>[bot]` identity BEFORE the
+     * trusted-bot allow-list, so the loop cannot launder its own review
+     * into a sign-off; and an allow-listed reviewer bot is dropped here
+     * too, even though its REJECTIONS are trusted. A bot saying "looks
+     * good" is not a person having looked.
+     *
+     * What is recorded is deliberately narrow: the commit the reviewer
+     * saw (`review.commit_id`), when, and their provider login as an
+     * untrusted display string. It is never an authorization — this repo
+     * has no provider-login → platform-user mapping on the review path,
+     * so an approval here cannot establish that somebody entitled to
+     * approve for the Task's Organization approved it. The authorising
+     * decision is the platform-side one in the Inbox.
+     *
+     * Best-effort, exactly like its rejection twin.
+     */
+    private async recordReviewApproval(
+        binding: GitHubEventsBinding,
+        body: GitHubWebhookBody,
+    ): Promise<void> {
+        const review = body.review;
+        if (!review || review.state?.toLowerCase() !== 'approved') return;
+        if (classifyReviewer(review.user, this.reviewBotPolicy()) !== 'human') return;
+
+        const fullName = body.repository?.full_name ?? '';
+        const [owner, repo] = fullName.split('/');
+        const prNumber = body.pull_request?.number;
+        if (!owner || !repo || typeof prNumber !== 'number') return;
+
+        const submittedAt = review.submitted_at ? new Date(review.submitted_at) : null;
+        try {
+            await this.approvals.recordPullRequestApproval({
+                userId: binding.userId,
+                owner,
+                repo,
+                prNumber,
+                // `review.commit_id` ONLY — never `pull_request.head.sha`.
+                // The branch head at delivery time may already be several
+                // commits past what the reviewer read, and storing it
+                // would launder an approval of an old diff into an
+                // approval of whatever has been pushed since. That is the
+                // exact invariant `TaskReviewApprovalService` states, and
+                // its no-commit-id branch already drops the record — a
+                // delivery without `commit_id` (a replay, a trimmed
+                // payload, a GHES variant) is simply not attributable.
+                headSha: review.commit_id ?? null,
+                reviewerLabel: review.user?.login ?? null,
+                approvedAt:
+                    submittedAt && !Number.isNaN(submittedAt.getTime()) ? submittedAt : new Date(),
+            });
+        } catch (error) {
+            this.logger.warn(
+                `PR approval record failed for ${fullName}#${prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Merge approval (self-build slice AE, EW-805) — retract a recorded
+     * provider-side approval when its author takes it back.
+     *
+     * GitHub delivers a `pull_request_review` with `state: 'dismissed'`
+     * when a review is dismissed, and a fresh `changes_requested` review
+     * when the same person reverses themselves at the same commit.
+     * Neither moves the head, so the SHA binding that protects against a
+     * new commit does nothing here — and without this the Inbox goes on
+     * telling whoever is authorising the merge that "alice reviewed this"
+     * long after alice explicitly withdrew that sign-off.
+     *
+     * Scoped to the SAME reviewer on purpose. Bob requesting changes does
+     * not unmake the fact that Alice read the diff; Alice withdrawing does.
+     * A delivery with no reviewer login cannot be attributed to the
+     * recorded approver and clears nothing.
+     *
+     * Best-effort, like everything else on this path.
+     */
+    private async withdrawReviewApproval(
+        binding: GitHubEventsBinding,
+        body: GitHubWebhookBody,
+    ): Promise<void> {
+        const review = body.review;
+        const state = review?.state?.toLowerCase();
+        if (!review || (state !== 'dismissed' && state !== 'changes_requested')) return;
+        // Bots never wrote one of these records, so they can never clear
+        // one either — the same rule, from the other side.
+        if (classifyReviewer(review.user, this.reviewBotPolicy()) !== 'human') return;
+
+        const fullName = body.repository?.full_name ?? '';
+        const [owner, repo] = fullName.split('/');
+        const prNumber = body.pull_request?.number;
+        if (!owner || !repo || typeof prNumber !== 'number') return;
+
+        try {
+            await this.approvals.clearPullRequestApproval({
+                userId: binding.userId,
+                owner,
+                repo,
+                prNumber,
+                reviewerLabel: review.user?.login ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `PR approval withdrawal failed for ${fullName}#${prNumber}: ${
                     error instanceof Error ? error.message : String(error)
                 }`,
             );

--- a/apps/api/src/migrations/1789700000000-AddMergeApprovalBinding.ts
+++ b/apps/api/src/migrations/1789700000000-AddMergeApprovalBinding.ts
@@ -1,0 +1,163 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+/**
+ * Merge approval in the Inbox (self-build slice AE, EW-805) — the two
+ * columns that make an approval un-replayable, plus the provider-review
+ * context shown to the person giving it.
+ *
+ * `agent_action_proposals.subjectKey`
+ *   WHAT a decision is about, in a form a consumer can look up by
+ *   equality: `merge:<taskId>:<prNumber>:<headSha>` for a
+ *   `merge_pull_request` proposal, NULL for every other action type (the
+ *   rest of the queue is a record nothing reads back). It is the whole
+ *   safety property of the slice — the merge path re-derives the key from
+ *   LIVE provider state, so an approval cannot be replayed onto a
+ *   different pull request, or onto the same one after a force-push.
+ *   Indexed UNIQUELY on `(actionType, subjectKey)`: the merge gate probes
+ *   it on every merge attempt, and the uniqueness is what stops the cron
+ *   worker and an API refresh both filing an approval for the same commit.
+ *   NULL subject keys (every other action type) stay unconstrained,
+ *   because NULLs are distinct in a unique index on Postgres and SQLite
+ *   alike.
+ *
+ * `tasks.mergeRefusedSha` / `…Code`
+ *   The last merge refusal reported for the Task, so a refusal that is a
+ *   property of the repository (a protected base branch, a required
+ *   review) is told to the human ONCE instead of once per two-minute
+ *   PR-status sweep.
+ *
+ * `tasks.prHeadSha`
+ *   The head commit the PROVIDER last reported for the Task's pull
+ *   request. `TaskPrStatusService` already fetched it and threw it away.
+ *   Note this does NOT contradict `recordRemotePush`, which deliberately
+ *   refuses to persist the head a run pushed ("the remote owns the branch
+ *   head") — that is the same rule from the other side.
+ *
+ * `tasks.prReviewApprovedSha` / `…At` / `…By`
+ *   A HUMAN provider-side review approval, stamped with the commit it was
+ *   given for. Never written for a bot of any kind. It is CONTEXT for the
+ *   platform-side approver, not an authorization: a provider login is not
+ *   a platform identity.
+ *
+ * Every column is nullable and additive. Existing rows read NULL, which
+ * is the correct history: no proposal before this migration was about a
+ * merge, no Task had a recorded head, and nobody had approved anything on
+ * a provider in a way the platform kept. Forward-only with per-step
+ * guards so a partially applied database converges; portable
+ * `TableColumn` DDL because CI and the e2e stack run better-sqlite3 while
+ * production runs Postgres.
+ */
+export class AddMergeApprovalBinding1789700000000 implements MigrationInterface {
+    name = 'AddMergeApprovalBinding1789700000000';
+
+    private static readonly TASK_COLUMNS: TableColumn[] = [
+        new TableColumn({ name: 'prHeadSha', type: 'varchar', length: '64', isNullable: true }),
+        new TableColumn({
+            name: 'prReviewApprovedSha',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+        }),
+        new TableColumn({ name: 'prReviewApprovedAt', type: 'timestamp', isNullable: true }),
+        new TableColumn({
+            name: 'prReviewApprovedBy',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+        }),
+        new TableColumn({
+            name: 'mergeRefusedSha',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+        }),
+        new TableColumn({
+            name: 'mergeRefusedCode',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+        }),
+    ];
+
+    /**
+     * UNIQUE on purpose: `MergeApprovalService.requestMergeApproval` is a
+     * check-then-create whose callers sit in two processes (the
+     * `task-pr-status-sync` cron worker and an API `?refresh=true`), so
+     * only the database can stop both of them filing an approval for the
+     * same (Task, pull request, head). `subjectKey` is NULL for every
+     * other action type and NULLs are DISTINCT in a unique index on both
+     * Postgres and SQLite, so nothing else in the queue is constrained.
+     */
+    private static readonly SUBJECT_INDEX = new TableIndex({
+        name: 'idx_agent_action_proposals_subject',
+        columnNames: ['actionType', 'subjectKey'],
+        isUnique: true,
+    });
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const proposals = await queryRunner.getTable('agent_action_proposals');
+        if (proposals) {
+            if (!proposals.findColumnByName('subjectKey')) {
+                await queryRunner.addColumn(
+                    'agent_action_proposals',
+                    new TableColumn({
+                        name: 'subjectKey',
+                        type: 'varchar',
+                        length: '200',
+                        isNullable: true,
+                    }),
+                );
+            }
+            const fresh = await queryRunner.getTable('agent_action_proposals');
+            const hasIndex = fresh?.indices.some(
+                (index) => index.name === AddMergeApprovalBinding1789700000000.SUBJECT_INDEX.name,
+            );
+            if (fresh?.findColumnByName('subjectKey') && !hasIndex) {
+                await queryRunner.createIndex(
+                    'agent_action_proposals',
+                    AddMergeApprovalBinding1789700000000.SUBJECT_INDEX,
+                );
+            }
+        }
+
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            for (const column of AddMergeApprovalBinding1789700000000.TASK_COLUMNS) {
+                if (!tasks.findColumnByName(column.name)) {
+                    await queryRunner.addColumn('tasks', column);
+                }
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            // Reverse order of `up`, and `dropColumn` rather than a raw
+            // `ALTER TABLE … DROP COLUMN`: the query runner rebuilds the
+            // table on drivers that cannot drop a column in place, which
+            // is exactly the driver CI uses.
+            for (const column of [...AddMergeApprovalBinding1789700000000.TASK_COLUMNS].reverse()) {
+                const found = tasks.findColumnByName(column.name);
+                if (found) {
+                    await queryRunner.dropColumn('tasks', found);
+                }
+            }
+        }
+
+        const proposals = await queryRunner.getTable('agent_action_proposals');
+        if (proposals) {
+            const index = proposals.indices.find(
+                (candidate) =>
+                    candidate.name === AddMergeApprovalBinding1789700000000.SUBJECT_INDEX.name,
+            );
+            if (index) {
+                await queryRunner.dropIndex('agent_action_proposals', index);
+            }
+            const column = proposals.findColumnByName('subjectKey');
+            if (column) {
+                await queryRunner.dropColumn('agent_action_proposals', column);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddMergeApprovalBinding.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddMergeApprovalBinding.spec.ts
@@ -1,0 +1,289 @@
+import { DataSource, Table } from 'typeorm';
+import { AddMergeApprovalBinding1789700000000 } from '../1789700000000-AddMergeApprovalBinding';
+
+/**
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ *
+ * Assertions are against the PHYSICAL schema — `PRAGMA table_info` and
+ * `PRAGMA index_list` — rather than against TypeORM's own view of it.
+ * The metadata reader is the thing under test as much as the DDL is: a
+ * migration that satisfies `getTable()` but leaves the table unchanged
+ * would pass a metadata-only check and fail in production. Watching an
+ * INSERT fail is not a substitute either — that only proves *a*
+ * constraint exists, not that the column does.
+ */
+describe('AddMergeApprovalBinding1789700000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddMergeApprovalBinding1789700000000();
+
+    const TASK_COLUMNS = [
+        'prHeadSha',
+        'prReviewApprovedSha',
+        'prReviewApprovedAt',
+        'prReviewApprovedBy',
+        'mergeRefusedSha',
+        'mergeRefusedCode',
+    ] as const;
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'agent_action_proposals',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'agentId', type: 'uuid' },
+                    { name: 'actionType', type: 'varchar', length: '32' },
+                    { name: 'title', type: 'varchar', length: '200' },
+                    { name: 'payload', type: 'text' },
+                    { name: 'riskFlags', type: 'text' },
+                    { name: 'status', type: 'varchar', length: '16', default: "'pending'" },
+                ],
+            }),
+        );
+        await runner.createTable(
+            new Table({
+                name: 'tasks',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'slug', type: 'varchar', length: '16' },
+                    { name: 'title', type: 'varchar', length: '200' },
+                    { name: 'status', type: 'varchar', length: '16' },
+                    { name: 'prNumber', type: 'int', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO agent_action_proposals (id, "userId", "agentId", "actionType", title, payload, "riskFlags", status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            ['p-1', 'user-1', 'agent-1', 'spawn_agent', 'Spawn a helper', '{}', '[]', 'pending'],
+        );
+        await runner.query(
+            `INSERT INTO tasks (id, "userId", slug, title, status, "prNumber") VALUES (?, ?, ?, ?, ?, ?)`,
+            ['t-1', 'user-1', 'T-1', 'Ship the thing', 'in_review', 7],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function physicalColumns(table: string): Promise<Map<string, string>> {
+        const rows: Array<{ name: string; type: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("${table}")`,
+        );
+        return new Map(rows.map((row) => [row.name, row.type]));
+    }
+
+    async function physicalIndexes(table: string): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA index_list("${table}")`,
+        );
+        return rows.map((row) => row.name);
+    }
+
+    it('adds subjectKey to agent_action_proposals as a nullable varchar', async () => {
+        expect((await physicalColumns('agent_action_proposals')).has('subjectKey')).toBe(false);
+        await runUp();
+
+        const columns = await physicalColumns('agent_action_proposals');
+        expect(columns.get('subjectKey')).toMatch(/varchar\(200\)/i);
+
+        const notNull: Array<{ name: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("agent_action_proposals")`,
+        );
+        expect(notNull.find((row) => row.name === 'subjectKey')?.notnull).toBe(0);
+    });
+
+    it('leaves every existing proposal with a NULL subject — none of them was about a merge', async () => {
+        await runUp();
+        expect(
+            await dataSource.query(
+                `SELECT id, "subjectKey" FROM agent_action_proposals WHERE id = ?`,
+                ['p-1'],
+            ),
+        ).toEqual([{ id: 'p-1', subjectKey: null }]);
+    });
+
+    it('creates the lookup index the merge gate probes on every merge', async () => {
+        await runUp();
+        expect(await physicalIndexes('agent_action_proposals')).toContain(
+            'idx_agent_action_proposals_subject',
+        );
+        const info: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA index_info("idx_agent_action_proposals_subject")`,
+        );
+        expect(info.map((row) => row.name)).toEqual(['actionType', 'subjectKey']);
+    });
+
+    // The index is UNIQUE, and that is a correctness property rather than
+    // a performance one: `requestMergeApproval` is a check-then-create
+    // whose callers live in two processes (the two-minute PR-status sweep
+    // in the worker, and `?refresh=true` in the API), so only the database
+    // can stop both of them filing an approval for the same commit. Two
+    // pending rows would put two Approve buttons in the Inbox for one
+    // merge, and a later click on the second would grant a fresh 24h
+    // validity window over a head the first already covered.
+
+    it('makes the subject index UNIQUE', async () => {
+        await runUp();
+        const rows: Array<{ name: string; unique: number }> = await dataSource.query(
+            `PRAGMA index_list("agent_action_proposals")`,
+        );
+        const index = rows.find((row) => row.name === 'idx_agent_action_proposals_subject');
+        expect(index).toBeDefined();
+        expect(index!.unique).toBe(1);
+    });
+
+    it('refuses a SECOND pending proposal for the same subject key', async () => {
+        await runUp();
+        const key = `merge:9f1c0d1e-6c1a-4c3a-9f6c-2b6a0a5d1e77:42:${'a'.repeat(40)}`;
+        const insert = (id: string) =>
+            dataSource.query(
+                `INSERT INTO agent_action_proposals (id, "userId", "agentId", "actionType", title, payload, "riskFlags", status, "subjectKey") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                [
+                    id,
+                    'user-1',
+                    'agent-1',
+                    'merge_pull_request',
+                    'Merge PR #42',
+                    '{}',
+                    '[]',
+                    'pending',
+                    key,
+                ],
+            );
+        await insert('p-merge-1');
+        await expect(insert('p-merge-2')).rejects.toThrow(/UNIQUE/i);
+    });
+
+    it('leaves NULL subject keys unconstrained — the rest of the queue is untouched', async () => {
+        // NULLs are DISTINCT in a unique index on both SQLite and
+        // Postgres, so every non-merge proposal is as unconstrained as it
+        // was before this migration.
+        await runUp();
+        const insert = (id: string) =>
+            dataSource.query(
+                `INSERT INTO agent_action_proposals (id, "userId", "agentId", "actionType", title, payload, "riskFlags", status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                [id, 'user-1', 'agent-1', 'spawn_agent', 'Spawn a helper', '{}', '[]', 'pending'],
+            );
+        await insert('p-2');
+        await insert('p-3');
+        expect(await dataSource.query(`SELECT COUNT(*) AS n FROM agent_action_proposals`)).toEqual([
+            { n: 3 },
+        ]);
+    });
+
+    it('stores a full subject key without truncating the head SHA', async () => {
+        await runUp();
+        // 200 chars is the declared width; a truncated head SHA would turn
+        // an exact-match lookup into a prefix match.
+        const key = `merge:9f1c0d1e-6c1a-4c3a-9f6c-2b6a0a5d1e77:42:${'a'.repeat(40)}`;
+        await dataSource.query(`UPDATE agent_action_proposals SET "subjectKey" = ? WHERE id = ?`, [
+            key,
+            'p-1',
+        ]);
+        const [row] = await dataSource.query(
+            `SELECT "subjectKey" FROM agent_action_proposals WHERE id = ?`,
+            ['p-1'],
+        );
+        expect(row.subjectKey).toBe(key);
+    });
+
+    it('adds the PR head / review / merge-refusal columns to tasks, all nullable', async () => {
+        await runUp();
+        const columns = await physicalColumns('tasks');
+        for (const name of TASK_COLUMNS) {
+            expect(columns.has(name)).toBe(true);
+        }
+        expect(columns.get('prHeadSha')).toMatch(/varchar\(64\)/i);
+        expect(columns.get('prReviewApprovedBy')).toMatch(/varchar\(128\)/i);
+        expect(columns.get('mergeRefusedSha')).toMatch(/varchar\(64\)/i);
+        expect(columns.get('mergeRefusedCode')).toMatch(/varchar\(64\)/i);
+
+        const info: Array<{ name: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("tasks")`,
+        );
+        for (const name of TASK_COLUMNS) {
+            expect(info.find((row) => row.name === name)?.notnull).toBe(0);
+        }
+    });
+
+    it('leaves existing Tasks with no recorded head, review or merge refusal', async () => {
+        await runUp();
+        expect(
+            await dataSource.query(
+                `SELECT "prHeadSha", "prReviewApprovedSha", "prReviewApprovedAt", "prReviewApprovedBy", "mergeRefusedSha", "mergeRefusedCode" FROM tasks WHERE id = ?`,
+                ['t-1'],
+            ),
+        ).toEqual([
+            {
+                prHeadSha: null,
+                prReviewApprovedSha: null,
+                prReviewApprovedAt: null,
+                prReviewApprovedBy: null,
+                mergeRefusedSha: null,
+                mergeRefusedCode: null,
+            },
+        ]);
+    });
+
+    it('is idempotent on re-run', async () => {
+        await runUp();
+        await runUp();
+        const columns = await physicalColumns('tasks');
+        for (const name of TASK_COLUMNS) expect(columns.has(name)).toBe(true);
+        expect(
+            (await physicalIndexes('agent_action_proposals')).filter(
+                (name) => name === 'idx_agent_action_proposals_subject',
+            ),
+        ).toHaveLength(1);
+    });
+
+    it('down() removes every column and the index, and is itself idempotent', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+
+        expect((await physicalColumns('agent_action_proposals')).has('subjectKey')).toBe(false);
+        expect(await physicalIndexes('agent_action_proposals')).not.toContain(
+            'idx_agent_action_proposals_subject',
+        );
+        const tasks = await physicalColumns('tasks');
+        for (const name of TASK_COLUMNS) expect(tasks.has(name)).toBe(false);
+
+        const second = dataSource.createQueryRunner();
+        await migration.down(second);
+        await second.release();
+        expect((await physicalColumns('agent_action_proposals')).has('subjectKey')).toBe(false);
+    });
+
+    it('down() preserves the rows it did not add', async () => {
+        await runUp();
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+        expect(await dataSource.query(`SELECT id FROM agent_action_proposals`)).toEqual([
+            { id: 'p-1' },
+        ]);
+        expect(await dataSource.query(`SELECT id, "prNumber" FROM tasks`)).toEqual([
+            { id: 't-1', prNumber: 7 },
+        ]);
+    });
+});

--- a/apps/web/e2e/flow-agent-approvals-queue-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-approvals-queue-deep.spec.ts
@@ -25,7 +25,7 @@
  *     404 too — existence is never leaked); malformed uuid → 400 via
  *     ParseUUIDPipe ("Validation failed (uuid is expected)").
  *   • approve-all is best-effort: no body / empty ids / unknown ids →
- *     { approved: 0, skipped: 0 } (never 404); 200 ids is the ArrayMaxSize
+ *     { approved: 0, skipped: 0, excluded: 0 } (never 404); 200 ids is the ArrayMaxSize
  *     boundary; a malformed / non-array / >200-element `ids` or an unknown key
  *     → 400.
  *   • the global AuthSessionGuard runs BEFORE the pipes, so an unauthenticated
@@ -309,7 +309,7 @@ test.describe('Agent Approval Queue — approve / reject a single proposal', () 
 });
 
 test.describe('Agent Approval Queue — bulk approve-all', () => {
-    test('an empty body, an absent body, and ids:[] all no-op to { approved: 0, skipped: 0 } (200)', async ({
+    test('an empty body, an absent body, and ids:[] all no-op to { approved: 0, skipped: 0, excluded: 0 } (200)', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -317,21 +317,21 @@ test.describe('Agent Approval Queue — bulk approve-all', () => {
 
         const emptyObj = await request.post(`${AQ_BASE}/approve-all`, { headers: H, data: {} });
         expect(emptyObj.status()).toBe(200);
-        expect(await emptyObj.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await emptyObj.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
 
         const noBody = await request.post(`${AQ_BASE}/approve-all`, { headers: H });
         expect(noBody.status()).toBe(200);
-        expect(await noBody.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await noBody.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
 
         const emptyIds = await request.post(`${AQ_BASE}/approve-all`, {
             headers: H,
             data: { ids: [] },
         });
         expect(emptyIds.status()).toBe(200);
-        expect(await emptyIds.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await emptyIds.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
     });
 
-    test('an unknown-id subset is silently ignored (never 404) → { approved: 0, skipped: 0 }', async ({
+    test('an unknown-id subset is silently ignored (never 404) → { approved: 0, skipped: 0, excluded: 0 }', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -342,7 +342,7 @@ test.describe('Agent Approval Queue — bulk approve-all', () => {
         expect(res.status()).toBe(200);
         // Cross-user / unknown ids don't match the owner-scoped query, so they
         // are neither approved nor counted as skipped — both counters stay 0.
-        expect(await res.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await res.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
     });
 
     test('a 200-id subset is accepted (the ArrayMaxSize boundary) and no-ops when none are owned', async ({
@@ -357,7 +357,7 @@ test.describe('Agent Approval Queue — bulk approve-all', () => {
         expect(res.status(), `approve-all 200 ids body=${await res.text().catch(() => '')}`).toBe(
             200,
         );
-        expect(await res.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await res.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
     });
 
     test('body validation: 201 ids, a non-uuid id, a non-array ids, and an unknown key are all rejected (400)', async ({

--- a/apps/web/e2e/flow-agent-approvals-validation-authz-matrix.spec.ts
+++ b/apps/web/e2e/flow-agent-approvals-validation-authz-matrix.spec.ts
@@ -45,7 +45,7 @@
  *     `ids` (""/{}/5) → the array/size/each cluster. A JSON-array *body*
  *     ([1,2,3]) → "property <n> should not exist"; an extra key beside a valid
  *     `ids` → "property foo should not exist". A duplicate-id array is a valid
- *     no-op → { approved: 0, skipped: 0 } (dedup is not required).
+ *     no-op → { approved: 0, skipped: 0, excluded: 0 } (dedup is not required).
  *   • Malformed Authorization (garbage bearer / empty bearer / Basic scheme /
  *     bare token) → 401 { message: "Unauthorized", statusCode: 401 }.
  *
@@ -496,7 +496,7 @@ test.describe('Agent Approvals approve-all — ids[] validation matrix', () => {
         expect(messageText(await res.json())).toContain('property foo should not exist');
     });
 
-    test('a duplicate-id array is a valid no-op → { approved: 0, skipped: 0 }; trailing slash also 200', async ({
+    test('a duplicate-id array is a valid no-op → { approved: 0, skipped: 0, excluded: 0 }; trailing slash also 200', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -508,12 +508,12 @@ test.describe('Agent Approvals approve-all — ids[] validation matrix', () => {
             data: { ids: [NIL_UUID, NIL_UUID] },
         });
         expect(dup.status()).toBe(200);
-        expect(await dup.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await dup.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
 
         // The route also matches with a trailing slash.
         const slash = await request.post(`${AQ_BASE}/approve-all/`, { headers: H, data: {} });
         expect(slash.status()).toBe(200);
-        expect(await slash.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await slash.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
     });
 });
 

--- a/apps/web/e2e/flow-agent-guardrails-policy-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-guardrails-policy-deep.spec.ts
@@ -17,7 +17,12 @@
  *   • shapes observed live: `{ mode }`, `{ mode, autoApproveActionTypes[] }`,
  *     `{ mode, blockedActionTypes[] }`, all three together. Modes come from
  *     AGENT_GUARDRAIL_MODES = ['require_approval','autonomous']; action types
- *     from ['spawn_agent','schedule_task','send_message','budget_override','other'].
+ *     from AGENT_ACTION_PROPOSAL_ACTION_TYPES —
+ *     ['spawn_agent','schedule_task','send_message','budget_override',
+ *      'merge_pull_request','other'] (six; `merge_pull_request` joined in
+ *     slice AE / EW-805). The "blocking all six known action types" test
+ *     below enumerates the same set and must stay in step with it — this
+ *     list is a reader's aid, that one is the coverage.
  *   • clearing: `{"guardrails":null}` OR an empty `{}` body → guardrails null.
  *   • DTO validation (400, message is a string[]): bad/missing/non-string mode;
  *     unknown action type in either list; a non-array list; an unknown key
@@ -183,12 +188,23 @@ test.describe('Agent Dispatch Guardrails — persistence + PUT semantics', () =>
         });
     });
 
-    test('blocking all five known action types is accepted', async ({ request }) => {
+    test('blocking all six known action types is accepted', async ({ request }) => {
         const user = await registerUserViaAPI(request);
         const agent = await createAgentViaAPI(request, user.access_token, {
             name: `GR block-all ${stamp()}`,
         });
-        const all = ['spawn_agent', 'schedule_task', 'send_message', 'budget_override', 'other'];
+        // Kept exhaustive on purpose: a new action type added to
+        // AGENT_ACTION_PROPOSAL_ACTION_TYPES without being listed here is a
+        // type the guardrails DTO would accept and this test would not
+        // cover. `merge_pull_request` joined the set in slice AE (EW-805).
+        const all = [
+            'spawn_agent',
+            'schedule_task',
+            'send_message',
+            'budget_override',
+            'merge_pull_request',
+            'other',
+        ];
 
         const res = await putGuardrails(request, user.access_token, agent.id, {
             guardrails: { mode: 'require_approval', blockedActionTypes: all },

--- a/apps/web/e2e/flow-cross-tenant-security-matrix-2.spec.ts
+++ b/apps/web/e2e/flow-cross-tenant-security-matrix-2.spec.ts
@@ -608,7 +608,7 @@ test.describe('Cross-tenant — Agent Approval Queue', () => {
             data: { ids: [UNKNOWN_UUID] },
         });
         expect(bulk.status()).toBe(200);
-        expect(await bulk.json()).toEqual({ approved: 0, skipped: 0 });
+        expect(await bulk.json()).toEqual({ approved: 0, skipped: 0, excluded: 0 });
     });
 });
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -623,6 +623,7 @@
                 "schedule_task": "جدولة مهمة",
                 "send_message": "إرسال رسالة",
                 "budget_override": "تجاوز الميزانية",
+                "merge_pull_request": "دمج طلب السحب",
                 "other": "إجراء"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "تم رفض الإجراء",
                 "bulkApproved": "تمت الموافقة على {count} إجراءات",
                 "bulkApprovedSkipped": "تمت الموافقة على {approved} إجراءات، و{skipped} تم البت فيها مسبقًا",
+                "bulkApprovedExcluded": "تمت الموافقة على {approved} إجراءات؛ {excluded} بحاجة إلى قرار فردي",
                 "error": "حدث خطأ ما. يُرجى المحاولة مرة أخرى."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "جدولة مهمة",
                     "send_message": "إرسال رسالة",
                     "budget_override": "تجاوز الميزانية",
+                    "merge_pull_request": "دمج طلب السحب",
                     "other": "أخرى"
                 },
                 "save": "حفظ الضوابط",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Планиране на задача",
                 "send_message": "Изпращане на съобщение",
                 "budget_override": "Надвишаване на бюджета",
+                "merge_pull_request": "Сливане на заявка",
                 "other": "Действие"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Действието е отхвърлено",
                 "bulkApproved": "Одобрени {count} действия",
                 "bulkApprovedSkipped": "Одобрени {approved} действия, {skipped} вече решени",
+                "bulkApprovedExcluded": "Одобрени са {approved} действия; {excluded} изискват отделно решение",
                 "error": "Нещо се обърка. Моля, опитайте отново."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "Планирай задача",
                     "send_message": "Изпрати съобщение",
                     "budget_override": "Промяна на бюджета",
+                    "merge_pull_request": "Сливане на заявка",
                     "other": "Друго"
                 },
                 "save": "Запази предпазните механизми",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Aufgabe planen",
                 "send_message": "Nachricht senden",
                 "budget_override": "Budgetüberschreibung",
+                "merge_pull_request": "Pull Request zusammenführen",
                 "other": "Aktion"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Aktion abgelehnt",
                 "bulkApproved": "{count} Aktionen genehmigt",
                 "bulkApprovedSkipped": "{approved} Aktionen genehmigt, {skipped} bereits entschieden",
+                "bulkApprovedExcluded": "{approved} Aktionen genehmigt; {excluded} benötigen eine einzelne Entscheidung",
                 "error": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "Aufgabe planen",
                     "send_message": "Nachricht senden",
                     "budget_override": "Budget-Überschreibung",
+                    "merge_pull_request": "Pull Request zusammenführen",
                     "other": "Sonstiges"
                 },
                 "save": "Guardrails speichern",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -824,6 +824,7 @@
                 "schedule_task": "Schedule task",
                 "send_message": "Send message",
                 "budget_override": "Budget override",
+                "merge_pull_request": "Merge pull request",
                 "other": "Action"
             },
             "riskFlags": {
@@ -837,6 +838,7 @@
                 "rejected": "Action rejected",
                 "bulkApproved": "Approved {count} actions",
                 "bulkApprovedSkipped": "Approved {approved} actions, {skipped} already decided",
+                "bulkApprovedExcluded": "Approved {approved} actions, {excluded} still need a decision one at a time",
                 "error": "Something went wrong. Please try again."
             }
         },
@@ -1398,6 +1400,7 @@
                     "schedule_task": "Schedule task",
                     "send_message": "Send message",
                     "budget_override": "Budget override",
+                    "merge_pull_request": "Merge pull request",
                     "other": "Other"
                 },
                 "save": "Save guardrails",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Programar tarea",
                 "send_message": "Enviar mensaje",
                 "budget_override": "Anulación de presupuesto",
+                "merge_pull_request": "Fusionar pull request",
                 "other": "Acción"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Acción rechazada",
                 "bulkApproved": "{count} acciones aprobadas",
                 "bulkApprovedSkipped": "{approved} acciones aprobadas, {skipped} ya decididas",
+                "bulkApprovedExcluded": "Se aprobaron {approved} acciones; {excluded} necesitan una decisión individual",
                 "error": "Algo salió mal. Inténtalo de nuevo."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "Programar tarea",
                     "send_message": "Enviar mensaje",
                     "budget_override": "Anulación de presupuesto",
+                    "merge_pull_request": "Fusionar pull request",
                     "other": "Otro"
                 },
                 "save": "Guardar salvaguardas",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Planifier une tâche",
                 "send_message": "Envoyer un message",
                 "budget_override": "Dépassement de budget",
+                "merge_pull_request": "Fusionner la pull request",
                 "other": "Action"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Action rejetée",
                 "bulkApproved": "{count} actions approuvées",
                 "bulkApprovedSkipped": "{approved} actions approuvées, {skipped} déjà décidées",
+                "bulkApprovedExcluded": "{approved} actions approuvées ; {excluded} nécessitent une décision individuelle",
                 "error": "Une erreur s'est produite. Veuillez réessayer."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "Planifier une tâche",
                     "send_message": "Envoyer un message",
                     "budget_override": "Dérogation de budget",
+                    "merge_pull_request": "Fusionner la pull request",
                     "other": "Autre"
                 },
                 "save": "Enregistrer les garde-fous",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -623,6 +623,7 @@
                 "schedule_task": "תזמון משימה",
                 "send_message": "שליחת הודעה",
                 "budget_override": "חריגה מתקציב",
+                "merge_pull_request": "מיזוג בקשת משיכה",
                 "other": "פעולה"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "הפעולה נדחתה",
                 "bulkApproved": "אושרו {count} פעולות",
                 "bulkApprovedSkipped": "אושרו {approved} פעולות, {skipped} כבר הוכרעו",
+                "bulkApprovedExcluded": "אושרו {approved} פעולות; {excluded} דורשות החלטה נפרדת",
                 "error": "משהו השתבש. נסה שוב."
             }
         },
@@ -1160,6 +1162,7 @@
                     "schedule_task": "תזמון משימה",
                     "send_message": "שליחת הודעה",
                     "budget_override": "עקיפת תקציב",
+                    "merge_pull_request": "מיזוג בקשת משיכה",
                     "other": "אחר"
                 },
                 "save": "שמור מעקות בטיחות",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -623,6 +623,7 @@
                 "schedule_task": "कार्य शेड्यूल करें",
                 "send_message": "संदेश भेजें",
                 "budget_override": "बजट ओवरराइड",
+                "merge_pull_request": "पुल रिक्वेस्ट मर्ज करें",
                 "other": "कार्रवाई"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "कार्रवाई अस्वीकृत हुई",
                 "bulkApproved": "{count} कार्रवाइयाँ स्वीकृत हुईं",
                 "bulkApprovedSkipped": "{approved} कार्रवाइयाँ स्वीकृत हुईं, {skipped} पर पहले ही निर्णय हो चुका है",
+                "bulkApprovedExcluded": "{approved} कार्रवाइयाँ स्वीकृत; {excluded} के लिए अलग निर्णय आवश्यक है",
                 "error": "कुछ गलत हो गया। कृपया पुनः प्रयास करें।"
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "कार्य शेड्यूल करें",
                     "send_message": "संदेश भेजें",
                     "budget_override": "बजट ओवरराइड",
+                    "merge_pull_request": "पुल रिक्वेस्ट मर्ज करें",
                     "other": "अन्य"
                 },
                 "save": "गार्डरेल सहेजें",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Jadwalkan tugas",
                 "send_message": "Kirim pesan",
                 "budget_override": "Penggantian anggaran",
+                "merge_pull_request": "Gabungkan pull request",
                 "other": "Tindakan"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Tindakan ditolak",
                 "bulkApproved": "{count} tindakan disetujui",
                 "bulkApprovedSkipped": "{approved} tindakan disetujui, {skipped} sudah diputuskan",
+                "bulkApprovedExcluded": "{approved} tindakan disetujui; {excluded} masih perlu diputuskan satu per satu",
                 "error": "Terjadi kesalahan. Silakan coba lagi."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Jadwalkan tugas",
                     "send_message": "Kirim pesan",
                     "budget_override": "Penggantian anggaran",
+                    "merge_pull_request": "Gabungkan pull request",
                     "other": "Lainnya"
                 },
                 "save": "Simpan pagar pengaman",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Pianifica attività",
                 "send_message": "Invia messaggio",
                 "budget_override": "Sostituzione del budget",
+                "merge_pull_request": "Unisci la pull request",
                 "other": "Azione"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Azione rifiutata",
                 "bulkApproved": "{count} azioni approvate",
                 "bulkApprovedSkipped": "{approved} azioni approvate, {skipped} già decise",
+                "bulkApprovedExcluded": "Approvate {approved} azioni; {excluded} richiedono una decisione singola",
                 "error": "Qualcosa è andato storto. Riprova."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Pianifica attività",
                     "send_message": "Invia messaggio",
                     "budget_override": "Deroga al budget",
+                    "merge_pull_request": "Unisci la pull request",
                     "other": "Altro"
                 },
                 "save": "Salva guardrail",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -623,6 +623,7 @@
                 "schedule_task": "タスクのスケジュール",
                 "send_message": "メッセージ送信",
                 "budget_override": "予算の上書き",
+                "merge_pull_request": "プルリクエストをマージ",
                 "other": "アクション"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "アクションを却下しました",
                 "bulkApproved": "{count} 件のアクションを承認しました",
                 "bulkApprovedSkipped": "{approved} 件のアクションを承認、{skipped} 件は決定済み",
+                "bulkApprovedExcluded": "{approved} 件を承認しました。{excluded} 件は個別の判断が必要です",
                 "error": "問題が発生しました。もう一度お試しください。"
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "タスクのスケジュール",
                     "send_message": "メッセージ送信",
                     "budget_override": "予算の上書き",
+                    "merge_pull_request": "プルリクエストをマージ",
                     "other": "その他"
                 },
                 "save": "ガードレールを保存",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -623,6 +623,7 @@
                 "schedule_task": "작업 예약",
                 "send_message": "메시지 보내기",
                 "budget_override": "예산 재정의",
+                "merge_pull_request": "풀 리퀘스트 병합",
                 "other": "작업"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "작업이 거부되었습니다",
                 "bulkApproved": "{count}개 작업이 승인되었습니다",
                 "bulkApprovedSkipped": "{approved}개 작업 승인, {skipped}개는 이미 결정됨",
+                "bulkApprovedExcluded": "{approved}개 작업을 승인했습니다. {excluded}개는 개별 결정이 필요합니다",
                 "error": "문제가 발생했습니다. 다시 시도해 주세요."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "작업 예약",
                     "send_message": "메시지 보내기",
                     "budget_override": "예산 재정의",
+                    "merge_pull_request": "풀 리퀘스트 병합",
                     "other": "기타"
                 },
                 "save": "가드레일 저장",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Taak inplannen",
                 "send_message": "Bericht versturen",
                 "budget_override": "Budgetoverschrijving",
+                "merge_pull_request": "Pull request samenvoegen",
                 "other": "Actie"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Actie afgewezen",
                 "bulkApproved": "{count} acties goedgekeurd",
                 "bulkApprovedSkipped": "{approved} acties goedgekeurd, {skipped} al beslist",
+                "bulkApprovedExcluded": "{approved} acties goedgekeurd; {excluded} vereisen een afzonderlijk besluit",
                 "error": "Er is iets misgegaan. Probeer het opnieuw."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Taak inplannen",
                     "send_message": "Bericht versturen",
                     "budget_override": "Budgetoverschrijving",
+                    "merge_pull_request": "Pull request samenvoegen",
                     "other": "Overig"
                 },
                 "save": "Vangrails opslaan",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Zaplanuj zadanie",
                 "send_message": "Wyślij wiadomość",
                 "budget_override": "Nadpisanie budżetu",
+                "merge_pull_request": "Scal pull request",
                 "other": "Działanie"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Działanie odrzucone",
                 "bulkApproved": "Zatwierdzono {count} działań",
                 "bulkApprovedSkipped": "Zatwierdzono {approved} działań, {skipped} już rozstrzygnięto",
+                "bulkApprovedExcluded": "Zatwierdzono {approved} akcji; {excluded} wymaga osobnej decyzji",
                 "error": "Coś poszło nie tak. Spróbuj ponownie."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Zaplanuj zadanie",
                     "send_message": "Wyślij wiadomość",
                     "budget_override": "Nadpisanie budżetu",
+                    "merge_pull_request": "Scal pull request",
                     "other": "Inne"
                 },
                 "save": "Zapisz bariery",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Agendar tarefa",
                 "send_message": "Enviar mensagem",
                 "budget_override": "Substituição de orçamento",
+                "merge_pull_request": "Mesclar pull request",
                 "other": "Ação"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Ação rejeitada",
                 "bulkApproved": "{count} ações aprovadas",
                 "bulkApprovedSkipped": "{approved} ações aprovadas, {skipped} já decididas",
+                "bulkApprovedExcluded": "{approved} ações aprovadas; {excluded} precisam de uma decisão individual",
                 "error": "Algo deu errado. Tente novamente."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Agendar tarefa",
                     "send_message": "Enviar mensagem",
                     "budget_override": "Substituição de orçamento",
+                    "merge_pull_request": "Mesclar pull request",
                     "other": "Outro"
                 },
                 "save": "Salvar salvaguardas",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Планирование задачи",
                 "send_message": "Отправка сообщения",
                 "budget_override": "Превышение бюджета",
+                "merge_pull_request": "Слить пул-реквест",
                 "other": "Действие"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Действие отклонено",
                 "bulkApproved": "Утверждено действий: {count}",
                 "bulkApprovedSkipped": "Утверждено действий: {approved}, уже решено: {skipped}",
+                "bulkApprovedExcluded": "Одобрено действий: {approved}; {excluded} требуют отдельного решения",
                 "error": "Что-то пошло не так. Пожалуйста, попробуйте ещё раз."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Запланировать задачу",
                     "send_message": "Отправить сообщение",
                     "budget_override": "Переопределение бюджета",
+                    "merge_pull_request": "Слить пул-реквест",
                     "other": "Другое"
                 },
                 "save": "Сохранить ограничители",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -623,6 +623,7 @@
                 "schedule_task": "กำหนดเวลางาน",
                 "send_message": "ส่งข้อความ",
                 "budget_override": "แทนที่งบประมาณ",
+                "merge_pull_request": "ผสานพูลรีเควสต์",
                 "other": "การดำเนินการ"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "ปฏิเสธการดำเนินการแล้ว",
                 "bulkApproved": "อนุมัติแล้ว {count} รายการ",
                 "bulkApprovedSkipped": "อนุมัติแล้ว {approved} รายการ, {skipped} รายการมีการตัดสินแล้ว",
+                "bulkApprovedExcluded": "อนุมัติ {approved} รายการ; {excluded} ต้องตัดสินใจแยกรายการ",
                 "error": "เกิดข้อผิดพลาด โปรดลองอีกครั้ง"
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "กำหนดเวลางาน",
                     "send_message": "ส่งข้อความ",
                     "budget_override": "แก้ไขงบประมาณ",
+                    "merge_pull_request": "ผสานพูลรีเควสต์",
                     "other": "อื่น ๆ"
                 },
                 "save": "บันทึกการ์ดเรล",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Görev zamanla",
                 "send_message": "Mesaj gönder",
                 "budget_override": "Bütçe aşımı",
+                "merge_pull_request": "Pull request birleştir",
                 "other": "Eylem"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Eylem reddedildi",
                 "bulkApproved": "{count} eylem onaylandı",
                 "bulkApprovedSkipped": "{approved} eylem onaylandı, {skipped} zaten karara bağlandı",
+                "bulkApprovedExcluded": "{approved} eylem onaylandı; {excluded} ayrı ayrı karar gerektiriyor",
                 "error": "Bir şeyler ters gitti. Lütfen tekrar deneyin."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Görev planla",
                     "send_message": "Mesaj gönder",
                     "budget_override": "Bütçe geçersiz kılma",
+                    "merge_pull_request": "Pull request birleştir",
                     "other": "Diğer"
                 },
                 "save": "Korkulukları kaydet",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Планування завдання",
                 "send_message": "Надсилання повідомлення",
                 "budget_override": "Перевищення бюджету",
+                "merge_pull_request": "Злити пул-реквест",
                 "other": "Дія"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Дію відхилено",
                 "bulkApproved": "Затверджено дій: {count}",
                 "bulkApprovedSkipped": "Затверджено дій: {approved}, вже вирішено: {skipped}",
+                "bulkApprovedExcluded": "Схвалено дій: {approved}; {excluded} потребують окремого рішення",
                 "error": "Щось пішло не так. Будь ласка, спробуйте ще раз."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Запланувати завдання",
                     "send_message": "Надіслати повідомлення",
                     "budget_override": "Перевизначення бюджету",
+                    "merge_pull_request": "Злити пул-реквест",
                     "other": "Інше"
                 },
                 "save": "Зберегти обмежувачі",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -623,6 +623,7 @@
                 "schedule_task": "Lên lịch nhiệm vụ",
                 "send_message": "Gửi tin nhắn",
                 "budget_override": "Ghi đè ngân sách",
+                "merge_pull_request": "Hợp nhất pull request",
                 "other": "Hành động"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "Đã từ chối hành động",
                 "bulkApproved": "Đã phê duyệt {count} hành động",
                 "bulkApprovedSkipped": "Đã phê duyệt {approved} hành động, {skipped} đã được quyết định",
+                "bulkApprovedExcluded": "Đã phê duyệt {approved} hành động; {excluded} cần quyết định riêng",
                 "error": "Đã xảy ra lỗi. Vui lòng thử lại."
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "Lên lịch nhiệm vụ",
                     "send_message": "Gửi tin nhắn",
                     "budget_override": "Ghi đè ngân sách",
+                    "merge_pull_request": "Hợp nhất pull request",
                     "other": "Khác"
                 },
                 "save": "Lưu rào chắn",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -623,6 +623,7 @@
                 "schedule_task": "安排任务",
                 "send_message": "发送消息",
                 "budget_override": "预算覆盖",
+                "merge_pull_request": "合并拉取请求",
                 "other": "操作"
             },
             "riskFlags": {
@@ -636,6 +637,7 @@
                 "rejected": "操作已拒绝",
                 "bulkApproved": "已批准 {count} 项操作",
                 "bulkApprovedSkipped": "已批准 {approved} 项操作，{skipped} 项已有决定",
+                "bulkApprovedExcluded": "已批准 {approved} 项操作，{excluded} 项仍需逐一决定",
                 "error": "出现问题，请重试。"
             }
         },
@@ -1111,6 +1113,7 @@
                     "schedule_task": "计划任务",
                     "send_message": "发送消息",
                     "budget_override": "预算覆盖",
+                    "merge_pull_request": "合并拉取请求",
                     "other": "其他"
                 },
                 "save": "保存护栏",

--- a/apps/web/src/components/approvals/ApprovalsQueue.tsx
+++ b/apps/web/src/components/approvals/ApprovalsQueue.tsx
@@ -40,7 +40,17 @@ export function ApprovalsQueue({ initialApprovals }: ApprovalsQueueProps) {
     >({});
     const [isApprovingAll, setIsApprovingAll] = useState(false);
 
-    const pendingIds = useMemo(() => proposals.map((p) => p.id), [proposals]);
+    // Merge approval (slice AE): a `merge_pull_request` proposal is
+    // deliberately NOT decidable in bulk — the server refuses to decide
+    // one here, and landing a pull request on a real branch has to be a
+    // per-pull-request act. It is excluded from the ids we SEND, so it
+    // also stays in the list below rather than being cleared as though it
+    // had been handled.
+    const bulkIds = useMemo(
+        () => proposals.filter((p) => p.actionType !== 'merge_pull_request').map((p) => p.id),
+        [proposals],
+    );
+    const excludedFromBulk = proposals.length - bulkIds.length;
 
     // Parent only mounts this block when the queue is non-empty, but keep
     // the guard so it disappears cleanly once the last row is decided.
@@ -90,15 +100,26 @@ export function ApprovalsQueue({ initialApprovals }: ApprovalsQueueProps) {
     };
 
     const handleApproveAll = async () => {
-        if (isApprovingAll || pendingIds.length === 0) return;
+        if (isApprovingAll || bulkIds.length === 0) return;
         setIsApprovingAll(true);
         try {
-            const { approved, skipped } = await approveAllProposalsAction(pendingIds);
+            const { approved, skipped } = await approveAllProposalsAction(bulkIds);
             // Approved rows AND skipped (concurrently-decided) rows are
-            // both no longer pending — clear every row we sent.
-            const sent = new Set(pendingIds);
+            // both no longer pending — clear every row we sent. Rows we
+            // deliberately did not send stay exactly where they are.
+            const sent = new Set(bulkIds);
             setProposals((prev) => prev.filter((p) => !sent.has(p.id)));
-            if (skipped > 0) {
+            if (excludedFromBulk > 0) {
+                // Said separately from `skipped`: these are still pending
+                // and still need a decision, which is the opposite of
+                // "already decided".
+                toast.success(
+                    t('toast.bulkApprovedExcluded', {
+                        approved,
+                        excluded: excludedFromBulk,
+                    }),
+                );
+            } else if (skipped > 0) {
                 toast.success(t('toast.bulkApprovedSkipped', { approved, skipped }));
             } else {
                 toast.success(t('toast.bulkApproved', { count: approved }));
@@ -133,7 +154,7 @@ export function ApprovalsQueue({ initialApprovals }: ApprovalsQueueProps) {
                         size="sm"
                         variant="secondary"
                         onClick={handleApproveAll}
-                        disabled={isApprovingAll}
+                        disabled={isApprovingAll || bulkIds.length === 0}
                         data-testid="approval-approve-all"
                         className="gap-1.5"
                     >

--- a/apps/web/src/lib/api/agent-approvals.ts
+++ b/apps/web/src/lib/api/agent-approvals.ts
@@ -13,6 +13,8 @@ export type AgentActionProposalActionType =
     | 'schedule_task'
     | 'send_message'
     | 'budget_override'
+    /** Merge approval (self-build slice AE, EW-805). */
+    | 'merge_pull_request'
     | 'other';
 
 export type AgentActionProposalStatus = 'pending' | 'approved' | 'rejected';
@@ -28,6 +30,13 @@ export interface AgentActionProposal {
     title: string;
     payload: Record<string, unknown>;
     riskFlags: AgentActionRiskFlag[];
+    /**
+     * Merge approval (slice AE) — `merge:<taskId>:<prNumber>:<headSha>` on a
+     * `merge_pull_request` proposal, null on every other kind. It is what
+     * distinguishes two approvals for the same pull request at different
+     * commits.
+     */
+    subjectKey: string | null;
     status: AgentActionProposalStatus;
     decidedById: string | null;
     decidedAt: string | null;
@@ -51,7 +60,17 @@ export interface ListAgentApprovalsResponse {
 
 export interface ApproveAllAgentApprovalsResult {
     approved: number;
+    /** Rows somebody had ALREADY decided before the bulk call landed. */
     skipped: number;
+    /**
+     * Merge approval (slice AE) — rows bulk approve deliberately refuses
+     * to decide, and which are therefore STILL PENDING. Distinct from
+     * `skipped` because telling a user their merge approval was "already
+     * decided" when it is still sitting in the queue is a lie about the
+     * one irreversible item in it. Optional on the wire so an older API
+     * response still parses.
+     */
+    excluded?: number;
 }
 
 function buildQuery(q: ListAgentApprovalsQuery = {}): string {

--- a/apps/web/src/lib/api/agents.shared.ts
+++ b/apps/web/src/lib/api/agents.shared.ts
@@ -24,6 +24,13 @@ export type AgentGuardrailActionType =
     | 'schedule_task'
     | 'send_message'
     | 'budget_override'
+    // Merge approval (self-build slice AE, EW-805). Listed here so the
+    // guardrails card can BLOCK it, which is meaningful. Auto-approving it
+    // is not: `evaluateGuardrails` refuses to auto-approve a merge
+    // whatever this Agent's policy says, and the merge verifier requires a
+    // decision made by a person. Ticking it in the auto-approve column is
+    // therefore inert by design, not a loophole.
+    | 'merge_pull_request'
     | 'other';
 
 export const AGENT_GUARDRAIL_ACTION_TYPES: readonly AgentGuardrailActionType[] = [
@@ -31,6 +38,7 @@ export const AGENT_GUARDRAIL_ACTION_TYPES: readonly AgentGuardrailActionType[] =
     'schedule_task',
     'send_message',
     'budget_override',
+    'merge_pull_request',
     'other',
 ] as const;
 

--- a/docs/runbooks/MERGE_APPROVAL.md
+++ b/docs/runbooks/MERGE_APPROVAL.md
@@ -1,0 +1,302 @@
+# Merge approval — operator runbook
+
+**Jira:** EW-805 (epic EW-762, self-build fleet) · **Slice:** AE
+
+This describes how an agent-opened pull request becomes a merged one, what
+a human has to do, and exactly what changes if you turn the approval
+requirement off.
+
+---
+
+## The short version
+
+1. An agent run pushes a branch and opens a pull request. **Nothing is
+   merged at this point** and nothing is said about merging.
+2. The `task-pr-status-sync` cron reads the pull request from the git
+   provider every ~2 minutes while it is open.
+3. The first time that read says **open + CI passing**, the platform files
+   a **`merge_pull_request` approval** in the Task owner's Inbox, bound to
+   the pull request's current head commit.
+4. A person clicks **Approve**.
+5. On the next status read (≤ ~2 minutes, or immediately via
+   `GET /api/tasks/:id/pr-status?refresh=true`), the platform re-checks
+   everything against the provider and merges, pinning the merge to the
+   approved commit.
+
+If any of that is not true, the merge is refused with a stable code and
+the pull request is left open and unchanged.
+
+---
+
+## What changed, and why
+
+The merge decision used to fire inside `openPullRequestForBranch`, seconds
+after the pull request was created — before any CI had run — and it passed
+`humanApproved: false` as a hardcoded literal
+(`packages/agent/src/tasks-domain/task-workspace.service.ts`). Under the
+shipped default (`requireHumanApproval: true`) that meant **an agent-opened
+pull request could never be merged by the platform, ever**, and there was
+no `merge_pull_request` proposal type for anybody to approve. The code
+comment was honest about the gap; the gap had simply never been filled.
+
+Slice AE fills it:
+
+| Before                                    | Now                                         |
+| ----------------------------------------- | ------------------------------------------- |
+| Merge judged at PR-open time, before CI   | Merge judged after each provider CI read    |
+| `humanApproved: false`, hardcoded         | Looked up from a recorded human decision    |
+| No approval surface at all                | `merge_pull_request` proposal in the Inbox  |
+| Merge sent with no head pin               | Merge pinned to the approved commit (`sha`) |
+| Nothing ever read `status === 'approved'` | The approval is what triggers the merge     |
+
+---
+
+## What must be true for a merge to land
+
+Every one of these is checked **at merge time**, against the provider, on
+every path that can reach a merge. Any failure refuses and leaves the pull
+request untouched.
+
+| #   | Condition                                                        | Refusal code                                 |
+| --- | ---------------------------------------------------------------- | -------------------------------------------- |
+| 1   | The effective merge policy allows agent merges                   | `agent-merge-disabled`                       |
+| 2   | The base branch is not protected                                 | `protected-branch` / `target-branch-unknown` |
+| 3   | The merge method is allowed                                      | `merge-method-not-allowed`                   |
+| 4   | The run's own quality gate is green (if `requireGreenGate`)      | `gate-not-green`                             |
+| 5   | The pull request is **open** right now (not draft/closed/merged) | `pull-request-not-open`                      |
+| 6   | **Provider CI is passing right now**                             | `pull-request-not-green`                     |
+| 7   | The CI read was **complete** — not a truncated sample            | `pull-request-not-green`                     |
+| 8   | The provider reports a head commit                               | `head-sha-unknown`                           |
+| 9   | An approval exists **for this pull request at this head commit** | `approval-missing` / `approval-stale`        |
+| 10  | It was made by a person, not a guardrail                         | `approval-not-human`                         |
+| 11  | It is less than 24 hours old                                     | `approval-expired`                           |
+| 12  | The approver is entitled to approve for this Task's scope        | `approver-not-entitled`                      |
+
+Conditions 9–12 apply only when the effective policy requires an approval
+(see below). Conditions 5–8 apply to **every** policy — an operator who
+turns approvals off has opted out of a person, not out of CI. Conditions
+1–4 are the pre-existing merge-policy matrix.
+
+### Things that deliberately do **not** count
+
+- **A green pull request from an hour ago.** CI is re-read from the
+  provider immediately before the merge. `tasks.ciState` is a cache the
+  sweep refreshes every couple of minutes and is never the merge input.
+- **A green verdict over part of the checks.** `GitPullRequestStatus.checks`
+  is a bounded DISPLAY list (20 rows); `ciState` is the roll-up over every
+  check on the head commit, and the provider reports
+  `checksComplete: false` when it could not read the whole set (a source
+  it lacks scope for, or more checks than its page budget). An incomplete
+  read is treated as not-green by both the gate and the merge path — the
+  pill still shows what it saw, but nothing authorises on a sample. This
+  monorepo's own CI runs well over 20 legs, with external commit statuses
+  last, so a sample is exactly where a red check hides.
+- **An approval for an earlier commit.** The approval is keyed
+  `merge:<taskId>:<prNumber>:<headSha>`. A force-push, a rebase or one
+  extra commit produces a different key, so the old decision matches
+  nothing and a fresh approval is raised for the new head.
+- **A guardrail auto-approval.** An Agent in `autonomous` mode cannot
+  auto-approve its own merge. Three independent layers stop it: the risk
+  scorer flags every merge `destructive`, `evaluateGuardrails` refuses to
+  auto-approve `merge_pull_request` unconditionally, and the verifier
+  requires `decidedVia = 'user'` with a non-null decider.
+- **A GitHub review approval.** These are now recorded (see below) and
+  shown to the approver as context, but a provider login is not a platform
+  identity — this platform cannot map one to an entitled Organization
+  member — so it never authorises anything on its own.
+- **"Approve all".** `merge_pull_request` proposals are excluded from
+  `POST /api/agent-approvals/approve-all`, with or without explicit ids.
+  They come back in a separate `excluded` counter, NOT in `skipped`:
+  `skipped` means "somebody already decided this", and the queue renders
+  it as such, so counting a still-pending merge there would tell the user
+  the one irreversible item in their queue had been handled. A merge has
+  to be decided one pull request at a time.
+
+### Who may approve
+
+Derived from platform state, never from the proposal:
+
+- **Task in an Organization** — the approver's `users.tenantId` must equal
+  the Task's `tenantId`, **and** one of: they hold an
+  `organization_members` row for that Organization, they are the Tenant
+  owner, or that Organization has no roster at all.
+
+    The roster clause is what makes removal mean something. Removing
+    somebody from an Organization deletes their roster row but only clears
+    `users.tenantId` once their LAST membership in the Tenant is gone — so a
+    pure tenant-equality check hands a removed member continuing merge
+    authority over the Organization they were removed from, whenever they
+    still belong to a sibling Organization. Everywhere else in the platform
+    that is a visibility question; here it is the one irreversible write.
+
+    The two exemptions keep the predicate from repeating a mistake this repo
+    has already made twice. The Tenant owner is a member of every
+    Organization by construction and holds no roster row to find, and
+    Organizations created before invitations existed have an empty roster —
+    roster-strictness against those admitted only the Tenant owner in
+    production, and had to be reverted in `assertActorReachable` and
+    `UploadsController` both. Where there is no roster there is no
+    revocation to honour.
+
+- **Task in a personal scope** — only the Task's owner.
+- The approver must be an **active, non-anonymous** account in either case.
+
+Note that today the approvals queue and the Inbox are **owner-scoped**:
+`AgentApprovalsService.decide` only lets a proposal's own `userId` decide
+it, so in practice the person who approves is always the Task owner. The
+tenant check above is the second gate, and it is what will hold when the
+queue becomes Organization-wide — it is deliberately derived from the Task
+row and the approver's user row, never from the proposal.
+
+---
+
+## Turning the approval off
+
+Set `requireHumanApproval: false` on the merge policy at whichever scope
+you want: Tenant, Organization, Work or Agent. (Merge policy resolves
+field by field, most specific wins:
+`platform default < tenant < organization < work < agent`.)
+
+**With `requireHumanApproval: false`:**
+
+- No `merge_pull_request` proposal is ever raised, and no Inbox item
+  appears. Asking for permission you have said you do not need would be
+  noise.
+- The merge is attempted **once**, from the same place as every other
+  merge: the post-CI gate, after the PR-status sweep reads the provider
+  and reports the pull request open and green. Nothing is attempted at
+  pull-request-open time under any policy — a branch pushed one second ago
+  has no check runs, so "is this green?" has no answer there yet.
+- Conditions 1–8 above still apply. `requireGreenGate` (on by default)
+  still gates on the run's acceptance checks, and provider CI still has to
+  be green: you opted out of a **person**, not out of CI. If you want
+  neither, the run's own quality gate is the knob (`requireGreenGate`),
+  and it is a separate decision.
+- The merge is **still pinned to the head commit** the platform just read
+  from the provider. Pinning can only ever refuse a merge whose head moved
+  under it, so it is applied whether or not an approval was required.
+- Expect the merge up to one sweep (~2 min) after CI reports, rather than
+  seconds after the pull request opens.
+
+**You still need `allowAgentMerge: true`.** The platform default is
+`false`, and with it nothing is attempted and nothing is said — an upgrade
+to this version changes no behaviour for any existing deployment.
+
+### Recommended production posture
+
+```jsonc
+// Organization- or Work-scoped mergePolicy
+{
+	"allowAgentMerge": true, // opt in
+	"requireGreenGate": true, // the run's own checks
+	"requireHumanApproval": true, // the Inbox approval  ← keep this
+	"allowedMergeMethods": ["squash"],
+	"protectedBranches": ["main", "master", "develop", "stage"]
+}
+```
+
+Note the protected-branch list is the platform default and it protects the
+branches the self-build fleet actually targets. An agent merging into
+`develop` needs that list narrowed deliberately.
+
+---
+
+## `AGENT_MERGE_POLICY_ENFORCEMENT=off`
+
+**This kill-switch no longer waives the approval requirement.**
+
+It disables the merge-policy _matrix_ — the branch, method and quality-gate
+rules (conditions 1–4) — and nothing else. Conditions 5–12 still apply,
+and the head pin is still sent.
+
+Why it was narrowed: the switch exists to un-break a deployment the matrix
+is refusing. Letting one environment variable also waive "a person said yes
+to this commit" would make the difference between a reviewed merge and an
+unreviewed one a pod env var, which is precisely the failure this slice
+exists to prevent. It waives nothing that used to work, either — before
+slice AE the approval could never be satisfied, so no merge ever depended
+on it.
+
+If you want agents to land green work with no human in the loop, set
+`requireHumanApproval: false` on the policy. It is scoped, auditable, and
+visible in the resolved-policy UI instead of in a deployment manifest.
+
+---
+
+## Provider-side review approvals
+
+A `pull_request_review` with state `approved` **from a human** is now
+recorded on the Task (`prReviewApprovedSha`, `prReviewApprovedAt`,
+`prReviewApprovedBy`), stamped with `review.commit_id` — the commit the
+reviewer actually opened, not the branch head at delivery time.
+
+It is shown to the person deciding the Inbox approval, and only when it
+covers the _current_ head. It is not an authorization.
+
+Bots are dropped, all of them:
+
+- the platform's own `<GITHUB_APP_SLUG>[bot]` identity, and
+- every allow-listed reviewer bot (`GITHUB_TRUSTED_REVIEW_BOTS` —
+  CodeRabbit, Copilot, Codex, Greptile …).
+
+Their _rejections_ are still trusted (finding R16). A bot saying "looks
+good" is not a person having looked.
+
+---
+
+## Where things live
+
+| Concern                       | File                                                               |
+| ----------------------------- | ------------------------------------------------------------------ |
+| Subject key + validity window | `packages/contracts/src/policy/merge-approval.types.ts`            |
+| Verifier + raiser             | `packages/agent/src/agent-approvals/merge-approval.service.ts`     |
+| Verifier port (token)         | `packages/agent/src/policy/merge-approval.port.ts`                 |
+| Enforcement                   | `packages/agent/src/facades/git.facade.ts` (`assertAgentMayMerge`) |
+| Post-CI re-evaluation         | `packages/agent/src/tasks-domain/task-merge-gate.service.ts`       |
+| CI read that triggers it      | `packages/agent/src/tasks-domain/task-pr-status.service.ts`        |
+| Provider review approvals     | `packages/agent/src/tasks-domain/task-review-approval.service.ts`  |
+| Webhook entry                 | `apps/api/src/ingest/github/github-pr-review-bridge.service.ts`    |
+| Schema                        | `apps/api/src/migrations/1789700000000-AddMergeApprovalBinding.ts` |
+
+---
+
+## Troubleshooting
+
+**"The Inbox never shows a merge approval."** In order:
+
+1. Is `allowAgentMerge` true at some scope? With the default `false` the
+   platform will not ask for permission it could not use. Check
+   `GET /api/merge-policy/resolve`.
+2. Is the Task's `agentId` set? A Task with no Agent has no policy scope
+   and no one to attribute the merge to; the gate stands down.
+3. Is provider CI actually green? Check `GET /api/tasks/:id/pr-status`.
+   `unknown` counts as not-green and is indistinguishable from "no CI
+   configured" and "the token lacks `checks:read`". A token that cannot
+   read one of the two check sources also reports `checksComplete: false`,
+   which counts as not-green even when the half it COULD read is passing —
+   grant `checks:read` to the installation if the pill looks green and the
+   gate still will not raise an approval.
+4. Is the pull request a draft? Drafts are excluded.
+5. Is the `task-pr-status-sync` cron running? It is the only trigger.
+
+**"The Task chat says the merge was refused, over and over."** It should
+not: a refusal is reported once per (head commit, refusal code) and the
+marker lives on `tasks.mergeRefusedSha` / `mergeRefusedCode`. The ATTEMPT
+still repeats every sweep, deliberately, so a transient provider fault
+clears itself. If you are seeing repeats, the head is moving or the code
+is changing — read the codes, they will say which.
+
+**"I approved it and nothing merged."** Give it one sync tick (~2 min), or
+force it with `GET /api/tasks/:id/pr-status?refresh=true`. If it still has
+not merged, the Task chat carries the refusal message with its code — see
+the table above. The most common are `pull-request-not-green` (something
+went red after you approved) and `approval-stale` (a commit landed after
+you approved; approve the new head).
+
+**"It says `approval-stale` but nobody pushed."** A rebase, an amend, or a
+"Update branch" click on the provider all change the head commit. The
+approval covers the commit that was reviewed; re-approve.
+
+**"The merge returned `Head branch was modified`."** The provider refused
+because the head moved between the check and the merge call. That is the
+pin working. The next sweep will raise a fresh approval for the new head.

--- a/packages/agent/src/agent-approvals/__tests__/agent-approvals.service.spec.ts
+++ b/packages/agent/src/agent-approvals/__tests__/agent-approvals.service.spec.ts
@@ -217,7 +217,7 @@ describe('AgentApprovalsService', () => {
 
             const result = await svc.approveAll('u1', ['p1', 'p2', 'p3']);
 
-            expect(result).toEqual({ approved: 2, skipped: 1 });
+            expect(result).toEqual({ approved: 2, skipped: 1, excluded: 0 });
             expect(proposals.find).toHaveBeenCalledWith({
                 where: expect.objectContaining({ userId: 'u1' }),
             });
@@ -237,7 +237,7 @@ describe('AgentApprovalsService', () => {
 
             const result = await svc.approveAll('u1');
 
-            expect(result).toEqual({ approved: 1, skipped: 0 });
+            expect(result).toEqual({ approved: 1, skipped: 0, excluded: 0 });
             expect(proposals.find).toHaveBeenCalledWith({
                 where: { userId: 'u1', status: 'pending' },
             });
@@ -248,16 +248,92 @@ describe('AgentApprovalsService', () => {
 
             const result = await svc.approveAll('u1', ['p1']);
 
-            expect(result).toEqual({ approved: 0, skipped: 1 });
+            expect(result).toEqual({ approved: 0, skipped: 1, excluded: 0 });
             expect(proposals.save).not.toHaveBeenCalled();
         });
 
         it('short-circuits on an explicit empty subset', async () => {
             const result = await svc.approveAll('u1', []);
 
-            expect(result).toEqual({ approved: 0, skipped: 0 });
+            expect(result).toEqual({ approved: 0, skipped: 0, excluded: 0 });
             expect(proposals.find).not.toHaveBeenCalled();
             expect(proposals.save).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('approveAll — merge approval carve-out (slice AE)', () => {
+        // CONTRACT REVERSAL (AE review). These two used to assert
+        // `{ approved: 1, skipped: 1 }` — counting a still-PENDING merge
+        // proposal in the same bucket as a row somebody had already
+        // decided. The web client renders `skipped` verbatim as
+        // "N already decided", so that pinned a lie about the one
+        // irreversible item in the queue: the user was told their merge
+        // approval had been handled while it sat there untouched, waiting
+        // to expire. `excluded` is the honest counter — deliberately not
+        // decided, still pending, still needs you.
+        it('never bulk-approves a merge, and counts it as EXCLUDED not skipped', async () => {
+            // "Approve all" is a clear-the-queue gesture. A merge onto a
+            // real branch is the one thing in this queue no follow-up
+            // commit can undo, so it has to be a deliberate per-pull-request
+            // act with the repository and the head commit in view.
+            proposals.find.mockResolvedValue([
+                makeProposal({ id: 'p1', actionType: 'spawn_agent', status: 'pending' }),
+                makeProposal({
+                    id: 'p2',
+                    actionType: 'merge_pull_request',
+                    status: 'pending',
+                    subjectKey: 'merge:task-1:7:' + 'a'.repeat(40),
+                }),
+            ]);
+
+            const result = await svc.approveAll('u1');
+
+            expect(result).toEqual({ approved: 1, skipped: 0, excluded: 1 });
+            const saved = proposals.save.mock.calls[0][0] as unknown as Array<{ id: string }>;
+            expect(saved.map((row) => row.id)).toEqual(['p1']);
+        });
+
+        it('excludes a merge even when its id is named explicitly', async () => {
+            proposals.find.mockResolvedValue([
+                makeProposal({ id: 'p2', actionType: 'merge_pull_request', status: 'pending' }),
+            ]);
+            await expect(svc.approveAll('u1', ['p2'])).resolves.toEqual({
+                approved: 0,
+                skipped: 0,
+                excluded: 1,
+            });
+            expect(proposals.save).not.toHaveBeenCalled();
+        });
+
+        it('keeps `skipped` for genuinely already-decided rows, alongside an exclusion', async () => {
+            // The two counters have to be independently readable: one says
+            // "nothing left to do", the other says "you still have to do
+            // this one". Collapsing them is what made the toast wrong.
+            proposals.find.mockResolvedValue([
+                makeProposal({ id: 'p1', actionType: 'spawn_agent', status: 'pending' }),
+                makeProposal({ id: 'p2', actionType: 'send_message', status: 'approved' }),
+                makeProposal({ id: 'p3', actionType: 'merge_pull_request', status: 'pending' }),
+            ]);
+
+            await expect(svc.approveAll('u1')).resolves.toEqual({
+                approved: 1,
+                skipped: 1,
+                excluded: 1,
+            });
+        });
+
+        it('counts an already-DECIDED merge as skipped, not excluded', async () => {
+            // Nothing to exclude about a row that is no longer pending —
+            // it really has been decided, and saying so is correct.
+            proposals.find.mockResolvedValue([
+                makeProposal({ id: 'p1', actionType: 'merge_pull_request', status: 'approved' }),
+            ]);
+
+            await expect(svc.approveAll('u1', ['p1'])).resolves.toEqual({
+                approved: 0,
+                skipped: 1,
+                excluded: 0,
+            });
         });
     });
 

--- a/packages/agent/src/agent-approvals/__tests__/merge-approval.module.spec.ts
+++ b/packages/agent/src/agent-approvals/__tests__/merge-approval.module.spec.ts
@@ -1,0 +1,50 @@
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MergeApprovalModule } from '../merge-approval.module';
+import { MergeApprovalService } from '../merge-approval.service';
+import { MERGE_APPROVAL_VERIFIER } from '../../policy/merge-approval.port';
+import { ENTITIES } from '../../database/database.config';
+
+/**
+ * The module compiles against a REAL Nest container.
+ *
+ * This exists because the slice that added `MergeApprovalService` shipped an
+ * unresolvable dependency — `TaskRepository` is not in
+ * `_repository-inventory.ts`, so `DatabaseModule` neither provides nor
+ * exports it, and every module that needs it must list it locally. Nothing
+ * caught it: the service's own spec constructs it directly, which proves the
+ * logic and says nothing about wiring, and the module specs that WOULD have
+ * caught it (`facades.module.spec.ts`, and the api-side module specs) cannot
+ * load in a working checkout because `@ever-works/agent-plugins` has no build
+ * output there. So the first thing that would have failed was the API
+ * refusing to boot.
+ *
+ * This spec deliberately imports only `MergeApprovalModule` over an in-memory
+ * database, avoiding that plugin chain entirely, so it runs everywhere.
+ * Delete the `TaskRepository` provider and it fails with "Nest can't resolve
+ * dependencies of the MergeApprovalService ... argument TaskRepository at
+ * index [1]" — verified, not assumed.
+ */
+describe('MergeApprovalModule — dependency injection', () => {
+    it('compiles and resolves both the class and the verifier token', async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                }),
+                MergeApprovalModule,
+            ],
+        }).compile();
+
+        // The token is what `GitFacadeService` injects. Resolving the class
+        // but not the token would still leave the gate unbound at runtime,
+        // which fails closed but refuses every merge — so both are asserted.
+        expect(moduleRef.get(MergeApprovalService)).toBeInstanceOf(MergeApprovalService);
+        expect(moduleRef.get(MERGE_APPROVAL_VERIFIER)).toBe(moduleRef.get(MergeApprovalService));
+
+        await moduleRef.close();
+    });
+});

--- a/packages/agent/src/agent-approvals/__tests__/merge-approval.service.spec.ts
+++ b/packages/agent/src/agent-approvals/__tests__/merge-approval.service.spec.ts
@@ -1,0 +1,609 @@
+import { MERGE_APPROVAL_MAX_AGE_MS, mergeApprovalSubjectKey } from '@ever-works/contracts';
+import { MergeApprovalService } from '../merge-approval.service';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the verifier.
+ *
+ * This is the file that decides whether a pull request gets merged, so
+ * every case below is written as "what would have to be true for an
+ * UNAPPROVED merge to land". The positives are one test; the rest is the
+ * list of ways a merge bot lands the wrong thing.
+ *
+ * The service is driven for real — no self-comparing fixtures. The only
+ * doubles are the repositories, and the assertions look at the exact
+ * lookup they receive, because a verifier that queried by Task alone
+ * would pass every "approved" test here while being catastrophically
+ * wrong.
+ */
+describe('MergeApprovalService', () => {
+    const TASK_ID = '9f1c0d1e-6c1a-4c3a-9f6c-2b6a0a5d1e77';
+    const HEAD = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+    const OLD_HEAD = '1111111111111111111111111111111111111111';
+    const PR = 42;
+    const KEY = mergeApprovalSubjectKey({ taskId: TASK_ID, prNumber: PR, headSha: HEAD });
+
+    const QUERY = { taskId: TASK_ID, prNumber: PR, headSha: HEAD };
+
+    function approvedRow(over: Record<string, unknown> = {}) {
+        return {
+            id: 'proposal-1',
+            actionType: 'merge_pull_request',
+            subjectKey: KEY,
+            status: 'approved',
+            decidedVia: 'user',
+            decidedById: 'human-1',
+            decidedAt: new Date(),
+            ...over,
+        };
+    }
+
+    function orgTask(over: Record<string, unknown> = {}) {
+        return {
+            id: TASK_ID,
+            userId: 'owner-1',
+            slug: 'T-42',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            ...over,
+        };
+    }
+
+    function build(
+        over: {
+            row?: unknown;
+            priorCount?: number;
+            task?: unknown;
+            user?: unknown;
+            findOneImpl?: jest.Mock;
+            /** Roster rows the approver's Organization holds. */
+            rosterSize?: number;
+            /** `tenants.ownerUserId` for the Task's Tenant. */
+            tenantOwnerUserId?: string | null;
+        } = {},
+    ) {
+        // `'row' in over` rather than `??`: an explicit `null` means "the
+        // store holds nothing", which is a different case from "the test
+        // did not care" and is exactly the case worth testing.
+        const proposals = {
+            findOne:
+                over.findOneImpl ??
+                jest.fn().mockResolvedValue('row' in over ? over.row : approvedRow()),
+            count: jest.fn().mockResolvedValue(over.priorCount ?? 0),
+        };
+        const tasks = {
+            findById: jest.fn().mockResolvedValue('task' in over ? over.task : orgTask()),
+        };
+        const users = {
+            findById: jest.fn().mockResolvedValue(
+                'user' in over
+                    ? over.user
+                    : {
+                          id: 'human-1',
+                          isActive: true,
+                          isAnonymous: false,
+                          tenantId: 'tenant-1',
+                      },
+            ),
+        };
+        const approvals = {
+            createProposal: jest.fn().mockResolvedValue({ id: 'proposal-new' }),
+        };
+        const members = {
+            findByOrgAndUser: jest.fn().mockResolvedValue({ id: 'member-1' }),
+            countForOrganization: jest.fn().mockResolvedValue(over.rosterSize ?? 3),
+        };
+        const tenants = {
+            findById: jest.fn().mockResolvedValue({
+                id: 'tenant-1',
+                ownerUserId: 'tenantOwnerUserId' in over ? over.tenantOwnerUserId : 'owner-of-t1',
+            }),
+        };
+        const service = new MergeApprovalService(
+            proposals as never,
+            tasks as never,
+            users as never,
+            approvals as never,
+            members as never,
+            tenants as never,
+        );
+        return { service, proposals, tasks, users, approvals, members, tenants };
+    }
+
+    // ── the one happy path ────────────────────────────────────────────
+
+    it('approves a human decision recorded for exactly this pull request and head', async () => {
+        const { service } = build();
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toEqual({
+            approved: true,
+            approvalId: 'proposal-1',
+            approvedById: 'human-1',
+            approvedAt: expect.any(Date),
+        });
+    });
+
+    it('looks the approval up by the EXACT subject key, not by Task or PR alone', async () => {
+        const { service, proposals } = build();
+        await service.verifyMergeApproval(QUERY);
+        expect(proposals.findOne).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    actionType: 'merge_pull_request',
+                    subjectKey: KEY,
+                    status: 'approved',
+                },
+            }),
+        );
+        // The key names the head, so a query built from it cannot match a
+        // decision made about a different commit.
+        expect(KEY).toContain(HEAD);
+    });
+
+    it('normalises a shouted head SHA to the same key the writer used', async () => {
+        const { service, proposals } = build();
+        await service.verifyMergeApproval({ ...QUERY, headSha: HEAD.toUpperCase() });
+        expect(proposals.findOne.mock.calls[0][0].where.subjectKey).toBe(KEY);
+    });
+
+    // ── nothing recorded ──────────────────────────────────────────────
+
+    it('refuses with approval-missing when nothing names this pull request', async () => {
+        const { service } = build({ row: null, priorCount: 0 });
+        const verdict = await service.verifyMergeApproval(QUERY);
+        expect(verdict).toMatchObject({ approved: false, code: 'approval-missing' });
+        expect(verdict.reason).toContain('No human approval is on record');
+    });
+
+    it('refuses with approval-STALE when the approval was for an earlier commit', async () => {
+        // This is the force-push / new-commit case, and it is the reason
+        // the head is in the key at all: the human approved a diff, and
+        // the diff changed underneath them.
+        const { service } = build({ row: null, priorCount: 1 });
+        const verdict = await service.verifyMergeApproval(QUERY);
+        expect(verdict).toMatchObject({ approved: false, code: 'approval-stale' });
+        expect(verdict.reason).toContain('approved for an earlier commit');
+    });
+
+    it('an approval for the same PR at another head does not satisfy this head', async () => {
+        // Driven end to end through the real key derivation: a store that
+        // only holds OLD_HEAD answers nothing for HEAD.
+        const stored = new Map([
+            [
+                mergeApprovalSubjectKey({ taskId: TASK_ID, prNumber: PR, headSha: OLD_HEAD }),
+                approvedRow({
+                    subjectKey: mergeApprovalSubjectKey({
+                        taskId: TASK_ID,
+                        prNumber: PR,
+                        headSha: OLD_HEAD,
+                    }),
+                }),
+            ],
+        ]);
+        const findOneImpl = jest.fn(async (opts: { where: { subjectKey?: string } }) =>
+            opts.where.subjectKey ? (stored.get(opts.where.subjectKey) ?? null) : null,
+        );
+        const { service } = build({ findOneImpl, priorCount: 1 });
+
+        await expect(
+            service.verifyMergeApproval({ ...QUERY, headSha: OLD_HEAD }),
+        ).resolves.toMatchObject({ approved: true });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-stale',
+        });
+    });
+
+    // ── the platform must not approve its own work ────────────────────
+
+    it('refuses a GUARDRAIL auto-approval — the platform cannot approve itself', async () => {
+        const { service } = build({
+            row: approvedRow({ decidedVia: 'guardrail', decidedById: null }),
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-not-human',
+        });
+    });
+
+    it('refuses an approved row with no decider at all', async () => {
+        const { service } = build({ row: approvedRow({ decidedById: null }) });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-not-human',
+        });
+    });
+
+    // ── freshness ─────────────────────────────────────────────────────
+
+    it('refuses an approval older than the validity window', async () => {
+        const { service } = build({
+            row: approvedRow({
+                decidedAt: new Date(Date.now() - MERGE_APPROVAL_MAX_AGE_MS - 1000),
+            }),
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-expired',
+        });
+    });
+
+    it('accepts an approval just inside the window', async () => {
+        const { service } = build({
+            row: approvedRow({
+                decidedAt: new Date(Date.now() - MERGE_APPROVAL_MAX_AGE_MS + 60_000),
+            }),
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({ approved: true });
+    });
+
+    it('refuses an approval with no decision time — its age cannot be established', async () => {
+        const { service } = build({ row: approvedRow({ decidedAt: null }) });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-expired',
+        });
+    });
+
+    // ── entitlement, derived from platform state ──────────────────────
+
+    it('refuses an approver from a DIFFERENT tenant', async () => {
+        const { service } = build({
+            user: { id: 'human-1', isActive: true, isAnonymous: false, tenantId: 'tenant-2' },
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approver-not-entitled',
+        });
+    });
+
+    it('refuses a deactivated approver', async () => {
+        const { service } = build({
+            user: { id: 'human-1', isActive: false, isAnonymous: false, tenantId: 'tenant-1' },
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approver-not-entitled',
+        });
+    });
+
+    it('refuses an ANONYMOUS approver — an unclaimed account is nobody', async () => {
+        const { service } = build({
+            user: { id: 'human-1', isActive: true, isAnonymous: true, tenantId: 'tenant-1' },
+        });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approver-not-entitled',
+        });
+    });
+
+    it('refuses when the approver row cannot be read at all', async () => {
+        const { service } = build({ user: null });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approver-not-entitled',
+        });
+    });
+
+    it('refuses when the Task itself is gone — entitlement has no scope to check', async () => {
+        const { service } = build({ task: null });
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approver-not-entitled',
+        });
+    });
+
+    it('derives the scope from the TASK, never from the proposal row', async () => {
+        const { service, tasks } = build();
+        await service.verifyMergeApproval(QUERY);
+        expect(tasks.findById).toHaveBeenCalledWith(TASK_ID);
+    });
+
+    it('admits an org approver who is on the roster', async () => {
+        const { service, members } = build();
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({ approved: true });
+        expect(members.findByOrgAndUser).toHaveBeenCalledWith('org-1', 'human-1');
+    });
+
+    // CONTRACT REVERSAL (AE review). This block used to hold one test —
+    // "admits an org approver WITHOUT a roster row — tenant equality is
+    // the predicate" — justified by the two production reverts where
+    // roster-strictness admitted only the Tenant owner.
+    //
+    // That justification does not transfer. Both reverts were on READ
+    // paths, where over-restriction is a visibility bug; this is the one
+    // irreversible WRITE in the queue. And tenant equality alone reads a
+    // revocation and ignores it: `removeMember` deletes the roster row but
+    // only clears `users.tenantId` once the person's LAST membership in
+    // the Tenant is gone, so somebody removed from Organization A while
+    // still in Organization B kept merge authority over A's repositories.
+    //
+    // The predicate is now roster row OR Tenant owner OR an Organization
+    // with no roster at all — which keeps every case the reverts were
+    // about working, and closes the one they were not about.
+    describe('Organization roster (entitlement)', () => {
+        it('REFUSES an approver removed from the Organization but still in the Tenant', async () => {
+            // The exact leak: Bob is removed from Org A, stays in Org B, so
+            // his users.tenantId survives. Org A's roster is populated, and
+            // his row in it is gone.
+            const { service, members } = build({ rosterSize: 4 });
+            members.findByOrgAndUser.mockResolvedValue(null);
+            const verdict = await service.verifyMergeApproval(QUERY);
+            expect(verdict).toMatchObject({ approved: false, code: 'approver-not-entitled' });
+            expect(verdict.reason).toContain('not a member of the Organization');
+        });
+
+        it('admits the TENANT OWNER, who holds no roster row by construction', async () => {
+            // `removeMember` refuses to remove the owner precisely because
+            // "the owner is a member of every Organization in their Tenant
+            // by construction — there is no roster row to delete". A
+            // roster-only check would admit everybody except them.
+            const { service, members } = build({
+                rosterSize: 4,
+                tenantOwnerUserId: 'human-1',
+            });
+            members.findByOrgAndUser.mockResolvedValue(null);
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: true,
+            });
+        });
+
+        it('admits a tenant member when the Organization has NO roster at all', async () => {
+            // Organizations that predate invitations have an empty
+            // `organization_members`. Where there is no roster there is no
+            // revocation to honour, and roster-strictness against these is
+            // exactly what had to be reverted twice before.
+            const { service, members } = build({ rosterSize: 0 });
+            members.findByOrgAndUser.mockResolvedValue(null);
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: true,
+            });
+        });
+
+        it('refuses when the roster size cannot be read — it does not guess', async () => {
+            const { service, members } = build();
+            members.findByOrgAndUser.mockResolvedValue(null);
+            members.countForOrganization.mockRejectedValue(new Error('db down'));
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: false,
+                code: 'approver-not-entitled',
+            });
+        });
+
+        it('never consults the roster for a personal-scope Task', async () => {
+            const { service, members } = build({
+                task: orgTask({ organizationId: null, tenantId: null }),
+                row: approvedRow({ decidedById: 'owner-1' }),
+                user: { id: 'owner-1', isActive: true, isAnonymous: false, tenantId: null },
+            });
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: true,
+            });
+            expect(members.findByOrgAndUser).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('personal scope (no Organization)', () => {
+        const personal = orgTask({ organizationId: null, tenantId: null, userId: 'owner-1' });
+
+        it('admits the Task owner', async () => {
+            const { service } = build({
+                task: personal,
+                row: approvedRow({ decidedById: 'owner-1' }),
+                user: { id: 'owner-1', isActive: true, isAnonymous: false, tenantId: null },
+            });
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: true,
+            });
+        });
+
+        it('refuses anybody else, even an active user', async () => {
+            const { service } = build({
+                task: personal,
+                row: approvedRow({ decidedById: 'stranger' }),
+                user: { id: 'stranger', isActive: true, isAnonymous: false, tenantId: null },
+            });
+            await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+                approved: false,
+                code: 'approver-not-entitled',
+            });
+        });
+    });
+
+    // ── unusable inputs and faults all fail CLOSED ────────────────────
+
+    it.each([
+        ['an empty task id', { ...QUERY, taskId: '  ' }, 'approval-missing'],
+        ['a branch name as the head', { ...QUERY, headSha: 'main' }, 'head-sha-unknown'],
+        ['an empty head', { ...QUERY, headSha: '' }, 'head-sha-unknown'],
+    ] as const)('refuses %s', async (_label, query, code) => {
+        const { service, proposals } = build();
+        await expect(service.verifyMergeApproval(query)).resolves.toMatchObject({
+            approved: false,
+            code,
+        });
+        expect(proposals.findOne).not.toHaveBeenCalled();
+    });
+
+    it('refuses when a positive PR number cannot be keyed', async () => {
+        const { service } = build();
+        await expect(service.verifyMergeApproval({ ...QUERY, prNumber: 0 })).resolves.toMatchObject(
+            { approved: false, code: 'approval-missing' },
+        );
+    });
+
+    it('refuses when the approval store throws — an unreadable record is not an approval', async () => {
+        const { service, proposals } = build();
+        proposals.findOne.mockRejectedValue(new Error('db down'));
+        await expect(service.verifyMergeApproval(QUERY)).resolves.toMatchObject({
+            approved: false,
+            code: 'approval-missing',
+        });
+    });
+
+    // ── requesting an approval ────────────────────────────────────────
+
+    describe('requestMergeApproval', () => {
+        const REQUEST = {
+            userId: 'owner-1',
+            taskId: TASK_ID,
+            taskLabel: 'T-42',
+            agentId: 'agent-1',
+            prNumber: PR,
+            headSha: HEAD,
+            targetBranch: 'develop',
+            repository: 'acme/site-data',
+            ciState: 'passing',
+        };
+
+        it('raises a merge_pull_request proposal keyed to this pull request AND head', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue(null);
+
+            const outcome = await service.requestMergeApproval(REQUEST);
+
+            expect(outcome).toMatchObject({ raised: true });
+            expect(approvals.createProposal).toHaveBeenCalledWith(
+                'owner-1',
+                expect.objectContaining({
+                    agentId: 'agent-1',
+                    actionType: 'merge_pull_request',
+                    subjectKey: KEY,
+                    payload: expect.objectContaining({
+                        taskId: TASK_ID,
+                        prNumber: PR,
+                        headSha: HEAD,
+                        targetBranch: 'develop',
+                        repository: 'acme/site-data',
+                        destructive: true,
+                    }),
+                }),
+            );
+        });
+
+        it('puts the pull request, base branch, repository and commit in the title', async () => {
+            // The title is the only string BOTH surfaces show — the Inbox
+            // item and the approvals queue. Somebody approving an
+            // irreversible merge has to be able to tell what they are
+            // approving from it alone.
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue(null);
+            await service.requestMergeApproval(REQUEST);
+            expect(approvals.createProposal.mock.calls[0][1].title).toBe(
+                'Merge PR #42 into develop in acme/site-data for T-42 (@ a1b2c3d4e5f6)',
+            );
+        });
+
+        it('degrades the title gracefully when the branch or repository is unknown', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue(null);
+            await service.requestMergeApproval({
+                ...REQUEST,
+                targetBranch: null,
+                repository: null,
+            });
+            expect(approvals.createProposal.mock.calls[0][1].title).toBe(
+                'Merge PR #42 for T-42 (@ a1b2c3d4e5f6)',
+            );
+        });
+
+        it('is idempotent per head — a repeated sweep files nothing new', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue({ id: 'p-1', status: 'pending' });
+            await expect(service.requestMergeApproval(REQUEST)).resolves.toEqual({
+                raised: false,
+                reason: 'already-open',
+            });
+            expect(approvals.createProposal).not.toHaveBeenCalled();
+        });
+
+        it('does not re-ask once a human has already decided this head', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue({ id: 'p-1', status: 'rejected' });
+            await expect(service.requestMergeApproval(REQUEST)).resolves.toEqual({
+                raised: false,
+                reason: 'already-decided',
+            });
+            expect(approvals.createProposal).not.toHaveBeenCalled();
+        });
+
+        it('a NEW head commit is a NEW ask — the previous decision does not carry over', async () => {
+            const seen = new Set<string>();
+            const findOneImpl = jest.fn(async (opts: { where: { subjectKey?: string } }) =>
+                opts.where.subjectKey && seen.has(opts.where.subjectKey)
+                    ? { id: 'p-1', status: 'approved' }
+                    : null,
+            );
+            const { service, approvals } = build({ findOneImpl });
+
+            await service.requestMergeApproval(REQUEST);
+            seen.add(KEY);
+            await service.requestMergeApproval(REQUEST); // same head → no second ask
+            await service.requestMergeApproval({ ...REQUEST, headSha: OLD_HEAD });
+
+            expect(approvals.createProposal).toHaveBeenCalledTimes(2);
+            const keys = approvals.createProposal.mock.calls.map(
+                (call: unknown[]) => (call[1] as { subjectKey: string }).subjectKey,
+            );
+            expect(keys).toEqual([
+                KEY,
+                mergeApprovalSubjectKey({ taskId: TASK_ID, prNumber: PR, headSha: OLD_HEAD }),
+            ]);
+        });
+
+        it('raises nothing when the head is not a commit SHA', async () => {
+            const { service, approvals } = build();
+            await expect(
+                service.requestMergeApproval({ ...REQUEST, headSha: 'main' }),
+            ).resolves.toEqual({ raised: false, reason: 'unusable-subject' });
+            expect(approvals.createProposal).not.toHaveBeenCalled();
+        });
+
+        it('reports a failure to raise rather than throwing at the sweep', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne.mockResolvedValue(null);
+            approvals.createProposal.mockRejectedValue(new Error('agent not found'));
+            await expect(service.requestMergeApproval(REQUEST)).resolves.toEqual({
+                raised: false,
+                reason: 'failed',
+            });
+        });
+
+        it('reports the WINNER when it loses the insert race, not a failure', async () => {
+            // This is a check-then-create across two processes — the
+            // two-minute `task-pr-status-sync` sweep in the worker and an
+            // API `?refresh=true` — so the read can say "nothing here" in
+            // both at once. The unique index on (actionType, subjectKey)
+            // is what stops two Approve buttons appearing for one merge,
+            // of which a later click on the second would grant a fresh 24h
+            // validity window over a head the first already covered. The
+            // loser has to recognise the collision rather than report a
+            // failure the sweep would retry into the same wall.
+            const { service, proposals, approvals } = build();
+            proposals.findOne
+                .mockResolvedValueOnce(null) // the optimistic read
+                .mockResolvedValueOnce({ id: 'p-winner', status: 'pending' }); // after the clash
+            approvals.createProposal.mockRejectedValue(
+                new Error('UNIQUE constraint failed: idx_agent_action_proposals_subject'),
+            );
+
+            await expect(service.requestMergeApproval(REQUEST)).resolves.toEqual({
+                raised: false,
+                reason: 'already-open',
+            });
+            // Exactly one attempt: it does not retry into the constraint.
+            expect(approvals.createProposal).toHaveBeenCalledTimes(1);
+        });
+
+        it('reports already-decided when the race winner has since been decided', async () => {
+            const { service, proposals, approvals } = build();
+            proposals.findOne
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce({ id: 'p-winner', status: 'approved' });
+            approvals.createProposal.mockRejectedValue(new Error('UNIQUE constraint failed'));
+
+            await expect(service.requestMergeApproval(REQUEST)).resolves.toEqual({
+                raised: false,
+                reason: 'already-decided',
+            });
+        });
+    });
+});

--- a/packages/agent/src/agent-approvals/__tests__/risk-scorer.spec.ts
+++ b/packages/agent/src/agent-approvals/__tests__/risk-scorer.spec.ts
@@ -87,4 +87,23 @@ describe('RISK_SCORER (pure)', () => {
         const input = { actionType: 'spawn_agent' as const, payload: { spawnDepth: 3 } };
         expect(RISK_SCORER(input)).toEqual(RISK_SCORER(input));
     });
+
+    // ── merge approval (self-build slice AE, EW-805) ─────────────────
+
+    it('flags a merge as destructive from the ACTION TYPE, not from the payload', () => {
+        // Read off the payload instead and a caller that forgot
+        // `destructive: true` would mint an unflagged — and therefore
+        // guardrail-auto-approvable — merge proposal.
+        expect(RISK_SCORER({ actionType: 'merge_pull_request' })).toEqual(['destructive']);
+        expect(RISK_SCORER({ actionType: 'merge_pull_request', payload: {} })).toEqual([
+            'destructive',
+        ]);
+        expect(
+            RISK_SCORER({ actionType: 'merge_pull_request', payload: { destructive: false } }),
+        ).toEqual(['destructive']);
+    });
+
+    it('does not flag other action types as destructive by accident', () => {
+        expect(RISK_SCORER({ actionType: 'schedule_task', payload: {} })).toEqual([]);
+    });
 });

--- a/packages/agent/src/agent-approvals/agent-approvals.service.ts
+++ b/packages/agent/src/agent-approvals/agent-approvals.service.ts
@@ -36,6 +36,14 @@ export interface CreateAgentActionProposalInput {
     payload?: AgentActionProposalPayload | null;
     /** Optional originating `agent_runs.id`. */
     runId?: string | null;
+    /**
+     * Merge approval (self-build slice AE) — the canonical subject this
+     * decision is about, so an approved row can be looked up by equality
+     * later. PLATFORM-SUPPLIED ONLY: there is no route that creates a
+     * proposal, and the merge gate derives this from provider state, never
+     * from anything a model wrote.
+     */
+    subjectKey?: string | null;
 }
 
 export interface ListAgentActionProposalsFilter {
@@ -120,6 +128,7 @@ export class AgentApprovalsService {
             title: title.slice(0, 200),
             payload,
             riskFlags,
+            subjectKey: input.subjectKey ?? null,
             status: 'pending',
             decidedById: null,
             decidedAt: null,
@@ -243,22 +252,44 @@ export class AgentApprovalsService {
      * one per row). Already-decided rows in the subset are skipped
      * rather than 409ing: bulk approval is best-effort by design.
      * Cross-user / unknown ids are silently ignored (no existence leak).
+     *
+     * `merge_pull_request` proposals are NEVER decided here (merge
+     * approval, self-build slice AE). Bulk approve is a "clear the queue"
+     * gesture; a merge onto a real branch is the one thing in this queue
+     * that cannot be undone by a follow-up commit, so it has to be the
+     * human's deliberate, per-pull-request act — through `decide` or the
+     * Inbox reply, where they have the repository, the base branch and the
+     * head commit in front of them.
+     *
+     * They are counted as `excluded`, NOT as `skipped`. The two mean
+     * opposite things to the person reading the toast: `skipped` is
+     * "somebody already decided this, there is nothing left to do", and
+     * the web client renders it as exactly that. A still-pending merge
+     * counted there would tell the user the one irreversible item in their
+     * queue had been handled while it sits there untouched — the precise
+     * misreport that makes an unattended merge approval expire, or get
+     * clicked later without being read.
      */
     async approveAll(
         userId: string,
         ids?: string[],
-    ): Promise<{ approved: number; skipped: number }> {
+    ): Promise<{ approved: number; skipped: number; excluded: number }> {
         if (ids && ids.length === 0) {
-            return { approved: 0, skipped: 0 };
+            return { approved: 0, skipped: 0, excluded: 0 };
         }
         const where: FindOptionsWhere<AgentActionProposal> = ids
             ? { userId, id: In(ids) }
             : { userId, status: 'pending' };
         const rows = await this.proposals.find({ where });
-        const pending = rows.filter((row) => row.status === 'pending');
-        const skipped = rows.length - pending.length;
+        const excluded = rows.filter(
+            (row) => row.status === 'pending' && row.actionType === 'merge_pull_request',
+        ).length;
+        const pending = rows.filter(
+            (row) => row.status === 'pending' && row.actionType !== 'merge_pull_request',
+        );
+        const skipped = rows.length - pending.length - excluded;
         if (pending.length === 0) {
-            return { approved: 0, skipped };
+            return { approved: 0, skipped, excluded };
         }
 
         const now = new Date();
@@ -270,7 +301,7 @@ export class AgentApprovalsService {
             row.updatedAt = now;
         }
         await this.proposals.save(pending);
-        return { approved: pending.length, skipped };
+        return { approved: pending.length, skipped, excluded };
     }
 
     // ── internals ─────────────────────────────────────────────────

--- a/packages/agent/src/agent-approvals/index.ts
+++ b/packages/agent/src/agent-approvals/index.ts
@@ -1,6 +1,9 @@
 // Public surface of the agent-side Agent Action Approval Queue module.
 export * from './agent-approvals.module';
 export * from './agent-approvals.service';
+// Merge approval (self-build slice AE) — the read-back half of the queue.
+export * from './merge-approval.module';
+export * from './merge-approval.service';
 export * from './risk-scorer';
 export * from './types';
 // Re-export the entity types so api callers don't need a deep import.

--- a/packages/agent/src/agent-approvals/merge-approval.module.ts
+++ b/packages/agent/src/agent-approvals/merge-approval.module.ts
@@ -1,0 +1,44 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { MERGE_APPROVAL_VERIFIER } from '../policy/merge-approval.port';
+import { AgentApprovalsModule } from './agent-approvals.module';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { MergeApprovalService } from './merge-approval.service';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the module that binds
+ * `MERGE_APPROVAL_VERIFIER`.
+ *
+ * It is separate from `AgentApprovalsModule` on purpose. That module is a
+ * two-entity leaf (proposals + agents) that api-side controllers import;
+ * verifying an approval additionally needs the Task, the approver's User
+ * row and the Organization roster, i.e. `DatabaseModule`. Folding those
+ * into the leaf would drag the whole repository graph into every
+ * controller that just wants the queue.
+ *
+ * Import direction: `FacadesModule` → here → (`AgentApprovalsModule`,
+ * `DatabaseModule`). Neither of those imports `FacadesModule`, so the
+ * graph stays acyclic — the same shape `PolicyModule` uses to stay
+ * importable from the facade layer.
+ *
+ * `TaskRepository` is provided HERE rather than imported: it is not in
+ * `_repository-inventory.ts`, so `DatabaseModule` neither provides nor
+ * exports it, and every module that needs it lists it locally — see
+ * `IngestModule`. Injecting it without this line is an unresolvable
+ * dependency and the API does not boot. `DatabaseModule` re-exports
+ * `TypeOrmModule` with every entity, so the `Task` repository it needs
+ * is already in scope.
+ *
+ * The token is bound with `useExisting` so consumers depend on the
+ * CONTRACT (`MergeApprovalVerifier`) and never on the concrete class.
+ */
+@Module({
+    imports: [DatabaseModule, AgentApprovalsModule],
+    providers: [
+        TaskRepository,
+        MergeApprovalService,
+        { provide: MERGE_APPROVAL_VERIFIER, useExisting: MergeApprovalService },
+    ],
+    exports: [MergeApprovalService, MERGE_APPROVAL_VERIFIER],
+})
+export class MergeApprovalModule {}

--- a/packages/agent/src/agent-approvals/merge-approval.service.ts
+++ b/packages/agent/src/agent-approvals/merge-approval.service.ts
@@ -1,0 +1,565 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Like, Repository } from 'typeorm';
+import {
+    MERGE_APPROVAL_MAX_AGE_MS,
+    mergeApprovalPullRequestKeyPrefix,
+    mergeApprovalSubjectKey,
+    normalizeCommitSha,
+} from '@ever-works/contracts';
+import { AgentActionProposal } from '../entities/agent-action-proposal.entity';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { UserRepository } from '../database/repositories/user.repository';
+import { OrganizationMemberRepository } from '../database/repositories/organization-member.repository';
+import { TenantRepository } from '../database/repositories/tenant.repository';
+import { ownershipScopeOf } from '../database/ownership-scope';
+import type {
+    MergeApprovalQuery,
+    MergeApprovalVerdict,
+    MergeApprovalVerifier,
+} from '../policy/merge-approval.port';
+import { AgentApprovalsService } from './agent-approvals.service';
+import type { AgentActionProposalDto } from './types';
+
+/** What the merge gate knows when it asks for an approval to be raised. */
+export interface RequestMergeApprovalInput {
+    /** Owner of the Task; the proposal is filed to their queue + Inbox. */
+    userId: string;
+    taskId: string;
+    /** Human-readable Task label for the proposal title. */
+    taskLabel: string;
+    /** The Agent whose pull request this is (ownership-checked downstream). */
+    agentId: string;
+    prNumber: number;
+    prUrl?: string | null;
+    /** Head commit read from the provider — the approval binds to it. */
+    headSha: string;
+    targetBranch?: string | null;
+    /** `owner/repo`. */
+    repository?: string | null;
+    /** Provider CI verdict at raise time (always `passing` today). */
+    ciState?: string | null;
+    /** Provider login of the human who approved on the provider, if any. */
+    reviewApprovedBy?: string | null;
+    runId?: string | null;
+}
+
+/**
+ * Flat rather than a discriminated union on purpose: this package
+ * compiles with `strictNullChecks: false`, under which TypeScript will
+ * NOT narrow `{ raised: true } | { raised: false }` at a call site, so the
+ * tidier shape reads worse than it looks.
+ */
+export interface RequestMergeApprovalOutcome {
+    raised: boolean;
+    /** Present iff `raised`. */
+    proposal?: AgentActionProposalDto;
+    /** Why nothing was raised. Absent iff `raised`. */
+    reason?: 'already-open' | 'already-decided' | 'unusable-subject' | 'failed';
+}
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the READ-BACK half of
+ * the approval queue, and the only consumer in the platform that treats
+ * an `agent_action_proposals` row as an authorization rather than an
+ * audit record.
+ *
+ * Two jobs, deliberately in one class because they must agree on the
+ * subject key byte for byte:
+ *
+ *   - {@link requestMergeApproval} raises the proposal, keyed by
+ *     `merge:<taskId>:<prNumber>:<headSha>`.
+ *   - {@link verifyMergeApproval} answers the git facade's question by
+ *     re-deriving that key from LIVE provider state and looking for an
+ *     approved row under it.
+ *
+ * Five things must ALL be true for `approved: true`, and each maps to a
+ * failure mode that has actually shipped in somebody's merge bot:
+ *
+ *   1. **A row exists under the exact key.** Not "for this Task", not
+ *      "for this PR" — for this PR at this commit. A force-push, a new
+ *      commit, or a rebase produces a different key, so the approval
+ *      given for the reviewed diff cannot land a different one.
+ *   2. **A human decided it.** `decidedVia === 'user'` AND `decidedById`
+ *      is set. Guardrail auto-approvals write `decidedVia: 'guardrail'`
+ *      with a null decider precisely so they are distinguishable, and
+ *      they are rejected here. The platform cannot approve its own work.
+ *   3. **The decider is a real, active, non-anonymous account.** An
+ *      anonymous (unclaimed, zero-friction) account is not somebody who
+ *      can be held to a merge.
+ *   4. **The decider is entitled to approve for this Task's scope**,
+ *      derived from PLATFORM STATE (the Task's own scope stamp, the
+ *      approver's `users` row and the Organization roster), never from
+ *      the proposal row — a proposal that carried its own entitlement
+ *      would be a proposal that authorised itself. Tenant equality is
+ *      necessary but NOT sufficient; see `entitledToApprove` for why a
+ *      member removed from the Organization must stop counting.
+ *   5. **The decision is not stale.** Older than
+ *      `MERGE_APPROVAL_MAX_AGE_MS` and it stops counting.
+ *
+ * Anything unexpected — a store error, a Task that vanished, a head SHA
+ * that is not a SHA — is a REFUSAL, not an exception and never an
+ * approval. There is no code path in this file that returns
+ * `approved: true` without having read a row.
+ */
+@Injectable()
+export class MergeApprovalService implements MergeApprovalVerifier {
+    private readonly logger = new Logger(MergeApprovalService.name);
+
+    constructor(
+        @InjectRepository(AgentActionProposal)
+        private readonly proposals: Repository<AgentActionProposal>,
+        private readonly tasks: TaskRepository,
+        private readonly users: UserRepository,
+        private readonly approvals: AgentApprovalsService,
+        // Organization roster — an entitlement input, see
+        // `entitledToApprove`. @Optional() per the positional-spec arity
+        // rule; absent, the predicate degrades to tenant equality and says
+        // so in the log.
+        @Optional() private readonly organizationMembers?: OrganizationMemberRepository,
+        // `tenants.ownerUserId`, so the Tenant owner — who is a member of
+        // every Organization in their Tenant BY CONSTRUCTION and therefore
+        // has no roster row to find — is not locked out by the roster
+        // check. Appended LAST per the positional-spec arity rule.
+        @Optional() private readonly tenants?: TenantRepository,
+    ) {}
+
+    // ── verify ────────────────────────────────────────────────────────
+
+    /** {@link MergeApprovalVerifier.verifyMergeApproval}. */
+    async verifyMergeApproval(query: MergeApprovalQuery): Promise<MergeApprovalVerdict> {
+        const headSha = normalizeCommitSha(query.headSha);
+        const taskId = (query.taskId ?? '').trim();
+        if (!taskId) {
+            return {
+                approved: false,
+                code: 'approval-missing',
+                reason:
+                    'This merge is not attached to a Task, so there is nothing an approval could ' +
+                    'have been recorded against. Refusing rather than merging unattributed work.',
+            };
+        }
+        if (!headSha) {
+            return {
+                approved: false,
+                code: 'head-sha-unknown',
+                reason:
+                    'The pull request head commit could not be determined, so no approval can be ' +
+                    'matched to what would actually be merged.',
+            };
+        }
+
+        let subjectKey: string;
+        try {
+            subjectKey = mergeApprovalSubjectKey({ taskId, prNumber: query.prNumber, headSha });
+        } catch (error) {
+            return {
+                approved: false,
+                code: 'approval-missing',
+                reason: `This merge cannot be keyed to an approval: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            };
+        }
+
+        let row: AgentActionProposal | null;
+        try {
+            row = await this.proposals.findOne({
+                where: {
+                    actionType: 'merge_pull_request',
+                    subjectKey,
+                    status: 'approved',
+                },
+                order: { decidedAt: 'DESC' },
+            });
+        } catch (error) {
+            // A store that cannot answer is not an approval.
+            this.logger.warn(
+                `Merge approval lookup failed for ${subjectKey} (refusing): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return {
+                approved: false,
+                code: 'approval-missing',
+                reason: 'The approval record could not be read, so this merge is refused.',
+            };
+        }
+
+        if (!row) {
+            return this.describeMissingApproval(taskId, query.prNumber, headSha);
+        }
+
+        if (row.decidedVia !== 'user' || !row.decidedById) {
+            // Reachable only if something bypassed `evaluateGuardrails`'
+            // merge rule; kept as a hard gate because the whole slice
+            // exists to stop the platform approving itself.
+            return {
+                approved: false,
+                code: 'approval-not-human',
+                reason:
+                    'The recorded decision for this pull request was not made by a person ' +
+                    `(decided via ${row.decidedVia ?? 'unknown'}). A merge needs a human approval.`,
+            };
+        }
+
+        const decidedAt = row.decidedAt ? new Date(row.decidedAt) : null;
+        if (!decidedAt || Number.isNaN(decidedAt.getTime())) {
+            return {
+                approved: false,
+                code: 'approval-expired',
+                reason: 'The approval for this pull request carries no decision time, so its age cannot be established.',
+            };
+        }
+        const ageMs = Date.now() - decidedAt.getTime();
+        if (ageMs > MERGE_APPROVAL_MAX_AGE_MS) {
+            const hours = Math.floor(ageMs / 3_600_000);
+            return {
+                approved: false,
+                code: 'approval-expired',
+                reason:
+                    `The approval for this pull request is ${hours}h old and approvals expire after ` +
+                    `${MERGE_APPROVAL_MAX_AGE_MS / 3_600_000}h. Approve it again to merge.`,
+            };
+        }
+
+        const entitlement = await this.entitledToApprove(taskId, row.decidedById);
+        if (!entitlement.entitled) {
+            return {
+                approved: false,
+                code: 'approver-not-entitled',
+                reason: entitlement.reason,
+            };
+        }
+
+        return {
+            approved: true,
+            approvalId: row.id,
+            approvedById: row.decidedById,
+            approvedAt: decidedAt,
+        };
+    }
+
+    // ── request ───────────────────────────────────────────────────────
+
+    /**
+     * Raise the human-facing approval for one green pull request.
+     *
+     * Idempotent per subject key: a second call for the same
+     * (Task, PR, head) finds the existing row and raises nothing, so the
+     * 2-minute PR-status sweep does not file one Inbox item per tick. A
+     * NEW head commit is a NEW subject and therefore correctly raises a
+     * fresh approval — the previous one is left decided-but-unusable,
+     * which is the honest record of what happened.
+     *
+     * The read below is not the guarantee, and cannot be: this is a
+     * check-then-create whose callers sit in TWO processes — the
+     * `task-pr-status-sync` cron worker and an API `?refresh=true` —
+     * so `TaskPrStatusService`'s in-process `inFlight` map does not
+     * serialize them. Two racing sweeps would both see nothing and both
+     * insert, putting two Approve buttons in the Inbox for one merge and
+     * letting a later click on the second grant a fresh 24h validity
+     * window over a head the first already covered. The real guarantee is
+     * the UNIQUE index on `(actionType, subjectKey)`; the read is the fast
+     * path, and the loser of the race is caught below and reported as
+     * `already-open` exactly as if it had lost the read.
+     */
+    async requestMergeApproval(
+        input: RequestMergeApprovalInput,
+    ): Promise<RequestMergeApprovalOutcome> {
+        const headSha = normalizeCommitSha(input.headSha);
+        if (!headSha) return { raised: false, reason: 'unusable-subject' };
+
+        let subjectKey: string;
+        try {
+            subjectKey = mergeApprovalSubjectKey({
+                taskId: input.taskId,
+                prNumber: input.prNumber,
+                headSha,
+            });
+        } catch {
+            return { raised: false, reason: 'unusable-subject' };
+        }
+
+        const existing = await this.proposals.findOne({
+            where: { actionType: 'merge_pull_request', subjectKey },
+            order: { createdAt: 'DESC' },
+        });
+        if (existing) {
+            return {
+                raised: false,
+                reason: existing.status === 'pending' ? 'already-open' : 'already-decided',
+            };
+        }
+
+        try {
+            // The title is the ONE string both surfaces show — the Inbox
+            // item and the approvals queue — so it carries everything a
+            // person needs to decide without opening anything: which pull
+            // request, into which branch, in which repository, at which
+            // commit. "Merge PR #7" alone is not a thing anybody can
+            // responsibly say yes to.
+            const target = input.targetBranch ? ` into ${input.targetBranch}` : '';
+            const where = input.repository ? ` in ${input.repository}` : '';
+            const proposal = await this.approvals.createProposal(input.userId, {
+                agentId: input.agentId,
+                actionType: 'merge_pull_request',
+                title: `Merge PR #${input.prNumber}${target}${where} for ${input.taskLabel} (@ ${headSha.slice(0, 12)})`.slice(
+                    0,
+                    200,
+                ),
+                subjectKey,
+                runId: input.runId ?? null,
+                payload: {
+                    taskId: input.taskId,
+                    prNumber: input.prNumber,
+                    prUrl: input.prUrl ?? null,
+                    headSha,
+                    targetBranch: input.targetBranch ?? null,
+                    repository: input.repository ?? null,
+                    ciState: input.ciState ?? null,
+                    reviewApprovedBy: input.reviewApprovedBy ?? null,
+                    // The RISK_SCORER flags every merge as destructive from
+                    // the action type alone; this is here so the payload a
+                    // human reads says the same thing the badge does.
+                    destructive: true,
+                },
+            });
+            this.logger.log(
+                `Task ${input.taskId}: merge approval requested for PR #${input.prNumber} at ${headSha} (proposal ${proposal.id}).`,
+            );
+            return { raised: true, proposal };
+        } catch (error) {
+            // Lost the insert race (or an equal-and-opposite fault). Ask
+            // the store what is actually there rather than reporting a
+            // failure the caller would retry into the same collision.
+            const winner = await this.proposals
+                .findOne({
+                    where: { actionType: 'merge_pull_request', subjectKey },
+                    order: { createdAt: 'DESC' },
+                })
+                .catch(() => null);
+            if (winner) {
+                this.logger.debug(
+                    `Task ${input.taskId}: merge approval for PR #${input.prNumber} at ${headSha} ` +
+                        `was raised concurrently (proposal ${winner.id}); not filing a second one.`,
+                );
+                return {
+                    raised: false,
+                    reason: winner.status === 'pending' ? 'already-open' : 'already-decided',
+                };
+            }
+            this.logger.warn(
+                `Task ${input.taskId}: could not raise the merge approval for PR #${input.prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { raised: false, reason: 'failed' };
+        }
+    }
+
+    // ── internals ─────────────────────────────────────────────────────
+
+    /**
+     * "Nobody approved this" and "somebody approved an earlier commit"
+     * are the same refusal to the policy and completely different things
+     * to the human reading it, so they get different codes and wording.
+     */
+    private async describeMissingApproval(
+        taskId: string,
+        prNumber: number,
+        headSha: string,
+    ): Promise<MergeApprovalVerdict> {
+        let priorForPr = 0;
+        try {
+            priorForPr = await this.proposals.count({
+                where: {
+                    actionType: 'merge_pull_request',
+                    status: 'approved',
+                    subjectKey: Like(`${mergeApprovalPullRequestKeyPrefix({ taskId, prNumber })}%`),
+                },
+            });
+        } catch {
+            // Cosmetic only — the refusal stands either way.
+            priorForPr = 0;
+        }
+
+        if (priorForPr > 0) {
+            return {
+                approved: false,
+                code: 'approval-stale',
+                reason:
+                    `PR #${prNumber} was approved for an earlier commit, but its head is now ` +
+                    `${headSha.slice(0, 12)}. The approval covers the commit that was reviewed, not this one — ` +
+                    'review and approve again.',
+            };
+        }
+        return {
+            approved: false,
+            code: 'approval-missing',
+            reason:
+                `No human approval is on record for PR #${prNumber} at commit ${headSha.slice(0, 12)}. ` +
+                'Approve it in the Inbox to let the agent merge.',
+        };
+    }
+
+    /**
+     * May this user approve a merge for this Task's scope?
+     *
+     * Derived entirely from platform state: the Task row's own scope
+     * stamp, the approver's `users` row and the Organization roster.
+     * Nothing on the proposal is consulted — the proposal is the thing
+     * being authorised.
+     *
+     * The predicate is GRADUATED, and the shape is deliberate:
+     *
+     *   tenant equality  AND  (roster row  OR  Tenant owner  OR  the
+     *                          Organization has no roster at all)
+     *
+     * Tenant equality ALONE — what the read paths use, and what this
+     * method did until the AE review — is wrong here. Removal from an
+     * Organization is expressed by deleting the roster row
+     * (`OrganizationInvitationFlowService.removeMember`), and that method
+     * only clears `users.tenantId` once the person's LAST membership in
+     * the Tenant is gone. So somebody removed from Organization A while
+     * still in Organization B keeps their `tenantId`, and a
+     * tenant-equality predicate keeps handing them merge authority over
+     * A's repositories — reading the revocation and ignoring it.
+     * Everywhere else that is a visibility question; here it is the single
+     * irreversible write in the queue.
+     *
+     * The two escape hatches are what stop this repeating the revert that
+     * `assertActorReachable` and `UploadsController` both needed:
+     *
+     *  - **Tenant owner.** They are a member of every Organization in
+     *    their Tenant by construction and have no roster row to find
+     *    (`removeMember` refuses to remove them for exactly that reason).
+     *    A roster-only check admits everybody EXCEPT the owner, which is
+     *    precisely backwards.
+     *  - **An Organization with an EMPTY roster.** `organization_members`
+     *    is unpopulated for Organizations that predate invitations, and
+     *    roster-strictness against those admitted only the Tenant owner in
+     *    production. Where there is no roster there is no revocation to
+     *    honour, so the documented v1 tenant-wide posture stands.
+     *
+     * A Task with no Organization is personal scope, and there the owner
+     * is the only entitled approver.
+     */
+    private async entitledToApprove(
+        taskId: string,
+        approverId: string,
+    ): Promise<{ entitled: boolean; reason?: string }> {
+        const task = await this.tasks.findById(taskId).catch(() => null);
+        if (!task) {
+            return {
+                entitled: false,
+                reason: `Task ${taskId} is no longer readable, so the approver's entitlement cannot be established.`,
+            };
+        }
+        const approver = await this.users.findById(approverId).catch(() => null);
+        if (!approver || !approver.isActive) {
+            return {
+                entitled: false,
+                reason: 'The account that approved this merge is not an active user.',
+            };
+        }
+        if (approver.isAnonymous) {
+            return {
+                entitled: false,
+                reason: 'An anonymous account cannot approve a merge.',
+            };
+        }
+
+        const scope = ownershipScopeOf(task);
+        if (!scope.organizationId) {
+            if (approverId !== task.userId) {
+                return {
+                    entitled: false,
+                    reason: 'This Task is in a personal scope and was approved by somebody other than its owner.',
+                };
+            }
+            return { entitled: true };
+        }
+
+        if (!scope.tenantId || approver.tenantId !== scope.tenantId) {
+            return {
+                entitled: false,
+                reason:
+                    'The approver does not belong to the Tenant that owns this Task, so they may not ' +
+                    'approve merges for its Organization.',
+            };
+        }
+
+        if (!this.organizationMembers) {
+            // No roster bound to consult. Tenant equality already held, so
+            // this is the pre-AE predicate — said out loud, not silently.
+            this.logger.warn(
+                `Merge approver ${approverId} admitted on tenant equality alone: no Organization ` +
+                    'roster is bound in this runtime.',
+            );
+            return { entitled: true };
+        }
+
+        const member = await this.organizationMembers
+            .findByOrgAndUser(scope.organizationId, approverId)
+            .catch(() => null);
+        if (member) return { entitled: true };
+
+        if (await this.isTenantOwner(approverId, scope.tenantId)) {
+            // The owner holds no roster row anywhere in their own Tenant.
+            return { entitled: true };
+        }
+
+        // No row and not the owner. Tell "removed from this Organization"
+        // apart from "this Organization has never had a roster" — only the
+        // first of those is a revocation.
+        let rosterSize: number | null = null;
+        try {
+            rosterSize =
+                typeof this.organizationMembers.countForOrganization === 'function'
+                    ? await this.organizationMembers.countForOrganization(scope.organizationId)
+                    : null;
+        } catch (error) {
+            this.logger.warn(
+                `Merge approval: Organization ${scope.organizationId} roster size unreadable, ` +
+                    `refusing rather than guessing: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+            );
+            return {
+                entitled: false,
+                reason:
+                    'The Organization roster could not be read, so the approver’s membership of it ' +
+                    'cannot be established. Refusing rather than assuming.',
+            };
+        }
+
+        if (rosterSize === 0) {
+            this.logger.debug(
+                `Merge approver ${approverId} admitted without a roster row: Organization ` +
+                    `${scope.organizationId} has no roster at all (pre-invitations Organization).`,
+            );
+            return { entitled: true };
+        }
+
+        return {
+            entitled: false,
+            reason:
+                'The approver is not a member of the Organization that owns this Task. Belonging to ' +
+                'the wider Tenant is not enough to approve a merge into that Organization’s ' +
+                'repository — being removed from an Organization has to mean something.',
+        };
+    }
+
+    /**
+     * `tenants.ownerUserId` is UNIQUE, so one read settles it. Mirrors
+     * `OrganizationInvitationFlowService.isTenantOwner`, which is where the
+     * "the owner is a member of every Organization by construction, so
+     * there is no roster row to delete" rule is stated and enforced.
+     */
+    private async isTenantOwner(userId: string, tenantId: string | null): Promise<boolean> {
+        if (!tenantId || !this.tenants) return false;
+        const tenant = await this.tenants.findById(tenantId).catch(() => null);
+        return Boolean(tenant && tenant.ownerUserId === userId);
+    }
+}

--- a/packages/agent/src/agent-approvals/risk-scorer.ts
+++ b/packages/agent/src/agent-approvals/risk-scorer.ts
@@ -37,7 +37,14 @@ export const HIGH_FANOUT_DEPTH = 3;
  *
  * Rules (agents approval-queue spec):
  *   - `budget_override` — the action itself is a budget override.
- *   - `destructive`     — `payload.destructive` is truthy.
+ *   - `destructive`     — `payload.destructive` is truthy, OR the action
+ *                         is a `merge_pull_request`. Landing a pull
+ *                         request onto a real branch is the one action in
+ *                         this queue that no later commit can undo, and
+ *                         the flag is load-bearing rather than cosmetic:
+ *                         `evaluateGuardrails` refuses to auto-approve
+ *                         ANY flagged action, which is what stops an
+ *                         autonomous Agent from approving its own merge.
  *   - `cross_scope`     — the action reaches into another scope, i.e.
  *                         `payload.crossScope === true` OR a non-null
  *                         `sourceScope`/`targetScope` pair that differs.
@@ -51,7 +58,10 @@ export function RISK_SCORER(input: RiskScorerInput): AgentActionRiskFlag[] {
         flags.add('budget_override');
     }
 
-    if (payload.destructive) {
+    // A merge is destructive by construction — see the rule list above.
+    // It is NOT read off the payload: a caller that forgot to set
+    // `destructive: true` would otherwise mint a self-approvable merge.
+    if (payload.destructive || input.actionType === 'merge_pull_request') {
         flags.add('destructive');
     }
 

--- a/packages/agent/src/agent-approvals/types.ts
+++ b/packages/agent/src/agent-approvals/types.ts
@@ -22,6 +22,13 @@ export interface AgentActionProposalDto {
     title: string;
     payload: AgentActionProposalPayload;
     riskFlags: AgentActionRiskFlag[];
+    /**
+     * Merge approval (slice AE) — the canonical subject an approved
+     * `merge_pull_request` row is consumed by. NULL for every other type.
+     * On the wire so the queue UI can tell two merge proposals for the
+     * same Task apart by the commit they name.
+     */
+    subjectKey: string | null;
     status: AgentActionProposalStatus;
     decidedById: string | null;
     decidedAt: Date | null;
@@ -42,6 +49,7 @@ export function toAgentActionProposalDto(row: AgentActionProposal): AgentActionP
         title: row.title,
         payload: row.payload ?? {},
         riskFlags: row.riskFlags ?? [],
+        subjectKey: row.subjectKey ?? null,
         status: row.status,
         decidedById: row.decidedById ?? null,
         decidedAt: row.decidedAt ?? null,

--- a/packages/agent/src/agents/__tests__/guardrails.spec.ts
+++ b/packages/agent/src/agents/__tests__/guardrails.spec.ts
@@ -170,4 +170,38 @@ describe('evaluateGuardrails (pure)', () => {
             expect(evaluateGuardrails(autonomous, actionType, [])).toBe('auto_approve');
         }
     });
+
+    // ── merge approval (self-build slice AE, EW-805) ─────────────────
+    //
+    // `merge_pull_request` is the one action type an Agent's own
+    // configuration may never authorise. A merge onto a real branch
+    // cannot be undone by a follow-up commit, so "the platform approved
+    // its own work" is the failure that has no recovery.
+
+    it('NEVER auto-approves a merge, whatever the Agent is configured to do', () => {
+        expect(evaluateGuardrails(autonomous, 'merge_pull_request', [])).toBe('queue');
+        expect(
+            evaluateGuardrails(
+                { mode: 'autonomous', autoApproveActionTypes: ['merge_pull_request'] },
+                'merge_pull_request',
+                [],
+            ),
+        ).toBe('queue');
+    });
+
+    it('still BLOCKS a merge when the Agent forbids it — the rule only stops approval', () => {
+        expect(
+            evaluateGuardrails(
+                { mode: 'autonomous', blockedActionTypes: ['merge_pull_request'] },
+                'merge_pull_request',
+                [],
+            ),
+        ).toBe('block');
+    });
+
+    it('queues a merge under a require_approval Agent, like everything else', () => {
+        expect(evaluateGuardrails({ mode: 'require_approval' }, 'merge_pull_request', [])).toBe(
+            'queue',
+        );
+    });
 });

--- a/packages/agent/src/agents/guardrails.ts
+++ b/packages/agent/src/agents/guardrails.ts
@@ -113,14 +113,29 @@ export function validateGuardrails(value: unknown): string | null {
  * Decision table (first match wins):
  *   1. No guardrails (`null`/`undefined`)      → `queue` (legacy behavior).
  *   2. `blockedActionTypes` contains the type  → `block`.
- *   3. `mode === 'autonomous'` AND no risk flags AND
+ *   3. `merge_pull_request`                    → `queue`, unconditionally.
+ *   4. `mode === 'autonomous'` AND no risk flags AND
  *      (`autoApproveActionTypes` omitted OR contains the type)
  *                                              → `auto_approve`.
- *   4. Everything else                         → `queue`.
+ *   5. Everything else                         → `queue`.
  *
  * Risk flags ALWAYS force the queue — an autonomous Agent never
  * self-approves a destructive / cross-scope / budget-override /
  * high-fanout action.
+ *
+ * Rule 3 is belt AND braces (merge approval, self-build slice AE). The
+ * `RISK_SCORER` already flags every `merge_pull_request` as `destructive`,
+ * so rule 4 could never fire for one — but that is a property of a
+ * DIFFERENT file, and the thing it prevents is an Agent's own
+ * configuration authorising a merge onto a real branch. The rule is
+ * stated here too so removing it has to be deliberate, and so this
+ * function is safe to read on its own.
+ *
+ * Note that a guardrail auto-approval could not satisfy a merge anyway:
+ * `MergeApprovalService` requires `decidedVia === 'user'` with a non-null
+ * `decidedById`, and guardrail rows carry neither. Three independent
+ * layers, because "the platform approved its own merge" is the failure
+ * that cannot be walked back.
  */
 export function evaluateGuardrails(
     guardrails: AgentGuardrails | null | undefined,
@@ -132,6 +147,9 @@ export function evaluateGuardrails(
     }
     if (guardrails.blockedActionTypes?.includes(actionType)) {
         return 'block';
+    }
+    if (actionType === 'merge_pull_request') {
+        return 'queue';
     }
     if (guardrails.mode === 'autonomous' && riskFlags.length === 0) {
         const allowList = guardrails.autoApproveActionTypes;

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -306,12 +306,107 @@ export class TaskRepository {
      */
     async updatePrStatusCache(
         taskId: string,
-        patch: Partial<Pick<Task, 'prState' | 'ciState' | 'ciCheckedAt' | 'prChecks'>>,
+        patch: Partial<
+            Pick<Task, 'prState' | 'ciState' | 'ciCheckedAt' | 'prChecks' | 'prHeadSha'>
+        >,
     ): Promise<void> {
         await this.repository
             .createQueryBuilder()
             .update(Task)
             .set(patch)
+            .where('id = :taskId', { taskId })
+            .execute();
+    }
+
+    /**
+     * Merge approval (self-build slice AE) — record that a HUMAN approved
+     * this Task's pull request on the git provider, for one specific
+     * commit.
+     *
+     * Same query-builder posture as `updatePrStatusCache` and for the same
+     * reason: this is provider telemetry arriving on a webhook, and it
+     * must not bump `updatedAt` and reshuffle the board.
+     *
+     * `prNumber` is part of the predicate, not just the id: a webhook is
+     * resolved to a Task by `(workId, prNumber)`, which is a newest-first
+     * lookup rather than a unique one, so the write re-asserts that the
+     * row it landed on still carries the pull request the review was for.
+     */
+    async recordPullRequestReviewApproval(
+        taskId: string,
+        prNumber: number,
+        patch: { headSha: string; approvedAt: Date; approvedBy: string | null },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set({
+                prReviewApprovedSha: patch.headSha,
+                prReviewApprovedAt: patch.approvedAt,
+                prReviewApprovedBy: patch.approvedBy,
+            })
+            .where('id = :taskId', { taskId })
+            .andWhere('prNumber = :prNumber', { prNumber })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Merge approval (self-build slice AE) — RETRACT a provider-side human
+     * review approval, because its author withdrew or reversed it.
+     *
+     * Guarded on the recorded approver: a dismissal by Alice clears
+     * Alice's attestation, and a `changes_requested` from Bob does not
+     * unmake the fact that Alice read the diff. Same query-builder posture
+     * as the writer — webhook telemetry must not bump `updatedAt`.
+     *
+     * Returns true when a Task row was cleared.
+     */
+    async clearPullRequestReviewApproval(
+        taskId: string,
+        prNumber: number,
+        approvedBy: string,
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set({
+                prReviewApprovedSha: null,
+                prReviewApprovedAt: null,
+                prReviewApprovedBy: null,
+            })
+            .where('id = :taskId', { taskId })
+            .andWhere('prNumber = :prNumber', { prNumber })
+            .andWhere('LOWER(prReviewApprovedBy) = :approvedBy', {
+                approvedBy: approvedBy.toLowerCase(),
+            })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Merge approval (self-build slice AE) — remember the last merge
+     * REFUSAL so it is told to the human once instead of every two
+     * minutes.
+     *
+     * The merge attempt now lives on the PR-status sweep, so a stable
+     * refusal (a protected base branch, a required review) repeats for as
+     * long as the pull request stays open. `TaskWorkspaceService`
+     * compares (head commit, refusal code) against what is stored here
+     * before it posts a chat message and writes an activity row.
+     *
+     * Query-builder update for the same reason as `updatePrStatusCache`:
+     * this is bookkeeping about a background sweep and must not bump
+     * `updatedAt` and reshuffle the updatedAt-ordered board.
+     */
+    async recordMergeRefusal(
+        taskId: string,
+        patch: { sha: string | null; code: string | null },
+    ): Promise<void> {
+        await this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set({ mergeRefusedSha: patch.sha, mergeRefusedCode: patch.code })
             .where('id = :taskId', { taskId })
             .execute();
     }

--- a/packages/agent/src/entities/agent-action-proposal.entity.ts
+++ b/packages/agent/src/entities/agent-action-proposal.entity.ts
@@ -29,6 +29,12 @@ export type AgentActionProposalActionType =
     | 'schedule_task'
     | 'send_message'
     | 'budget_override'
+    // Merge approval (self-build slice AE, EW-805). The ONE action type
+    // whose approved row is READ BACK and enforced: `MergeApprovalService`
+    // looks it up by {@link AgentActionProposal.subjectKey} and the git
+    // facade refuses the merge without it. Every other type is still a
+    // durable decision record only.
+    | 'merge_pull_request'
     | 'other';
 
 export const AGENT_ACTION_PROPOSAL_ACTION_TYPES: readonly AgentActionProposalActionType[] = [
@@ -36,6 +42,7 @@ export const AGENT_ACTION_PROPOSAL_ACTION_TYPES: readonly AgentActionProposalAct
     'schedule_task',
     'send_message',
     'budget_override',
+    'merge_pull_request',
     'other',
 ] as const;
 
@@ -70,6 +77,25 @@ export type AgentActionRiskFlag = 'budget_override' | 'destructive' | 'cross_sco
 export interface AgentActionProposalPayload {
     /** Set by a destructive action (delete / hard-reset / purge). */
     destructive?: boolean;
+    // ── merge_pull_request (self-build slice AE) ──────────────────
+    // DISPLAY + AUDIT ONLY. The decision is bound by `subjectKey`,
+    // never by these — a verifier that trusted the payload would be
+    // trusting a JSON blob to say which pull request was approved.
+    /** Task the pull request belongs to (also encoded in `subjectKey`). */
+    taskId?: string;
+    /** Provider pull-request number (also encoded in `subjectKey`). */
+    prNumber?: number;
+    prUrl?: string | null;
+    /** Head commit the approval is for (also encoded in `subjectKey`). */
+    headSha?: string;
+    /** Base branch the merge would land on, as shown to the approver. */
+    targetBranch?: string | null;
+    /** `owner/repo`, as shown to the approver. */
+    repository?: string | null;
+    /** Provider CI verdict at the moment the proposal was raised. */
+    ciState?: string | null;
+    /** Provider login of the human who approved the PR on the provider, if any. */
+    reviewApprovedBy?: string | null;
     /** True when the action reaches into a scope other than the source. */
     crossScope?: boolean;
     /** Source + target scope ids — a mismatch flags `cross_scope`. */
@@ -84,6 +110,22 @@ export interface AgentActionProposalPayload {
 @Index('idx_agent_action_proposals_org_status', ['organizationId', 'status'])
 @Index('idx_agent_action_proposals_agent', ['agentId'])
 @Index('idx_agent_action_proposals_user_status', ['userId', 'status'])
+// Merge approval (slice AE) — the verifier's ONLY lookup (exact match on
+// actionType + subjectKey, then status) AND the constraint that makes
+// `requestMergeApproval` idempotent for real.
+//
+// UNIQUE, because that method is a check-then-create and its two callers
+// live in different processes: the two-minute `task-pr-status-sync` sweep
+// in the worker and `?refresh=true` in the API. `TaskPrStatusService`'s
+// in-process `inFlight` map does not span them, so without a constraint
+// both can find nothing and both can insert — two Approve buttons for one
+// merge, of which the second grants a fresh 24h validity window over a
+// head the first already covered.
+//
+// `subjectKey` is NULL for every other action type, and NULLs are
+// DISTINCT in a unique index on both Postgres and SQLite, so the rest of
+// the queue is unconstrained exactly as before.
+@Index('idx_agent_action_proposals_subject', ['actionType', 'subjectKey'], { unique: true })
 export class AgentActionProposal {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -107,6 +149,26 @@ export class AgentActionProposal {
 
     @Column('simple-json')
     payload: AgentActionProposalPayload;
+
+    /**
+     * Merge approval (self-build slice AE, EW-805) — WHAT this decision is
+     * about, in a form a consumer can look up by equality.
+     *
+     * For `merge_pull_request` it is
+     * `mergeApprovalSubjectKey({ taskId, prNumber, headSha })`, i.e.
+     * `merge:<taskId>:<prNumber>:<headSha>`. NULL for every other action
+     * type: the rest of the queue is a decision RECORD nothing reads back,
+     * so there is nothing to key it by.
+     *
+     * The column is what makes an approval un-replayable. A decision is
+     * consumed only by exact key match, so a merge of a different pull
+     * request, of the same pull request at a different head, or of the same
+     * PR number under a different Task, all find nothing and refuse. It is
+     * written by the platform when the proposal is raised and is never
+     * accepted from a model or a request body.
+     */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    subjectKey?: string | null;
 
     /** Computed risk annotations (string[]) — see `RISK_SCORER`. */
     @Column('simple-json')

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -247,6 +247,70 @@ export class Task {
         detailsUrl?: string;
     }> | null;
 
+    // ── Merge approval (self-build slice AE, EW-805) ─────────────────
+    // The pull request's head commit and the provider-side human review
+    // of it. Written by `TaskPrStatusService` (head) and the GitHub
+    // review bridge (review), both alongside the columns above.
+    //
+    // `prHeadSha` closes a documented gap: `recordRemotePush` deliberately
+    // does NOT persist the head a run pushed ("the remote owns the branch
+    // head"), and that is still right — this column holds the head the
+    // PROVIDER reported, which is the only head anybody should reason
+    // about. It is a cache for display and for deciding whether an
+    // approval is worth raising; the merge gate always re-reads live.
+
+    /** Head commit of the pull request as last observed from the provider. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    prHeadSha?: string | null;
+
+    /**
+     * Head commit a HUMAN reviewer approved on the git provider. Never
+     * written for a bot review of any kind — not the platform's own app,
+     * not an allow-listed reviewer bot: the whole point is that a person
+     * looked. Compare against `prHeadSha` to know whether the approval
+     * still covers the current head.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    prReviewApprovedSha?: string | null;
+
+    /** When that provider-side approval arrived. */
+    @PortableDateColumn({ nullable: true })
+    prReviewApprovedAt?: Date | null;
+
+    /**
+     * Provider login of the approving reviewer. UNTRUSTED display string —
+     * a provider login is not a platform identity and is never an
+     * entitlement input. The authorising decision is the platform-side
+     * approval on `agent_action_proposals`.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    prReviewApprovedBy?: string | null;
+
+    // The last merge REFUSAL the agent-merge path recorded, so it is
+    // recorded ONCE rather than once every two minutes.
+    //
+    // The merge attempt now lives on the PR-status sweep, which runs on a
+    // two-minute cron for as long as the pull request stays open. A
+    // stable refusal — a protected base branch, a required CODEOWNERS
+    // review, a merge method the policy forbids — therefore repeats
+    // forever, and `recordMergeFailure` posts a task-chat message and an
+    // activity row for each one: ~720 of each per Task per day. These two
+    // columns are the memory that turns that into one message per
+    // (commit, reason). A new head commit, or a different reason, is
+    // genuinely new news and is reported again.
+    //
+    // Deliberately NOT a suppression of the ATTEMPT: a provider fault is
+    // indistinguishable from a policy refusal at this level, and retrying
+    // is how a transient one clears itself.
+
+    /** Head commit the last recorded merge refusal was about. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    mergeRefusedSha?: string | null;
+
+    /** Stable refusal code of that refusal (or `not-merged` when untyped). */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    mergeRefusedCode?: string | null;
+
     // ── Latest-run denorm (kanban run cockpit, Wave 2) ───────────────
     // Maintained by `TaskRunDenormService` on queued creation, claim and
     // terminal transition of task-kind AgentRuns. Denormalized so the

--- a/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
@@ -1,14 +1,21 @@
-import type { MergeDecision } from '@ever-works/contracts';
+import type { MergeDecision, MergePolicy, ResolvedMergePolicy } from '@ever-works/contracts';
 import { GitFacadeService, MergePolicyRefusedError } from '../git.facade';
 import type { MergePolicyEnforcer } from '../../policy/merge-policy.enforcer';
+import type { MergeApprovalVerdict, MergeApprovalVerifier } from '../../policy/merge-approval.port';
 
 /**
- * Merge-policy matrix (Wave 3, D4) — enforcement at the ONE place a
- * pull request can actually be landed.
+ * Merge-policy matrix (Wave 3, D4) + merge approval (self-build slice AE,
+ * EW-805) — enforcement at the ONE place a pull request can actually be
+ * landed.
  *
  * The load-bearing assertions here are the negative ones: on a refusal
  * the provider plugin must never be called at all. A gate that merges
  * first and complains second is not a gate.
+ *
+ * These specs drive the REAL `assertAgentMayMerge` through the public
+ * `mergePullRequest` entry point. Only the plugin/token resolution is
+ * stubbed (it has its own spec) — the policy, the approval verifier and
+ * the live provider read are all exercised for real.
  */
 
 const ALLOW: MergeDecision = { allowed: true, source: 'work' };
@@ -19,7 +26,52 @@ const REFUSE: MergeDecision = {
     source: 'work',
 };
 
-function makeFacade(decision?: MergeDecision) {
+const HEAD = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+const OTHER_HEAD = 'ffffffffffffffffffffffffffffffffffffffff';
+
+const NEEDS_APPROVAL: MergePolicy = {
+    allowAgentMerge: true,
+    requireGreenGate: true,
+    requireHumanApproval: true,
+    allowedMergeMethods: ['squash'],
+    protectedBranches: ['main'],
+};
+
+const NO_APPROVAL_NEEDED: MergePolicy = { ...NEEDS_APPROVAL, requireHumanApproval: false };
+
+function resolution(policy: MergePolicy): ResolvedMergePolicy {
+    return { policy, source: 'work', chain: [] };
+}
+
+const APPROVED: MergeApprovalVerdict = {
+    approved: true,
+    approvalId: 'proposal-1',
+    approvedById: 'human-1',
+    approvedAt: new Date(),
+};
+
+interface FacadeOpts {
+    decision?: MergeDecision;
+    policy?: MergePolicy;
+    verdict?: MergeApprovalVerdict;
+    /** Omit to bind no verifier at all (fail-closed path). */
+    bindVerifier?: boolean;
+    status?: {
+        state: 'open' | 'draft' | 'closed' | 'merged';
+        ciState: 'passing' | 'failing' | 'pending' | 'unknown';
+        headSha: string | null;
+        /** Omitted = "not reported", which is not a warning. */
+        checksComplete?: boolean;
+    } | null;
+    /** Omit `resolve` from the enforcer (a minimal legacy double). */
+    resolvable?: boolean;
+}
+
+function makeFacade(opts: FacadeOpts = {}) {
+    const status =
+        opts.status === undefined
+            ? { state: 'open' as const, ciState: 'passing' as const, headSha: HEAD }
+            : opts.status;
     const plugin = {
         id: 'github',
         state: 'loaded',
@@ -34,9 +86,18 @@ function makeFacade(decision?: MergeDecision) {
             createdAt: '',
             updatedAt: '',
         }),
+        getPullRequestStatus: jest
+            .fn()
+            .mockResolvedValue(status ? { number: 7, merged: false, checks: [], ...status } : null),
     };
     const enforcer: MergePolicyEnforcer = {
-        canAgentMerge: jest.fn().mockResolvedValue(decision ?? ALLOW),
+        canAgentMerge: jest.fn().mockResolvedValue(opts.decision ?? ALLOW),
+    };
+    if (opts.resolvable !== false) {
+        enforcer.resolve = jest.fn().mockResolvedValue(resolution(opts.policy ?? NEEDS_APPROVAL));
+    }
+    const verifier: MergeApprovalVerifier = {
+        verifyMergeApproval: jest.fn().mockResolvedValue(opts.verdict ?? APPROVED),
     };
     const facade = new GitFacadeService(
         {} as never,
@@ -45,6 +106,7 @@ function makeFacade(decision?: MergeDecision) {
         {} as never,
         {} as never,
         enforcer,
+        opts.bindVerifier === false ? undefined : verifier,
     );
     // The token/plugin resolution path is exercised by git.facade.spec.ts;
     // here we stub it so the test is about the policy decision only.
@@ -53,37 +115,43 @@ function makeFacade(decision?: MergeDecision) {
             resolvePluginAndToken: () => Promise<{ plugin: unknown; token: string }>;
         }
     ).resolvePluginAndToken = jest.fn().mockResolvedValue({ plugin, token: 'tok' });
-    return { facade, plugin, enforcer };
+    return { facade, plugin, enforcer, verifier };
 }
 
 const OPTIONS = { providerId: 'github', userId: 'user-1', workId: 'work-1' } as const;
+const ACTOR = { agentId: 'agent-1', taskId: 'task-1', targetBranch: 'feature/x' } as const;
 
 describe('GitFacadeService.mergePullRequest — merge policy', () => {
     afterEach(() => {
         delete process.env.AGENT_MERGE_POLICY_ENFORCEMENT;
     });
 
-    it('does NOT consult the policy for a human-driven merge (no agent actor)', async () => {
+    // CONTRACT REVERSAL (merge approval, slice AE). This file used to
+    // assert "does NOT consult the policy for a human-driven merge (no
+    // agent actor)" — i.e. omitting the sixth argument merged with no
+    // policy at all. That test encoded a real hole rather than a real
+    // requirement: the gate was opt-in, and any future caller that forgot
+    // the argument would silently merge unchecked, with the compiler
+    // saying nothing. `agentActor` is now REQUIRED, there was exactly one
+    // production caller and it always passed one, so nothing that worked
+    // stopped working. The replacement assertion is that the gate cannot
+    // be skipped.
+    it('runs the gate for EVERY caller — the actor is not optional any more', async () => {
         const { facade, plugin, enforcer } = makeFacade();
-        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS);
-        expect(enforcer.canAgentMerge).not.toHaveBeenCalled();
+        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS, ACTOR);
+        expect(enforcer.canAgentMerge).toHaveBeenCalledTimes(1);
         expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
     });
 
     it('consults the policy for an agent-driven merge and proceeds when allowed', async () => {
-        const { facade, plugin, enforcer } = makeFacade(ALLOW);
+        const { facade, plugin, enforcer } = makeFacade({ decision: ALLOW });
         const result = await facade.mergePullRequest(
             'o',
             'r',
             7,
             { mergeMethod: 'squash' },
             OPTIONS,
-            {
-                agentId: 'agent-1',
-                gateStatus: 'green',
-                humanApproved: true,
-                targetBranch: 'feature/x',
-            },
+            { ...ACTOR, gateStatus: 'green' },
         );
         expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -100,9 +168,9 @@ describe('GitFacadeService.mergePullRequest — merge policy', () => {
     });
 
     it('REFUSES with the policy reason and never calls the provider', async () => {
-        const { facade, plugin } = makeFacade(REFUSE);
+        const { facade, plugin } = makeFacade({ decision: REFUSE });
         await expect(
-            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' }),
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
         ).rejects.toMatchObject({
             name: 'MergePolicyRefusedError',
             message: REFUSE.reason,
@@ -111,9 +179,9 @@ describe('GitFacadeService.mergePullRequest — merge policy', () => {
     });
 
     it('carries the refusal code + policy source on the thrown error (403 mapping input)', async () => {
-        const { facade } = makeFacade(REFUSE);
+        const { facade } = makeFacade({ decision: REFUSE });
         const error = await facade
-            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' })
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
             .catch((e: unknown) => e);
         expect(error).toBeInstanceOf(MergePolicyRefusedError);
         expect((error as MergePolicyRefusedError).code).toBe('agent-merge-disabled');
@@ -121,8 +189,11 @@ describe('GitFacadeService.mergePullRequest — merge policy', () => {
     });
 
     it('looks the base branch up through the provider when the caller did not supply it', async () => {
-        const { facade, plugin, enforcer } = makeFacade(ALLOW);
-        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' });
+        const { facade, plugin, enforcer } = makeFacade({ decision: ALLOW });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, {
+            agentId: 'agent-1',
+            taskId: 'task-1',
+        });
         expect(plugin.getPullRequest).toHaveBeenCalledWith('o', 'r', 7, 'tok');
         expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
             expect.objectContaining({ targetBranch: 'main' }),
@@ -145,16 +216,378 @@ describe('GitFacadeService.mergePullRequest — merge policy', () => {
         ).resolvePluginAndToken = jest.fn().mockResolvedValue({ plugin, token: 'tok' });
 
         await expect(
-            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' }),
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
         ).rejects.toBeInstanceOf(MergePolicyRefusedError);
         expect(plugin.mergePullRequest).not.toHaveBeenCalled();
     });
 
-    it('honours the operator kill-switch (AGENT_MERGE_POLICY_ENFORCEMENT=off)', async () => {
+    // CONTRACT REVERSAL (merge approval, slice AE). This used to assert
+    // that `AGENT_MERGE_POLICY_ENFORCEMENT=off` skipped EVERYTHING and
+    // merged. It now skips the branch / method / gate MATRIX only — the
+    // approval requirement still applies. The old contract made one
+    // environment variable the difference between a merge a human
+    // authorised and one nobody did, which is the exact failure this
+    // slice exists to prevent; and it waives nothing real, because before
+    // this slice the approval could never be satisfied anyway.
+    //
+    // An operator who wants agents to land green work unattended sets
+    // `requireHumanApproval: false` on the merge policy — scoped,
+    // auditable, and visible in the resolved-policy UI.
+    it('kill-switch skips the policy MATRIX but still requires the approval', async () => {
         process.env.AGENT_MERGE_POLICY_ENFORCEMENT = 'off';
-        const { facade, plugin, enforcer } = makeFacade(REFUSE);
-        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' });
+        const { facade, plugin, enforcer } = makeFacade({ decision: REFUSE });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
         expect(enforcer.canAgentMerge).not.toHaveBeenCalled();
         expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('kill-switch does NOT waive a missing approval', async () => {
+        process.env.AGENT_MERGE_POLICY_ENFORCEMENT = 'off';
+        const { facade, plugin } = makeFacade({
+            verdict: {
+                approved: false,
+                code: 'approval-missing',
+                reason: 'No human approval is on record.',
+            },
+        });
+        await expect(
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+        ).rejects.toMatchObject({ code: 'approval-missing' });
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+});
+
+describe('GitFacadeService.mergePullRequest — merge approval gate (slice AE)', () => {
+    afterEach(() => {
+        delete process.env.AGENT_MERGE_POLICY_ENFORCEMENT;
+    });
+
+    it('verifies the approval against the LIVE head, not against anything the caller said', async () => {
+        const { facade, verifier, plugin } = makeFacade();
+        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            prNumber: 7,
+            headSha: HEAD,
+        });
+        expect(plugin.getPullRequestStatus).toHaveBeenCalledWith('o', 'r', 7, 'tok');
+    });
+
+    it('PINS the merge to the head it verified', async () => {
+        const { facade, plugin } = makeFacade();
+        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS, ACTOR);
+        expect(plugin.mergePullRequest).toHaveBeenCalledWith(
+            'o',
+            'r',
+            7,
+            { mergeMethod: 'squash', expectedHeadSha: HEAD },
+            'tok',
+        );
+    });
+
+    it('reports humanApproved:false to the matrix when it verified nothing', async () => {
+        // The resolve-only read said "no approval needed", so none was
+        // verified. `canAgentMerge` resolves the policy a SECOND time; if
+        // an operator flipped `requireHumanApproval` on in between,
+        // claiming approval here would merge under the policy that was in
+        // force a millisecond ago. Reporting what was actually verified
+        // makes that race refuse.
+        const { facade, enforcer } = makeFacade({ policy: NO_APPROVAL_NEEDED });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+        expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
+            expect.objectContaining({ humanApproved: false }),
+        );
+    });
+
+    it('refuses when the policy gains an approval requirement between the two reads', async () => {
+        const { facade, plugin, enforcer } = makeFacade({
+            policy: NO_APPROVAL_NEEDED,
+            decision: {
+                allowed: false,
+                code: 'human-approval-required',
+                reason: 'The effective merge policy requires a human approval before an agent may merge.',
+                source: 'work',
+            },
+        });
+        await expect(
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+        ).rejects.toMatchObject({ code: 'human-approval-required' });
+        expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
+            expect.objectContaining({ humanApproved: false }),
+        );
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('pins the head even when the policy requires NO approval', async () => {
+        const { facade, plugin, verifier } = makeFacade({ policy: NO_APPROVAL_NEEDED });
+        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).not.toHaveBeenCalled();
+        expect(plugin.mergePullRequest).toHaveBeenCalledWith(
+            'o',
+            'r',
+            7,
+            { mergeMethod: 'squash', expectedHeadSha: HEAD },
+            'tok',
+        );
+    });
+
+    // CONTRACT EXTENSION (AE review). The live read, the "is it open?"
+    // check and the "is it green?" check used to sit INSIDE the
+    // `requiresApproval` branch, so an operator with
+    // `requireHumanApproval: false` got a facade that merged whatever was
+    // there — no state check, no CI check — while
+    // `TaskMergeGateService`, on the identical policy, waited for green.
+    // They opted out of a human, not out of CI. Both policies now take the
+    // same two checks; only the approval lookup is skipped.
+    describe('state + CI apply to EVERY policy, not just approval-required ones', () => {
+        it.each([
+            ['closed', 'pull-request-not-open'],
+            ['draft', 'pull-request-not-open'],
+            ['merged', 'pull-request-not-open'],
+        ] as const)('refuses a %s pull request with no approval required', async (state, code) => {
+            const { facade, plugin } = makeFacade({
+                policy: NO_APPROVAL_NEEDED,
+                status: { state, ciState: 'passing', headSha: HEAD },
+            });
+            await expect(
+                facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+            ).rejects.toMatchObject({ code });
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+
+        it.each(['failing', 'pending', 'unknown'] as const)(
+            'refuses %s CI with no approval required',
+            async (ciState) => {
+                // `unknown` is the state a pull request is in seconds after
+                // it is opened — which is exactly when the old code path
+                // reached here — so this is the case that used to merge
+                // before a single check had started.
+                const { facade, plugin } = makeFacade({
+                    policy: NO_APPROVAL_NEEDED,
+                    status: { state: 'open', ciState, headSha: HEAD },
+                });
+                await expect(
+                    facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+                ).rejects.toMatchObject({ code: 'pull-request-not-green' });
+                expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+            },
+        );
+
+        it('refuses an unreadable pull request with no approval required', async () => {
+            const { facade, plugin } = makeFacade({ policy: NO_APPROVAL_NEEDED, status: null });
+            await expect(
+                facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+            ).rejects.toMatchObject({ code: 'head-sha-unknown' });
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+    });
+
+    // An INCOMPLETE check read is not green. `ciState` is documented as
+    // the roll-up for the whole head commit while `checks` is a bounded
+    // display sample; a provider that says it could not read the full set
+    // is handing back a verdict over a SUBSET, and a failure may sit in
+    // the part nobody read. Authorising a merge on a sample is the same
+    // defect as authorising one on a truncated list.
+    describe('checksComplete', () => {
+        it.each([true, false] as const)(
+            'requires an approval regardless — completeness is %s',
+            async (checksComplete) => {
+                const { facade } = makeFacade({
+                    status: { state: 'open', ciState: 'passing', headSha: HEAD, checksComplete },
+                    verdict: { approved: false, code: 'approval-missing', reason: 'none' },
+                });
+                await expect(
+                    facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+                ).rejects.toBeInstanceOf(MergePolicyRefusedError);
+            },
+        );
+
+        it('refuses a "passing" verdict the provider says it could not read in full', async () => {
+            const { facade, plugin, verifier } = makeFacade({
+                status: { state: 'open', ciState: 'passing', headSha: HEAD, checksComplete: false },
+            });
+            const error = await facade
+                .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+                .catch((e: unknown) => e);
+            expect((error as MergePolicyRefusedError).code).toBe('pull-request-not-green');
+            expect((error as MergePolicyRefusedError).message).toContain(
+                'could not be read in full',
+            );
+            // It never even asks whether somebody approved: there is
+            // nothing an approval could be an approval OF.
+            expect(verifier.verifyMergeApproval).not.toHaveBeenCalled();
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+
+        it('refuses it with no approval required, too', async () => {
+            const { facade, plugin } = makeFacade({
+                policy: NO_APPROVAL_NEEDED,
+                status: { state: 'open', ciState: 'passing', headSha: HEAD, checksComplete: false },
+            });
+            await expect(
+                facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR),
+            ).rejects.toMatchObject({ code: 'pull-request-not-green' });
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+
+        it('merges when the provider explicitly says the read WAS complete', async () => {
+            const { facade, plugin } = makeFacade({
+                status: { state: 'open', ciState: 'passing', headSha: HEAD, checksComplete: true },
+            });
+            await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+            expect(plugin.mergePullRequest).toHaveBeenCalled();
+        });
+    });
+
+    it('normalises a shouted head SHA before pinning and verifying', async () => {
+        const { facade, plugin, verifier } = makeFacade({
+            status: { state: 'open', ciState: 'passing', headSha: HEAD.toUpperCase() },
+        });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ headSha: HEAD }),
+        );
+        expect(plugin.mergePullRequest.mock.calls[0][3]).toEqual({ expectedHeadSha: HEAD });
+    });
+
+    it.each([
+        ['approval-missing', 'Nobody approved this.'],
+        ['approval-stale', 'Approved at an earlier commit.'],
+        ['approval-expired', 'That approval is 40h old.'],
+        ['approval-not-human', 'A guardrail decided it.'],
+        ['approver-not-entitled', 'Not a member of that Tenant.'],
+    ] as const)('refuses with %s and never calls the provider', async (code, reason) => {
+        const { facade, plugin } = makeFacade({ verdict: { approved: false, code, reason } });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(MergePolicyRefusedError);
+        expect((error as MergePolicyRefusedError).code).toBe(code);
+        expect((error as MergePolicyRefusedError).message).toContain(reason);
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses when green at approval time is not green at MERGE time', async () => {
+        const { facade, plugin, verifier } = makeFacade({
+            status: { state: 'open', ciState: 'failing', headSha: HEAD },
+        });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('pull-request-not-green');
+        // The approval is not even consulted — a red pull request cannot
+        // be merged whatever anyone approved.
+        expect(verifier.verifyMergeApproval).not.toHaveBeenCalled();
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it.each(['pending', 'unknown'] as const)(
+        'treats a %s CI verdict as not-green (fail closed)',
+        async (ciState) => {
+            const { facade, plugin } = makeFacade({
+                status: { state: 'open', ciState, headSha: HEAD },
+            });
+            const error = await facade
+                .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+                .catch((e: unknown) => e);
+            expect((error as MergePolicyRefusedError).code).toBe('pull-request-not-green');
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(['draft', 'closed', 'merged'] as const)('refuses a %s pull request', async (state) => {
+        const { facade, plugin } = makeFacade({
+            status: { state, ciState: 'passing', headSha: HEAD },
+        });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('pull-request-not-open');
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the provider cannot be read at all', async () => {
+        const { facade, plugin } = makeFacade({ status: null });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('head-sha-unknown');
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the provider reports no head commit', async () => {
+        const { facade, plugin } = makeFacade({
+            status: { state: 'open', ciState: 'passing', headSha: null },
+        });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('head-sha-unknown');
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses when no approval VERIFIER is bound — unbound is not "approved"', async () => {
+        const { facade, plugin } = makeFacade({ bindVerifier: false });
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('approval-missing');
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('treats a THROWN verifier as a refusal, never as an approval', async () => {
+        const { facade, plugin, verifier } = makeFacade();
+        (verifier.verifyMergeApproval as jest.Mock).mockRejectedValue(new Error('db down'));
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR)
+            .catch((e: unknown) => e);
+        expect((error as MergePolicyRefusedError).code).toBe('approval-missing');
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses a merge that names no Task — an approval must be bound to something', async () => {
+        const { facade, plugin, verifier } = makeFacade({
+            verdict: {
+                approved: false,
+                code: 'approval-missing',
+                reason: 'This merge is not attached to a Task.',
+            },
+        });
+        await expect(
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' }),
+        ).rejects.toBeInstanceOf(MergePolicyRefusedError);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ taskId: '' }),
+        );
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('assumes an approval is required when the enforcer cannot resolve a policy', async () => {
+        // A minimal enforcer (no `resolve`) is the fail-closed reading:
+        // an unevaluated policy is never a satisfied policy.
+        const { facade, verifier } = makeFacade({ resolvable: false });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledTimes(1);
+    });
+
+    it('assumes an approval is required when the policy READ throws', async () => {
+        const { facade, enforcer, verifier } = makeFacade();
+        (enforcer.resolve as jest.Mock).mockRejectedValue(new Error('db down'));
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledTimes(1);
+    });
+
+    it('a head that moved between approval and merge produces a different lookup', async () => {
+        // The verifier is asked about the head the provider reports NOW.
+        // The stale-approval refusal itself lives in MergeApprovalService;
+        // what this pins is that the facade never asks about a remembered
+        // head.
+        const { facade, verifier } = makeFacade({
+            status: { state: 'open', ciState: 'passing', headSha: OTHER_HEAD },
+        });
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, ACTOR);
+        expect(verifier.verifyMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ headSha: OTHER_HEAD }),
+        );
     });
 });

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -4,6 +4,7 @@ import { UsageModule } from '../usage/usage.module';
 import { BudgetsModule } from '../budgets/budgets.module';
 import { PolicyModule } from '../policy/policy.module';
 import { AgentPluginsModule } from '../agent-plugins/agent-plugins.module';
+import { MergeApprovalModule } from '../agent-approvals/merge-approval.module';
 
 import { AiFacadeService } from './ai.facade';
 import { SearchFacadeService } from './search.facade';
@@ -89,7 +90,19 @@ const FACADES = [
     // importing it here cannot cycle. It binds AGENT_PLUGIN_SKILL_SOURCE,
     // which SkillsFacadeService consumes @Optional() to merge Agent Plugins
     // package skills into the catalog as an additive last source.
-    imports: [DatabaseModule, UsageModule, BudgetsModule, PolicyModule, AgentPluginsModule],
+    imports: [
+        DatabaseModule,
+        UsageModule,
+        BudgetsModule,
+        PolicyModule,
+        AgentPluginsModule,
+        // Merge approval (self-build slice AE, EW-805) — binds
+        // MERGE_APPROVAL_VERIFIER, which GitFacadeService consumes before
+        // it lets any merge reach a provider. Imported here (not folded
+        // into PolicyModule) so PolicyModule stays the entity-only leaf
+        // every policy consumer can depend on.
+        MergeApprovalModule,
+    ],
     providers: FACADES,
     exports: FACADES,
 })

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -44,6 +44,8 @@ import {
 import { WorkRepository } from '../database/repositories/work.repository';
 import { GitHubAppInstallationRepository } from '../database/repositories/github-app-installation.repository';
 import { MERGE_POLICY_ENFORCER, type MergePolicyEnforcer } from '../policy/merge-policy.enforcer';
+import { MERGE_APPROVAL_VERIFIER, type MergeApprovalVerifier } from '../policy/merge-approval.port';
+import { normalizeCommitSha } from '@ever-works/contracts';
 import type { AuthAccount } from '../entities/auth-account.entity';
 import { FacadeError } from './base.facade';
 import { config } from '@src/config';
@@ -189,12 +191,14 @@ export type GitFacadeOptions = GitFacadeTokenAuth | GitFacadeUserAuth;
  * Merge-policy matrix (Wave 3, founder decision D4) — the "who is asking"
  * for {@link GitFacadeService.mergePullRequest}.
  *
- * PRESENT  ⇒ the merge is AGENT-DRIVEN and is routed through the single
- *            decision point (`MergePolicyService.canAgentMerge`) before
- *            the provider is called at all.
- * ABSENT   ⇒ the merge is human-driven; behaviour is exactly as it was
- *            before this feature landed. Human merges are governed by the
- *            git provider's own branch protection, not by this matrix.
+ * REQUIRED since merge approval (self-build slice AE, EW-805). It used to
+ * be optional, and its absence meant "human-driven merge, skip the
+ * matrix". That made the gate OPT-IN: any caller that forgot the sixth
+ * argument merged with no policy at all, and the compiler said nothing.
+ * There was exactly one production caller and it did pass an actor, so
+ * making the parameter required cost nothing and closed the door for
+ * good. A future human-driven merge path must construct an actor that
+ * says who the human is, rather than being exempted by omission.
  */
 export interface AgentMergeActor {
     /** The Agent asking to merge. Required — it is what makes this agent-driven. */
@@ -205,8 +209,18 @@ export interface AgentMergeActor {
     tenantId?: string | null;
     /** Latest quality-gate verdict for the run behind this pull request. */
     gateStatus?: GateStatus | null;
-    /** Whether a human approval is on record for this merge. */
-    humanApproved?: boolean;
+    /**
+     * Merge approval (slice AE) — the Task this pull request belongs to.
+     * It is WHAT an approval is looked up by, together with the pull
+     * request number and the live head commit.
+     *
+     * Note what is NOT on this interface any more: `humanApproved`. A
+     * caller cannot assert that a human approved; it can only say which
+     * merge this is, and the facade asks the record. The previous shape
+     * let the asker answer the question, and the one production caller
+     * hardcoded `false` — the gap this slice closes.
+     */
+    taskId?: string | null;
     /**
      * Base branch of the pull request. Optional: when omitted the facade
      * looks it up through the provider. If it still cannot be determined
@@ -278,6 +292,17 @@ export class GitFacadeService implements IGitFacade {
         @Optional()
         @Inject(MERGE_POLICY_ENFORCER)
         private readonly mergePolicy?: MergePolicyEnforcer,
+        // Merge approval (self-build slice AE, EW-805) — bound to
+        // MergeApprovalService by MergeApprovalModule (imported by
+        // FacadesModule). Appended LAST + @Optional() per the
+        // positional-spec arity rule, but note the SEMANTICS differ from
+        // every other optional dependency in this class: unbound is NOT
+        // "degrade gracefully", it is "no approval can be produced", and
+        // a policy that requires one therefore refuses. See
+        // `assertAgentMayMerge`.
+        @Optional()
+        @Inject(MERGE_APPROVAL_VERIFIER)
+        private readonly mergeApprovals?: MergeApprovalVerifier,
     ) {}
 
     private getRequiredOAuthScopes(providerId: string): readonly string[] {
@@ -790,15 +815,19 @@ export class GitFacadeService implements IGitFacade {
     }
 
     /**
-     * Land a pull request.
+     * Land a pull request. THE one place a merge can happen.
      *
-     * Merge-policy matrix (Wave 3, founder decision D4): when `agentActor`
-     * is supplied the merge is AGENT-DRIVEN and is routed through the
-     * single decision point before the provider is touched. A refusal
-     * throws {@link MergePolicyRefusedError} carrying the reason — the
-     * provider call never happens, so a policy violation cannot land even
-     * partially. Without `agentActor` (human-driven merges) nothing
-     * changes.
+     * `agentActor` is REQUIRED (merge approval, self-build slice AE): the
+     * gate below runs for every caller, so there is no "forgot the last
+     * argument" path to an unchecked merge. A refusal throws
+     * {@link MergePolicyRefusedError} carrying the reason — the provider
+     * call never happens, so a policy violation cannot land even
+     * partially.
+     *
+     * The merge is additionally PINNED to the head commit the gate just
+     * verified (`expectedHeadSha` → GitHub's `sha` parameter), so a push
+     * that lands between the check and this call is refused by the
+     * provider instead of being merged in place of what was approved.
      */
     async mergePullRequest(
         owner: string,
@@ -806,32 +835,60 @@ export class GitFacadeService implements IGitFacade {
         prNumber: number,
         mergeOptions: MergeOptions | undefined,
         options: GitFacadeOptions,
-        agentActor?: AgentMergeActor,
+        agentActor: AgentMergeActor,
     ): Promise<MergeResult> {
-        if (agentActor?.agentId) {
-            await this.assertAgentMayMerge(
-                owner,
-                repo,
-                prNumber,
-                mergeOptions,
-                options,
-                agentActor,
-            );
-        }
+        const { expectedHeadSha } = await this.assertAgentMayMerge(
+            owner,
+            repo,
+            prNumber,
+            mergeOptions,
+            options,
+            agentActor,
+        );
         const { plugin, token } = await this.resolvePluginAndToken(options);
-        return plugin.mergePullRequest(owner, repo, prNumber, mergeOptions, token);
+        const pinned = expectedHeadSha
+            ? { ...(mergeOptions ?? {}), expectedHeadSha }
+            : mergeOptions;
+        return plugin.mergePullRequest(owner, repo, prNumber, pinned, token);
     }
 
     /**
-     * The enforcement half of the merge-policy matrix. Throws
-     * {@link MergePolicyRefusedError} when the effective policy refuses.
+     * The enforcement half of the merge-policy matrix + the merge-approval
+     * gate. Throws {@link MergePolicyRefusedError} when either refuses.
+     * Returns the head commit the merge must be pinned to, when one could
+     * be established.
      *
-     * Fail-CLOSED by design (the opposite posture from the concurrency
+     * Order, and why:
+     *
+     *  1. **Resolve the policy** (not a decision — just the fields), so we
+     *     know whether an approval is required before we do anything else.
+     *     An unbound enforcer, or one too minimal to resolve, is read as
+     *     "approval required": an unevaluated policy is never a satisfied
+     *     policy.
+     *  2. **Read the pull request LIVE, for every policy** — its state,
+     *     its head commit and its CI verdict, from the provider, right
+     *     now. Not `tasks.ciState`, which is a cache the PR-status sweep
+     *     refreshes every couple of minutes. "It was green when the human
+     *     approved" is exactly the thing that must not be trusted. This
+     *     step used to be inside the "an approval is required" branch, so
+     *     an operator who set `requireHumanApproval: false` got no state
+     *     check and no CI check whatsoever; they opted out of a human, not
+     *     out of CI.
+     *  3. **Verify the approval** against that live head, WHEN the policy
+     *     requires one. Missing, stale (given for an earlier commit),
+     *     expired, non-human or unentitled all refuse, each with its own
+     *     code.
+     *  4. **The operator kill-switch** (`AGENT_MERGE_POLICY_ENFORCEMENT=
+     *     off`) skips the policy MATRIX below — and only that. It no
+     *     longer skips the approval gate. See the note at the check.
+     *  5. **The matrix** (`canAgentMerge`), with `humanApproved` supplied
+     *     by step 3 rather than by the caller.
+     *
+     * Fail-CLOSED throughout (the opposite posture from the concurrency
      * valve in `RunDispatchGateService`, and deliberately so): a merge is
-     * irreversible, so an unavailable enforcer or an undeterminable target
-     * branch refuses instead of proceeding. The only bypass is the
-     * operator kill-switch `AGENT_MERGE_POLICY_ENFORCEMENT=off`, which
-     * restores the pre-feature behaviour wholesale.
+     * irreversible, so an unavailable enforcer, an unreadable pull
+     * request or an undeterminable target branch refuses instead of
+     * proceeding.
      */
     private async assertAgentMayMerge(
         owner: string,
@@ -840,15 +897,7 @@ export class GitFacadeService implements IGitFacade {
         mergeOptions: MergeOptions | undefined,
         options: GitFacadeOptions,
         agentActor: AgentMergeActor,
-    ): Promise<void> {
-        if (!config.agents.isMergePolicyEnforcementEnabled()) {
-            this.logger.warn(
-                `Merge-policy enforcement is DISABLED (AGENT_MERGE_POLICY_ENFORCEMENT=off) — ` +
-                    `agent ${agentActor.agentId} merging ${owner}/${repo}#${prNumber} unchecked.`,
-            );
-            return;
-        }
-
+    ): Promise<{ expectedHeadSha: string | null }> {
         if (!this.mergePolicy) {
             throw new MergePolicyRefusedError(
                 {
@@ -860,6 +909,196 @@ export class GitFacadeService implements IGitFacade {
                 },
                 options.providerId,
             );
+        }
+
+        const scope = {
+            agentId: agentActor.agentId,
+            workId: agentActor.workId ?? options.workId ?? null,
+            organizationId: agentActor.organizationId ?? null,
+            tenantId: agentActor.tenantId ?? null,
+        };
+
+        // (1) Does this scope require a human approval? Resolve-only, no
+        // decision. An enforcer without `resolve` (a minimal double, an
+        // older binding) is read as "yes" — fail closed.
+        let requiresApproval = true;
+        let policySource: MergePolicySource | undefined;
+        if (typeof this.mergePolicy.resolve === 'function') {
+            try {
+                const resolved = await this.mergePolicy.resolve(scope);
+                requiresApproval = resolved.policy.requireHumanApproval;
+                policySource = resolved.source;
+            } catch (error) {
+                this.logger.warn(
+                    `Merge policy: could not resolve the approval requirement for ` +
+                        `${owner}/${repo}#${prNumber}; assuming an approval is required: ` +
+                        `${error instanceof Error ? error.message : String(error)}`,
+                );
+                requiresApproval = true;
+            }
+        }
+
+        // (2) The LIVE read, for EVERY policy. It used to sit inside the
+        // `if (requiresApproval)` branch, which meant an operator who set
+        // `requireHumanApproval: false` got no state check and no CI check
+        // at all — the facade merged whatever was there, seconds after the
+        // pull request was opened and before a single check run existed.
+        // That is not what "no approval required" buys: the operator opted
+        // out of a HUMAN, not out of CI, and `TaskMergeGateService` (the
+        // other side of the same policy) always waited for green. The two
+        // paths now agree, and this is the enforcement point, so it is
+        // stated here rather than left to whichever caller got there.
+        const live = await this.readLivePullRequest(owner, repo, prNumber, options);
+        if (!live) {
+            throw new MergePolicyRefusedError(
+                {
+                    allowed: false,
+                    code: 'head-sha-unknown',
+                    reason:
+                        `The pull request ${owner}/${repo}#${prNumber} could not be read from the provider, ` +
+                        'so neither its head commit nor its CI verdict can be confirmed at merge time.',
+                    source: policySource,
+                },
+                options.providerId,
+            );
+        }
+        if (live.state !== 'open') {
+            throw new MergePolicyRefusedError(
+                {
+                    allowed: false,
+                    code: 'pull-request-not-open',
+                    reason: `Pull request #${prNumber} is '${live.state}', not open — nothing to merge.`,
+                    source: policySource,
+                },
+                options.providerId,
+            );
+        }
+        // Green is re-checked HERE, at merge time, against the provider. A
+        // pull request that was green when the human approved it and is
+        // red now must not merge, and the Task's cached `ciState` is up to
+        // two minutes behind.
+        //
+        // `checksComplete === false` is treated as not-green on purpose:
+        // it means the provider read could not see the commit's whole
+        // check set (a source it lacks scope for, or more checks than the
+        // page budget), so the roll-up is over a SAMPLE and a failure may
+        // be hiding in the part nobody read. An authorization input may
+        // not be a sample.
+        if (live.ciState !== 'passing' || live.checksComplete === false) {
+            throw new MergePolicyRefusedError(
+                {
+                    allowed: false,
+                    code: 'pull-request-not-green',
+                    reason:
+                        live.checksComplete === false
+                            ? `Provider CI for pull request #${prNumber} could not be read in full, so its ` +
+                              "verdict is a sample rather than a roll-up. A merge needs the whole commit's checks."
+                            : `Provider CI for pull request #${prNumber} is '${live.ciState}' at merge time. ` +
+                              'An approval covers a green pull request; this one is not green now.',
+                    source: policySource,
+                },
+                options.providerId,
+            );
+        }
+        const expectedHeadSha = normalizeCommitSha(live.headSha);
+        if (!expectedHeadSha) {
+            throw new MergePolicyRefusedError(
+                {
+                    allowed: false,
+                    code: 'head-sha-unknown',
+                    reason:
+                        `The provider did not report a head commit for pull request #${prNumber}, so the ` +
+                        'merge cannot be pinned to what was checked.',
+                    source: policySource,
+                },
+                options.providerId,
+            );
+        }
+
+        // (3) The approval gate, which IS skipped when the effective policy
+        // does not require one — that operator chose "agents land their own
+        // green work", and this method must not quietly re-impose a gate
+        // they turned off.
+        let approval: { approvedById?: string; approvalId?: string } | null = null;
+        if (requiresApproval) {
+            const headSha = expectedHeadSha;
+            if (!this.mergeApprovals) {
+                throw new MergePolicyRefusedError(
+                    {
+                        allowed: false,
+                        code: 'approval-missing',
+                        reason:
+                            'The effective merge policy requires a human approval, and this runtime has no ' +
+                            'approval verifier bound — so no approval can exist to satisfy it.',
+                        source: policySource,
+                    },
+                    options.providerId,
+                );
+            }
+
+            const verdict = await this.mergeApprovals
+                .verifyMergeApproval({
+                    taskId: agentActor.taskId ?? '',
+                    prNumber,
+                    headSha,
+                })
+                .catch((error: unknown) => {
+                    // A verifier that threw did not approve anything.
+                    this.logger.warn(
+                        `Merge approval verification threw for ${owner}/${repo}#${prNumber} (refusing): ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                    return {
+                        approved: false as const,
+                        code: 'approval-missing' as const,
+                        reason: 'The approval record could not be verified, so this merge is refused.',
+                    };
+                });
+
+            if (!verdict.approved) {
+                this.logger.log(
+                    `Merge approval REFUSED agent ${agentActor.agentId} on ${owner}/${repo}#${prNumber} ` +
+                        `(${verdict.code ?? 'approval-missing'}).`,
+                );
+                throw new MergePolicyRefusedError(
+                    {
+                        allowed: false,
+                        code: verdict.code ?? 'approval-missing',
+                        reason:
+                            verdict.reason ??
+                            'No usable human approval is on record for this merge.',
+                        source: policySource,
+                    },
+                    options.providerId,
+                );
+            }
+            approval = { approvedById: verdict.approvedById, approvalId: verdict.approvalId };
+        }
+        // No `else`. The head pin, the open check and the green check are
+        // above and apply to both policies; the only thing an operator's
+        // `requireHumanApproval: false` skips is the approval lookup.
+
+        // (4) The operator kill-switch. It restores the pre-feature
+        // behaviour of the POLICY MATRIX and nothing else.
+        //
+        // It deliberately no longer covers the approval gate above. The
+        // switch was added to un-break a deployment the matrix refused —
+        // an escape hatch for branch/method/gate rules. Letting it also
+        // waive "a human said yes to this commit" would make one env var
+        // the difference between a reviewed merge and an unreviewed one,
+        // which is precisely the failure this slice exists to prevent.
+        // An operator who genuinely wants agents to land green work
+        // without a human sets `requireHumanApproval: false` on the merge
+        // policy: same outcome, but scoped, auditable, and visible in the
+        // resolved-policy UI rather than in a pod's environment.
+        if (!config.agents.isMergePolicyEnforcementEnabled()) {
+            this.logger.warn(
+                `Merge-policy MATRIX is disabled (AGENT_MERGE_POLICY_ENFORCEMENT=off) — ` +
+                    `agent ${agentActor.agentId} merging ${owner}/${repo}#${prNumber} without the ` +
+                    `branch / method / gate rules. The approval requirement still applied.`,
+            );
+            return { expectedHeadSha };
         }
 
         // Resolve the base branch when the caller did not supply it — the
@@ -878,13 +1117,19 @@ export class GitFacadeService implements IGitFacade {
             }
         }
 
+        // (5) The matrix. `humanApproved` now comes from the RECORD, never
+        // from the caller.
+        //
+        // Note it is `approval !== null`, NOT "true when no approval was
+        // required". `canAgentMerge` resolves the policy a second time, and
+        // if an operator flipped `requireHumanApproval` on in the
+        // milliseconds between the two reads, claiming approval here would
+        // merge under the OLD policy. Reporting what we actually verified
+        // makes that race refuse instead.
         const decision = await this.mergePolicy.canAgentMerge({
-            agentId: agentActor.agentId,
-            workId: agentActor.workId ?? options.workId ?? null,
-            organizationId: agentActor.organizationId ?? null,
-            tenantId: agentActor.tenantId ?? null,
+            ...scope,
             gateStatus: agentActor.gateStatus ?? null,
-            humanApproved: agentActor.humanApproved ?? false,
+            humanApproved: approval !== null,
             targetBranch,
             mergeMethod: mergeOptions?.mergeMethod ?? null,
         });
@@ -899,8 +1144,35 @@ export class GitFacadeService implements IGitFacade {
 
         this.logger.log(
             `Merge policy ALLOWED agent ${agentActor.agentId} on ${owner}/${repo}#${prNumber} ` +
-                `(policy source: ${decision.source ?? 'default'}).`,
+                `(policy source: ${decision.source ?? 'default'}` +
+                `${approval?.approvedById ? `, approved by user ${approval.approvedById}` : ''}` +
+                `${expectedHeadSha ? `, pinned to ${expectedHeadSha.slice(0, 12)}` : ''}).`,
         );
+        return { expectedHeadSha };
+    }
+
+    /**
+     * Live provider read of a pull request's state, head commit and CI
+     * verdict — never a cache. `null` when the provider cannot answer
+     * (the capability is unsupported, the PR is gone, the token lacks
+     * scope), which every caller treats as a refusal.
+     */
+    private async readLivePullRequest(
+        owner: string,
+        repo: string,
+        prNumber: number,
+        options: GitFacadeOptions,
+    ): Promise<GitPullRequestStatus | null> {
+        try {
+            return await this.getPullRequestStatus(owner, repo, prNumber, options);
+        } catch (error) {
+            this.logger.warn(
+                `Merge gate: live status read failed for ${owner}/${repo}#${prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
     }
 
     async listPullRequests(

--- a/packages/agent/src/policy/index.ts
+++ b/packages/agent/src/policy/index.ts
@@ -5,6 +5,9 @@
 // facade consumes, and the `resolve_merge_policy` chat-tool factory.
 export * from './merge-policy';
 export * from './merge-policy.enforcer';
+// Merge approval (self-build slice AE) — token + contract for the
+// "is there a real, current, human approval for this merge?" question.
+export * from './merge-approval.port';
 export * from './merge-policy.repository';
 export * from './merge-policy.service';
 // Quality gates — the PR gate every non-worker `createPullRequest` caller

--- a/packages/agent/src/policy/merge-approval.port.ts
+++ b/packages/agent/src/policy/merge-approval.port.ts
@@ -1,0 +1,70 @@
+import type { MergeRefusalCode } from '@ever-works/contracts';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — injection token +
+ * contract for the "is there a real, current, human approval for THIS
+ * merge?" question.
+ *
+ * Token + contract only (leaf file, type-only imports — the same
+ * circular-dep dodge as `merge-policy.enforcer.ts` and the other agent
+ * injection tokens). `GitFacadeService` consumes it via
+ * `@Optional() @Inject(...)`; `MergeApprovalModule` binds it to
+ * `MergeApprovalService`.
+ *
+ * Why a PORT and not a boolean argument: before this landed, the facade
+ * took `humanApproved` from its CALLER, and the only production caller
+ * passed the literal `false`. A caller-supplied boolean is not an
+ * approval — it is a claim, and the whole point of the gate is that the
+ * thing being gated cannot make the claim. So the facade now asks this
+ * port, which answers from the durable record.
+ *
+ * FAIL-CLOSED when unbound. `GitFacadeService` treats an absent verifier
+ * as "no approval exists": a runtime that cannot look one up must not
+ * merge on a policy that requires one. This is the opposite of the
+ * `@Optional()` convention elsewhere in the package, and deliberately so
+ * — a merge is irreversible.
+ */
+
+/** WHICH merge is being asked about. Every field is required. */
+export interface MergeApprovalQuery {
+    /** The Task the pull request belongs to. */
+    taskId: string;
+    /** Provider pull-request number. */
+    prNumber: number;
+    /**
+     * The head commit as read from the provider MOMENTS AGO — not from a
+     * cache, and not from the caller's memory of what it pushed. This is
+     * the value the recorded approval must name.
+     */
+    headSha: string;
+}
+
+/** What the verifier found. */
+export interface MergeApprovalVerdict {
+    /** True only when a real, current, human, entitled approval exists. */
+    approved: boolean;
+    /** Stable refusal code when `approved` is false. */
+    code?: MergeRefusalCode;
+    /** Human-readable reason naming what was found instead. */
+    reason?: string;
+    /** `agent_action_proposals.id` of the consumed approval. */
+    approvalId?: string;
+    /** The human who approved (`users.id`). Never an agent or a bot. */
+    approvedById?: string;
+    approvedAt?: Date;
+}
+
+export interface MergeApprovalVerifier {
+    /**
+     * Is there a recorded human approval for exactly this pull request at
+     * exactly this head commit, still inside its validity window, given by
+     * somebody entitled to approve for this Task's scope?
+     *
+     * Implementations MUST NOT throw for "no" — a refusal is a verdict.
+     * They may throw for genuine faults (the store is unreachable), and
+     * the caller treats a throw as a refusal.
+     */
+    verifyMergeApproval(query: MergeApprovalQuery): Promise<MergeApprovalVerdict>;
+}
+
+export const MERGE_APPROVAL_VERIFIER = 'MERGE_APPROVAL_VERIFIER' as const;

--- a/packages/agent/src/policy/merge-policy.enforcer.ts
+++ b/packages/agent/src/policy/merge-policy.enforcer.ts
@@ -1,4 +1,9 @@
-import type { GateStatus, MergeDecision, MergeMethod } from '@ever-works/contracts';
+import type {
+    GateStatus,
+    MergeDecision,
+    MergeMethod,
+    ResolvedMergePolicy,
+} from '@ever-works/contracts';
 
 /**
  * Merge-policy matrix (Wave 3, founder decision D4) — injection token +
@@ -36,6 +41,21 @@ export interface MergePolicyEnforcer {
      * throw for policy reasons — a refusal is `{ allowed: false, reason }`.
      */
     canAgentMerge(input: MergePolicyDecisionInput): Promise<MergeDecision>;
+    /**
+     * Merge approval (self-build slice AE) — the resolved policy WITHOUT
+     * a decision, so the enforcement site can read one field before it
+     * evaluates anything: does this scope require a human approval?
+     *
+     * The facade needs that answer earlier than `canAgentMerge` can give
+     * it, because the approval must be verified (and the head commit
+     * pinned) BEFORE the matrix runs, and because the operator
+     * kill-switch skips the matrix but must not skip the approval.
+     *
+     * Optional on the contract so a minimal test double still satisfies
+     * `MergePolicyEnforcer`. Absent, the facade assumes an approval IS
+     * required — the fail-closed reading.
+     */
+    resolve?(input: MergePolicyDecisionInput): Promise<ResolvedMergePolicy>;
 }
 
 export const MERGE_POLICY_ENFORCER = 'MERGE_POLICY_ENFORCER' as const;

--- a/packages/agent/src/tasks-domain/__tests__/task-merge-gate.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-merge-gate.service.spec.ts
@@ -1,0 +1,349 @@
+import type { MergePolicy } from '@ever-works/contracts';
+import { TaskMergeGateService } from '../task-merge-gate.service';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the post-CI gate.
+ *
+ * This is the service that turns "CI went green" into either an Inbox
+ * approval or a merge, and it is the answer to the original defect: the
+ * merge decision no longer fires at pull-request-open time, when no CI
+ * has run and no human has been asked.
+ *
+ * Everything is driven through the real `onPullRequestStatusRefreshed`
+ * with a real `GitPullRequestStatus`-shaped payload; the collaborators
+ * (policy, approvals, workspace) are doubles whose calls are the
+ * assertions.
+ */
+describe('TaskMergeGateService', () => {
+    const HEAD = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+    const NEEDS_APPROVAL: MergePolicy = {
+        allowAgentMerge: true,
+        requireGreenGate: true,
+        requireHumanApproval: true,
+        allowedMergeMethods: ['squash'],
+        protectedBranches: ['main'],
+    };
+
+    const task = (over: Record<string, unknown> = {}) =>
+        ({
+            id: 'task-1',
+            userId: 'owner-1',
+            slug: 'T-42',
+            workId: 'work-1',
+            agentId: 'agent-1',
+            prNumber: 7,
+            prUrl: 'https://github.com/acme/site-data/pull/7',
+            ...over,
+        }) as never;
+
+    const status = (over: Record<string, unknown> = {}) =>
+        ({
+            number: 7,
+            state: 'open',
+            merged: false,
+            ciState: 'passing',
+            headSha: HEAD,
+            checks: [],
+            ...over,
+        }) as never;
+
+    function build(over: { policy?: MergePolicy; approved?: boolean } = {}) {
+        const works = {
+            findById: jest.fn().mockResolvedValue({
+                id: 'work-1',
+                organizationId: 'org-1',
+                tenantId: 'tenant-1',
+                taskIsolationBaseBranch: 'develop',
+                getRepoOwner: () => 'acme',
+                getDataRepo: () => 'site-data',
+            }),
+        };
+        const mergePolicy = {
+            resolve: jest.fn().mockResolvedValue({
+                policy: over.policy ?? NEEDS_APPROVAL,
+                source: 'work',
+                chain: [],
+            }),
+        };
+        const taskWorkspace = {
+            attemptMergeForOpenPullRequest: jest
+                .fn()
+                .mockResolvedValue({ attempted: true, merged: true }),
+        };
+        const mergeApprovals = {
+            verifyMergeApproval: jest
+                .fn()
+                .mockResolvedValue(
+                    over.approved
+                        ? { approved: true, approvalId: 'p-1', approvedById: 'human-1' }
+                        : { approved: false, code: 'approval-missing' },
+                ),
+            requestMergeApproval: jest
+                .fn()
+                .mockResolvedValue({ raised: true, proposal: { id: 'p-new' } }),
+        };
+        const service = new TaskMergeGateService(
+            works as never,
+            mergePolicy as never,
+            taskWorkspace as never,
+            mergeApprovals as never,
+        );
+        return { service, works, mergePolicy, taskWorkspace, mergeApprovals };
+    }
+
+    // ── the ask ───────────────────────────────────────────────────────
+
+    it('raises the approval for a green, open pull request, bound to the live head', async () => {
+        const { service, mergeApprovals, taskWorkspace } = build();
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: 'owner-1',
+                taskId: 'task-1',
+                agentId: 'agent-1',
+                prNumber: 7,
+                headSha: HEAD,
+                targetBranch: 'develop',
+                repository: 'acme/site-data',
+                ciState: 'passing',
+            }),
+        );
+        // Nothing is merged just because CI went green.
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a provider review approval only when it covers THIS head', async () => {
+        const { service, mergeApprovals } = build();
+
+        await service.onPullRequestStatusRefreshed(
+            task({ prReviewApprovedSha: HEAD, prReviewApprovedBy: 'octocat' }),
+            status(),
+        );
+        expect(mergeApprovals.requestMergeApproval.mock.calls[0][0].reviewApprovedBy).toBe(
+            'octocat',
+        );
+
+        mergeApprovals.requestMergeApproval.mockClear();
+        await service.onPullRequestStatusRefreshed(
+            task({ prReviewApprovedSha: 'b'.repeat(40), prReviewApprovedBy: 'octocat' }),
+            status(),
+        );
+        // The reviewer looked at a different commit; saying "octocat
+        // approved" next to this diff would be a lie.
+        expect(mergeApprovals.requestMergeApproval.mock.calls[0][0].reviewApprovedBy).toBeNull();
+    });
+
+    // ── an INCOMPLETE CI read is not green ────────────────────────────
+    //
+    // `ciState` is a roll-up over the head commit's checks; `checks` is a
+    // bounded display sample. A provider that could not read the whole set
+    // reports `checksComplete: false`, and the roll-up it gives back is
+    // therefore a statement about a subset — a failure may sit in the part
+    // nobody read. Authorising on it would show the human a green badge
+    // the platform manufactured.
+
+    it('neither asks nor merges when the provider could not read all the checks', async () => {
+        const { service, mergeApprovals, taskWorkspace } = build();
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            task(),
+            status({ ciState: 'passing', checksComplete: false }),
+        );
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'ci-incomplete' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not merge an APPROVED pull request on an incomplete CI read either', async () => {
+        const { service, taskWorkspace } = build({ approved: true });
+        await service.onPullRequestStatusRefreshed(
+            task(),
+            status({ ciState: 'passing', checksComplete: false }),
+        );
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not merge on an incomplete CI read when the policy asks for no approval', async () => {
+        const { service, taskWorkspace } = build({
+            policy: { ...NEEDS_APPROVAL, requireHumanApproval: false },
+        });
+        await service.onPullRequestStatusRefreshed(
+            task(),
+            status({ ciState: 'passing', checksComplete: false }),
+        );
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('proceeds normally when the provider does not report completeness at all', async () => {
+        // Only an explicit `false` is a warning — an older provider that
+        // omits the field is taken at its word, exactly as before.
+        const { service, mergeApprovals } = build();
+        await service.onPullRequestStatusRefreshed(task(), status());
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalled();
+    });
+
+    it('reports approval-pending rather than re-asking on the next sweep', async () => {
+        const { service, mergeApprovals } = build();
+        mergeApprovals.requestMergeApproval.mockResolvedValue({
+            raised: false,
+            reason: 'already-open',
+        });
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'approval-pending',
+        });
+    });
+
+    // ── the merge ─────────────────────────────────────────────────────
+
+    it('MERGES once a human approval exists for the current head', async () => {
+        const { service, taskWorkspace, mergeApprovals } = build({ approved: true });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(mergeApprovals.verifyMergeApproval).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            prNumber: 7,
+            headSha: HEAD,
+        });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith({
+            task: expect.objectContaining({ id: 'task-1' }),
+            agentId: 'agent-1',
+            gateStatus: 'green',
+            // The head read LIVE moments ago, forwarded so the refusal
+            // record can be keyed by it and told to the human once rather
+            // than on every two-minute sweep. Never an input to the
+            // decision — the facade re-reads and pins the head itself.
+            headSha: HEAD,
+        });
+        expect(outcome).toEqual({
+            action: 'merge-attempted',
+            merge: { attempted: true, merged: true },
+        });
+        // The approved action is EXECUTED, not merely recorded. Before this
+        // slice nothing in the platform ever read `status === 'approved'`.
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    it('merges without an approval only when the policy asked for none', async () => {
+        const { service, taskWorkspace, mergeApprovals } = build({
+            policy: { ...NEEDS_APPROVAL, requireHumanApproval: false },
+        });
+        await service.onPullRequestStatusRefreshed(task(), status());
+        expect(mergeApprovals.verifyMergeApproval).not.toHaveBeenCalled();
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    // ── everything that stops it ──────────────────────────────────────
+
+    it.each([
+        ['draft', { state: 'draft' }, 'pr-draft'],
+        ['closed', { state: 'closed' }, 'pr-closed'],
+        ['already merged', { state: 'merged' }, 'pr-merged'],
+        ['failing CI', { ciState: 'failing' }, 'ci-failing'],
+        ['pending CI', { ciState: 'pending' }, 'ci-pending'],
+        ['unknown CI', { ciState: 'unknown' }, 'ci-unknown'],
+        ['no head commit', { headSha: null }, 'head-sha-unknown'],
+    ] as const)('does nothing for %s', async (_label, over, reason) => {
+        const { service, mergeApprovals, taskWorkspace } = build();
+        await expect(service.onPullRequestStatusRefreshed(task(), status(over))).resolves.toEqual({
+            action: 'skipped',
+            reason,
+        });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not ask a human for permission the policy could never use', async () => {
+        // `allowAgentMerge: false` is the shipped default. An approval
+        // raised under it would be an Inbox item whose Approve button does
+        // nothing.
+        const { service, mergeApprovals } = build({
+            policy: { ...NEEDS_APPROVAL, allowAgentMerge: false },
+        });
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'skipped',
+            reason: 'agent-merge-disabled',
+        });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    it('stands down for a Task with no Agent — nobody to attribute the merge to', async () => {
+        const { service, mergeApprovals } = build();
+        await expect(
+            service.onPullRequestStatusRefreshed(task({ agentId: null }), status()),
+        ).resolves.toEqual({ action: 'skipped', reason: 'no-agent' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    it('stands down for a Task with no pull request', async () => {
+        const { service } = build();
+        await expect(
+            service.onPullRequestStatusRefreshed(task({ prNumber: null }), status()),
+        ).resolves.toEqual({ action: 'skipped', reason: 'no-pull-request' });
+    });
+
+    it('stands down when the Work is unreadable', async () => {
+        const { service, works } = build();
+        works.findById.mockResolvedValue(null);
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'skipped',
+            reason: 'no-work',
+        });
+    });
+
+    it('never merges and never raises when the verifier is unbound', async () => {
+        const works = {
+            findById: jest.fn().mockResolvedValue({
+                id: 'work-1',
+                getRepoOwner: () => 'acme',
+                getDataRepo: () => 'site-data',
+            }),
+        };
+        const mergePolicy = {
+            resolve: jest
+                .fn()
+                .mockResolvedValue({ policy: NEEDS_APPROVAL, source: 'work', chain: [] }),
+        };
+        const taskWorkspace = { attemptMergeForOpenPullRequest: jest.fn() };
+        const service = new TaskMergeGateService(
+            works as never,
+            mergePolicy as never,
+            taskWorkspace as never,
+        );
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'skipped',
+            reason: 'no-approval-verifier',
+        });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    // ── it can never break the sweep that calls it ────────────────────
+
+    it('swallows a thrown collaborator — a status refresh must not fail on the gate', async () => {
+        const { service, mergePolicy } = build();
+        mergePolicy.resolve.mockRejectedValue(new Error('db down'));
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'skipped',
+            reason: 'evaluation-failed',
+        });
+    });
+
+    it('a failed merge attempt is reported, not thrown', async () => {
+        const { service, taskWorkspace } = build({ approved: true });
+        taskWorkspace.attemptMergeForOpenPullRequest.mockResolvedValue({
+            attempted: true,
+            merged: false,
+            refusalCode: 'protected-branch',
+        });
+        await expect(service.onPullRequestStatusRefreshed(task(), status())).resolves.toEqual({
+            action: 'merge-attempted',
+            merge: { attempted: true, merged: false, refusalCode: 'protected-branch' },
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-pr-status.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-pr-status.service.spec.ts
@@ -6,6 +6,7 @@ import type { TaskRepository } from '../../database/repositories/task.repository
 import type { WorkRepository } from '../../database/repositories/work.repository';
 import type { GitFacadeService } from '../../facades/git.facade';
 import type { TaskTransitionService } from '../task-transition.service';
+import type { TaskMergeGateService } from '../task-merge-gate.service';
 
 /**
  * PR insights (kanban run cockpit, plan 04 M5/M6/M7) — the sync + read
@@ -41,6 +42,7 @@ describe('TaskPrStatusService', () => {
         getCompareDiff: jest.Mock;
     };
     let transitions: { transition: jest.Mock };
+    let mergeGate: { onPullRequestStatusRefreshed: jest.Mock };
     let service: TaskPrStatusService;
 
     const makeTask = (overrides: Partial<Task> = {}): Task =>
@@ -66,7 +68,7 @@ describe('TaskPrStatusService', () => {
         state: 'open' as const,
         merged: false,
         mergeable: true,
-        headSha: 'abc',
+        headSha: 'abc1234',
         reviewDecision: null,
         ciState: 'passing' as const,
         checks: [{ name: 'build', status: 'completed' as const, conclusion: 'success' as const }],
@@ -109,11 +111,18 @@ describe('TaskPrStatusService', () => {
             }),
         };
         transitions = { transition: jest.fn().mockResolvedValue(undefined) };
+        // Merge approval (self-build slice AE, EW-805) — the post-CI gate.
+        mergeGate = {
+            onPullRequestStatusRefreshed: jest
+                .fn()
+                .mockResolvedValue({ action: 'skipped', reason: 'no-agent' }),
+        };
         service = new TaskPrStatusService(
             tasks as unknown as TaskRepository,
             works as unknown as WorkRepository,
             git as unknown as GitFacadeService,
             transitions as unknown as TaskTransitionService,
+            mergeGate as unknown as TaskMergeGateService,
         );
     });
 
@@ -396,5 +405,94 @@ describe('TaskPrStatusService', () => {
             refreshed: 0,
         });
         expect(tasks.findDuePrStatusSync).not.toHaveBeenCalled();
+    });
+
+    // ── Merge approval (self-build slice AE, EW-805) ─────────────────
+    //
+    // A provider read is the ONLY moment the platform knows whether a
+    // pull request is green, which is why the merge question is re-asked
+    // from here and not from the finalize path that opened the PR.
+
+    describe('post-CI merge gate', () => {
+        it('persists the head commit the provider reported', async () => {
+            tasks.findByIdAndUser.mockResolvedValue(makeTask({ ciCheckedAt: null }));
+            await service.getForTask(USER, 'task-1');
+            expect(tasks.updatePrStatusCache).toHaveBeenCalledWith(
+                'task-1',
+                expect.objectContaining({ prHeadSha: 'abc1234' }),
+            );
+        });
+
+        it('normalises the head SHA and stores null for a value that is not one', async () => {
+            git.getPullRequestStatus.mockResolvedValue({ ...openStatus, headSha: 'main' });
+            tasks.findByIdAndUser.mockResolvedValue(makeTask({ ciCheckedAt: null }));
+            await service.getForTask(USER, 'task-1');
+            expect(tasks.updatePrStatusCache).toHaveBeenCalledWith(
+                'task-1',
+                expect.objectContaining({ prHeadSha: null }),
+            );
+        });
+
+        it('hands the LIVE provider status to the gate, not the Task cache', async () => {
+            const task = makeTask({ ciCheckedAt: null, ciState: 'pending' });
+            tasks.findByIdAndUser.mockResolvedValue(task);
+
+            await service.getForTask(USER, 'task-1');
+
+            expect(mergeGate.onPullRequestStatusRefreshed).toHaveBeenCalledTimes(1);
+            const [seenTask, seenStatus] = mergeGate.onPullRequestStatusRefreshed.mock.calls[0];
+            expect(seenTask.id).toBe('task-1');
+            // `openStatus` is green; the Task row said `pending` on the way
+            // in. Passing the cached value would gate merges on a verdict
+            // that is up to two minutes old.
+            expect(seenStatus.ciState).toBe('passing');
+            expect(seenStatus.headSha).toBe('abc1234');
+        });
+
+        it('runs the gate on the cron sweep too, once per refreshed Task', async () => {
+            tasks.findDuePrStatusSync.mockResolvedValue([
+                makeTask({ id: 'task-1', ciCheckedAt: null }),
+                makeTask({ id: 'task-2', ciCheckedAt: null }),
+            ]);
+            await service.syncDuePrStatuses();
+            expect(mergeGate.onPullRequestStatusRefreshed).toHaveBeenCalledTimes(2);
+        });
+
+        it('does NOT run the gate when the pull request is gone from the provider', async () => {
+            git.getPullRequestStatus.mockResolvedValue(null);
+            tasks.findByIdAndUser.mockResolvedValue(makeTask({ ciCheckedAt: null }));
+            await service.getForTask(USER, 'task-1');
+            expect(mergeGate.onPullRequestStatusRefreshed).not.toHaveBeenCalled();
+        });
+
+        it('does NOT run the gate when the cache is served inside the floor', async () => {
+            tasks.findByIdAndUser.mockResolvedValue(
+                makeTask({ ciCheckedAt: new Date(Date.now() - 5_000) }),
+            );
+            await service.getForTask(USER, 'task-1');
+            expect(mergeGate.onPullRequestStatusRefreshed).not.toHaveBeenCalled();
+        });
+
+        it('a gate that throws never fails the status refresh', async () => {
+            mergeGate.onPullRequestStatusRefreshed.mockRejectedValue(new Error('boom'));
+            tasks.findByIdAndUser.mockResolvedValue(makeTask({ ciCheckedAt: null }));
+            const view = await service.getForTask(USER, 'task-1');
+            // The refresh still happened and still answered.
+            expect(view.ciState).toBe('passing');
+            expect(tasks.updatePrStatusCache).toHaveBeenCalled();
+        });
+
+        it('is entirely absent in a runtime with no gate bound', async () => {
+            const bare = new TaskPrStatusService(
+                tasks as unknown as TaskRepository,
+                works as unknown as WorkRepository,
+                git as unknown as GitFacadeService,
+                transitions as unknown as TaskTransitionService,
+            );
+            tasks.findByIdAndUser.mockResolvedValue(makeTask({ ciCheckedAt: null }));
+            await expect(bare.getForTask(USER, 'task-1')).resolves.toMatchObject({
+                ciState: 'passing',
+            });
+        });
     });
 });

--- a/packages/agent/src/tasks-domain/__tests__/task-review-approval.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-review-approval.service.spec.ts
@@ -1,0 +1,181 @@
+import { TaskReviewApprovalService } from '../task-review-approval.service';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the provider-side human
+ * review recorder.
+ *
+ * The property that matters is WHICH COMMIT gets stamped. An approval
+ * recorded against the branch head at delivery time rather than against
+ * the commit the reviewer opened would silently turn "I read this diff"
+ * into "I read whatever is there now" — the same class of bug the merge
+ * gate's head pin exists to prevent, one layer earlier.
+ */
+describe('TaskReviewApprovalService', () => {
+    const REVIEWED = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+    function build(over: { work?: unknown; task?: unknown; updated?: boolean } = {}) {
+        const tasks = {
+            findByWorkAndPrNumber: jest
+                .fn()
+                .mockResolvedValue('task' in over ? over.task : { id: 'task-1', prNumber: 9 }),
+            recordPullRequestReviewApproval: jest.fn().mockResolvedValue(over.updated ?? true),
+            clearPullRequestReviewApproval: jest.fn().mockResolvedValue(over.updated ?? true),
+        };
+        const works = {
+            findByUser: jest.fn().mockResolvedValue(
+                'work' in over
+                    ? over.work
+                    : [
+                          {
+                              id: 'work-1',
+                              repositoryUrl: 'https://github.com/acme/site-data',
+                              getRepoOwner: () => 'acme',
+                              getDataRepo: () => 'site-data',
+                          },
+                      ],
+            ),
+        };
+        return {
+            service: new TaskReviewApprovalService(tasks as never, works as never),
+            tasks,
+            works,
+        };
+    }
+
+    const INPUT = {
+        userId: 'user-1',
+        owner: 'acme',
+        repo: 'site-data',
+        prNumber: 9,
+        headSha: REVIEWED,
+        reviewerLabel: 'octocat',
+        approvedAt: new Date('2026-09-01T10:00:00Z'),
+    };
+
+    it('stamps the approval onto the Task with the commit the reviewer saw', async () => {
+        const { service, tasks } = build();
+        await expect(service.recordPullRequestApproval(INPUT)).resolves.toBe(true);
+        expect(tasks.recordPullRequestReviewApproval).toHaveBeenCalledWith('task-1', 9, {
+            headSha: REVIEWED,
+            approvedAt: new Date('2026-09-01T10:00:00Z'),
+            approvedBy: 'octocat',
+        });
+    });
+
+    it('normalises the commit id so it matches what the merge gate compares against', async () => {
+        const { service, tasks } = build();
+        await service.recordPullRequestApproval({ ...INPUT, headSha: REVIEWED.toUpperCase() });
+        expect(tasks.recordPullRequestReviewApproval.mock.calls[0][2].headSha).toBe(REVIEWED);
+    });
+
+    it.each([
+        ['nothing', null],
+        ['a branch name', 'main'],
+        ['an abbreviation', 'a1b2c3'],
+    ])('records NOTHING when the review names %s as its commit', async (_label, headSha) => {
+        // An approval that cannot be attached to a commit is an approval of
+        // nothing in particular; guessing the branch head instead is the
+        // exact laundering this guards against.
+        const { service, tasks } = build();
+        await expect(service.recordPullRequestApproval({ ...INPUT, headSha })).resolves.toBe(false);
+        expect(tasks.recordPullRequestReviewApproval).not.toHaveBeenCalled();
+    });
+
+    it('records nothing when the repository maps to no Work', async () => {
+        const { service, tasks } = build({ work: [] });
+        await expect(service.recordPullRequestApproval(INPUT)).resolves.toBe(false);
+        expect(tasks.recordPullRequestReviewApproval).not.toHaveBeenCalled();
+    });
+
+    it('records nothing when the pull request maps to no Task', async () => {
+        const { service, tasks } = build({ task: null });
+        await expect(service.recordPullRequestApproval(INPUT)).resolves.toBe(false);
+        expect(tasks.recordPullRequestReviewApproval).not.toHaveBeenCalled();
+    });
+
+    it('reports false rather than throwing when the write loses its row', async () => {
+        // `findByWorkAndPrNumber` is newest-first, not unique, so the row it
+        // returns may no longer carry this pull request by the time the
+        // update runs; the repository re-asserts `prNumber` in its WHERE.
+        const { service } = build({ updated: false });
+        await expect(service.recordPullRequestApproval(INPUT)).resolves.toBe(false);
+    });
+
+    it('caps an absurdly long reviewer login to the column width', async () => {
+        const { service, tasks } = build();
+        await service.recordPullRequestApproval({ ...INPUT, reviewerLabel: 'x'.repeat(400) });
+        expect(tasks.recordPullRequestReviewApproval.mock.calls[0][2].approvedBy).toHaveLength(128);
+    });
+
+    it('stores a null reviewer rather than an empty string', async () => {
+        const { service, tasks } = build();
+        await service.recordPullRequestApproval({ ...INPUT, reviewerLabel: '   ' });
+        expect(tasks.recordPullRequestReviewApproval.mock.calls[0][2].approvedBy).toBeNull();
+    });
+
+    it('swallows a store fault — a webhook must still answer 200', async () => {
+        const { service, works } = build();
+        works.findByUser.mockRejectedValue(new Error('db down'));
+        await expect(service.recordPullRequestApproval(INPUT)).resolves.toBe(false);
+    });
+
+    // ── the reviewer takes it back ────────────────────────────────────
+    //
+    // The head-SHA binding covers "the code changed under the approval".
+    // It does NOT cover "the reviewer changed their mind about the same
+    // commit", which is exactly the case where a person read the diff
+    // again and decided against it — and nothing else in the tree ever
+    // cleared these three columns, so the merge Inbox kept reporting a
+    // withdrawn sign-off as current human attestation.
+
+    describe('clearPullRequestApproval', () => {
+        const WITHDRAW = {
+            userId: 'user-1',
+            owner: 'acme',
+            repo: 'site-data',
+            prNumber: 9,
+            reviewerLabel: 'octocat',
+        };
+
+        it('clears the record for the reviewer who withdrew it', async () => {
+            const { service, tasks } = build();
+            await expect(service.clearPullRequestApproval(WITHDRAW)).resolves.toBe(true);
+            expect(tasks.clearPullRequestReviewApproval).toHaveBeenCalledWith(
+                'task-1',
+                9,
+                'octocat',
+            );
+        });
+
+        it('clears NOTHING when the delivery names no reviewer', async () => {
+            // Unattributable: it cannot be matched to the stored approver,
+            // and clearing on a nameless delivery would let one malformed
+            // webhook erase the record for good.
+            const { service, tasks } = build();
+            await expect(
+                service.clearPullRequestApproval({ ...WITHDRAW, reviewerLabel: '  ' }),
+            ).resolves.toBe(false);
+            expect(tasks.clearPullRequestReviewApproval).not.toHaveBeenCalled();
+        });
+
+        it('clears nothing when the repository maps to no Work', async () => {
+            const { service, tasks } = build({ work: [] });
+            await expect(service.clearPullRequestApproval(WITHDRAW)).resolves.toBe(false);
+            expect(tasks.clearPullRequestReviewApproval).not.toHaveBeenCalled();
+        });
+
+        it('reports false when the stored approver is somebody else', async () => {
+            // The repository guards on the recorded login, so Bob
+            // requesting changes does not unmake the fact that Alice read
+            // the diff.
+            const { service } = build({ updated: false });
+            await expect(service.clearPullRequestApproval(WITHDRAW)).resolves.toBe(false);
+        });
+
+        it('swallows a store fault — a webhook must still answer 200', async () => {
+            const { service, works } = build();
+            works.findByUser.mockRejectedValue(new Error('db down'));
+            await expect(service.clearPullRequestApproval(WITHDRAW)).resolves.toBe(false);
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-workspace.merge.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-workspace.merge.spec.ts
@@ -70,7 +70,7 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
     };
 
     let works: { findById: jest.Mock };
-    let tasks: { updateById: jest.Mock; findById: jest.Mock };
+    let tasks: { updateById: jest.Mock; findById: jest.Mock; recordMergeRefusal: jest.Mock };
     let runs: { setWorkspaceMeta: jest.Mock };
     let workspaceFacade: { finalize: jest.Mock; simulateMerge: jest.Mock; provision: jest.Mock };
     let gitFacade: {
@@ -120,6 +120,7 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         tasks = {
             updateById: jest.fn().mockResolvedValue(undefined),
             findById: jest.fn().mockResolvedValue(makeTask()),
+            recordMergeRefusal: jest.fn().mockResolvedValue(undefined),
         };
         runs = { setWorkspaceMeta: jest.fn() };
         workspaceFacade = {
@@ -152,13 +153,42 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         );
     };
 
+    /**
+     * CONTRACT REVERSAL (AE review). Every assertion below used to drive
+     * the merge through `finalizeRun` — i.e. from PULL-REQUEST-OPEN time,
+     * milliseconds after `createPullRequest`. Nothing merges from there
+     * any more, under ANY policy, because nothing CAN be judged there: a
+     * branch pushed one second ago has no check runs, so "is this pull
+     * request green?" has no answer yet. An intermediate revision of this
+     * slice kept the old behaviour for operators with
+     * `requireHumanApproval: false`, and it merged pull requests before a
+     * single check had started — while the post-CI gate, on the same
+     * policy, waited for green. Those operators opted out of a PERSON,
+     * not out of CI.
+     *
+     * The merge path itself is unchanged and is still exactly one method;
+     * this helper is the entry point the post-CI gate uses, so the
+     * assertions are about the same code as before.
+     */
+    const openPrTask = (overrides: Record<string, unknown> = {}) =>
+        ({ ...makeTask(), prNumber: 7, prUrl: 'https://x/pull/7', ...overrides }) as never;
+
+    const mergeNow = (
+        over: { task?: unknown; gateStatus?: 'green' | 'red' | null; headSha?: string | null } = {},
+    ) =>
+        build().attemptMergeForOpenPullRequest({
+            task: (over.task ?? openPrTask()) as never,
+            agentId: 'agent-1',
+            gateStatus: over.gateStatus ?? 'green',
+            ...('headSha' in over ? { headSha: over.headSha } : {}),
+        });
+
     // ── 1. The permissive path actually merges ────────────────────────
 
-    it('merges the PR it just opened when the resolved policy allows it', async () => {
-        const result = await build().finalizeRun(finalizeInput());
+    it('merges an open pull request when the resolved policy allows it', async () => {
+        const outcome = await mergeNow();
 
-        expect(result.outcome).toBe('pr-opened');
-        expect(result.merge).toEqual(
+        expect(outcome).toEqual(
             expect.objectContaining({
                 attempted: true,
                 merged: true,
@@ -170,7 +200,7 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
     });
 
     it('constructs the AgentMergeActor from the real run context', async () => {
-        await build().finalizeRun(finalizeInput());
+        await mergeNow();
 
         const [owner, repo, prNumber, mergeOptions, options, actor] =
             gitFacade.mergePullRequest.mock.calls[0];
@@ -181,13 +211,24 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         expect(options).toEqual(
             expect.objectContaining({ userId: 'user-1', providerId: 'github', workId: 'work-1' }),
         );
+        // CONTRACT REVERSAL (merge approval, slice AE). This assertion used
+        // to include `humanApproved: false` — the hardcoded literal this
+        // slice removes. The claim was genuinely wrong: an ASKER cannot
+        // answer "did a human approve this?", and because the literal was
+        // always false, a policy with `requireHumanApproval: true` (the
+        // shipped default) refused every agent merge forever with no way
+        // for anyone to say yes.
+        //
+        // What replaces it is `taskId`: the actor now names WHICH merge
+        // this is, and `GitFacadeService` looks the approval up itself
+        // against the live head commit.
         expect(actor).toEqual({
             agentId: 'agent-1',
             workId: 'work-1',
             organizationId: 'org-1',
             tenantId: 'tenant-1',
             gateStatus: 'green',
-            humanApproved: false,
+            taskId: '123e4567-e89b-12d3-a456-426614174000',
             // The Work's configured base branch, not the repo default —
             // the protected-branch rule is worthless against the wrong one.
             targetBranch: 'release',
@@ -198,12 +239,12 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         mergePolicy.resolve.mockResolvedValue(
             resolution({ ...PERMISSIVE, allowedMergeMethods: ['rebase', 'squash'] }),
         );
-        await build().finalizeRun(finalizeInput());
+        await mergeNow();
         expect(gitFacade.mergePullRequest.mock.calls[0][3]).toEqual({ mergeMethod: 'rebase' });
     });
 
     it('records a landed merge to task chat and the activity log, and flips branchState', async () => {
-        await build().finalizeRun(finalizeInput());
+        await mergeNow();
 
         expect(taskChat.post).toHaveBeenCalledWith(
             'user-1',
@@ -286,12 +327,10 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         async ({ code, reason }) => {
             refuse({ allowed: false, code, reason, source: 'organization' });
 
-            const result = await build().finalizeRun(finalizeInput());
+            const outcome = await mergeNow();
 
-            // The PR still exists — a refusal is not a finalize failure.
-            expect(result.outcome).toBe('pr-opened');
-            expect(result.prNumber).toBe(7);
-            expect(result.merge).toEqual(
+            // The PR still exists — a refusal never throws at the sweep.
+            expect(outcome).toEqual(
                 expect.objectContaining({
                     attempted: true,
                     merged: false,
@@ -323,34 +362,90 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
 
     it('never marks the branch merged on a refusal', async () => {
         refuse({ allowed: false, code: 'gate-not-green', reason: 'red', source: 'work' });
-        await build().finalizeRun(finalizeInput());
+        await mergeNow();
         const states = tasks.updateById.mock.calls.map(
             (call: unknown[]) => (call[1] as { branchState?: string }).branchState,
         );
         expect(states).not.toContain('merged');
-        expect(states).toContain('pr-open');
     });
 
     it('forwards a red gate verdict to the decision point rather than hiding it', async () => {
-        await build().finalizeRun(finalizeInput({ gateStatus: 'red' }));
+        await mergeNow({ gateStatus: 'red' });
         expect(gitFacade.mergePullRequest.mock.calls[0][5]).toEqual(
             expect.objectContaining({ gateStatus: 'red' }),
         );
     });
 
+    // ── 3b. A stable refusal is told to the human ONCE ────────────────
+    //
+    // The attempt sits on the two-minute PR-status sweep now, so a
+    // refusal that is a property of the repository — a protected base
+    // branch, a required CODEOWNERS review — is still true on the next
+    // tick and every tick after it. Reporting each one buried the Task's
+    // chat under ~720 identical messages a day and wrote as many activity
+    // rows: a correct refusal turning into an outage.
+
+    it('reports the same refusal at the same head only once', async () => {
+        refuse({
+            allowed: false,
+            code: 'protected-branch',
+            reason: "Branch 'release' is protected.",
+            source: 'work',
+        });
+        const HEAD = 'a'.repeat(40);
+        const task = openPrTask();
+
+        const first = await mergeNow({ task, headSha: HEAD });
+        const second = await mergeNow({ task, headSha: HEAD });
+
+        // Both attempts really happened — a transient provider fault must
+        // still get retried; it is the REPORT that is deduped.
+        expect(gitFacade.mergePullRequest).toHaveBeenCalledTimes(2);
+        expect(first).toEqual(expect.objectContaining({ refusalCode: 'protected-branch' }));
+        expect(second).toEqual(expect.objectContaining({ refusalCode: 'protected-branch' }));
+        expect(taskChat.post).toHaveBeenCalledTimes(1);
+        expect(activityLog.log).toHaveBeenCalledTimes(1);
+        expect(tasks.recordMergeRefusal).toHaveBeenCalledWith(
+            (task as unknown as { id: string }).id,
+            { sha: HEAD, code: 'protected-branch' },
+        );
+    });
+
+    it('reports again when the head commit moves — a new commit is new news', async () => {
+        refuse({
+            allowed: false,
+            code: 'protected-branch',
+            reason: "Branch 'release' is protected.",
+            source: 'work',
+        });
+        const task = openPrTask();
+        await mergeNow({ task, headSha: 'a'.repeat(40) });
+        await mergeNow({ task, headSha: 'b'.repeat(40) });
+        expect(taskChat.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports again when the SAME head produces a DIFFERENT refusal', async () => {
+        const task = openPrTask();
+        const HEAD = 'a'.repeat(40);
+        refuse({ allowed: false, code: 'protected-branch', reason: 'protected', source: 'work' });
+        await mergeNow({ task, headSha: HEAD });
+        refuse({ allowed: false, code: 'gate-not-green', reason: 'red', source: 'work' });
+        await mergeNow({ task, headSha: HEAD });
+        expect(taskChat.post).toHaveBeenCalledTimes(2);
+    });
+
     // ── 4. Non-policy failures are reported, never thrown ─────────────
 
-    it('reports a provider that declines the merge without failing the finalize', async () => {
+    it('reports a provider that declines the merge without throwing', async () => {
         gitFacade.mergePullRequest.mockResolvedValue({
             merged: false,
             sha: '',
             message: 'Required status check is pending',
         });
 
-        const result = await build().finalizeRun(finalizeInput());
+        const outcome = await mergeNow();
 
-        expect(result.outcome).toBe('pr-opened');
-        expect(result.merge).toEqual(
+        expect(outcome).toEqual(
             expect.objectContaining({
                 attempted: true,
                 merged: false,
@@ -360,21 +455,19 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
         expect(taskChat.post).toHaveBeenCalled();
     });
 
-    it('reports a transport fault without failing the finalize', async () => {
+    it('reports a transport fault without throwing', async () => {
         gitFacade.mergePullRequest.mockRejectedValue(new Error('socket hang up'));
 
-        const result = await build().finalizeRun(finalizeInput());
+        const outcome = await mergeNow();
 
-        expect(result.outcome).toBe('pr-opened');
-        expect(result.merge).toEqual(
+        expect(outcome).toEqual(
             expect.objectContaining({ attempted: true, merged: false, reason: 'socket hang up' }),
         );
     });
 
     it('an activity-log outage never fails a merge that already landed', async () => {
         activityLog.log.mockRejectedValue(new Error('activity table locked'));
-        const result = await build().finalizeRun(finalizeInput());
-        expect(result.merge).toEqual(expect.objectContaining({ merged: true }));
+        await expect(mergeNow()).resolves.toEqual(expect.objectContaining({ merged: true }));
     });
 
     // ── 5. The merge is only ever reached on the PR-opened path ───────
@@ -394,6 +487,112 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
             finalizeInput({ agentCanOpenPullRequests: false }),
         );
         expect(result.outcome).toBe('pushed-no-pr');
+        expect(gitFacade.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    // ── 6. Merge approval (slice AE): the merge moved off PR-open ─────
+    //
+    // The merge is no longer attempted at pull-request-open time under ANY
+    // policy. Under the shipped default (`requireHumanApproval: true`) it
+    // could never have succeeded — the old code passed
+    // `humanApproved: false` — and under either policy it could not even
+    // be judged: the pull request was created milliseconds earlier, so no
+    // CI has run. `TaskMergeGateService` re-asks after the provider
+    // reports.
+
+    const NEEDS_APPROVAL: MergePolicy = { ...PERMISSIVE, requireHumanApproval: true };
+
+    it('defers the merge instead of attempting one when the policy requires an approval', async () => {
+        mergePolicy.resolve.mockResolvedValue(resolution(NEEDS_APPROVAL));
+
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result.outcome).toBe('pr-opened');
+        expect(result.prNumber).toBe(7);
+        expect(result.merge).toEqual({
+            attempted: false,
+            merged: false,
+            awaitingApproval: true,
+            awaitingCi: true,
+            policySource: 'work',
+        });
+        expect(gitFacade.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('says NOTHING to the user when it defers — the human has not been asked yet', async () => {
+        mergePolicy.resolve.mockResolvedValue(resolution(NEEDS_APPROVAL));
+        await build().finalizeRun(finalizeInput());
+        // The old code posted a `human-approval-required` refusal to task
+        // chat on every single agent pull request: the platform announcing
+        // it would not do something nobody had been given the chance to
+        // authorise. The Inbox approval is the message now.
+        expect(taskChat.post).not.toHaveBeenCalled();
+        expect(activityLog.log).not.toHaveBeenCalled();
+    });
+
+    // CONTRACT REVERSAL (AE review). This used to be "still merges
+    // immediately for an operator who turned the approval off", pinning a
+    // merge that fired seconds after `createPullRequest` — before any
+    // check run existed. That operator opted out of a HUMAN, not out of
+    // CI, and the post-CI gate on the identical policy waited for green,
+    // so the two entry points disagreed about what their own policy
+    // meant. They agree now: green first, in both.
+    it('waits for CI even when the operator turned the approval off', async () => {
+        // PERMISSIVE has requireHumanApproval: false.
+        const result = await build().finalizeRun(finalizeInput());
+        expect(result.merge).toEqual({
+            attempted: false,
+            merged: false,
+            awaitingCi: true,
+            policySource: 'work',
+        });
+        expect(gitFacade.mergePullRequest).not.toHaveBeenCalled();
+        // …and stays silent: the gate will merge it on the next sweep.
+        expect(taskChat.post).not.toHaveBeenCalled();
+    });
+
+    // ── 7. The post-CI entry point ────────────────────────────────────
+
+    it('attemptMergeForOpenPullRequest drives the SAME merge path as finalize', async () => {
+        const task = { ...makeTask(), prNumber: 7, prUrl: 'https://x/pull/7' };
+        const outcome = await build().attemptMergeForOpenPullRequest({
+            task: task as never,
+            agentId: 'agent-1',
+            gateStatus: 'green',
+        });
+
+        expect(outcome).toEqual(
+            expect.objectContaining({ attempted: true, merged: true, mergeMethod: 'squash' }),
+        );
+        const [owner, repo, prNumber, , , actor] = gitFacade.mergePullRequest.mock.calls[0];
+        expect([owner, repo, prNumber]).toEqual(['acme', 'site-data', 7]);
+        expect(actor).toEqual(
+            expect.objectContaining({
+                agentId: 'agent-1',
+                taskId: task.id,
+                // The Work's configured base branch, exactly as finalize does.
+                targetBranch: 'release',
+            }),
+        );
+    });
+
+    it('attemptMergeForOpenPullRequest does nothing for a Task with no pull request', async () => {
+        const outcome = await build().attemptMergeForOpenPullRequest({
+            task: makeTask(),
+            agentId: 'agent-1',
+        });
+        expect(outcome).toBeUndefined();
+        expect(gitFacade.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('attemptMergeForOpenPullRequest still obeys allowAgentMerge', async () => {
+        mergePolicy.resolve.mockResolvedValue(resolution(CONSERVATIVE, 'default'));
+        const task = { ...makeTask(), prNumber: 7 };
+        const outcome = await build().attemptMergeForOpenPullRequest({
+            task: task as never,
+            agentId: 'agent-1',
+        });
+        expect(outcome).toEqual({ attempted: false, merged: false, policySource: 'default' });
         expect(gitFacade.mergePullRequest).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -58,6 +58,9 @@ export {
     UserTaskCounterRepository,
 } from '../database/repositories/task-side.repositories';
 export * from './task-review-rejection.service';
+// Merge approval (self-build slice AE, EW-805).
+export * from './task-review-approval.service';
+export * from './task-merge-gate.service';
 // Git activity ingestion (audit item j) — branch/PR → Task resolver.
 export * from './task-git-link.service';
 export {

--- a/packages/agent/src/tasks-domain/task-merge-gate.service.ts
+++ b/packages/agent/src/tasks-domain/task-merge-gate.service.ts
@@ -1,0 +1,210 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { GitPullRequestStatus } from '@ever-works/plugin';
+import { normalizeCommitSha } from '@ever-works/contracts';
+import { Task } from '../entities/task.entity';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { MergePolicyService } from '../policy/merge-policy.service';
+import { MergeApprovalService } from '../agent-approvals/merge-approval.service';
+import { TaskWorkspaceService, type TaskAgentMergeOutcome } from './task-workspace.service';
+
+/** What one post-CI evaluation did, for logs and for the sweep summary. */
+export type TaskMergeGateOutcome =
+    | { action: 'skipped'; reason: string }
+    | { action: 'approval-requested'; proposalId: string }
+    | { action: 'approval-pending' }
+    | { action: 'merge-attempted'; merge: TaskAgentMergeOutcome | undefined };
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the RE-EVALUATION the
+ * merge path never had.
+ *
+ * Before this, the single merge decision fired inside
+ * `openPullRequestForBranch`, seconds after the pull request was created
+ * and therefore before any CI existed to be green. This service asks the
+ * question at the only moment it can be answered: right after
+ * `TaskPrStatusService` has read the provider and knows the pull
+ * request's state, its head commit and its rolled-up CI verdict.
+ *
+ * One method, three outcomes:
+ *
+ *   1. **Not ready** — the PR is not open, CI is not green, the policy
+ *      does not allow agent merges. Nothing happens, nothing is said.
+ *   2. **Ready and an approval is required** — raise the
+ *      `merge_pull_request` proposal for THIS head commit, which lands in
+ *      the human's Inbox with Approve / Reject. Idempotent per head, so a
+ *      sweep every two minutes files one item, not seven hundred a day.
+ *   3. **Ready and the merge may proceed** — either the policy asked for
+ *      no approval, or a human already gave one for this head. Hand off
+ *      to the ONE merge path, which re-verifies everything against the
+ *      provider before it lands anything.
+ *
+ * Case 3 is what makes an approval *do* something. `AgentActionProposal`
+ * has always documented itself as "the durable queue + decision record
+ * only — executing the approved action is a follow-up increment". For
+ * `merge_pull_request`, this is that increment.
+ *
+ * BEST-EFFORT BY CONTRACT. Its caller is a status refresh whose job is to
+ * keep a cache honest; a merge gate that threw would turn a provider
+ * hiccup into a failed PR-status sweep for every Task behind it. Every
+ * path here returns rather than throws.
+ *
+ * Latency, stated because operators will ask: an approval clicked in the
+ * Inbox lands the merge on the NEXT PR-status refresh for that Task —
+ * within about two minutes on the two-minute sweep, or immediately if anyone
+ * loads the Task's PR status with `?refresh=true`. The approval is not a
+ * merge trigger by itself, and that is deliberate: routing the merge
+ * through the CI refresh is what guarantees the "green is re-checked at
+ * merge time" property for every merge, rather than for some of them.
+ */
+@Injectable()
+export class TaskMergeGateService {
+    private readonly logger = new Logger(TaskMergeGateService.name);
+
+    constructor(
+        private readonly works: WorkRepository,
+        private readonly mergePolicy: MergePolicyService,
+        private readonly taskWorkspace: TaskWorkspaceService,
+        // Merge approval verifier + raiser. @Optional() and appended LAST
+        // per the positional-spec arity rule; absent, the gate degrades to
+        // "never raise, never merge", which is the safe direction.
+        @Optional() private readonly mergeApprovals?: MergeApprovalService,
+    ) {}
+
+    /**
+     * Called by `TaskPrStatusService` after every successful provider
+     * read. `status` is that read — live, not the Task's cache.
+     */
+    async onPullRequestStatusRefreshed(
+        task: Task,
+        status: GitPullRequestStatus,
+    ): Promise<TaskMergeGateOutcome> {
+        try {
+            return await this.evaluate(task, status);
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: post-CI merge evaluation failed (PR status still recorded): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { action: 'skipped', reason: 'evaluation-failed' };
+        }
+    }
+
+    private async evaluate(
+        task: Task,
+        status: GitPullRequestStatus,
+    ): Promise<TaskMergeGateOutcome> {
+        if (!task.prNumber || !task.workId) {
+            return { action: 'skipped', reason: 'no-pull-request' };
+        }
+        if (status.state !== 'open') {
+            // Draft, closed or already merged. A draft is deliberately
+            // excluded: an author who has not marked it ready has not
+            // asked anybody to look at it.
+            return { action: 'skipped', reason: `pr-${status.state}` };
+        }
+        if (status.ciState !== 'passing') {
+            return { action: 'skipped', reason: `ci-${status.ciState}` };
+        }
+        // `checksComplete === false` means the provider read could not see
+        // the commit's whole check set, so `ciState` is a roll-up over a
+        // SAMPLE. Raising an approval on it would show a human a green
+        // badge the platform manufactured, and merging on it would land a
+        // pull request whose failing leg nobody ever read. Neither happens.
+        if (status.checksComplete === false) {
+            return { action: 'skipped', reason: 'ci-incomplete' };
+        }
+        const headSha = normalizeCommitSha(status.headSha);
+        if (!headSha) {
+            return { action: 'skipped', reason: 'head-sha-unknown' };
+        }
+
+        const work = await this.works.findById(task.workId);
+        if (!work) return { action: 'skipped', reason: 'no-work' };
+
+        // The Agent that owns this Task's runs. Without one there is no
+        // scope to resolve an Agent-level policy against and nobody to
+        // attribute the merge to, so the gate stands down rather than
+        // guessing.
+        const agentId = task.agentId ?? null;
+        if (!agentId) return { action: 'skipped', reason: 'no-agent' };
+
+        const resolved = await this.mergePolicy.resolve({
+            agentId,
+            workId: work.id,
+            organizationId: work.organizationId ?? null,
+            tenantId: work.tenantId ?? null,
+        });
+
+        if (!resolved.policy.allowAgentMerge) {
+            // Raising an approval the policy could never act on would be
+            // asking a human for permission the platform cannot use.
+            return { action: 'skipped', reason: 'agent-merge-disabled' };
+        }
+
+        if (!resolved.policy.requireHumanApproval) {
+            // The operator opted out of approvals for this scope. Green
+            // provider CI is the trigger; the facade still pins the head
+            // and still applies the branch / method / gate rules.
+            const merge = await this.taskWorkspace.attemptMergeForOpenPullRequest({
+                task,
+                agentId,
+                gateStatus: 'green',
+                headSha,
+            });
+            return { action: 'merge-attempted', merge };
+        }
+
+        if (!this.mergeApprovals) {
+            return { action: 'skipped', reason: 'no-approval-verifier' };
+        }
+
+        const verdict = await this.mergeApprovals.verifyMergeApproval({
+            taskId: task.id,
+            prNumber: task.prNumber,
+            headSha,
+        });
+        if (verdict.approved) {
+            const merge = await this.taskWorkspace.attemptMergeForOpenPullRequest({
+                task,
+                agentId,
+                gateStatus: 'green',
+                headSha,
+            });
+            return { action: 'merge-attempted', merge };
+        }
+
+        // Not approved (yet). Raise the ask — idempotent per head commit,
+        // so a stale approval for an earlier commit correctly produces a
+        // NEW request rather than being silently reused.
+        const request = await this.mergeApprovals.requestMergeApproval({
+            userId: task.userId,
+            taskId: task.id,
+            taskLabel: task.slug ?? task.id,
+            agentId,
+            prNumber: task.prNumber,
+            prUrl: task.prUrl ?? null,
+            headSha,
+            targetBranch:
+                (work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || null,
+            repository: `${work.getRepoOwner()}/${work.getDataRepo()}`,
+            ciState: status.ciState,
+            // Provider-side human review, surfaced to the approver as
+            // context. It is NOT an authorization: a GitHub login is not a
+            // platform identity, and this platform cannot map one to an
+            // entitled Organization member. Shown so the person deciding
+            // knows whether anybody has actually read the diff.
+            reviewApprovedBy:
+                task.prReviewApprovedSha && task.prReviewApprovedSha === headSha
+                    ? (task.prReviewApprovedBy ?? null)
+                    : null,
+        });
+
+        if (request.raised && request.proposal) {
+            return { action: 'approval-requested', proposalId: request.proposal.id };
+        }
+        return request.reason === 'already-open' || request.reason === 'already-decided'
+            ? { action: 'approval-pending' }
+            : { action: 'skipped', reason: request.reason ?? 'not-raised' };
+    }
+}

--- a/packages/agent/src/tasks-domain/task-pr-status.service.ts
+++ b/packages/agent/src/tasks-domain/task-pr-status.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import type { GitDiffResult, GitPullRequestStatus } from '@ever-works/plugin';
 import { DEFAULT_DIFF_MAX_BYTES, DEFAULT_DIFF_MAX_FILES, capChecks } from '@ever-works/plugin';
+import { normalizeCommitSha } from '@ever-works/contracts';
 import { Task, TaskStatus } from '../entities/task.entity';
 import { TaskRepository } from '../database/repositories/task.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { GitFacadeService } from '../facades/git.facade';
 import { TaskTransitionService } from './task-transition.service';
+import { TaskMergeGateService } from './task-merge-gate.service';
 
 /**
  * PR insights (kanban run cockpit, plan 04 M5 + M6 + the merged half of
@@ -37,6 +39,13 @@ import { TaskTransitionService } from './task-transition.service';
  *     status write, so the approver + blocker gates keep holding. A Task
  *     whose approvals are still pending simply stays in review — the
  *     merge is recorded, the transition is not forced.
+ *  6. **This is also where the MERGE question gets re-asked** (merge
+ *     approval, self-build slice AE). A provider read is the only moment
+ *     the platform knows whether a pull request is green, so every
+ *     successful refresh hands the LIVE status to
+ *     `TaskMergeGateService`, which raises the human approval for a green
+ *     pull request and lands an approved one. Best-effort, per rule 4:
+ *     the gate can never fail a status refresh.
  */
 
 /** Minimum seconds between two provider reads for the same Task. */
@@ -96,6 +105,11 @@ export class TaskPrStatusService {
         private readonly works: WorkRepository,
         @Optional() private readonly gitFacade?: GitFacadeService,
         @Optional() private readonly transitions?: TaskTransitionService,
+        // Merge approval (self-build slice AE, EW-805) — the post-CI
+        // re-evaluation of the merge. Appended LAST + @Optional() per the
+        // positional-spec arity rule; absent, this service behaves exactly
+        // as it did before the slice (refresh the cache, land merged PRs).
+        @Optional() private readonly mergeGate?: TaskMergeGateService,
     ) {}
 
     // ── Read paths ────────────────────────────────────────────────────
@@ -292,7 +306,27 @@ export class TaskPrStatusService {
                     .catch(() => undefined);
                 Object.assign(task, { branchState: 'merged' });
             }
-            return Object.assign(task, patch);
+            Object.assign(task, patch);
+
+            // Merge approval (self-build slice AE) — THIS is the moment
+            // the merge question can finally be answered: the provider has
+            // just told us the pull request's state, head commit and CI
+            // verdict. Best-effort by contract (rule 4 above): the gate
+            // never fails a status refresh, and it is deliberately given
+            // the LIVE `status` rather than the Task's cache.
+            if (this.mergeGate) {
+                await this.mergeGate
+                    .onPullRequestStatusRefreshed(task, status)
+                    .catch((error: unknown) => {
+                        this.logger.warn(
+                            `Task ${task.id}: merge gate threw after a PR status refresh: ${
+                                error instanceof Error ? error.message : String(error)
+                            }`,
+                        );
+                        return undefined;
+                    });
+            }
+            return task;
         })().finally(() => {
             this.inFlight.delete(task.id);
         });
@@ -304,11 +338,17 @@ export class TaskPrStatusService {
     private toCachePatch(
         status: GitPullRequestStatus,
         checkedAt: Date,
-    ): Pick<Task, 'prState' | 'ciState' | 'ciCheckedAt' | 'prChecks'> {
+    ): Pick<Task, 'prState' | 'ciState' | 'ciCheckedAt' | 'prChecks' | 'prHeadSha'> {
         return {
             prState: status.state,
             ciState: status.ciState,
             ciCheckedAt: checkedAt,
+            // Merge approval (slice AE): the head the PROVIDER reports.
+            // `recordRemotePush` still refuses to persist the head a run
+            // pushed — the remote owns the branch head — and this is the
+            // same rule from the other side: the only head worth caching
+            // is the one the provider just named.
+            prHeadSha: normalizeCommitSha(status.headSha),
             prChecks: capChecks(status.checks).map((check) => ({
                 name: check.name,
                 status: check.status,

--- a/packages/agent/src/tasks-domain/task-review-approval.service.ts
+++ b/packages/agent/src/tasks-domain/task-review-approval.service.ts
@@ -1,0 +1,174 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { normalizeCommitSha } from '@ever-works/contracts';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { matchWorkByRepo } from '../works/work-repo-match';
+
+/**
+ * Merge approval (self-build slice AE, EW-805) — the missing half of the
+ * provider review signal.
+ *
+ * `TaskReviewRejectionService` records `changes_requested` reviews as
+ * durable feedback for the next run. Approvals had NO path into the
+ * platform at all: `github-pr-review-bridge` handled every
+ * `pull_request_review` delivery by looking for a rejection and returning,
+ * and its own spec pinned that ("ignores an approval — only a rejection
+ * carries feedback for the next run"). That was true of the *feedback
+ * loop*, which is what the spec was about, and it left the platform
+ * unable to answer "has a person looked at this pull request?" — a
+ * question slice AE has to put in front of whoever is about to authorise
+ * a merge.
+ *
+ * WHAT THIS IS NOT: an authorization. A provider login is not a platform
+ * identity — this repo has no GitHub-login → user mapping on the review
+ * path (`github_app_user_links` is consulted only for installation
+ * ownership), so an approval here cannot establish that somebody entitled
+ * to approve for the Task's Organization approved it. It is CONTEXT,
+ * recorded against the commit it was given for and shown to the human who
+ * makes the real decision in the Inbox.
+ *
+ * Bots are dropped, all of them. The classification happens in the bridge
+ * (`classifyReviewer`, which checks the platform's own identity BEFORE the
+ * trusted-bot allow-list); this service only ever sees `human`. An
+ * allow-listed reviewer bot's approval is deliberately worth nothing here:
+ * the loop must never treat its own reviewers as the people who signed off
+ * on its work.
+ *
+ * Best-effort by contract, exactly like the rejection twin: the caller is
+ * a webhook that must answer 200 quickly, and "this PR maps to no Task"
+ * is an ordinary outcome.
+ */
+@Injectable()
+export class TaskReviewApprovalService {
+    private readonly logger = new Logger(TaskReviewApprovalService.name);
+
+    constructor(
+        private readonly tasks: TaskRepository,
+        private readonly works: WorkRepository,
+    ) {}
+
+    /**
+     * A HUMAN approved the agent's pull request on the git provider.
+     *
+     * `headSha` is the review's own `commit_id` — the commit the reviewer
+     * actually looked at, not the branch head now. Storing the branch head
+     * instead would silently launder an approval of an old diff into an
+     * approval of whatever was pushed since.
+     *
+     * Returns true when a Task row was updated.
+     */
+    async recordPullRequestApproval(input: {
+        userId: string;
+        owner: string;
+        repo: string;
+        prNumber: number;
+        /** `review.commit_id` — the commit the human reviewed. */
+        headSha?: string | null;
+        reviewerLabel?: string | null;
+        approvedAt?: Date | null;
+    }): Promise<boolean> {
+        const headSha = normalizeCommitSha(input.headSha);
+        if (!headSha) {
+            // An approval we cannot attach to a commit is an approval of
+            // nothing in particular. Dropped rather than stored against a
+            // head we guessed.
+            this.logger.debug(
+                `PR approval for ${input.owner}/${input.repo}#${input.prNumber} carried no commit id; ignored.`,
+            );
+            return false;
+        }
+        try {
+            const candidates = await this.works.findByUser(input.userId);
+            const work = matchWorkByRepo(candidates ?? [], input.owner, input.repo);
+            if (!work) return false;
+            const task = await this.tasks.findByWorkAndPrNumber(work.id, input.prNumber);
+            if (!task) return false;
+
+            const updated = await this.tasks.recordPullRequestReviewApproval(
+                task.id,
+                input.prNumber,
+                {
+                    headSha,
+                    approvedAt: input.approvedAt ?? new Date(),
+                    approvedBy: (input.reviewerLabel ?? '').trim().slice(0, 128) || null,
+                },
+            );
+            if (updated) {
+                this.logger.log(
+                    `Task ${task.id}: human review approval recorded for ${input.owner}/${input.repo}#${input.prNumber} at ${headSha.slice(0, 12)}.`,
+                );
+            }
+            return updated;
+        } catch (error) {
+            this.logger.warn(
+                `PR approval record failed for ${input.owner}/${input.repo}#${input.prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+
+    /**
+     * The same human took their approval back — a dismissal, or a
+     * `changes_requested` review replacing their own sign-off.
+     *
+     * This exists because the head-SHA binding does NOT cover it. That
+     * binding answers "did the code change under the approval?"; a
+     * reviewer changing their mind about the SAME commit leaves the head
+     * exactly where it was, so without this the record stays and the
+     * merge proposal keeps telling whoever is authorising it that a named
+     * person reviewed this diff after that person explicitly said
+     * otherwise. It is context rather than authorization, which is why
+     * this is a clear and not a refusal — but it is the ONLY signal the
+     * Inbox offers about whether a human read the pull request, so it has
+     * to be true.
+     *
+     * Guarded on the recorded approver's login: only the person whose
+     * attestation is on the row can retract it.
+     *
+     * Returns true when a Task row was cleared.
+     */
+    async clearPullRequestApproval(input: {
+        userId: string;
+        owner: string;
+        repo: string;
+        prNumber: number;
+        /** Provider login of the reviewer withdrawing. */
+        reviewerLabel?: string | null;
+    }): Promise<boolean> {
+        const reviewer = (input.reviewerLabel ?? '').trim();
+        if (!reviewer) {
+            // Unattributable: it cannot be matched to the stored approver,
+            // and clearing every approval on a nameless delivery would let
+            // one malformed webhook erase the record for good.
+            return false;
+        }
+        try {
+            const candidates = await this.works.findByUser(input.userId);
+            const work = matchWorkByRepo(candidates ?? [], input.owner, input.repo);
+            if (!work) return false;
+            const task = await this.tasks.findByWorkAndPrNumber(work.id, input.prNumber);
+            if (!task) return false;
+
+            const cleared = await this.tasks.clearPullRequestReviewApproval(
+                task.id,
+                input.prNumber,
+                reviewer,
+            );
+            if (cleared) {
+                this.logger.log(
+                    `Task ${task.id}: human review approval WITHDRAWN by ${reviewer} for ${input.owner}/${input.repo}#${input.prNumber}.`,
+                );
+            }
+            return cleared;
+        } catch (error) {
+            this.logger.warn(
+                `PR approval withdrawal failed for ${input.owner}/${input.repo}#${input.prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+}

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -9,6 +9,7 @@ import type {
     MergeRefusalCode,
 } from '@ever-works/contracts';
 import {
+    normalizeCommitSha,
     normalizeFleetRunEnvFileRefs,
     normalizeFleetRunEnvGrants,
     normalizeFleetTaskWorkspaceMounts,
@@ -69,6 +70,23 @@ export interface TaskAgentMergeOutcome {
     policySource?: MergePolicySource;
     /** Merge commit SHA when the provider reported one. */
     sha?: string;
+    /**
+     * Merge approval (self-build slice AE): nothing was attempted because
+     * the effective policy requires a human approval, and that decision
+     * cannot exist yet — the pull request was opened seconds ago and CI
+     * has not run. The merge is re-evaluated after CI reports, by
+     * `TaskMergeGateService`. Distinct from `attempted: false` alone,
+     * which means the policy does not allow agent merges at all.
+     */
+    awaitingApproval?: boolean;
+    /**
+     * Merge approval (self-build slice AE): nothing was attempted because
+     * provider CI has not reported yet. Set on EVERY deferral from
+     * pull-request-open time, including for an operator whose policy asks
+     * for no human approval — they opted out of a person, not out of CI,
+     * and a pull request opened one second ago has no checks to be green.
+     */
+    awaitingCi?: boolean;
 }
 
 export interface TaskWorkspaceFinalizeOutcome {
@@ -1316,22 +1334,16 @@ export class TaskWorkspaceService {
                 `${await this.describeMergePolicy(args.agentId, work.id)}.`,
         );
 
-        // Merge-policy matrix (Wave 3, D4) — the agent-merge path. The PR
-        // exists and the gate has already spoken; ask the policy whether
-        // THIS agent may land it. Everything below is best-effort by
-        // contract: an open pull request is the promise this method made,
-        // and no merge outcome may retroactively fail it.
-        const merge = await this.attemptAgentMerge({
+        // Merge approval (slice AE) — the PR exists and the gate has
+        // already spoken, but nothing is merged from here any more. This
+        // only reports WHY the merge is being left to the post-CI gate.
+        // Best-effort by contract: an open pull request is the promise
+        // this method made, and no merge outcome may retroactively fail it.
+        const merge = await this.evaluateMergeAtPullRequestOpen({
             task,
             work,
-            userId,
             agentId: args.agentId,
-            owner,
-            repo,
-            gitOptions,
             prNumber: pr.number,
-            baseRef,
-            gateStatus: args.gateStatus,
         });
 
         return {
@@ -1340,6 +1352,148 @@ export class TaskWorkspaceService {
             prUrl: pr.url,
             ...(merge ? { merge } : {}),
         };
+    }
+
+    /**
+     * Merge approval (self-build slice AE, EW-805) — what happens at
+     * PULL-REQUEST OPEN time, which is now almost always "nothing yet".
+     *
+     * The bug this replaces: `attemptAgentMerge` was called from here,
+     * six lines after `createPullRequest`, and it passed
+     * `humanApproved: false` as a literal. Under the shipped default
+     * (`requireHumanApproval: true`) that produced a guaranteed refusal
+     * on every single agent pull request, recorded as a chat message and
+     * a `task_merge_refused` activity row — the platform telling the user
+     * it would not do a thing it was never going to be able to do. And
+     * the timing was wrong regardless: no CI has run one second after a
+     * branch is pushed, so "is this mergeable?" cannot be answered here
+     * even in principle.
+     *
+     * So NOTHING is merged here, under any policy. The merge question is
+     * asked exactly once, by `TaskMergeGateService`, after the PR-status
+     * sweep has read provider CI:
+     *
+     *  - **Approval required** (the shipped default): the gate raises the
+     *    Inbox approval for a GREEN pull request and merges once a human
+     *    has decided.
+     *  - **Approval NOT required** (an operator who opted out): the gate
+     *    merges on green, with no human in the loop. That operator opted
+     *    out of a PERSON, not out of CI — and an early attempt here could
+     *    only ever be judged against zero check runs, because the branch
+     *    was pushed seconds ago. An intermediate revision of this slice
+     *    did attempt the merge here for that policy; it merged pull
+     *    requests before a single check had started, and disagreed with
+     *    the gate about what "no approval required" means.
+     *
+     * All this method still does is decide whether there is anything to
+     * wait FOR, so the outcome it reports is honest. A policy read that
+     * fails, or one that forbids agent merges, says so and stops.
+     */
+    private async evaluateMergeAtPullRequestOpen(args: {
+        task: Task;
+        work: { id: string; organizationId?: string | null; tenantId?: string | null };
+        agentId: string;
+        prNumber: number;
+    }): Promise<TaskAgentMergeOutcome | undefined> {
+        if (!this.mergePolicy || !this.gitFacade) return undefined;
+
+        let resolved;
+        try {
+            resolved = await this.mergePolicy.resolve({
+                agentId: args.agentId,
+                workId: args.work.id,
+                organizationId: args.work.organizationId ?? null,
+                tenantId: args.work.tenantId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Task ${args.task.id} merge-policy read failed before the merge attempt (no merge attempted): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { attempted: false, merged: false };
+        }
+
+        if (!resolved.policy.allowAgentMerge) {
+            // The conservative default. Nothing attempted, nothing said.
+            return { attempted: false, merged: false, policySource: resolved.source };
+        }
+
+        // Silent by design in both directions: the human has not been
+        // asked yet, and the thing that will ask them (the post-CI gate)
+        // files an Inbox item. A refusal message here would be noise about
+        // a decision nobody has been given the chance to make.
+        this.logger.log(
+            `Task ${args.task.id} PR #${args.prNumber}: merge deferred until provider CI reports` +
+                `${resolved.policy.requireHumanApproval ? ' and a human approves' : ''} ` +
+                `(policy source: ${resolved.source}).`,
+        );
+        return {
+            attempted: false,
+            merged: false,
+            ...(resolved.policy.requireHumanApproval ? { awaitingApproval: true } : {}),
+            awaitingCi: true,
+            policySource: resolved.source,
+        };
+    }
+
+    /**
+     * Merge approval (self-build slice AE) — the POST-CI entry point.
+     *
+     * `TaskMergeGateService` calls this once provider CI has reported
+     * green for a Task's pull request and (when the policy requires it) a
+     * human approval is on record. It resolves the repository coordinates
+     * the same way finalize does and hands off to the one merge path, so
+     * a merge triggered by CI and a merge triggered at finalize are
+     * indistinguishable downstream — same policy, same approval gate,
+     * same head pin, same recording.
+     *
+     * Returns `undefined` when the Task is not in a mergeable shape (no
+     * Work, no pull request, no facade); that is an ordinary outcome for
+     * a sweep, not an error.
+     */
+    async attemptMergeForOpenPullRequest(input: {
+        task: Task;
+        agentId: string;
+        gateStatus?: GateStatus | null;
+        /**
+         * The head commit the caller just read LIVE from the provider.
+         * Used only to key the "have we already told the human about this
+         * refusal?" record — the facade re-reads and pins the head itself,
+         * and never trusts this value.
+         */
+        headSha?: string | null;
+    }): Promise<TaskAgentMergeOutcome | undefined> {
+        const { task } = input;
+        if (!this.gitFacade || !this.mergePolicy) return undefined;
+        if (!task.workId || !task.prNumber) return undefined;
+
+        const work = await this.works.findById(task.workId);
+        if (!work) return undefined;
+
+        const owner = work.getRepoOwner();
+        const repo = work.getDataRepo();
+        const gitOptions = {
+            userId: task.userId,
+            providerId: work.gitProvider,
+            workId: work.id,
+        };
+        const baseRef =
+            (work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || 'main';
+
+        return this.attemptAgentMerge({
+            task,
+            work,
+            userId: task.userId,
+            agentId: input.agentId,
+            owner,
+            repo,
+            gitOptions,
+            prNumber: task.prNumber,
+            baseRef,
+            gateStatus: input.gateStatus ?? null,
+            headSha: input.headSha ?? task.prHeadSha ?? null,
+        });
     }
 
     /**
@@ -1359,11 +1513,24 @@ export class TaskWorkspaceService {
      *    `AgentMergeActor`, and the facade routes it through
      *    `MergePolicyService.canAgentMerge`. Gate status, protected
      *    branches, allowed methods and human approval are evaluated THERE.
-     *    No rule is duplicated here.
-     * 3. **Refusals are recorded, never swallowed.** A refusal posts a task
-     *    chat message naming the stable code, the human reason and the
-     *    governing scope, and writes a `task_merge_refused` activity row.
-     *    A user can always answer "why did the agent not merge this?"
+     *    No rule is duplicated here. Merge approval (slice AE): the actor
+     *    says WHICH merge this is (`taskId` + the PR number); it does not
+     *    and cannot claim that a human approved it. The facade reads the
+     *    live head from the provider, verifies the recorded approval
+     *    against that head, and pins the merge to it.
+     *
+     *    ONE caller reaches this method:
+     *    {@link attemptMergeForOpenPullRequest}, the post-CI gate. Nothing
+     *    merges at pull-request-open time under any policy — see
+     *    {@link evaluateMergeAtPullRequestOpen}.
+     * 3. **Refusals are recorded ONCE, never swallowed.** A refusal posts a
+     *    task chat message naming the stable code, the human reason and
+     *    the governing scope, and writes a `task_merge_refused` activity
+     *    row — the first time it is seen for a given (head commit, code).
+     *    The attempt itself is on a two-minute sweep, so a stable refusal
+     *    like a protected base branch would otherwise report itself ~720
+     *    times a day; the same refusal at a NEW head, or a different
+     *    refusal at the same head, is news and is reported again.
      */
     private async attemptAgentMerge(args: {
         task: Task;
@@ -1376,6 +1543,8 @@ export class TaskWorkspaceService {
         prNumber: number;
         baseRef: string;
         gateStatus: GateStatus | null;
+        /** Head commit the refusal record is keyed by. Never an input to the decision. */
+        headSha?: string | null;
     }): Promise<TaskAgentMergeOutcome | undefined> {
         const { task, work, userId, agentId, owner, repo, prNumber, baseRef } = args;
         if (!this.mergePolicy || !this.gitFacade) return undefined;
@@ -1425,11 +1594,20 @@ export class TaskWorkspaceService {
                     organizationId: work.organizationId ?? null,
                     tenantId: work.tenantId ?? null,
                     gateStatus: args.gateStatus,
-                    // No human-approval record exists for an agent-opened PR
-                    // at finalize time. A policy that requires one therefore
-                    // refuses here BY DESIGN — the approval lives with the
-                    // human who gives it, not with the agent asking.
-                    humanApproved: false,
+                    // Merge approval (self-build slice AE, EW-805): this
+                    // used to be `humanApproved: false`, a literal, with a
+                    // comment explaining that a policy requiring approval
+                    // therefore refused here BY DESIGN — "the approval
+                    // lives with the human who gives it, not with the
+                    // agent asking". That was honest and it was a dead
+                    // end: no surface existed for the human to give one.
+                    //
+                    // The claim is gone entirely. The actor now says WHICH
+                    // merge this is (`taskId` + `prNumber`), and the
+                    // facade looks the approval up itself against the live
+                    // head commit. An asker that could assert its own
+                    // approval would not be a gate.
+                    taskId: task.id,
                     targetBranch: baseRef,
                 },
             );
@@ -1510,8 +1688,24 @@ export class TaskWorkspaceService {
 
     /**
      * The "recorded, not swallowed" half: one task chat message a human can
-     * read plus one activity row a feed can render, for every merge that
-     * was attempted and did not land.
+     * read plus one activity row a feed can render, for a merge that was
+     * attempted and did not land.
+     *
+     * ONE, not one per attempt (merge approval, slice AE). The attempt sits
+     * on the two-minute PR-status sweep now, and a refusal that is a
+     * property of the repository rather than of the moment — a protected
+     * base branch, a required CODEOWNERS review, a merge method the policy
+     * forbids — is still true two minutes later and every two minutes
+     * after that. Reporting it each time buries the Task's chat under
+     * hundreds of identical messages a day and writes as many activity
+     * rows, which is how a correct refusal becomes an outage.
+     *
+     * The dedup key is (head commit, refusal code), read from and written
+     * to the Task row so it holds across the API process and the cron
+     * worker. A new commit is a new situation and is reported again; so is
+     * a DIFFERENT refusal at the same commit. The ATTEMPT is never
+     * suppressed — a provider fault is indistinguishable from a policy
+     * refusal here, and retrying is how a transient one clears.
      */
     private async recordMergeFailure(
         args: {
@@ -1520,6 +1714,7 @@ export class TaskWorkspaceService {
             agentId: string;
             prNumber: number;
             baseRef: string;
+            headSha?: string | null;
         },
         outcome: TaskAgentMergeOutcome,
     ): Promise<TaskAgentMergeOutcome> {
@@ -1533,6 +1728,32 @@ export class TaskWorkspaceService {
                     outcome.policySource ?? 'default'
                 }).`,
         );
+
+        const refusalSha = normalizeCommitSha(args.headSha) ?? null;
+        const refusalCode = outcome.refusalCode ?? 'not-merged';
+        const alreadyTold =
+            (task.mergeRefusedSha ?? null) === refusalSha &&
+            (task.mergeRefusedCode ?? null) === refusalCode;
+        if (alreadyTold) {
+            this.logger.debug(
+                `Task ${task.id}: PR #${prNumber} refusal '${refusalCode}' at ` +
+                    `${refusalSha ?? 'unknown head'} was already reported — not repeating it.`,
+            );
+            return outcome;
+        }
+        // Written BEFORE the message so a crash between the two repeats at
+        // most one message rather than looping forever on the next sweep.
+        try {
+            await this.tasks.recordMergeRefusal(task.id, { sha: refusalSha, code: refusalCode });
+            Object.assign(task, { mergeRefusedSha: refusalSha, mergeRefusedCode: refusalCode });
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: could not record the merge refusal marker (the message is still posted): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+
         await this.postSystemMessage(
             { task, userId, agentId },
             [

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -49,11 +49,14 @@ import { TaskGraphFanoutService } from './task-graph-fanout.service';
 import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
 import { TaskReviewRejectionService } from './task-review-rejection.service';
+import { TaskReviewApprovalService } from './task-review-approval.service';
+import { TaskMergeGateService } from './task-merge-gate.service';
 import { TaskGitLinkService } from './task-git-link.service';
 import { TaskWorkspaceService } from './task-workspace.service';
 import { TaskPrStatusService } from './task-pr-status.service';
 import { FacadesModule } from '../facades/facades.module';
 import { PolicyModule } from '../policy/policy.module';
+import { MergeApprovalModule } from '../agent-approvals/merge-approval.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { AgentsModule } from '../agents/agents.module';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -118,6 +121,10 @@ import { DatabaseModule } from '../database/database.module';
         // Wave 3 D4 — TaskWorkspaceService.finalizeRun records the scope
         // that governs this Work's merges in its PR-opened log line.
         PolicyModule,
+        // Merge approval (self-build slice AE, EW-805) — TaskMergeGate
+        // raises the human approval for a green pull request and verifies
+        // one before it asks for a merge.
+        MergeApprovalModule,
     ],
     providers: [
         TaskRepository,
@@ -153,6 +160,15 @@ import { DatabaseModule } from '../database/database.module';
         // TaskReviewRejectionRepository, which AgentsModule (imported
         // above) owns and exports alongside AgentRunRepository.
         TaskReviewRejectionService,
+        // Merge approval (slice AE) — the approval twin of the rejection
+        // recorder above: a HUMAN provider review approval, stamped with
+        // the commit it was given for. Context for the person who makes
+        // the real (platform-side) merge decision; never an authorization.
+        TaskReviewApprovalService,
+        // Merge approval (slice AE) — the post-CI re-evaluation of the
+        // merge. Consumed by TaskPrStatusService right after every
+        // successful provider read.
+        TaskMergeGateService,
         // Git activity ingestion (audit item j) — read-only branch/PR →
         // Task resolver the GitHub receiver stamps onto push / commit /
         // merge events. Reads TaskRepository + WorkRepository, both
@@ -198,6 +214,8 @@ import { DatabaseModule } from '../database/database.module';
         TaskRunDenormService,
         TaskWorkspaceService,
         TaskReviewRejectionService,
+        TaskReviewApprovalService,
+        TaskMergeGateService,
         TaskGitLinkService,
         TaskPrStatusService,
         TaskGateRunnerService,

--- a/packages/contracts/src/policy/__tests__/index.spec.ts
+++ b/packages/contracts/src/policy/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import * as policy from '../index.js';
 
 /**
- * The barrel declares nothing of its own (five `export *` lines), but it IS the
+ * The barrel declares nothing of its own (six `export *` lines), but it IS the
  * public surface every consumer reaches through `@ever-works/contracts`. A
  * dropped re-export line compiles fine here and only breaks at the call site in
  * another package, so it is pinned explicitly.
@@ -19,7 +19,12 @@ const FUNCTION_EXPORTS = [
 	'matchesAnyToolPattern',
 	'toolPatternCovers',
 	'credentialRefPattern',
-	'isCredentialKey'
+	'isCredentialKey',
+	// Merge approval (self-build slice AE, EW-805) — the subject-key
+	// derivation the merge path and the approval writer must share.
+	'mergeApprovalSubjectKey',
+	'mergeApprovalPullRequestKeyPrefix',
+	'normalizeCommitSha'
 ] as const;
 
 const VALUE_EXPORTS = [
@@ -32,7 +37,9 @@ const VALUE_EXPORTS = [
 	'AGENT_INIT_SCRIPT_MAX_BYTES',
 	'TOOL_NAME_PATTERN',
 	'TOOL_GRANT_PATTERN',
-	'CREDENTIAL_KEY_PATTERN'
+	'CREDENTIAL_KEY_PATTERN',
+	'MERGE_APPROVAL_MAX_AGE_MS',
+	'MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH'
 ] as const;
 
 const REGEXP_EXPORTS = ['TOOL_NAME_PATTERN', 'TOOL_GRANT_PATTERN', 'CREDENTIAL_KEY_PATTERN'] as const;
@@ -50,18 +57,19 @@ describe('policy barrel', () => {
 		expect((policy as Record<string, unknown>)[name]).toBeInstanceOf(RegExp);
 	});
 
-	it('exposes exactly these 17 runtime symbols', () => {
+	it('exposes exactly these 22 runtime symbols', () => {
 		// Regression guard in BOTH directions: a re-export accidentally deleted
 		// from index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — forcing the author back to cover it.
 		expect(Object.keys(policy).sort()).toEqual([...FUNCTION_EXPORTS, ...VALUE_EXPORTS].sort());
-		expect(Object.keys(policy)).toHaveLength(17);
+		expect(Object.keys(policy)).toHaveLength(22);
 	});
 
-	it('names each of the five source modules in the barrel', () => {
+	it('names each of the six source modules in the barrel', () => {
 		// One symbol per `export *` line, so a whole missing line is unmissable.
 		expect(policy.MERGE_METHODS).toBeDefined(); // merge-policy.types.js
 		expect(policy.sanitizeMergePolicyOverride).toBeDefined(); // merge-policy.sanitize.js
+		expect(policy.mergeApprovalSubjectKey).toBeDefined(); // merge-approval.types.js
 		expect(policy.TOOL_GRANT_SCOPE_PRECEDENCE).toBeDefined(); // tool-grant.types.js
 		expect(policy.sanitizeToolGrantOverride).toBeDefined(); // tool-grant.sanitize.js
 		expect(policy.AGENT_INIT_SCRIPT_MAX_BYTES).toBeDefined(); // agent-capabilities.types.js

--- a/packages/contracts/src/policy/__tests__/merge-approval.types.spec.ts
+++ b/packages/contracts/src/policy/__tests__/merge-approval.types.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	MERGE_APPROVAL_MAX_AGE_MS,
+	MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH,
+	mergeApprovalPullRequestKeyPrefix,
+	mergeApprovalSubjectKey,
+	normalizeCommitSha
+} from '../merge-approval.types.js';
+
+/**
+ * The subject key is the entire "an approval cannot be replayed" property
+ * of slice AE, so it is pinned as an exact string, not just "is defined".
+ * If the format ever changes, every approval recorded under the old format
+ * must stop matching — which is safe (refuse) but must be a DELIBERATE
+ * change, and this file is where it gets noticed.
+ */
+describe('mergeApprovalSubjectKey', () => {
+	const SUBJECT = {
+		taskId: '9f1c0d1e-6c1a-4c3a-9f6c-2b6a0a5d1e77',
+		prNumber: 42,
+		headSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+	};
+
+	it('produces the canonical merge:<task>:<pr>:<sha> key', () => {
+		expect(mergeApprovalSubjectKey(SUBJECT)).toBe(
+			'merge:9f1c0d1e-6c1a-4c3a-9f6c-2b6a0a5d1e77:42:a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+		);
+	});
+
+	it('normalises SHA case so a provider that shouts cannot mint a second key', () => {
+		expect(mergeApprovalSubjectKey({ ...SUBJECT, headSha: SUBJECT.headSha.toUpperCase() })).toBe(
+			mergeApprovalSubjectKey(SUBJECT)
+		);
+	});
+
+	it('changes when the head commit changes — this is the force-push guard', () => {
+		const after = mergeApprovalSubjectKey({
+			...SUBJECT,
+			headSha: 'ffffffffffffffffffffffffffffffffffffffff'
+		});
+		expect(after).not.toBe(mergeApprovalSubjectKey(SUBJECT));
+	});
+
+	it('changes when the pull request changes, even at the same head', () => {
+		expect(mergeApprovalSubjectKey({ ...SUBJECT, prNumber: 43 })).not.toBe(mergeApprovalSubjectKey(SUBJECT));
+	});
+
+	it('changes when the Task changes, so a recycled PR number cannot borrow an approval', () => {
+		expect(mergeApprovalSubjectKey({ ...SUBJECT, taskId: 'other-task' })).not.toBe(
+			mergeApprovalSubjectKey(SUBJECT)
+		);
+	});
+
+	it.each([
+		['an empty task id', { ...SUBJECT, taskId: '   ' }],
+		['a zero pull-request number', { ...SUBJECT, prNumber: 0 }],
+		['a negative pull-request number', { ...SUBJECT, prNumber: -1 }],
+		['a fractional pull-request number', { ...SUBJECT, prNumber: 1.5 }],
+		['a missing head sha', { ...SUBJECT, headSha: '' }],
+		['a branch name in place of a head sha', { ...SUBJECT, headSha: 'refs/heads/main' }],
+		['a 6-character abbreviation', { ...SUBJECT, headSha: 'a1b2c3' }]
+	])('throws rather than minting a partial key for %s', (_label, subject) => {
+		expect(() => mergeApprovalSubjectKey(subject)).toThrow();
+	});
+
+	it('refuses a key the column would truncate', () => {
+		expect(() =>
+			mergeApprovalSubjectKey({ ...SUBJECT, taskId: 'x'.repeat(MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH) })
+		).toThrow(/exceeds/);
+	});
+
+	it('fits a realistic uuid subject inside the column width', () => {
+		expect(mergeApprovalSubjectKey(SUBJECT).length).toBeLessThanOrEqual(MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH);
+	});
+});
+
+describe('mergeApprovalPullRequestKeyPrefix', () => {
+	it('is a strict prefix of every subject key for the same pull request', () => {
+		const prefix = mergeApprovalPullRequestKeyPrefix({ taskId: 't-1', prNumber: 7 });
+		const key = mergeApprovalSubjectKey({
+			taskId: 't-1',
+			prNumber: 7,
+			headSha: 'abcdef1234567890abcdef1234567890abcdef12'
+		});
+		expect(key.startsWith(prefix)).toBe(true);
+		expect(prefix).toBe('merge:t-1:7:');
+	});
+
+	it('does not prefix a DIFFERENT pull request whose number starts with the same digits', () => {
+		const prefix = mergeApprovalPullRequestKeyPrefix({ taskId: 't-1', prNumber: 7 });
+		const other = mergeApprovalSubjectKey({
+			taskId: 't-1',
+			prNumber: 70,
+			headSha: 'abcdef1234567890abcdef1234567890abcdef12'
+		});
+		// The trailing ':' is what makes this true — without it `merge:t-1:7`
+		// would LIKE-match PR #70, #71, #700 …
+		expect(other.startsWith(prefix)).toBe(false);
+	});
+});
+
+describe('normalizeCommitSha', () => {
+	it.each([
+		[
+			'a full lower-case sha',
+			'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+			'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+		],
+		['an upper-case sha', 'ABCDEF1234567890ABCDEF1234567890ABCDEF12', 'abcdef1234567890abcdef1234567890abcdef12'],
+		['a padded sha', '  abcdef1234567  ', 'abcdef1234567'],
+		['a sha-256 object id', 'f'.repeat(64), 'f'.repeat(64)]
+	])('accepts %s', (_label, input, expected) => {
+		expect(normalizeCommitSha(input)).toBe(expected);
+	});
+
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an empty string', ''],
+		['a branch name', 'main'],
+		['a ref', 'refs/heads/feature'],
+		['a 6-char abbreviation', 'abcdef'],
+		['a 65-char value', 'a'.repeat(65)],
+		['non-hex characters', 'z1b2c3d4e5f60718293a4b5c6d7e8f9012345678']
+	])('returns null (fail closed) for %s', (_label, input) => {
+		expect(normalizeCommitSha(input as string | null | undefined)).toBeNull();
+	});
+});
+
+describe('MERGE_APPROVAL_MAX_AGE_MS', () => {
+	it('is 24 hours', () => {
+		expect(MERGE_APPROVAL_MAX_AGE_MS).toBe(86_400_000);
+	});
+});

--- a/packages/contracts/src/policy/index.ts
+++ b/packages/contracts/src/policy/index.ts
@@ -1,5 +1,6 @@
 export * from './merge-policy.types.js';
 export * from './merge-policy.sanitize.js';
+export * from './merge-approval.types.js';
 export * from './tool-grant.types.js';
 export * from './tool-grant.sanitize.js';
 export * from './agent-capabilities.types.js';

--- a/packages/contracts/src/policy/merge-approval.types.ts
+++ b/packages/contracts/src/policy/merge-approval.types.ts
@@ -1,0 +1,120 @@
+/**
+ * Merge approval — the RECORD an agent-driven merge consumes in place of
+ * a hardcoded `humanApproved` literal (self-build slice AE, EW-805).
+ *
+ * The merge policy (`merge-policy.types.ts`) says WHETHER a human approval
+ * is required. This file says what one IS, and it is deliberately the
+ * narrowest possible thing: a canonical key naming exactly one pull
+ * request at exactly one head commit, plus the age past which a recorded
+ * decision stops counting.
+ *
+ * The key is the whole safety property. An approval is stored against
+ * `mergeApprovalSubjectKey({ taskId, prNumber, headSha })`, and the merge
+ * path re-derives that key from LIVE provider state at merge time. So a
+ * decision cannot be replayed onto
+ *
+ *   - a different pull request (`prNumber` is in the key),
+ *   - a different Task that happens to share a PR number (`taskId` is too),
+ *   - or the same pull request after a force-push or a new commit
+ *     (`headSha` is, and a rewritten branch has a different head).
+ *
+ * Zero-dependency and pure so the API, the worker and the fleet
+ * reconciler all derive byte-identical keys — two implementations of this
+ * function is how a stale approval becomes a merge.
+ */
+
+/** Namespace prefix so a subject key can never collide with another kind. */
+const SUBJECT_PREFIX = 'merge';
+
+/**
+ * How long a recorded approval stays usable. A human who approved a green
+ * pull request yesterday did not approve today's repository — branch
+ * protection, the base branch and the reviewers have all had a day to
+ * change underneath a decision that names none of them.
+ *
+ * 24h is a deliberate compromise: long enough that "approve now, the CI
+ * queue is backed up" works, short enough that a forgotten approval is not
+ * a standing merge permit. The head-SHA binding is the hard guarantee;
+ * this is the soft one.
+ */
+export const MERGE_APPROVAL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Physical width of `agent_action_proposals.subjectKey`. A key that would
+ * be TRUNCATED by the column is refused rather than stored short — a
+ * truncated head SHA is a prefix match waiting to happen.
+ */
+export const MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH = 200;
+
+/** What one recorded approval is bound to. All three are required. */
+export interface MergeApprovalSubject {
+	/** The Task the pull request belongs to — resolved from platform state. */
+	readonly taskId: string;
+	/** Provider pull-request number. */
+	readonly prNumber: number;
+	/** Head commit the approval was given for. */
+	readonly headSha: string;
+}
+
+/**
+ * Canonical form of a commit SHA, or `null` when the input is not one.
+ *
+ * Providers echo SHAs in mixed case and callers pass through webhooks,
+ * caches and JSON columns, so the comparison is normalised in exactly one
+ * place. Anything that is not a plausible hex object id — an abbreviated
+ * ref, a branch name, an empty string, a SHA with a stray `refs/` prefix —
+ * returns `null`, and every caller treats `null` as "unknown head", which
+ * fails closed. Minimum 7 (git's own abbreviation floor) so an accidental
+ * one-character value can never be accepted; maximum 64 so SHA-256 object
+ * ids keep working when providers move.
+ */
+export function normalizeCommitSha(sha: string | null | undefined): string | null {
+	if (typeof sha !== 'string') return null;
+	const trimmed = sha.trim().toLowerCase();
+	return /^[0-9a-f]{7,64}$/.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * THE key. `merge:<taskId>:<prNumber>:<headSha>`.
+ *
+ * Throws on an unusable subject rather than returning a partial key: a
+ * caller that cannot name the head commit has nothing to look an approval
+ * up by, and silently producing `merge:t:7:null` would match a row written
+ * by the same bug on the other side.
+ */
+export function mergeApprovalSubjectKey(subject: MergeApprovalSubject): string {
+	const taskId = (subject.taskId ?? '').trim();
+	if (!taskId) throw new Error('A merge approval subject needs a taskId.');
+	if (!Number.isInteger(subject.prNumber) || subject.prNumber <= 0) {
+		throw new Error(`A merge approval subject needs a positive pull-request number, got ${subject.prNumber}.`);
+	}
+	const headSha = normalizeCommitSha(subject.headSha);
+	if (!headSha) {
+		throw new Error('A merge approval subject needs a head commit SHA.');
+	}
+	const key = `${SUBJECT_PREFIX}:${taskId}:${subject.prNumber}:${headSha}`;
+	if (key.length > MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH) {
+		throw new Error(
+			`Merge approval subject key exceeds ${MERGE_APPROVAL_SUBJECT_KEY_MAX_LENGTH} characters (${key.length}).`
+		);
+	}
+	return key;
+}
+
+/**
+ * Every key for one pull request, regardless of head — the SQL `LIKE`
+ * prefix (`merge:<taskId>:<prNumber>:`).
+ *
+ * Used only to tell "nobody has approved this pull request" apart from
+ * "somebody approved an EARLIER commit of it", which are the same refusal
+ * with very different wording for the human reading it. It is never a
+ * lookup an approval can be satisfied by.
+ */
+export function mergeApprovalPullRequestKeyPrefix(subject: Pick<MergeApprovalSubject, 'taskId' | 'prNumber'>): string {
+	const taskId = (subject.taskId ?? '').trim();
+	if (!taskId) throw new Error('A merge approval subject needs a taskId.');
+	if (!Number.isInteger(subject.prNumber) || subject.prNumber <= 0) {
+		throw new Error(`A merge approval subject needs a positive pull-request number, got ${subject.prNumber}.`);
+	}
+	return `${SUBJECT_PREFIX}:${taskId}:${subject.prNumber}:`;
+}

--- a/packages/contracts/src/policy/merge-policy.types.ts
+++ b/packages/contracts/src/policy/merge-policy.types.ts
@@ -143,7 +143,31 @@ export type MergeRefusalCode =
 	| 'target-branch-unknown'
 	| 'merge-method-not-allowed'
 	| 'gate-not-green'
-	| 'human-approval-required';
+	| 'human-approval-required'
+	// ── Merge approval (self-build slice AE, EW-805) ──────────────────
+	// `human-approval-required` above is the POLICY refusal: the policy
+	// wants an approval and the merge path could not produce one. The
+	// codes below are the APPROVAL refusals — the merge path looked, and
+	// says precisely what it found instead. They are separate values on
+	// purpose: "nobody approved this" and "somebody approved a commit
+	// that is no longer the head" are the same policy outcome and
+	// completely different things for the human reading the refusal.
+	/** No recorded approval names this pull request at all. */
+	| 'approval-missing'
+	/** An approval exists for this pull request, but for an EARLIER head commit. */
+	| 'approval-stale'
+	/** A matching approval exists but is older than `MERGE_APPROVAL_MAX_AGE_MS`. */
+	| 'approval-expired'
+	/** The recorded decision was not made by a human (guardrail / no decider). */
+	| 'approval-not-human'
+	/** The approver is not entitled to approve for this Task's scope. */
+	| 'approver-not-entitled'
+	/** The pull request is draft/closed/merged at merge time. */
+	| 'pull-request-not-open'
+	/** Provider CI is not green at merge time (it may have been at approval time). */
+	| 'pull-request-not-green'
+	/** The live head commit could not be read, so nothing can be pinned to it. */
+	| 'head-sha-unknown';
 
 /** Outcome of the single decision point (`canAgentMerge`). */
 export interface MergeDecision {

--- a/packages/plugin/src/contracts/__tests__/git-pr-insights-conformance.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/git-pr-insights-conformance.spec.ts
@@ -16,8 +16,13 @@
  *      degrades to "no pill", it does not show an error.
  *   3. `merged` and `state` agree: `state === 'merged'` iff `merged`.
  *   4. The check list is bounded by `MAX_PR_CHECKS`.
- *   5. `ciState` matches `deriveCiState(checks)` — a provider may not
- *      invent its own rollup (one red check is never reported green).
+ *   5. `ciState` never contradicts the checks it returned (a red one you
+ *      can see is never reported green), and equals `deriveCiState` on
+ *      the nose whenever nothing was dropped. It is deliberately NOT
+ *      "equals `deriveCiState(checks)`" — `checks` is a bounded DISPLAY
+ *      sample and `ciState` is the verdict for the whole head commit, so
+ *      a provider that rolled up its own truncated list would satisfy
+ *      that and merge red work (merge approval, slice AE).
  *   6. `getPullRequestDiff` honours `maxFiles` and flags `truncated`.
  *   7. `getPullRequestDiff` honours `maxBytes`: returned patch text never
  *      exceeds the budget, and dropping a patch sets `truncated`.
@@ -148,10 +153,39 @@ export function runGitPrInsightsContractSuite(
 				expect(status!.checks.length).toBeLessThanOrEqual(MAX_PR_CHECKS);
 			});
 
-			it('derives ciState from the checks with the shared rule', async () => {
+			// CONTRACT REVERSAL (merge approval, slice AE). This used to
+			// assert `ciState === deriveCiState(status.checks)` — the
+			// roll-up over the CAPPED display list. That is the wrong
+			// invariant and it actively hid a hole: `checks` is bounded by
+			// MAX_PR_CHECKS while `ciState` is documented as the verdict
+			// for the whole head commit, so a provider with 25 checks
+			// satisfied the old assertion precisely by rolling up the
+			// first 20 and reporting a red pull request green. Slice AE
+			// then made `ciState` an authorization input, which turned a
+			// wrong display value into an unapproved merge.
+			//
+			// The suite cannot see the provider's full set, so it asserts
+			// the two halves it CAN:
+			//   • the sample may never contradict the verdict (a failure
+			//     you can see must be reported as failing), and
+			//   • when nothing was dropped — the sample is short of the
+			//     cap and the provider says the read was complete — the
+			//     verdict must equal the shared rule exactly.
+			it('never reports a verdict its own check sample contradicts', async () => {
 				const subject = await createSubject();
 				if (!subject.getPullRequestStatus) return;
 				const status = await subject.getPullRequestStatus(cfg.owner, cfg.repo, cfg.prNumber, cfg.token);
+				if (deriveCiState(status!.checks) === 'failing') {
+					expect(status!.ciState).toBe('failing');
+				}
+			});
+
+			it('derives ciState with the shared rule when nothing was dropped', async () => {
+				const subject = await createSubject();
+				if (!subject.getPullRequestStatus) return;
+				const status = await subject.getPullRequestStatus(cfg.owner, cfg.repo, cfg.prNumber, cfg.token);
+				const nothingDropped = status!.checks.length < MAX_PR_CHECKS && status!.checksComplete !== false;
+				if (!nothingDropped) return;
 				expect(status!.ciState).toBe(deriveCiState(status!.checks));
 			});
 		});

--- a/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
@@ -146,6 +146,28 @@ export interface MergeOptions {
 	readonly commitTitle?: string;
 	readonly commitMessage?: string;
 	readonly mergeMethod?: 'merge' | 'squash' | 'rebase';
+	/**
+	 * OPTIMISTIC-CONCURRENCY GUARD (merge approval, self-build slice AE).
+	 *
+	 * The commit the caller believes is the pull request's head. When set,
+	 * an implementation MUST ask the provider to refuse the merge if the
+	 * head has moved since — GitHub's `PUT /pulls/{n}/merge` takes exactly
+	 * this as its `sha` parameter and answers 409.
+	 *
+	 * It exists because everything the platform decides about a pull
+	 * request — CI is green, a human approved it, the diff is what was
+	 * reviewed — is a statement about ONE commit, and between the decision
+	 * and the merge call a push can replace it. Re-reading the head and
+	 * then merging without pinning it just narrows the race; pinning
+	 * closes it, because the provider evaluates the guard atomically with
+	 * the merge.
+	 *
+	 * Optional on the contract so providers that cannot express the guard
+	 * still compile. A provider that ignores it silently downgrades the
+	 * guarantee to "recently checked", which is why the agent-side merge
+	 * path ALSO re-reads the head immediately before calling.
+	 */
+	readonly expectedHeadSha?: string;
 }
 
 export interface MergeResult {
@@ -284,9 +306,32 @@ export interface GitPullRequestStatus {
 	readonly mergeable?: boolean | null;
 	readonly headSha?: string | null;
 	readonly reviewDecision?: GitReviewDecision | null;
+	/**
+	 * Roll-up over EVERY check the provider reports for the head commit —
+	 * never over the bounded `checks` sample below.
+	 *
+	 * Merge approval (slice AE) turned this from a display value into an
+	 * authorization input (`GitFacadeService.assertAgentMayMerge` and
+	 * `TaskMergeGateService` both refuse a merge unless it is `passing`),
+	 * so an implementation that rolled up its own truncated display list
+	 * would report a red pull request green. Roll up first, cap second.
+	 */
 	readonly ciState: GitCiState;
 	/** Bounded list — implementations cap it (see `MAX_PR_CHECKS`). */
 	readonly checks: readonly GitPullRequestCheck[];
+	/**
+	 * False when the implementation could NOT read the provider's whole
+	 * check set for this commit (a source it lacks scope for, more checks
+	 * than it is willing to page through), so `ciState` is a roll-up over
+	 * a subset and a failure may be hiding in the part it never saw.
+	 *
+	 * Undefined means "not reported", which older implementations and
+	 * simple doubles will leave as-is; only an explicit `false` is a
+	 * warning. Display surfaces may ignore it — a mostly-right dot is
+	 * still useful — but anything using `ciState` to AUTHORIZE (the merge
+	 * gate) must treat `false` as "not green".
+	 */
+	readonly checksComplete?: boolean;
 	readonly url?: string;
 	readonly title?: string;
 }

--- a/packages/plugin/src/contracts/capabilities/git-provider.pr-insights.ts
+++ b/packages/plugin/src/contracts/capabilities/git-provider.pr-insights.ts
@@ -28,7 +28,16 @@ export const DEFAULT_DIFF_MAX_FILES = 100;
 export const HARD_DIFF_MAX_BYTES = 1024 * 1024;
 export const HARD_DIFF_MAX_FILES = 300;
 
-/** Cap on checks carried on a PR status (the pill lists a handful). */
+/**
+ * Cap on checks carried on a PR status (the pill lists a handful).
+ *
+ * DISPLAY BOUND ONLY. `deriveCiState` must be given the provider's FULL
+ * check list — a roll-up computed over `capChecks(...)` reports a red
+ * pull request green as soon as the failure sits past index 20, and this
+ * repository's own CI runs far more than twenty legs. Slice AE (merge
+ * approval) made `ciState` an authorization input, so getting that
+ * ordering wrong merges red work.
+ */
 export const MAX_PR_CHECKS = 20;
 
 /**

--- a/packages/plugins/github/src/__tests__/github-api.service.merge.spec.ts
+++ b/packages/plugins/github/src/__tests__/github-api.service.merge.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Merge approval (self-build slice AE, EW-805) — the head-SHA pin on
+ * `GitHubApiService.mergePullRequest`.
+ *
+ * The pin is the ONLY thing that closes the window between "we checked
+ * that this pull request is green and approved at commit X" and "we
+ * merged it". Without `sha`, GitHub merges whatever the head is at the
+ * instant the request lands, so a push arriving in that gap is merged in
+ * place of the reviewed diff.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('libsodium-wrappers', () => ({
+	default: {
+		ready: Promise.resolve(),
+		from_base64: vi.fn(),
+		crypto_box_seal: vi.fn(),
+		to_base64: vi.fn()
+	}
+}));
+
+const pullsMergeMock = vi.fn();
+
+vi.mock('octokit', () => {
+	class FakeOctokit {
+		rest = {
+			pulls: { merge: pullsMergeMock },
+			orgs: { checkMembershipForUser: vi.fn() }
+		};
+		constructor(public opts: unknown) {}
+	}
+	class FakeRequestError extends Error {
+		readonly status: number;
+		constructor(message: string, status: number) {
+			super(message);
+			this.status = status;
+		}
+	}
+	return { Octokit: FakeOctokit, RequestError: FakeRequestError };
+});
+
+const { GitHubApiService } = await import('../github-api.service.js');
+
+const OWNER = 'acme';
+const REPO = 'widgets';
+const PR = 7;
+const HEAD = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+describe('GitHubApiService.mergePullRequest — head pin', () => {
+	let service: InstanceType<typeof GitHubApiService>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		pullsMergeMock.mockResolvedValue({
+			data: { sha: 'merge-commit', merged: true, message: 'Pull Request successfully merged' }
+		});
+		service = new GitHubApiService();
+	});
+
+	it('sends `sha` when the caller pins an expected head', async () => {
+		await service.mergePullRequest(OWNER, REPO, PR, { mergeMethod: 'squash', expectedHeadSha: HEAD }, 'tok');
+
+		expect(pullsMergeMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				owner: OWNER,
+				repo: REPO,
+				pull_number: PR,
+				merge_method: 'squash',
+				sha: HEAD
+			})
+		);
+	});
+
+	it('omits `sha` entirely when no head is pinned — never sends undefined', async () => {
+		// `sha: undefined` is not the same as no `sha`: an octokit request
+		// with the key present serialises it, and a provider that reads it
+		// as an empty string would refuse every merge.
+		await service.mergePullRequest(OWNER, REPO, PR, { mergeMethod: 'squash' }, 'tok');
+		expect('sha' in pullsMergeMock.mock.calls[0][0]).toBe(false);
+	});
+
+	it('omits `sha` when there are no merge options at all', async () => {
+		await service.mergePullRequest(OWNER, REPO, PR, undefined, 'tok');
+		expect('sha' in pullsMergeMock.mock.calls[0][0]).toBe(false);
+		expect(pullsMergeMock.mock.calls[0][0].merge_method).toBe('merge');
+	});
+
+	it('surfaces the provider refusal when the head moved (409) rather than retrying', async () => {
+		const { RequestError } = await import('octokit');
+		pullsMergeMock.mockRejectedValue(
+			new (RequestError as unknown as new (m: string, s: number) => Error)(
+				'Head branch was modified. Review and try the merge again.',
+				409
+			)
+		);
+
+		await expect(
+			service.mergePullRequest(OWNER, REPO, PR, { mergeMethod: 'squash', expectedHeadSha: HEAD }, 'tok')
+		).rejects.toThrow(/Head branch was modified/);
+	});
+
+	it('passes the commit title and message through unchanged alongside the pin', async () => {
+		await service.mergePullRequest(
+			OWNER,
+			REPO,
+			PR,
+			{
+				commitTitle: 'Task T-42',
+				commitMessage: 'Automated changes',
+				mergeMethod: 'rebase',
+				expectedHeadSha: HEAD
+			},
+			'tok'
+		);
+		expect(pullsMergeMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				commit_title: 'Task T-42',
+				commit_message: 'Automated changes',
+				merge_method: 'rebase',
+				sha: HEAD
+			})
+		);
+	});
+});

--- a/packages/plugins/github/src/__tests__/github-api.service.pr-insights.spec.ts
+++ b/packages/plugins/github/src/__tests__/github-api.service.pr-insights.spec.ts
@@ -211,6 +211,109 @@ describe('GitHubApiService — getPullRequestStatus', () => {
 		expect(status!.ciState).toBe('failing');
 	});
 
+	// ── ciState is an AUTHORIZATION input (merge approval, slice AE) ──
+	//
+	// `checks` is a display list bounded at MAX_PR_CHECKS. `ciState` is
+	// the verdict for the whole head commit. Rolling the verdict up over
+	// the bounded list — which is what this service did until the AE
+	// review — reports a red pull request green as soon as the failing leg
+	// sorts past index 20, and the merge gate then merges it.
+
+	it('reds the dot when the ONLY failure sits past the display cap', async () => {
+		const runs = Array.from({ length: 24 }, (_unused, i) => ({
+			name: `leg-${i}`,
+			status: 'completed',
+			conclusion: i === 23 ? 'failure' : 'success',
+			details_url: null
+		}));
+		checksListForRefMock.mockResolvedValueOnce({ data: { check_runs: runs } });
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		// The failing leg is NOT in the list a human sees…
+		expect(status!.checks).toHaveLength(20);
+		expect(status!.checks.some((c) => c.conclusion === 'failure')).toBe(false);
+		// …and the verdict still says so.
+		expect(status!.ciState).toBe('failing');
+		expect(status!.checksComplete).toBe(true);
+	});
+
+	it('rolls up commit statuses even though they are appended after the cap', async () => {
+		// External CI publishes commit statuses, which readChecks appends
+		// LAST — so on a busy PR they were always the rows the cap dropped.
+		checksListForRefMock.mockResolvedValueOnce({
+			data: {
+				check_runs: Array.from({ length: 20 }, (_unused, i) => ({
+					name: `leg-${i}`,
+					status: 'completed',
+					conclusion: 'success',
+					details_url: null
+				}))
+			}
+		});
+		listCommitStatusesMock.mockResolvedValueOnce({
+			data: [{ context: 'ci/external', state: 'failure', target_url: null }]
+		});
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		expect(status!.checks).toHaveLength(20);
+		expect(status!.ciState).toBe('failing');
+	});
+
+	it('pages the check runs until GitHub says it has shown them all', async () => {
+		const page = (from: number, conclusion: string) => ({
+			data: {
+				total_count: 150,
+				check_runs: Array.from({ length: 100 }, (_unused, i) => ({
+					name: `leg-${from + i}`,
+					status: 'completed',
+					conclusion,
+					details_url: null
+				})).slice(0, from === 100 ? 50 : 100)
+			}
+		});
+		checksListForRefMock.mockResolvedValueOnce(page(0, 'success')).mockResolvedValueOnce(page(100, 'failure'));
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		expect(checksListForRefMock).toHaveBeenCalledTimes(2);
+		expect(checksListForRefMock.mock.calls[1][0].page).toBe(2);
+		expect(status!.ciState).toBe('failing');
+		expect(status!.checksComplete).toBe(true);
+	});
+
+	it('reports checksComplete:false when more checks exist than it will page through', async () => {
+		checksListForRefMock.mockResolvedValue({
+			data: {
+				total_count: 100_000,
+				check_runs: Array.from({ length: 100 }, (_unused, i) => ({
+					name: `leg-${i}`,
+					status: 'completed',
+					conclusion: 'success',
+					details_url: null
+				}))
+			}
+		});
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		// The sample it did read is all green, so the rollup says passing —
+		// but the read is flagged incomplete, and the merge gate refuses to
+		// authorize on a sample.
+		expect(status!.ciState).toBe('passing');
+		expect(status!.checksComplete).toBe(false);
+	});
+
+	it('reports checksComplete:false when a check source could not be read at all', async () => {
+		checksListForRefMock.mockRejectedValueOnce(new Error('Resource not accessible'));
+		listCommitStatusesMock.mockResolvedValueOnce({
+			data: [{ context: 'ci/external', state: 'success', target_url: null }]
+		});
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		// The board still gets a green dot from what WAS readable…
+		expect(status!.ciState).toBe('passing');
+		// …but nobody may merge on it: the Actions runs were never seen.
+		expect(status!.checksComplete).toBe(false);
+	});
+
+	it('reports checksComplete:true on an ordinary complete read', async () => {
+		const status = await new GitHubApiService().getPullRequestStatus(OWNER, REPO, 41, TOKEN);
+		expect(status!.checksComplete).toBe(true);
+	});
+
 	it('skips the checks reads entirely when the PR has no head sha', async () => {
 		pullsGetMock.mockResolvedValueOnce({
 			data: {

--- a/packages/plugins/github/src/github-api.service.ts
+++ b/packages/plugins/github/src/github-api.service.ts
@@ -68,6 +68,19 @@ const REVIEW_DECISION_MAP: Record<string, GitReviewDecision> = {
 /** Pages of check-runs/statuses to read before giving up (rate budget). */
 const CHECKS_PER_PAGE = 100;
 
+/**
+ * Merge approval (slice AE) — how many pages of check-runs / commit
+ * statuses we will read for ONE commit before admitting we cannot see
+ * them all.
+ *
+ * `ciState` is an authorization input now, so "we read the first page and
+ * called it green" is not an answer. 5 × 100 covers every realistic PR
+ * (this monorepo's own matrix is dozens, not hundreds); past that the
+ * read reports `checksComplete: false` and the merge gate refuses rather
+ * than rolling up a sample.
+ */
+const CHECKS_MAX_PAGES = 5;
+
 /** GitHub file payload → the contract's provider-neutral diff row. */
 function toDiffFile(file: {
 	filename: string;
@@ -631,13 +644,21 @@ export class GitHubApiService {
 	): Promise<MergeResult> {
 		const octokit = this.createOctokit(token, baseUrl);
 
+		// `sha` is GitHub's own optimistic-concurrency guard: the merge is
+		// refused (409 `Head branch was modified`) when the pull request's
+		// head is no longer this commit. The agent merge path pins it to
+		// the head it just verified as green and approved, so a push that
+		// lands in the gap between the check and this call cannot be
+		// merged in place of what was reviewed. Omitted when the caller
+		// does not supply one, which is the pre-existing behaviour.
 		const { data } = await octokit.rest.pulls.merge({
 			owner,
 			repo,
 			pull_number: prNumber,
 			commit_title: options?.commitTitle,
 			commit_message: options?.commitMessage,
-			merge_method: options?.mergeMethod || 'merge'
+			merge_method: options?.mergeMethod || 'merge',
+			...(options?.expectedHeadSha ? { sha: options.expectedHeadSha } : {})
 		});
 
 		return {
@@ -745,7 +766,18 @@ export class GitHubApiService {
 		}
 
 		const headSha: string | null = pr.head?.sha ?? null;
-		const checks = headSha ? await this.readChecks(octokit, owner, repo, headSha) : [];
+		// Merge approval (slice AE): roll up FIRST, cap SECOND. `capped` is
+		// the display sample the pill renders; `checks` is the whole set
+		// the verdict is computed over. Deriving `ciState` from `capped`
+		// (which is what this did until the AE review) reports a red pull
+		// request green the moment the failing leg sorts past index 20 —
+		// and this repository's own CI runs far more than twenty legs,
+		// with external commit statuses appended LAST so they were always
+		// the ones dropped.
+		const read = headSha
+			? await this.readChecks(octokit, owner, repo, headSha)
+			: { checks: [] as GitPullRequestCheck[], complete: true };
+		const checks = read.checks;
 		const capped = capChecks(checks);
 
 		const merged = pr.merged === true || pr.merged_at != null;
@@ -769,8 +801,9 @@ export class GitHubApiService {
 			mergeable: typeof pr.mergeable === 'boolean' ? pr.mergeable : null,
 			headSha,
 			reviewDecision,
-			ciState: deriveCiState(capped),
+			ciState: deriveCiState(checks),
 			checks: capped,
+			checksComplete: read.complete,
 			url: pr.html_url,
 			title: pr.title
 		};
@@ -778,50 +811,91 @@ export class GitHubApiService {
 
 	/**
 	 * Read check-runs AND commit-statuses for one commit and normalise
-	 * both onto the contract vocabulary. Best-effort per source: a token
-	 * missing one scope still gets the other half.
+	 * both onto the contract vocabulary.
+	 *
+	 * Best-effort per source: a token missing one scope still gets the
+	 * other half. But "best-effort" is now REPORTED rather than silently
+	 * absorbed — `complete` is false whenever a source could not be read
+	 * at all, or whenever the commit carries more checks than the page
+	 * budget will fetch. `getPullRequestStatus` passes that straight
+	 * through as `checksComplete`, and the merge gate refuses to treat an
+	 * incomplete roll-up as green (merge approval, slice AE). The board's
+	 * dot is unaffected — a mostly-right pill still beats no pill.
 	 */
 	private async readChecks(
 		octokit: Octokit,
 		owner: string,
 		repo: string,
 		ref: string
-	): Promise<GitPullRequestCheck[]> {
+	): Promise<{ checks: GitPullRequestCheck[]; complete: boolean }> {
 		const out: GitPullRequestCheck[] = [];
+		let complete = true;
 
 		try {
-			const { data } = await octokit.rest.checks.listForRef({
-				owner,
-				repo,
-				ref,
-				per_page: CHECKS_PER_PAGE
-			});
-			for (const run of data.check_runs ?? []) {
-				const check: GitPullRequestCheck = {
-					name: run.name,
-					status: CHECK_STATUS_MAP[run.status] ?? 'unknown',
-					conclusion: run.conclusion ? (CHECK_CONCLUSION_MAP[run.conclusion] ?? null) : null,
-					...(run.details_url ? { detailsUrl: run.details_url } : {})
-				};
-				out.push(check);
+			let page = 1;
+			let seen = 0;
+			for (;;) {
+				const { data } = await octokit.rest.checks.listForRef({
+					owner,
+					repo,
+					ref,
+					per_page: CHECKS_PER_PAGE,
+					page
+				});
+				const runs = data.check_runs ?? [];
+				for (const run of runs) {
+					const check: GitPullRequestCheck = {
+						name: run.name,
+						status: CHECK_STATUS_MAP[run.status] ?? 'unknown',
+						conclusion: run.conclusion ? (CHECK_CONCLUSION_MAP[run.conclusion] ?? null) : null,
+						...(run.details_url ? { detailsUrl: run.details_url } : {})
+					};
+					out.push(check);
+				}
+				seen += runs.length;
+				// `total_count` is GitHub's own count for the ref, so this
+				// is the only honest way to know whether a page-1 read saw
+				// everything. A response without it is taken at face value.
+				const total = typeof data.total_count === 'number' ? data.total_count : seen;
+				if (seen >= total || runs.length === 0) break;
+				if (page >= CHECKS_MAX_PAGES) {
+					complete = false;
+					break;
+				}
+				page += 1;
 			}
 		} catch {
 			// `checks:read` not granted, or a provider without the Checks
-			// API. Fall through to commit statuses.
+			// API. Fall through to commit statuses — but say so: a verdict
+			// rolled up without the Checks API cannot claim to have seen
+			// every Actions run on the commit.
+			complete = false;
 		}
 
 		try {
-			const { data } = await octokit.rest.repos.listCommitStatusesForRef({
-				owner,
-				repo,
-				ref,
-				per_page: CHECKS_PER_PAGE
-			});
 			// Statuses are append-only per context — keep the newest per
 			// context so a fixed re-run doesn't leave a stale red behind.
-			const newestByContext = new Map<string, (typeof data)[number]>();
-			for (const status of data) {
-				if (!newestByContext.has(status.context)) newestByContext.set(status.context, status);
+			// GitHub returns them newest-first, so the FIRST row wins.
+			const newestByContext = new Map<string, { context: string; state: string; target_url?: string | null }>();
+			let page = 1;
+			for (;;) {
+				const { data } = await octokit.rest.repos.listCommitStatusesForRef({
+					owner,
+					repo,
+					ref,
+					per_page: CHECKS_PER_PAGE,
+					page
+				});
+				for (const status of data) {
+					if (!newestByContext.has(status.context)) newestByContext.set(status.context, status);
+				}
+				// No total_count on this endpoint: a short page is the end.
+				if (data.length < CHECKS_PER_PAGE) break;
+				if (page >= CHECKS_MAX_PAGES) {
+					complete = false;
+					break;
+				}
+				page += 1;
 			}
 			for (const status of newestByContext.values()) {
 				const settled = status.state !== 'pending';
@@ -833,10 +907,12 @@ export class GitHubApiService {
 				});
 			}
 		} catch {
-			// Same posture — an unreadable source contributes nothing.
+			// Same posture — an unreadable source contributes nothing, and
+			// is reported as a gap rather than as "there was nothing here".
+			complete = false;
 		}
 
-		return out;
+		return { checks: out, complete };
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AE**. Refs **EW-805**, closes finding R19, implements the program's open decision 2 end to end.

**This is the keystone the self-build program was missing.** A Task became a run that opened a pull request, and there it stopped: the platform could never merge, and no human could let it.

### The defect, verified at HEAD before any code was written

The single merge decision fired inside `openPullRequestForBranch`, **27 lines after the pull request was created** and before CI had started, and it passed `humanApproved: false` as a **literal**. The comment said a policy requiring approval refuses there *by design*, because "the approval lives with the human who gives it".

But no human could give it. The proposal action types were `spawn_agent`, `schedule_task`, `send_message`, `budget_override`, `other`, and `merge_pull_request` appeared **nowhere in the tree**. With the shipped default `requireHumanApproval: true`, that refusal was permanent.

A sixth defect turned up beside it: every `pull_request_review` was routed to `recordReviewRejection`, which returns early unless the state is `changes_requested`. **Reviewer approvals never reached the platform at all.**

### What this adds

- A **`merge_pull_request` proposal**, raised when the pull request is green and approved rather than at open time, surfaced as an Inbox approval, and read back by the merge path as the approval it was always asking for.
- An approval keyed `merge:<taskId>:<prNumber>:<headSha>` and checked against the head **the provider reports at merge time**, so a force-push leaves no matching record. That head is then passed to the provider as octokit's `sha`, so **GitHub itself refuses** a merge whose head moved underneath us.
- **`agentActor` is now a required parameter** of `GitFacadeService.mergePullRequest`. This is the important structural change: the gate cannot be skipped by omission, and any future caller fails to compile rather than merging unapproved.
- A **post-CI re-evaluation**, which also closes a hole the readers found: a Task that already had a pull request returned early from `finalizeRemotePush` and never asked again.
- **Live state on every policy.** The provider read used to sit inside the "approval required" branch, so an operator who set `requireHumanApproval: false` got no state check and no CI check at all. They opted out of a human, not out of CI.

### Self-approval is refused at three layers

The risk scorer marks every merge destructive **from the action type, not the payload**; guardrails queue `merge_pull_request` unconditionally; and the verifier requires `decidedVia === 'user'` with a non-null decider, which no guardrail row has. Approvals from the platform's own bot and from allow-listed reviewer bots are dropped when reviews are classified, and `approveAll` excludes merges entirely.

Everything fails closed: no verifier bound, a verifier that throws, a store that throws, a missing `taskId`, an unreadable provider and an unresolvable policy all refuse, each with its own code.

### A P0 was caught before this was opened

`TaskRepository` is not in `_repository-inventory.ts`, so `DatabaseModule` neither provides nor exports it, and `MergeApprovalService` injected it as required. **The API could not boot.**

Nothing caught it. The service's own spec constructs it directly, which proves the logic and says nothing about wiring, and the module specs that would have caught it cannot load in a working checkout because `@ever-works/agent-plugins` has no build output there. The first thing that would have failed was the API refusing to start.

`merge-approval.module.spec.ts` now compiles the module against a **real Nest container** over an in-memory database, deliberately avoiding that plugin chain so it runs everywhere. It was mutation-checked: removing the provider reproduces the exact failure, `Nest can't resolve dependencies of the MergeApprovalService … argument TaskRepository at index [1]`.

### Verified locally

| Check | Result |
| --- | --- |
| `packages/contracts` whole suite | 35 files / 1755 tests, no type errors |
| `packages/agent` policy, approvals, tasks-domain, facades, database, events | 140 suites / 2170 tests |
| `apps/api` migrations + ingest | 544 tests, 0 failures |
| `packages/plugins/github` | 6 files / 131 tests |
| 21 locale files | 3 new keys present in every one, no dotted leaf names |
| `prettier --check` over all 77 changed files | clean |
| conflict markers / NUL bytes | none |

Migration `1789700000000`, with a spec asserting the physical schema.

### Not verified locally, stated plainly

- **Six `apps/api` suites and `facades.module.spec.ts` cannot load here** — `@ever-works/agent-plugins` has no build output in this checkout. They run in CI.
- **Four Playwright specs are touched and only type-check here.** e2e never runs locally, and the stage gate has been red for weeks, so a green develop→stage PR is not e2e coverage either.
- **Real GitHub behaviour is mocked**: that `pulls.merge({sha})` actually 409s on a moved head, and the check-run paging semantics. The head pin is defence in depth behind the platform-side gate, not the only control.
- **Postgres behaviour of the new unique index** — every migration assertion here is SQLite.
- `checksComplete === undefined` is treated as "proceed", which is correct while GitHub is the only provider and is pinned by a deliberate test. It becomes a hole the day a second provider ships. Flagging, not failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
