### PR TITLE
test(e2e): pin the sidebar expanded for the runner-status pill flow (4 of 6 stage failures)

### DIFF
--- a/apps/web/e2e/flow-fleet-runner-pill.spec.ts
+++ b/apps/web/e2e/flow-fleet-runner-pill.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { test, expect, type APIRequestContext, type Browser, type Page } from '@playwright/test';
 import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
 import { loginViaUI } from './helpers/auth';
 
@@ -60,6 +60,34 @@ async function openDashboard(page: Page): Promise<void> {
     await page.goto('/en/works', { waitUntil: 'networkidle' });
 }
 
+/**
+ * A fresh, signed-out context with the sidebar pinned EXPANDED.
+ *
+ * Every assertion in this file about the pill's TEXT depends on it. The
+ * server layout defaults the sidebar to COLLAPSED when the
+ * `sidebar-collapsed` cookie is absent (`layout.tsx`:
+ * `collapsedCookie === undefined ? true : …`), and these tests deliberately
+ * start from an empty `storageState`, so no cookie is present and the
+ * sidebar renders as an icon rail. `RunnerStatusPill.tsx` gates the whole
+ * label block — including `runner-status-count` — on `!isCollapsed`, so the
+ * button is visible while the count element does not exist at all.
+ *
+ * That is exactly how these four tests failed on `stage`: `runner-status-pill`
+ * was visible and `getByTestId('runner-status-count')` reported "element(s)
+ * not found". They had never passed in CI, because e2e does not run on
+ * `pull_request` and never runs locally.
+ *
+ * `flow-a11y-key-flows-axe.spec.ts` pins the same cookie for the same reason.
+ * The origin mirrors `playwright.config.ts`'s own `baseURL` default.
+ */
+const ORIGIN = new URL(process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000').origin;
+
+async function freshExpandedContext(browser: Browser) {
+    const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    await context.addCookies([{ name: 'sidebar-collapsed', value: '0', url: ORIGIN }]);
+    return context;
+}
+
 test.describe('runner-status pill', () => {
     test('GET /api/fleet/runner-status: a fresh account has no runners and advertises the 30s cadence', async ({
         request,
@@ -89,7 +117,7 @@ test.describe('runner-status pill', () => {
         request,
     }) => {
         const u = await registerUserViaAPI(request);
-        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const context = await freshExpandedContext(browser);
         const page = await context.newPage();
         try {
             await loginViaUI(page, { email: u.email, password: u.password });
@@ -112,7 +140,7 @@ test.describe('runner-status pill', () => {
         const u = await registerUserViaAPI(request);
         const node = await enrollNode(request, u.access_token);
 
-        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const context = await freshExpandedContext(browser);
         const page = await context.newPage();
         try {
             await loginViaUI(page, { email: u.email, password: u.password });
@@ -145,7 +173,7 @@ test.describe('runner-status pill', () => {
         const u = await registerUserViaAPI(request);
         const node = await enrollNode(request, u.access_token);
 
-        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const context = await freshExpandedContext(browser);
         const page = await context.newPage();
         try {
             await loginViaUI(page, { email: u.email, password: u.password });
@@ -187,7 +215,7 @@ test.describe('runner-status pill', () => {
         });
         expect(beat.status()).toBe(401);
 
-        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const context = await freshExpandedContext(browser);
         const page = await context.newPage();
         try {
             await loginViaUI(page, { email: u.email, password: u.password });
@@ -222,7 +250,7 @@ test.describe('runner-status pill', () => {
             [first.nodeId, second.nodeId].sort(),
         );
 
-        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const context = await freshExpandedContext(browser);
         const page = await context.newPage();
         try {
             await loginViaUI(page, { email: u.email, password: u.password });


### PR DESCRIPTION
## Summary

Fixes **4 of the 6 remaining e2e failures on `stage`**, and they are failures this program introduced.

Stage run [`33989749596`](https://github.com/ever-works/ever-works/actions/runs/33989749596) is **31 of 33 shards green**. The two red ones are shard 10 — these four tests — and shard 13, which is EW-785 and untouched here. Landing this leaves the gate with a single known-red shard.

### The defect

The four pill tests assert the pill's **text**, and the server layout defaults the sidebar to **collapsed** when the `sidebar-collapsed` cookie is absent:

```ts
// apps/web/src/app/[locale]/(dashboard)/layout.tsx
const sidebarCollapsed = collapsedCookie === undefined ? true : collapsedCookie === '1';
```

These tests deliberately start from an empty `storageState`, so no cookie is present, the sidebar renders as an icon rail, and `RunnerStatusPill.tsx` gates its whole label block — `runner-status-count` included — on `!isCollapsed`.

That is exactly the observed failure: `runner-status-pill` **visible**, `getByTestId('runner-status-count')` **"element(s) not found"**.

### Why nothing caught it

The spec shipped with **slice S (EW-775)** and has never passed in CI. `e2e.yml` runs only on push to `stage` — not on `pull_request` — and e2e never runs locally, so there was no point at which this could have gone red before the promotion.

### The fix

`flow-a11y-key-flows-axe.spec.ts` already pins the same cookie for the same reason, with a comment naming the same line of `layout.tsx`. This follows that pattern rather than inventing one, and routes all five context creations through a single helper so a sixth cannot forget.

**No assertion changes.** What changes is that a precondition the tests always relied on is stated instead of assumed.

### Worth a human decision, separately

**The two defaults disagree.** The server cookie path defaults to **collapsed**; `use-sidebar-persistence.ts` defaults its localStorage value to `false`, i.e. **expanded**. So a first-time visitor gets a collapsed sidebar. That may well be intended, but it is a product choice and not something to change under a test fix, so this PR does not touch it.

### Verified

| Check | Result |
| --- | --- |
| `prettier --check` | clean |
| `tsc --noEmit` for `apps/web` | clean |

### Not verified

**e2e never runs locally**, so this is reasoned from the collapse mechanism and the sibling spec that already solved it, not observed green. The proof will be the next `stage` run. If shard 10 is still red after this lands, the diagnosis was wrong and the trace is the next step — note that the artifact store has been at its storage quota, so no Playwright report has uploaded for several runs (see `CI_RELEASE_GATES.md` §13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
