### PR TITLE
feat(ingest): a red build now resumes the run, once, under a budget (EW-806)

### DIFF
--- a/apps/api/src/ingest/github/github-check-intake.autoresume.integration.spec.ts
+++ b/apps/api/src/ingest/github/github-check-intake.autoresume.integration.spec.ts
@@ -1,0 +1,1297 @@
+/**
+ * `@ever-works/agent-plugins` is a workspace package with no built
+ * `dist` in a bare checkout; CI installs it. Loading the REAL
+ * tasks-domain barrel (which this suite needs — the whole point is to
+ * drive production classes) pulls `facades → agent-plugins`, so the
+ * package is stubbed here rather than the code under test being watered
+ * down. Nothing in this suite touches a plugin.
+ */
+jest.mock(
+    '@ever-works/agent-plugins',
+    () =>
+        new Proxy(
+            {},
+            {
+                get: (_target, property) => (property === '__esModule' ? true : jest.fn()),
+            },
+        ),
+    { virtual: true },
+);
+jest.mock('@ever-works/agent/pr-review', () => ({ PrReviewService: class {} }));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginSettingsService: class {},
+    UserPluginRepository: class {},
+}));
+jest.mock('../../integrations/github-app/github-app-sync.service', () => ({
+    GitHubAppSyncService: class {},
+}));
+
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { ENTITIES } from '@ever-works/agent/database';
+import { AgentRun, User } from '@ever-works/agent/entities';
+import { Task, TaskStatus, Work } from '@ever-works/agent/entities';
+import { TaskCiAutoResumeAttempt } from '@ever-works/agent/entities';
+import { TaskReviewRejection } from '@ever-works/agent/entities';
+import { AgentRunRepository } from '@ever-works/agent/database';
+import {
+    TaskCiAutoResumeAttemptRepository,
+    TaskCiAutoResumeService,
+    TaskGitLinkService,
+    TaskRepository,
+    TaskReviewRejectionRepository,
+    TasksDomainModule,
+} from '@ever-works/agent/tasks-domain';
+import { WorkRepository } from '@ever-works/agent/database';
+import type { RunResumeRequest, RunResumeResult } from '@ever-works/agent/tasks-domain';
+import type { IngestResult } from '@ever-works/agent/ingest';
+import { GITHUB_CHECK_EVENT_KIND, GitHubCheckIntakeService } from './github-check-intake.service';
+import type { GitHubEventsBinding } from './github-pr-review-bridge.service';
+
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the RESUME
+ * STORM test, and the rest of the refusal contract, driven through the
+ * REAL handler over a REAL schema.
+ *
+ * Everything below the webhook body is production code: the real
+ * normalizer, the real `GitHubCheckIntakeService.handle`, the real
+ * `TaskCiAutoResumeService`, the real repositories, and a real
+ * better-sqlite3 database carrying the real UNIQUE index the migration
+ * creates. Exactly two things are stubbed, and neither is a decision:
+ *
+ *  - the ingest spine, replaced by a dedupe-by-`sourceEventId` recorder
+ *    (the spine's own dedupe has its own tests, and this one needs to
+ *    observe which envelopes were offered);
+ *  - the run-steering port, replaced by a recorder that inserts the run
+ *    row a real resume would insert.
+ *
+ * A test that compared a fixture to itself would prove nothing here —
+ * the whole risk of this slice is that thirty deliveries become thirty
+ * model runs, and that is only observable end to end.
+ */
+describe('GitHub check intake → auto-resume (better-sqlite3, real handler)', () => {
+    const OWNER_USER = '11111111-1111-4111-8111-111111111111';
+    const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+    const BINDING: GitHubEventsBinding = {
+        userId: OWNER_USER,
+        webhookSecret: 'sec',
+        matchedBy: 'binding',
+    };
+
+    let dataSource: DataSource;
+    let taskRows: Repository<Task>;
+    let workRows: Repository<Work>;
+    let runRows: Repository<AgentRun>;
+    let attemptRows: Repository<TaskCiAutoResumeAttempt>;
+    let rejectionRows: Repository<TaskReviewRejection>;
+
+    let tasks: TaskRepository;
+    let works: WorkRepository;
+    let runs: AgentRunRepository;
+    let attempts: TaskCiAutoResumeAttemptRepository;
+    let rejections: TaskReviewRejectionRepository;
+
+    /** Every envelope the handler offered the spine, in order. */
+    let ingested: Array<{ userId: string; sourceEventId: string; kind: string }>;
+    /** Dedupe identities the fake spine has already seen. */
+    let seen: Set<string>;
+    /** Every resume the handler asked for. THE number under test. */
+    let resumes: RunResumeRequest[];
+    /** Inbox notices filed. */
+    let notices: Array<{ userId: string; title: string; body: string; taskId?: string | null }>;
+
+    const spine = {
+        ingest: jest.fn(async (userId: string, envelopes: unknown[]): Promise<IngestResult> => {
+            const result: IngestResult = {
+                inserted: 0,
+                duplicates: 0,
+                rejected: 0,
+                filtered: 0,
+            };
+            for (const envelope of envelopes as Array<{
+                sourceEventId: string;
+                kind: string;
+            }>) {
+                const key = `${userId}|${envelope.sourceEventId}`;
+                ingested.push({
+                    userId,
+                    sourceEventId: envelope.sourceEventId,
+                    kind: envelope.kind,
+                });
+                if (seen.has(key)) result.duplicates += 1;
+                else {
+                    seen.add(key);
+                    result.inserted += 1;
+                }
+            }
+            return result;
+        }),
+    };
+
+    const steering = {
+        steer: jest.fn(),
+        resumeRun: jest.fn(async (request: RunResumeRequest): Promise<RunResumeResult> => {
+            resumes.push(request);
+            const source = await runRows.findOneByOrFail({ id: request.runId });
+            const next = await runRows.save(
+                runRows.create({
+                    agentId: source.agentId,
+                    userId: request.userId,
+                    triggerKind: 'task',
+                    taskId: source.taskId,
+                    status: 'queued',
+                }),
+            );
+            return {
+                runId: next.id,
+                resumedFromRunId: request.runId,
+                queued: false,
+                rejectionsReplayed: 0,
+            };
+        }),
+    };
+
+    const inbox = {
+        escalationRaised: jest.fn(),
+        proposalPending: jest.fn(),
+        questionRaised: jest.fn(),
+        notice: jest.fn(
+            async (
+                userId: string,
+                input: { title: string; body: string; taskId?: string | null },
+            ) => {
+                notices.push({ userId, ...input });
+            },
+        ),
+    };
+
+    function buildService(overrides: { autoResume?: TaskCiAutoResumeService } = {}) {
+        const autoResume =
+            overrides.autoResume ??
+            new TaskCiAutoResumeService(
+                tasks,
+                attempts,
+                new TaskGitLinkService(tasks, works),
+                runs,
+                rejections,
+                steering,
+                inbox,
+            );
+        // The dispatcher is only a registration sink here; the delivery is
+        // handed to `handle()` directly, exactly as the dispatcher would.
+        const dispatcher = { registerConsumer: jest.fn() };
+        return new GitHubCheckIntakeService(dispatcher as never, spine as never, autoResume);
+    }
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+        taskRows = dataSource.getRepository(Task);
+        workRows = dataSource.getRepository(Work);
+        runRows = dataSource.getRepository(AgentRun);
+        attemptRows = dataSource.getRepository(TaskCiAutoResumeAttempt);
+        rejectionRows = dataSource.getRepository(TaskReviewRejection);
+        // Foreign keys are ON under better-sqlite3, and `works.userId`
+        // references `users`. `agent_runs.agentId` deliberately carries no
+        // FK (cycle avoidance — see the entity), so no Agent row is needed.
+        await dataSource.getRepository(User).save(
+            dataSource.getRepository(User).create({
+                id: OWNER_USER,
+                username: 'evereq',
+                slug: 'evereq',
+            } as Partial<User>),
+        );
+        tasks = new TaskRepository(taskRows);
+        works = new WorkRepository(workRows);
+        runs = new AgentRunRepository(runRows);
+        attempts = new TaskCiAutoResumeAttemptRepository(attemptRows);
+        rejections = new TaskReviewRejectionRepository(rejectionRows);
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        delete process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS;
+        ingested = [];
+        seen = new Set();
+        resumes = [];
+        notices = [];
+        await attemptRows.clear();
+        await rejectionRows.clear();
+        await runRows.clear();
+        await taskRows.clear();
+        await workRows.clear();
+    });
+
+    // ── fixtures ────────────────────────────────────────────────────
+
+    async function seedWorkTaskAndRun(
+        overrides: {
+            taskStatus?: TaskStatus;
+            runStatus?: string;
+            awaitingInput?: boolean;
+            ciHeadSha?: string | null;
+            ciHeadSeenAt?: Date | null;
+        } = {},
+    ) {
+        const work = await workRows.save(
+            workRows.create({
+                userId: OWNER_USER,
+                name: 'Site',
+                slug: 'site',
+                owner: 'octo',
+                description: 'the fleet self-build target',
+                // A Work owns THREE repositories and the shared matcher
+                // matches all three, but Task worktrees and Task pull
+                // requests are opened in the DATA repo
+                // (`TaskWorkspaceService`), so that is the only one
+                // `tasks.prNumber` is unique within. Declared explicitly
+                // rather than left to the slug defaults so the difference
+                // is visible — and so `refuses a check on the Work's
+                // OTHER repository` has something to be about.
+                sourceRepository: {
+                    relatedRepositories: {
+                        data: { owner: 'octo', repo: 'site' },
+                        work: { owner: 'octo', repo: 'site-main' },
+                        website: { owner: 'octo', repo: 'site-www' },
+                    },
+                },
+            } as Partial<Work>),
+        );
+        const task = await taskRows.save(
+            taskRows.create({
+                userId: OWNER_USER,
+                workId: work.id,
+                slug: 't-42',
+                title: 'Add the login button',
+                status: overrides.taskStatus ?? TaskStatus.IN_REVIEW,
+                createdByType: 'user',
+                createdById: OWNER_USER,
+                requireAllApprovers: true,
+                prNumber: 42,
+                branchRef: 'task/t-42-9f3c1a2b',
+                ciHeadSha: overrides.ciHeadSha ?? null,
+                ciHeadSeenAt: overrides.ciHeadSeenAt ?? null,
+            } as Partial<Task>),
+        );
+        const run = await runRows.save(
+            runRows.create({
+                agentId: AGENT_ID,
+                userId: OWNER_USER,
+                triggerKind: 'task',
+                taskId: task.id,
+                status: overrides.runStatus ?? 'completed',
+                awaitingInput: overrides.awaitingInput ?? false,
+            } as Partial<AgentRun>),
+        );
+        return { work, task, run };
+    }
+
+    const HEAD = 'a'.repeat(40);
+
+    function checkRun(
+        options: {
+            id?: number;
+            name?: string;
+            status?: string;
+            conclusion?: string | null;
+            headSha?: string;
+            /**
+             * What the delivery says the PULL REQUEST's head is right now.
+             * GitHub puts it on every same-repo `pull_requests[]` entry,
+             * and it is what makes a superseded commit detectable without
+             * commit ancestry. Defaults to the check's own head, i.e.
+             * "this check is for the current head".
+             */
+            prHeadSha?: string;
+            completedAt?: string;
+            summary?: string;
+            repoFullName?: string;
+        } = {},
+    ) {
+        const headSha = options.headSha ?? HEAD;
+        return {
+            action: options.status === 'completed' ? 'completed' : 'created',
+            repository: {
+                full_name: options.repoFullName ?? 'octo/site',
+                owner: { login: 'octo' },
+            },
+            sender: { login: 'github-actions[bot]', type: 'Bot' },
+            check_run: {
+                id: options.id ?? 1,
+                name: options.name ?? 'lint-and-test',
+                status: options.status ?? 'completed',
+                conclusion: options.conclusion === undefined ? 'failure' : options.conclusion,
+                head_sha: headSha,
+                html_url: 'https://github.com/octo/site/runs/1',
+                started_at: '2026-09-06T10:00:00Z',
+                completed_at: options.completedAt ?? '2026-09-06T10:05:00Z',
+                app: { slug: 'github-actions' },
+                output: {
+                    title: '1 failing test',
+                    summary: options.summary ?? 'apps/web login.spec.ts › renders — expected true',
+                },
+                check_suite: { id: 9, head_branch: 'task/t-42-9f3c1a2b', head_sha: headSha },
+                pull_requests: [
+                    {
+                        number: 42,
+                        head: { ref: 'task/t-42-9f3c1a2b', sha: options.prHeadSha ?? headSha },
+                    },
+                ],
+            },
+        };
+    }
+
+    // ── THE storm ───────────────────────────────────────────────────
+
+    it('turns a whole push worth of check deliveries — plus redeliveries — into exactly ONE resume', async () => {
+        const { task, run } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        // One push on a 12-job matrix: `created` then `completed` for each
+        // job, four of them red, plus the aggregate suite and workflow
+        // events. Then GitHub redelivers the whole lot.
+        const deliveries: Array<[string, Record<string, unknown>]> = [];
+        for (let job = 1; job <= 12; job += 1) {
+            deliveries.push([
+                'check_run',
+                checkRun({ id: job, name: `job-${job}`, status: 'in_progress', conclusion: null }),
+            ]);
+            deliveries.push([
+                'check_run',
+                checkRun({
+                    id: job,
+                    name: `job-${job}`,
+                    status: 'completed',
+                    conclusion: job % 3 === 0 ? 'failure' : 'success',
+                }),
+            ]);
+        }
+        deliveries.push([
+            'check_suite',
+            {
+                action: 'completed',
+                repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+                sender: { login: 'github-actions[bot]', type: 'Bot' },
+                check_suite: {
+                    id: 9,
+                    status: 'completed',
+                    conclusion: 'failure',
+                    head_sha: HEAD,
+                    head_branch: 'task/t-42-9f3c1a2b',
+                    updated_at: '2026-09-06T10:06:00Z',
+                    app: { slug: 'github-actions' },
+                    pull_requests: [{ number: 42 }],
+                },
+            },
+        ]);
+        deliveries.push([
+            'workflow_run',
+            {
+                action: 'completed',
+                repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+                sender: { login: 'github-actions[bot]', type: 'Bot' },
+                workflow_run: {
+                    id: 77,
+                    name: 'CI',
+                    status: 'completed',
+                    conclusion: 'failure',
+                    head_sha: HEAD,
+                    head_branch: 'task/t-42-9f3c1a2b',
+                    run_attempt: 1,
+                    html_url: 'https://github.com/octo/site/actions/runs/77',
+                    updated_at: '2026-09-06T10:07:00Z',
+                    pull_requests: [{ number: 42 }],
+                },
+            },
+        ]);
+
+        const all = [...deliveries, ...deliveries]; // GitHub redelivers everything
+        for (const [eventName, body] of all) {
+            await service.handle(BINDING, eventName, body as never);
+        }
+
+        expect(all.length).toBe(52);
+        // CONTRACT CHANGE, deliberate: this used to assert that all 52
+        // deliveries were offered to the spine. The 24 `in_progress`
+        // announcements are now dropped at the edge — each ingested
+        // envelope costs a REQUIRED activity_log write plus a paid
+        // embedding wherever a memory provider is configured, and a check
+        // that has not completed carries no verdict anything reads. What
+        // survives is every COMPLETED result (12 jobs x 2 deliveries) plus
+        // the suite and workflow aggregates x 2, which is the whole of the
+        // ingest half anyone can act on.
+        expect(ingested).toHaveLength(28);
+        expect(ingested.every((row) => row.kind === GITHUB_CHECK_EVENT_KIND)).toBe(true);
+        // … and exactly one of them bought a model run.
+        expect(resumes).toHaveLength(1);
+        expect(resumes[0]).toMatchObject({
+            runId: run.id,
+            userId: OWNER_USER,
+            allowCompleted: true,
+        });
+
+        // The ledger says the same thing, durably.
+        const ledger = await attempts.listForTask(task.id);
+        expect(ledger).toHaveLength(1);
+        expect(ledger[0]).toMatchObject({ trigger: 'ci', claimKey: `ci:${HEAD}`, headSha: HEAD });
+        expect(ledger[0].resumedRunId).toBeTruthy();
+
+        // And the resumed run reads the failure, because a durable
+        // rejection row was written for `resume` to replay.
+        const feedback = await rejectionRows.find({ where: { taskId: task.id } });
+        expect(feedback).toHaveLength(1);
+        expect(feedback[0].source).toBe('gate');
+        expect(feedback[0].feedback).toContain('Continuous integration is RED');
+        expect(feedback[0].feedback).toContain(HEAD);
+    });
+
+    it('never resumes twice for one head even when the failing jobs differ', async () => {
+        await seedWorkTaskAndRun();
+        const service = buildService();
+        for (const name of ['lint', 'typecheck', 'unit', 'e2e']) {
+            await service.handle(
+                BINDING,
+                'check_run',
+                checkRun({ id: name.length, name, summary: `${name} blew up` }) as never,
+            );
+        }
+        expect(resumes).toHaveLength(1);
+    });
+
+    // ── the refusals ────────────────────────────────────────────────
+
+    it('refuses a green result, and a green re-run arriving after a red one', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({ id: 5, conclusion: 'success' }) as never,
+        );
+        expect(resumes).toHaveLength(0);
+        // …but the head WAS recorded, which is what makes staleness work.
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBe(HEAD);
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 6 }) as never);
+        expect(resumes).toHaveLength(1);
+
+        // A re-run of the same job goes green afterwards: not a failure,
+        // so nothing more is spent.
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({ id: 7, conclusion: 'success' }) as never,
+        );
+        expect(resumes).toHaveLength(1);
+    });
+
+    it('refuses a cancelled, neutral or skipped conclusion — a human stopping a job is not a defect', async () => {
+        await seedWorkTaskAndRun();
+        const service = buildService();
+        for (const conclusion of ['cancelled', 'neutral', 'skipped', 'stale']) {
+            await service.handle(BINDING, 'check_run', checkRun({ id: 10, conclusion }) as never);
+        }
+        expect(resumes).toHaveLength(0);
+    });
+
+    it('refuses a stale head — CI catching up on a commit that has been replaced', async () => {
+        const newerHead = 'b'.repeat(40);
+        const { task } = await seedWorkTaskAndRun({
+            ciHeadSha: newerHead,
+            ciHeadSeenAt: new Date('2026-09-06T12:00:00Z'),
+        });
+        const service = buildService();
+
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 3,
+                prHeadSha: newerHead,
+                completedAt: '2026-09-06T10:05:00Z',
+            }) as never,
+        );
+
+        expect(resumes).toHaveLength(0);
+        // …and the dead commit was NOT written back over the live head.
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBe(newerHead);
+        // The envelope is still ingested — the FACT is real, only the
+        // action is refused.
+        expect(ingested).toHaveLength(1);
+        expect(ingested[0].kind).toBe(GITHUB_CHECK_EVENT_KIND);
+    });
+
+    /**
+     * THE head-staleness regression, end to end.
+     *
+     * Ordering two different commits by their provider timestamps is
+     * wrong in the expensive direction: a push's jobs finish at wildly
+     * different times (this repo's CI runs ~15 job instances per push), so
+     * a slow job belonging to the OLD commit routinely completes after the
+     * NEW commit has already reported its first check. Under the timestamp
+     * rule that late result read as `advanced`, rewrote `tasks.ciHeadSha`
+     * BACKWARDS to the dead commit, and spent one of the Task's two
+     * lifetime attempts fixing code nobody has any more — two of those and
+     * the genuine red on the real head files "automatic retries stopped"
+     * instead of fixing anything.
+     */
+    it('refuses an old commit whose slow job finished AFTER the new head was recorded', async () => {
+        const oldHead = 'a'.repeat(40);
+        const newHead = 'b'.repeat(40);
+        const { task } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        // The fast `lint` job on commit A reports green at 10:05.
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 50,
+                name: 'lint',
+                conclusion: 'success',
+                headSha: oldHead,
+                completedAt: '2026-09-06T10:05:00Z',
+            }) as never,
+        );
+        // The agent pushes commit B at 10:10; its first result lands.
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 51,
+                name: 'lint',
+                conclusion: 'success',
+                headSha: newHead,
+                completedAt: '2026-09-06T10:10:00Z',
+            }) as never,
+        );
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBe(newHead);
+
+        // Commit A's e2e shard — started before the push — finally fails
+        // at 10:25, i.e. with a FRESHER timestamp than the new head.
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 52,
+                name: 'e2e',
+                headSha: oldHead,
+                prHeadSha: newHead,
+                completedAt: '2026-09-06T10:25:00Z',
+            }) as never,
+        );
+
+        expect(resumes).toHaveLength(0);
+        expect(await attempts.countForTask(task.id)).toBe(0);
+        // The live head is untouched: nothing rewound it to the dead commit.
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBe(newHead);
+    });
+
+    /**
+     * A Work owns three repositories and `matchWorkByRepo` matches all
+     * three, but `findByWorkAndPrNumber` has no repository dimension — so
+     * pull request #42 in the Work's WEBSITE repo used to resolve to the
+     * Task that opened #42 in the data repo, clobber its `ciHeadSha` with
+     * a commit from the wrong repository, and spend an attempt telling an
+     * agent to fix a repository the failure is not in.
+     */
+    it('refuses a check on the OTHER repositories of the same Work', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        for (const [index, repoFullName] of ['octo/site-www', 'octo/site-main'].entries()) {
+            await service.handle(
+                BINDING,
+                'check_run',
+                checkRun({
+                    id: 60 + index,
+                    headSha: 'f'.repeat(40),
+                    repoFullName,
+                }) as never,
+            );
+        }
+
+        expect(resumes).toHaveLength(0);
+        expect(await attempts.countForTask(task.id)).toBe(0);
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBeNull();
+        // The FACTS are still ingested — they are real CI results for real
+        // repositories, they just belong to no Task of this owner.
+        expect(ingested).toHaveLength(2);
+    });
+
+    /**
+     * The merged -> DONE transition is poll-driven, runs on a two-minute
+     * cron and only fires from `in_progress` / `in_review`, and a pull
+     * request the owner CLOSED without merging is never transitioned at
+     * all. So `TaskStatus` alone does not answer "is there anything left
+     * to push a fix to?" — `prState` / `branchState` do, and they are on
+     * the row the evaluator already holds.
+     */
+    it('refuses a straggler on a merged or closed pull request', async () => {
+        for (const patch of [
+            { prState: 'merged' },
+            { prState: 'closed' },
+            { branchState: 'merged' },
+        ]) {
+            await attemptRows.clear();
+            await runRows.clear();
+            await taskRows.clear();
+            await workRows.clear();
+            resumes = [];
+            const { task } = await seedWorkTaskAndRun({ taskStatus: TaskStatus.BLOCKED });
+            await taskRows.update({ id: task.id }, patch as never);
+            const service = buildService();
+            await service.handle(BINDING, 'check_run', checkRun({ id: 61 }) as never);
+            expect(resumes).toHaveLength(0);
+            expect(await attempts.countForTask(task.id)).toBe(0);
+        }
+    });
+
+    it('accepts a NEWER head and refuses the older one that follows it', async () => {
+        const { task } = await seedWorkTaskAndRun({
+            ciHeadSha: 'c'.repeat(40),
+            ciHeadSeenAt: new Date('2026-09-06T09:00:00Z'),
+        });
+        const service = buildService();
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 11 }) as never);
+        expect(resumes).toHaveLength(1);
+        expect((await tasks.findById(task.id))?.ciHeadSha).toBe(HEAD);
+    });
+
+    it('refuses a done or cancelled Task', async () => {
+        for (const status of [TaskStatus.DONE, TaskStatus.CANCELLED]) {
+            await attemptRows.clear();
+            await runRows.clear();
+            await taskRows.clear();
+            await workRows.clear();
+            resumes = [];
+            await seedWorkTaskAndRun({ taskStatus: status });
+            const service = buildService();
+            await service.handle(BINDING, 'check_run', checkRun({ id: 12 }) as never);
+            expect(resumes).toHaveLength(0);
+        }
+    });
+
+    it('refuses while a run is already queued or running — the fix may be in flight', async () => {
+        await seedWorkTaskAndRun({ runStatus: 'running' });
+        const service = buildService();
+        await service.handle(BINDING, 'check_run', checkRun({ id: 13 }) as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    it('refuses a run parked on a question — that is the owner’s to answer', async () => {
+        await seedWorkTaskAndRun({ awaitingInput: true });
+        const service = buildService();
+        await service.handle(BINDING, 'check_run', checkRun({ id: 14 }) as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    it('refuses a cancelled run', async () => {
+        await seedWorkTaskAndRun({ runStatus: 'cancelled' });
+        const service = buildService();
+        await service.handle(BINDING, 'check_run', checkRun({ id: 15 }) as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    it('refuses a repository that belongs to no Work of this owner', async () => {
+        await seedWorkTaskAndRun();
+        const service = buildService();
+        await service.handle(BINDING, 'check_run', {
+            ...checkRun({ id: 16 }),
+            repository: { full_name: 'someone/else', owner: { login: 'someone' } },
+        } as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    // ── the budget ──────────────────────────────────────────────────
+
+    it('spends exactly the budget across many pushes, then files exactly ONE notice however many events arrive', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        // Three separate pushes, each with its own head and its own
+        // distinct failure. The default budget is two.
+        const heads = ['1'.repeat(40), '2'.repeat(40), '3'.repeat(40)];
+        for (const [index, headSha] of heads.entries()) {
+            await service.handle(
+                BINDING,
+                'check_run',
+                checkRun({
+                    id: 100 + index,
+                    headSha,
+                    summary: `failure number ${index}`,
+                    completedAt: `2026-09-06T1${index}:00:00Z`,
+                }) as never,
+            );
+        }
+
+        expect(resumes).toHaveLength(2);
+        expect(await attempts.countForTask(task.id)).toBe(2);
+        expect(notices).toHaveLength(1);
+        expect(notices[0].title).toContain('automatic retries stopped');
+        expect(notices[0].userId).toBe(OWNER_USER);
+
+        // Twenty more deliveries on the spent budget: still one notice,
+        // and — the part that used to be wrong — not one further write.
+        // "budget spent" is terminal for the rest of the Task's life, but
+        // every delivery re-entered the branch and re-issued a
+        // compare-and-set UPDATE against `tasks` that could never affect a
+        // row: a permanent write path on the busiest table in the schema,
+        // per open Task, across six machines. The marker is on the row the
+        // evaluator already loaded, so the steady state is now a read.
+        const cas = jest.spyOn(tasks, 'casMarkCiAutoResumeNoticed');
+        for (let i = 0; i < 20; i += 1) {
+            await service.handle(
+                BINDING,
+                'check_run',
+                checkRun({
+                    id: 200 + i,
+                    headSha: '4'.repeat(40),
+                    summary: `yet another failure ${i}`,
+                    completedAt: `2026-09-07T00:${String(i).padStart(2, '0')}:00Z`,
+                }) as never,
+            );
+        }
+        expect(resumes).toHaveLength(2);
+        expect(notices).toHaveLength(1);
+        expect(cas).not.toHaveBeenCalled();
+        cas.mockRestore();
+    });
+
+    it('stops on an UNCHANGED failure on a new head — retrying it again is not progress', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const service = buildService();
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 20 }) as never);
+        expect(resumes).toHaveLength(1);
+
+        // Same job, byte-identical output, new commit: the agent pushed
+        // something and the build broke the same way.
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 21,
+                headSha: 'd'.repeat(40),
+                completedAt: '2026-09-06T11:00:00Z',
+            }) as never,
+        );
+
+        expect(resumes).toHaveLength(1);
+        expect(await attempts.countForTask(task.id)).toBe(1);
+        expect(notices).toHaveLength(1);
+        expect(notices[0].body).toContain('came back unchanged');
+
+        // …and the notice told the truth. It says "nothing further will be
+        // retried automatically for this task", and it used to be filed
+        // while the loop happily carried on resuming any DIFFERENT failure
+        // inside the remaining budget — AND it burned the one-shot marker,
+        // so the real budget-spent event later filed nothing at all. The
+        // marker is now the stop flag: a brand-new failure on a brand-new
+        // head buys nothing more, and no second notice appears.
+        expect(notices[0].body).toContain('Nothing further will be retried automatically');
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 22,
+                headSha: '9'.repeat(40),
+                summary: 'a completely different failure',
+                completedAt: '2026-09-06T12:00:00Z',
+            }) as never,
+        );
+        expect(resumes).toHaveLength(1);
+        expect(await attempts.countForTask(task.id)).toBe(1);
+        expect(notices).toHaveLength(1);
+    });
+
+    it('dispatches at most the budget even when every racer read a stale count', async () => {
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = '1';
+        const { task } = await seedWorkTaskAndRun();
+        // Both deliveries observe "0 attempts used" — the shape two API
+        // replicas handling two different pushes in the same instant
+        // produce. The pre-check cannot stop the second; the ledger's own
+        // ordering has to.
+        const racing = new TaskCiAutoResumeAttemptRepository(attemptRows);
+        const realCount = TaskCiAutoResumeAttemptRepository.prototype.countForTask;
+        let reads = 0;
+        jest.spyOn(racing, 'countForTask').mockImplementation(async (id: string) => {
+            reads += 1;
+            // Odd reads are the PRE-claim budget check, and every racer
+            // sees the same stale zero. Even reads are the post-claim
+            // settle, which sees the truth — that is the guard under test.
+            return reads % 2 === 1 ? 0 : realCount.call(racing, id);
+        });
+        const service = buildService({
+            autoResume: new TaskCiAutoResumeService(
+                tasks,
+                racing,
+                new TaskGitLinkService(tasks, works),
+                runs,
+                rejections,
+                steering,
+                inbox,
+            ),
+        });
+
+        for (const [index, headSha] of ['7'.repeat(40), '8'.repeat(40)].entries()) {
+            await service.handle(
+                BINDING,
+                'check_run',
+                checkRun({
+                    id: 300 + index,
+                    headSha,
+                    summary: `race ${index}`,
+                    completedAt: `2026-09-08T0${index}:00:00Z`,
+                }) as never,
+            );
+        }
+
+        // Both CLAIMED — their coordinates genuinely differ, so the unique
+        // index cannot help — but only the first one in the ledger ran.
+        expect(await racing.listForTask(task.id)).toHaveLength(2);
+        expect(resumes).toHaveLength(1);
+        expect(notices).toHaveLength(1);
+    });
+
+    it('STOPS when the budget cannot be read — an uncountable budget is not a budget', async () => {
+        await seedWorkTaskAndRun();
+        const broken = new TaskCiAutoResumeAttemptRepository({} as never);
+        jest.spyOn(broken, 'countForTask').mockRejectedValue(new Error('database is locked'));
+        const claim = jest.spyOn(broken, 'claim');
+        const autoResume = new TaskCiAutoResumeService(
+            tasks,
+            broken,
+            new TaskGitLinkService(tasks, works),
+            runs,
+            rejections,
+            steering,
+            inbox,
+        );
+        const service = buildService({ autoResume });
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 30 }) as never);
+
+        expect(resumes).toHaveLength(0);
+        expect(claim).not.toHaveBeenCalled();
+    });
+
+    it('resumes nothing at all when the budget is configured to zero', async () => {
+        await seedWorkTaskAndRun();
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = '0';
+        const service = buildService();
+        await service.handle(BINDING, 'check_run', checkRun({ id: 31 }) as never);
+        expect(resumes).toHaveLength(0);
+        // …but the result is still ingested and still lands on the board.
+        expect(ingested).toHaveLength(1);
+    });
+
+    it('refuses when the global stop flag is set, and when it cannot be read', async () => {
+        await seedWorkTaskAndRun();
+        for (const killSwitch of [
+            { shouldHaltDispatch: async () => true },
+            {
+                shouldHaltDispatch: async () => {
+                    throw new Error('fleet_kill_switch is unreachable');
+                },
+            },
+        ]) {
+            const autoResume = new TaskCiAutoResumeService(
+                tasks,
+                attempts,
+                new TaskGitLinkService(tasks, works),
+                runs,
+                rejections,
+                steering,
+                inbox,
+                killSwitch,
+            );
+            await buildService({ autoResume }).handle(
+                BINDING,
+                'check_run',
+                checkRun({ id: 32 }) as never,
+            );
+        }
+        expect(resumes).toHaveLength(0);
+    });
+
+    // ── the reviewer half ───────────────────────────────────────────
+
+    it('resumes ONCE on a recorded reviewer rejection, and not again for the same row', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const recorded = await rejections.record({
+            taskId: task.id,
+            source: 'pull-request',
+            feedback: 'This drops the null check on line 40.',
+            reviewerLabel: 'coderabbitai[bot]',
+            reviewerKind: 'bot',
+            severity: 'major',
+            prNumber: 42,
+        });
+        const service = buildService();
+
+        const review = {
+            action: 'submitted',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            pull_request: { number: 42 },
+            review: { id: 1, state: 'changes_requested', body: 'no' },
+        };
+        await service.handle(BINDING, 'pull_request_review', review as never);
+        await service.handle(BINDING, 'pull_request_review', review as never);
+
+        expect(resumes).toHaveLength(1);
+        const ledger = await attempts.listForTask(task.id);
+        expect(ledger).toHaveLength(1);
+        expect(ledger[0]).toMatchObject({
+            trigger: 'review',
+            claimKey: `review:${recorded!.id}`,
+        });
+        // The reviewer half writes NO new rejection — the row already exists.
+        expect(await rejectionRows.count({ where: { taskId: task.id } })).toBe(1);
+    });
+
+    it('does nothing for a review delivery with no recorded rejection behind it', async () => {
+        await seedWorkTaskAndRun();
+        const service = buildService();
+        await service.handle(BINDING, 'pull_request_review', {
+            action: 'submitted',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            pull_request: { number: 42 },
+            review: { id: 2, state: 'approved' },
+        } as never);
+        await service.handle(BINDING, 'issue_comment', {
+            action: 'created',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+            comment: { id: 3, body: 'nice' },
+        } as never);
+        expect(resumes).toHaveLength(0);
+        expect(ingested).toHaveLength(0);
+    });
+
+    /**
+     * A comment delivery is a DOORBELL: `issue_comment` carries no link to
+     * the row it is meant to answer, so the consumer used to act on
+     * `findPendingForTask(task.id, 1)` — the oldest unconsumed rejection
+     * of ANY source and ANY age. That let any created comment on the pull
+     * request cash in a `gate` row this same service had left pending
+     * after its own dispatch failed, spending the Task's last attempt
+     * replaying a CI failure the owner had already fixed by hand.
+     */
+    it('never lets a comment cash in the fix loop’s OWN pending CI row', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        // Exactly the row a dispatch-failed CI attempt leaves behind.
+        await rejections.record({
+            taskId: task.id,
+            source: 'gate',
+            feedback: 'Continuous integration is RED for octo/site at commit abc.',
+            reviewerLabel: 'lint-and-test',
+            reviewerKind: 'bot',
+            severity: 'critical',
+            prNumber: 42,
+        });
+        const service = buildService();
+
+        await service.handle(BINDING, 'issue_comment', {
+            action: 'created',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+            comment: {
+                id: 9,
+                body: 'thanks, fixed it myself',
+                user: { login: 'evereq', type: 'User' },
+            },
+        } as never);
+
+        expect(resumes).toHaveLength(0);
+        expect(await attempts.countForTask(task.id)).toBe(0);
+    });
+
+    it('never lets a comment cash in a rejection recorded for a DIFFERENT pull request', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        await rejections.record({
+            taskId: task.id,
+            source: 'pull-request',
+            feedback: 'wrong PR entirely',
+            reviewerLabel: 'a-human',
+            prNumber: 7,
+        });
+        const service = buildService();
+        await service.handle(BINDING, 'issue_comment', {
+            action: 'created',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+            comment: { id: 10, body: 'ping', user: { login: 'evereq', type: 'User' } },
+        } as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    it('never lets a MONTHS-OLD abandoned rejection be cashed in by a passing comment', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        const stale = await rejections.record({
+            taskId: task.id,
+            source: 'task-review',
+            feedback: 'recorded in the web UI last quarter and handled by hand',
+            reviewerLabel: 'a-human',
+            prNumber: 42,
+        });
+        await rejectionRows.update({ id: stale!.id }, {
+            createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        } as never);
+        const service = buildService();
+        await service.handle(BINDING, 'issue_comment', {
+            action: 'created',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+            comment: { id: 11, body: 'still here?', user: { login: 'evereq', type: 'User' } },
+        } as never);
+        expect(resumes).toHaveLength(0);
+    });
+
+    /**
+     * The doorbell classified no author, so the platform's OWN status
+     * comment on the pull request — the PR link the fleet posts, a
+     * progress note — was a valid trigger and the loop could wake itself.
+     * The PR-review bridge refuses `self` and `untrusted-bot` before it
+     * records anything; this consumer makes the same judgement.
+     */
+    it('is not rung by the platform’s own bot, or by an untrusted one', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        await rejections.record({
+            taskId: task.id,
+            source: 'pull-request',
+            feedback: 'a genuine human rejection, still pending',
+            reviewerLabel: 'a-human',
+            prNumber: 42,
+        });
+        const service = buildService();
+
+        for (const user of [
+            { login: `${process.env.GITHUB_APP_SLUG ?? 'ever-works'}[bot]`, type: 'Bot' },
+            { login: 'dependabot[bot]', type: 'Bot' },
+        ]) {
+            await service.handle(BINDING, 'issue_comment', {
+                action: 'created',
+                repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+                issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+                comment: { id: 12, body: 'Opened PR #42 for task t-42.', user },
+            } as never);
+        }
+        expect(resumes).toHaveLength(0);
+
+        // …and a human's comment on the same thread still rings it.
+        await service.handle(BINDING, 'issue_comment', {
+            action: 'created',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+            comment: { id: 13, body: 'any update?', user: { login: 'evereq', type: 'User' } },
+        } as never);
+        expect(resumes).toHaveLength(1);
+    });
+
+    /**
+     * `RunSteeringService.resume` replays only the THREE OLDEST
+     * unconsumed rejections, and the CI row this service writes is the
+     * newest. A Task already carrying three unconsumed reviewer findings
+     * therefore spent a full model run seeded with three stale review
+     * comments and was never told CI was red at all — `message` was
+     * `null`, because the fallback was only set when the rejection WRITE
+     * threw, which it had not.
+     */
+    it('hands the failure text to the resume directly when the replay window is full', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        for (const label of ['coderabbitai[bot]', 'codex[bot]', 'a-human']) {
+            await rejections.record({
+                taskId: task.id,
+                source: 'pull-request',
+                feedback: `finding from ${label}`,
+                reviewerLabel: label,
+                prNumber: 42,
+            });
+        }
+        const service = buildService();
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 70 }) as never);
+
+        expect(resumes).toHaveLength(1);
+        expect(resumes[0].message).toContain('Continuous integration is RED');
+        expect(resumes[0].message).toContain(HEAD);
+    });
+
+    it('leaves the message to the replay when the window has room for the CI row', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        await rejections.record({
+            taskId: task.id,
+            source: 'pull-request',
+            feedback: 'one older finding',
+            reviewerLabel: 'a-human',
+            prNumber: 42,
+        });
+        const service = buildService();
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 71 }) as never);
+
+        expect(resumes).toHaveLength(1);
+        // The durable row IS the channel here — `resume` claims it and
+        // seeds it ahead of any caller message, so duplicating the text
+        // would only cost prompt tokens.
+        expect(resumes[0].message).toBeNull();
+        const rows = await rejectionRows.find({ where: { taskId: task.id } });
+        expect(rows.some((row) => row.source === 'gate')).toBe(true);
+    });
+
+    it('shares ONE budget between the CI half and the reviewer half', async () => {
+        const { task } = await seedWorkTaskAndRun();
+        await rejections.record({
+            taskId: task.id,
+            source: 'pull-request',
+            feedback: 'fix the null check',
+            reviewerLabel: 'a-human',
+            prNumber: 42,
+        });
+        const service = buildService();
+
+        await service.handle(BINDING, 'check_run', checkRun({ id: 40 }) as never);
+        await service.handle(BINDING, 'pull_request_review', {
+            action: 'submitted',
+            repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+            pull_request: { number: 42 },
+            review: { id: 4, state: 'changes_requested' },
+        } as never);
+        await service.handle(
+            BINDING,
+            'check_run',
+            checkRun({
+                id: 41,
+                headSha: 'e'.repeat(40),
+                summary: 'a completely different failure',
+                completedAt: '2026-09-06T13:00:00Z',
+            }) as never,
+        );
+
+        expect(resumes).toHaveLength(2);
+        expect(await attempts.countForTask(task.id)).toBe(2);
+    });
+});
+
+/**
+ * MODULE wiring — the half a hand-written provider array cannot see.
+ *
+ * The container check below proves the service's dependency LIST is
+ * satisfiable. It says nothing about whether `TasksDomainModule` actually
+ * lists those providers, because it compiles an array declared in this
+ * file: removing `TaskCiAutoResumeAttemptRepository` from
+ * `tasks.module.ts` — a change that makes the API fail to boot with an
+ * unresolvable dependency — left all of it green, and so did dropping
+ * `TaskCiAutoResumeService` from that module's `exports`, which silently
+ * disables the whole fix loop (the intake injects it `@Optional()`, so an
+ * unexported provider is not an error, just a consumer that resumes
+ * nothing, forever, with no test red).
+ *
+ * `TasksDomainModule` cannot be COMPILED here — it drags
+ * facades → agent-plugins, which has no dist in a bare checkout — but its
+ * decorator metadata reads fine under the same virtual mock the suite
+ * above already installs, and that metadata is exactly the list the Nest
+ * container would resolve at boot.
+ */
+describe('TasksDomainModule declares the fix loop (module metadata)', () => {
+    const providers = () => Reflect.getMetadata('providers', TasksDomainModule) as unknown[];
+    const exported = () => Reflect.getMetadata('exports', TasksDomainModule) as unknown[];
+
+    it('PROVIDES the attempt ledger repository — without it the API cannot boot', () => {
+        expect(providers()).toContain(TaskCiAutoResumeAttemptRepository);
+    });
+
+    it('PROVIDES and EXPORTS the evaluator — the intake injects it @Optional()', () => {
+        expect(providers()).toContain(TaskCiAutoResumeService);
+        // Not exported ⇒ `GitHubCheckIntakeService` silently receives
+        // `undefined` and every check delivery is ingested and then
+        // dropped. Nothing else would go red.
+        expect(exported()).toContain(TaskCiAutoResumeService);
+    });
+
+    it('registers the attempt entity with TypeORM — the repository is useless without it', () => {
+        // `TypeOrmModule.forFeature([...])` lands in `imports`; the
+        // registered entity list is on the dynamic module's providers, so
+        // assert on the ENTITY inventory the module feeds instead, which
+        // is the same list `DatabaseModule` and the migration must agree
+        // with.
+        expect(ENTITIES).toContain(TaskCiAutoResumeAttempt);
+    });
+});
+
+/**
+ * DI compile check — the failure this catches happens at API BOOT, not
+ * in any unit test.
+ *
+ * `TaskCiAutoResumeService` asks for five providers by class. Four of
+ * them TasksDomainModule already had; the fifth
+ * (`TaskCiAutoResumeAttemptRepository`) this slice added, and forgetting
+ * it in `providers` is invisible to `tsc`, invisible to every spec that
+ * constructs the service by hand, and fatal on the first pod boot. So
+ * the graph is compiled against a real Nest container over a real
+ * in-memory schema, and the second case is the mutation check: remove
+ * the repository and the compile must fail.
+ */
+describe('TaskCiAutoResumeService DI wiring (real container)', () => {
+    const providers = [
+        TaskRepository,
+        WorkRepository,
+        AgentRunRepository,
+        TaskReviewRejectionRepository,
+        TaskCiAutoResumeAttemptRepository,
+        TaskGitLinkService,
+        TaskCiAutoResumeService,
+    ];
+
+    /**
+     * Only the entities the graph touches, and only this module — the
+     * real TasksDomainModule drags the whole facades/agent-plugins chain
+     * a bare checkout cannot load.
+     */
+    const buildModule = (provide: unknown[]) =>
+        Test.createTestingModule({
+            imports: [
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                    logging: false,
+                }),
+                TypeOrmModule.forFeature([
+                    Task,
+                    Work,
+                    AgentRun,
+                    TaskReviewRejection,
+                    TaskCiAutoResumeAttempt,
+                ]),
+            ],
+            providers: provide as never,
+        }).compile();
+
+    it('compiles with every provider the service needs', async () => {
+        const module = await buildModule(providers);
+        expect(module.get(TaskCiAutoResumeService)).toBeInstanceOf(TaskCiAutoResumeService);
+        await module.close();
+    });
+
+    it('FAILS to compile when the attempt ledger repository is not provided', async () => {
+        await expect(
+            buildModule(providers.filter((p) => p !== TaskCiAutoResumeAttemptRepository)),
+        ).rejects.toThrow(/TaskCiAutoResumeAttemptRepository/);
+    });
+});

--- a/apps/api/src/ingest/github/github-check-intake.service.spec.ts
+++ b/apps/api/src/ingest/github/github-check-intake.service.spec.ts
@@ -1,0 +1,494 @@
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class {},
+    IngestInstallBindingRepository: class {},
+}));
+jest.mock('@ever-works/agent/pr-review', () => ({ PrReviewService: class {} }));
+jest.mock('@ever-works/agent/database', () => ({
+    GitHubAppInstallationRepository: class {},
+    GitHubAppUserLinkRepository: class {},
+}));
+jest.mock('../../integrations/github-app/github-app-sync.service', () => ({
+    GitHubAppSyncService: class {},
+}));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginSettingsService: class {},
+    UserPluginRepository: class {},
+}));
+// The intake reaches tasks-domain for the evaluator and two pure
+// helpers. Mocking the subpath keeps this unit suite off
+// TasksDomainModule's import graph (facades → agent-plugins → …); the
+// REAL evaluator is driven end to end by the sibling
+// `*.autoresume.integration.spec.ts`.
+// The intake reaches tasks-domain for the evaluator and two pure
+// helpers. Mocking the subpath keeps this unit suite off
+// TasksDomainModule's import graph (facades → agent-plugins → …); the
+// REAL evaluator is driven end to end by the sibling
+// `*.autoresume.integration.spec.ts`.
+//
+// The two HELPERS are the real ones, pulled straight from the pure policy
+// leaf (its only import is `node:crypto`, so it drags nothing). They used
+// to be hand-copied into this factory, which made the test named
+// "classifies conclusions the way the board rollup does" assert the copy
+// rather than production — and the copy had already drifted: it compared
+// `status` without lower-casing, so `{status: 'COMPLETED', conclusion:
+// 'FAILURE'}` was `pending` here and `failing` in the shipped classifier.
+// A test that pins a copy of the code cannot fail when the code changes,
+// which is the whole point of having it.
+jest.mock('@ever-works/agent/tasks-domain', () => {
+    const policy = jest.requireActual(
+        '../../../../../packages/agent/src/tasks-domain/task-ci-auto-resume',
+    );
+    return {
+        TaskCiAutoResumeService: class {},
+        classifyCheckResult: policy.classifyCheckResult,
+        computeCiFailureKey: policy.computeCiFailureKey,
+    };
+});
+
+import {
+    GITHUB_CHECK_EVENT_KIND,
+    GITHUB_CHECK_EVENTS,
+    GITHUB_REVIEW_EVENTS,
+    GitHubCheckIntakeService,
+    isReviewFeedbackDelivery,
+    normalizeGitHubCheck,
+} from './github-check-intake.service';
+
+const HEAD = '9f3c1a2b9f3c1a2b9f3c1a2b9f3c1a2b9f3c1a2b';
+
+function checkRunBody(
+    overrides: Record<string, unknown> & { check_run?: Record<string, unknown> } = {},
+) {
+    // `check_run` is MERGED, everything else replaces — spreading the
+    // overrides last would silently blank the nested payload and make
+    // every "these ids differ" assertion pass for the wrong reason.
+    const { check_run: runOverrides, ...rest } = overrides;
+    return {
+        action: 'completed',
+        repository: { full_name: 'octo/site', owner: { login: 'octo' } },
+        sender: { login: 'github-actions[bot]', type: 'Bot' },
+        ...rest,
+        check_run: {
+            id: 4815162342,
+            name: 'lint-and-test',
+            status: 'completed',
+            conclusion: 'failure' as string | null | undefined,
+            head_sha: HEAD as string | undefined,
+            html_url: 'https://github.com/octo/site/runs/4815162342',
+            started_at: '2026-09-06T10:00:00Z',
+            completed_at: '2026-09-06T10:05:00Z',
+            app: { slug: 'github-actions' },
+            output: {
+                title: '1 failing test',
+                summary: 'apps/web login.spec.ts › renders — expected true, received false',
+            },
+            check_suite: { id: 9, head_branch: 'task/t-42-9f3c1a2b', head_sha: HEAD } as {
+                id: number;
+                head_branch: string | null;
+                head_sha: string;
+            },
+            pull_requests: [{ number: 42 }] as Array<{ number: number }>,
+            ...runOverrides,
+        },
+    };
+}
+
+describe('normalizeGitHubCheck', () => {
+    it('turns a failing check_run into a github.check envelope keyed on the head commit', () => {
+        const normalized = normalizeGitHubCheck('check_run', checkRunBody() as never);
+        expect(normalized?.envelope).toMatchObject({
+            source: 'github',
+            kind: GITHUB_CHECK_EVENT_KIND,
+            sourceEventId: `check:octo/site@${HEAD}:run:4815162342:completed:failure`,
+            occurredAt: '2026-09-06T10:05:00.000Z',
+            actor: { name: 'github-actions[bot]' },
+            subject: {
+                type: 'check',
+                externalId: `octo/site@${HEAD}`,
+                title: 'lint-and-test: failure',
+            },
+            workHint: { kind: 'repo', externalId: 'octo/site' },
+            sourceUrl: 'https://github.com/octo/site/runs/4815162342',
+            payload: {
+                granularity: 'check_run',
+                repoFullName: 'octo/site',
+                headSha: HEAD,
+                headBranch: 'task/t-42-9f3c1a2b',
+                status: 'completed',
+                conclusion: 'failure',
+                verdict: 'failing',
+                name: 'lint-and-test',
+                pullRequests: [42],
+                outputTitle: '1 failing test',
+            },
+        });
+        expect(normalized?.signal).toMatchObject({
+            owner: 'octo',
+            repo: 'site',
+            headSha: HEAD,
+            headBranch: 'task/t-42-9f3c1a2b',
+            prNumbers: [42],
+            verdict: 'failing',
+            granularity: 'check_run',
+            checkName: 'lint-and-test',
+            conclusion: 'failure',
+        });
+        expect(normalized?.signal.failureKey).toEqual(expect.stringMatching(/^[0-9a-f]{32}$/));
+    });
+
+    /**
+     * The dedupe contract, stated as three facts about one id. This is
+     * the whole of the spine's protection against a redelivered check
+     * result being counted twice, and against a genuine re-run being
+     * swallowed as one.
+     */
+    describe('sourceEventId', () => {
+        const idOf = (body: unknown) =>
+            normalizeGitHubCheck('check_run', body as never)?.envelope.sourceEventId;
+
+        it('is IDENTICAL for a byte-identical redelivery', () => {
+            expect(idOf(checkRunBody())).toBe(idOf(checkRunBody()));
+        });
+
+        it('DIFFERS when the same job moves from queued to completed', () => {
+            expect(
+                idOf(checkRunBody({ check_run: { status: 'queued', conclusion: null } })),
+            ).not.toBe(idOf(checkRunBody()));
+        });
+
+        it('DIFFERS for a RE-RUN of the same commit (a new check_run id)', () => {
+            expect(idOf(checkRunBody({ check_run: { id: 999 } }))).not.toBe(idOf(checkRunBody()));
+        });
+
+        it('DIFFERS for a new workflow run_attempt on the same commit', () => {
+            const workflow = (attempt: number) =>
+                normalizeGitHubCheck('workflow_run', {
+                    repository: { full_name: 'octo/site' },
+                    workflow_run: {
+                        id: 77,
+                        name: 'CI',
+                        status: 'completed',
+                        conclusion: 'failure',
+                        head_sha: HEAD,
+                        run_attempt: attempt,
+                        updated_at: '2026-09-06T10:07:00Z',
+                    },
+                } as never)?.envelope.sourceEventId;
+            expect(workflow(1)).not.toBe(workflow(2));
+        });
+    });
+
+    it('reads a check_suite, which carries no per-job output and no page link', () => {
+        const normalized = normalizeGitHubCheck('check_suite', {
+            action: 'completed',
+            repository: { full_name: 'octo/site' },
+            check_suite: {
+                id: 9,
+                status: 'completed',
+                conclusion: 'failure',
+                head_sha: HEAD,
+                head_branch: 'task/t-42',
+                updated_at: '2026-09-06T10:06:00Z',
+                app: { slug: 'github-actions' },
+                pull_requests: [{ number: 42 }],
+            },
+        } as never);
+        expect(normalized?.envelope.sourceEventId).toBe(
+            `check:octo/site@${HEAD}:suite:9:completed:failure`,
+        );
+        expect(normalized?.envelope.sourceUrl).toBeUndefined();
+        expect(normalized?.signal.outputSummary).toBeNull();
+        expect(normalized?.signal.verdict).toBe('failing');
+    });
+
+    it('classifies conclusions the way the board rollup does', () => {
+        const verdictOf = (status: string, conclusion: string | null) =>
+            normalizeGitHubCheck(
+                'check_run',
+                checkRunBody({ check_run: { status, conclusion } }) as never,
+            )?.signal.verdict;
+
+        expect(verdictOf('completed', 'failure')).toBe('failing');
+        expect(verdictOf('completed', 'timed_out')).toBe('failing');
+        expect(verdictOf('completed', 'action_required')).toBe('failing');
+        expect(verdictOf('completed', 'success')).toBe('passing');
+        // A human stopping a job, or a job that decided it had nothing to
+        // do, is not something to spend a model run fixing.
+        expect(verdictOf('completed', 'cancelled')).toBe('inconclusive');
+        expect(verdictOf('completed', 'neutral')).toBe('inconclusive');
+        expect(verdictOf('completed', 'skipped')).toBe('inconclusive');
+        expect(verdictOf('completed', 'stale')).toBe('inconclusive');
+        // Completed with no verdict is never laundered into a pass.
+        expect(verdictOf('completed', null)).toBe('inconclusive');
+    });
+
+    /**
+     * CONTRACT CHANGE, deliberate: this used to assert
+     * `verdictOf('in_progress', 'failure') === 'pending'`, i.e. that an
+     * unfinished check produced a normalized envelope carrying a
+     * `pending` verdict. It no longer produces one at all.
+     *
+     * The old behaviour ingested a durable row for EVERY state
+     * transition, and each ingested row costs a REQUIRED activity_log
+     * write plus an `AgentMemoryFacadeService.saveMemory` call that is a
+     * paid embedding wherever a memory provider is configured. This
+     * repo's `ci.yml` runs ~15 job instances per pull request push, each
+     * announcing `queued` → `in_progress` → `completed`, with the suite
+     * and workflow events restating every transition: roughly half of the
+     * resulting tens of thousands of rows a day carried no verdict
+     * anything reads. `classifyCheckResult`'s `pending` rule is unchanged
+     * and still unit-tested next to the function; what changed is that
+     * the intake stops before building an envelope for one.
+     */
+    it('produces NOTHING for a check that has not completed', () => {
+        expect(
+            normalizeGitHubCheck(
+                'check_run',
+                checkRunBody({
+                    check_run: { status: 'in_progress', conclusion: 'failure' },
+                }) as never,
+            ),
+        ).toBeNull();
+        expect(
+            normalizeGitHubCheck(
+                'check_run',
+                checkRunBody({ check_run: { status: 'queued', conclusion: null } }) as never,
+            ),
+        ).toBeNull();
+        // …but every COMPLETED verdict, green and inconclusive included,
+        // is still ingested: the board and the inbound trigger matcher
+        // read those.
+        for (const conclusion of ['success', 'cancelled', 'failure']) {
+            expect(
+                normalizeGitHubCheck(
+                    'check_run',
+                    checkRunBody({ check_run: { conclusion } }) as never,
+                ),
+            ).not.toBeNull();
+        }
+    });
+
+    it('carries no failureKey for anything that is not a failure', () => {
+        expect(
+            normalizeGitHubCheck(
+                'check_run',
+                checkRunBody({ check_run: { conclusion: 'success' } }) as never,
+            )?.signal.failureKey,
+        ).toBeNull();
+    });
+
+    it('survives a fork pull request: no branch, no PR numbers, still a head commit', () => {
+        const normalized = normalizeGitHubCheck(
+            'check_run',
+            checkRunBody({
+                check_run: {
+                    pull_requests: [],
+                    check_suite: { id: 9, head_branch: null, head_sha: HEAD },
+                },
+            }) as never,
+        );
+        expect(normalized?.signal).toMatchObject({ headBranch: null, prNumbers: [] });
+        expect(normalized?.signal.headSha).toBe(HEAD);
+    });
+
+    it('returns null for a delivery with no head commit, no repository, or an unknown event', () => {
+        expect(
+            normalizeGitHubCheck(
+                'check_run',
+                checkRunBody({ check_run: { head_sha: undefined } }) as never,
+            ),
+        ).toBeNull();
+        expect(
+            normalizeGitHubCheck('check_run', { check_run: { head_sha: HEAD } } as never),
+        ).toBeNull();
+        expect(normalizeGitHubCheck('pull_request', checkRunBody() as never)).toBeNull();
+    });
+});
+
+describe('isReviewFeedbackDelivery', () => {
+    const POLICY = {
+        trusted: new Set(['coderabbitai[bot]']),
+        self: new Set(['ever-works[bot]']),
+    };
+    const human = { login: 'evereq', type: 'User' };
+
+    it('accepts only the shapes the review bridge records a rejection for', () => {
+        expect(
+            isReviewFeedbackDelivery(
+                'pull_request_review',
+                { review: { state: 'changes_requested', user: human } } as never,
+                POLICY,
+            ),
+        ).toBe(true);
+        expect(
+            isReviewFeedbackDelivery(
+                'pull_request_review',
+                { review: { state: 'approved', user: human } } as never,
+                POLICY,
+            ),
+        ).toBe(false);
+        expect(
+            isReviewFeedbackDelivery(
+                'pull_request_review_comment',
+                {
+                    action: 'created',
+                    pull_request: { number: 42 },
+                    comment: { user: human },
+                } as never,
+                POLICY,
+            ),
+        ).toBe(true);
+        expect(
+            isReviewFeedbackDelivery(
+                'pull_request_review_comment',
+                {
+                    action: 'edited',
+                    pull_request: { number: 42 },
+                    comment: { user: human },
+                } as never,
+                POLICY,
+            ),
+        ).toBe(false);
+        // A PR thread reports as an issue; a PLAIN issue comment is not
+        // about a pull request and must not cost a Task lookup.
+        expect(
+            isReviewFeedbackDelivery(
+                'issue_comment',
+                {
+                    action: 'created',
+                    issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+                    comment: { user: human },
+                } as never,
+                POLICY,
+            ),
+        ).toBe(true);
+        expect(
+            isReviewFeedbackDelivery(
+                'issue_comment',
+                { action: 'created', issue: { number: 42 }, comment: { user: human } } as never,
+                POLICY,
+            ),
+        ).toBe(false);
+        expect(isReviewFeedbackDelivery('push', {} as never, POLICY)).toBe(false);
+    });
+
+    /**
+     * The doorbell used to check only `action === 'created'` and the
+     * PR-thread shape, never the author — so the platform's OWN bot
+     * comment on the pull request (a status update, the PR link the fleet
+     * posts) was a valid trigger, and the loop could wake itself and
+     * spend a model run echoing its own output. The PR-review bridge
+     * refuses `self` and `untrusted-bot` before it records anything;
+     * this consumer has to make the same judgement rather than inherit it.
+     */
+    it('refuses the platform’s own identity and any untrusted bot', () => {
+        const thread = {
+            action: 'created',
+            issue: { number: 42, pull_request: { url: 'https://api.github.com/x' } },
+        };
+        for (const user of [
+            { login: 'ever-works[bot]', type: 'Bot' },
+            { login: 'dependabot[bot]', type: 'Bot' },
+            { login: 'github-actions[bot]', type: 'Bot' },
+        ]) {
+            expect(
+                isReviewFeedbackDelivery(
+                    'issue_comment',
+                    { ...thread, comment: { user } } as never,
+                    POLICY,
+                ),
+            ).toBe(false);
+        }
+        // …an allow-listed reviewer bot still rings it.
+        expect(
+            isReviewFeedbackDelivery(
+                'issue_comment',
+                {
+                    ...thread,
+                    comment: { user: { login: 'coderabbitai[bot]', type: 'Bot' } },
+                } as never,
+                POLICY,
+            ),
+        ).toBe(true);
+    });
+
+    it('refuses a `changes_requested` review submitted by the platform itself', () => {
+        expect(
+            isReviewFeedbackDelivery(
+                'pull_request_review',
+                {
+                    review: {
+                        state: 'changes_requested',
+                        user: { login: 'ever-works[bot]', type: 'Bot' },
+                    },
+                } as never,
+                POLICY,
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('GitHubCheckIntakeService (consumer wiring)', () => {
+    it('registers itself on the ONE dispatcher for the CI and reviewer deliveries', () => {
+        const dispatcher = { registerConsumer: jest.fn() };
+        const service = new GitHubCheckIntakeService(dispatcher as never, {} as never);
+        service.onModuleInit();
+        expect(dispatcher.registerConsumer).toHaveBeenCalledWith(service);
+        // Miss one of these names and the feature half-ships in silence:
+        // the dispatcher's `consumer.events.includes(eventName)` simply
+        // never matches and nothing errors.
+        expect(service.events).toEqual([
+            'check_run',
+            'check_suite',
+            'workflow_run',
+            'pull_request_review',
+            'issue_comment',
+            'pull_request_review_comment',
+        ]);
+        expect([...GITHUB_CHECK_EVENTS, ...GITHUB_REVIEW_EVENTS]).toEqual(service.events);
+    });
+
+    it('ingests the envelope and resumes nothing when no evaluator is bound', async () => {
+        const ingest = jest.fn().mockResolvedValue({
+            inserted: 1,
+            duplicates: 0,
+            rejected: 0,
+            filtered: 0,
+        });
+        const service = new GitHubCheckIntakeService(
+            { registerConsumer: jest.fn() } as never,
+            { ingest } as never,
+        );
+        const result = await service.handle(
+            { userId: 'u1', webhookSecret: 's', matchedBy: 'binding' },
+            'check_run',
+            checkRunBody() as never,
+        );
+        expect(ingest).toHaveBeenCalledTimes(1);
+        expect(result.ingested).toMatchObject({ inserted: 1 });
+        expect(result.autoResume).toBeUndefined();
+    });
+
+    it('skips the evaluator on a confirmed redelivery, but not on a salience drop', async () => {
+        const onCheckResult = jest.fn().mockResolvedValue({ reason: 'no-task' });
+        const ingest = jest
+            .fn()
+            .mockResolvedValueOnce({ inserted: 0, duplicates: 1, rejected: 0, filtered: 0 })
+            .mockResolvedValueOnce({ inserted: 0, duplicates: 0, rejected: 0, filtered: 1 });
+        const service = new GitHubCheckIntakeService(
+            { registerConsumer: jest.fn() } as never,
+            { ingest } as never,
+            { onCheckResult } as never,
+        );
+        const binding = { userId: 'u1', webhookSecret: 's', matchedBy: 'binding' as const };
+
+        await service.handle(binding, 'check_run', checkRunBody() as never);
+        expect(onCheckResult).not.toHaveBeenCalled();
+
+        // A filtered envelope is NOT a duplicate: an operator's salience
+        // configuration must not be able to switch the fix loop off.
+        await service.handle(binding, 'check_run', checkRunBody() as never);
+        expect(onCheckResult).toHaveBeenCalledTimes(1);
+        expect(onCheckResult).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1' }));
+    });
+});

--- a/apps/api/src/ingest/github/github-check-intake.service.ts
+++ b/apps/api/src/ingest/github/github-check-intake.service.ts
@@ -1,0 +1,545 @@
+import { randomUUID } from 'node:crypto';
+import { Injectable, Logger, Optional, type OnModuleInit } from '@nestjs/common';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { EventIngestService, type IngestResult } from '@ever-works/agent/ingest';
+import {
+    TaskCiAutoResumeService,
+    classifyCheckResult,
+    computeCiFailureKey,
+    type AutoResumeOutcome,
+    type CheckVerdict,
+    type CiCheckResultInput,
+} from '@ever-works/agent/tasks-domain';
+import {
+    INGESTED_EVENT_ACTOR_MAX_CHARS,
+    INGESTED_EVENT_SOURCE_EVENT_ID_MAX_CHARS,
+    INGESTED_EVENT_SUBJECT_EXTERNAL_ID_MAX_CHARS,
+    INGESTED_EVENT_TEXT_MAX_CHARS,
+    INGESTED_EVENT_TITLE_MAX_CHARS,
+    capped,
+    httpsUrl,
+    isoOrNow,
+    nonEmpty,
+} from '../ingest-envelope.util';
+import {
+    GITHUB_PLUGIN_ID,
+    type GitHubEventsBinding,
+    type GitHubWebhookBody,
+} from './github-pr-review-bridge.service';
+import {
+    GitHubWebhookDispatcherService,
+    type GitHubWebhookConsumer,
+} from './github-webhook-dispatcher.service';
+import { classifyReviewer, type ReviewBotPolicy } from './github-review-bots';
+import { config } from '../../config/constants';
+
+/** The ingested-event kind for CI results (sibling of `github.pr`). */
+export const GITHUB_CHECK_EVENT_KIND = 'github.check';
+
+/** The three vendor deliveries that report a CI result. */
+export const GITHUB_CHECK_EVENTS: readonly string[] = ['check_run', 'check_suite', 'workflow_run'];
+
+/**
+ * Provider deliveries that mean "a reviewer said something about the
+ * pull request". The PR-review bridge has ALREADY decided whether each
+ * one is a durable rejection by the time this consumer runs (the
+ * dispatcher awaits the review leg before the intake leg), so this
+ * service never re-classifies a reviewer — it acts on the recorded row.
+ */
+export const GITHUB_REVIEW_EVENTS: readonly string[] = [
+    'pull_request_review',
+    'issue_comment',
+    'pull_request_review_comment',
+];
+
+/** How much of a check's reported output rides along. */
+export const CHECK_OUTPUT_SUMMARY_MAX_CHARS = 2000;
+
+// ── payload shapes ──────────────────────────────────────────────────
+
+interface CheckPullRequestRef {
+    number?: number;
+    /**
+     * The pull request's head AT DELIVERY TIME. Present on every
+     * same-repository check delivery and absent for forks. It is the only
+     * thing in the payload that can say "this check ran against a commit
+     * the branch has already moved past" without commit ancestry — see
+     * `decideCiHead`.
+     */
+    head?: { sha?: string; ref?: string };
+}
+
+/** One pull request a delivery names, plus where that PR's head is now. */
+export interface CheckPullRequestHead {
+    number: number;
+    headSha: string | null;
+}
+
+/** The subset of the three CI deliveries this intake reads. */
+export interface GitHubCheckWebhookBody extends GitHubWebhookBody {
+    check_run?: {
+        id?: number;
+        name?: string;
+        status?: string;
+        conclusion?: string | null;
+        head_sha?: string;
+        html_url?: string;
+        details_url?: string;
+        started_at?: string;
+        completed_at?: string | null;
+        app?: { slug?: string; name?: string };
+        output?: { title?: string | null; summary?: string | null; text?: string | null };
+        check_suite?: { id?: number; head_branch?: string | null; head_sha?: string };
+        pull_requests?: CheckPullRequestRef[];
+    };
+    check_suite?: {
+        id?: number;
+        status?: string;
+        conclusion?: string | null;
+        head_sha?: string;
+        head_branch?: string | null;
+        created_at?: string;
+        updated_at?: string;
+        app?: { slug?: string };
+        pull_requests?: CheckPullRequestRef[];
+    };
+    workflow_run?: {
+        id?: number;
+        name?: string;
+        status?: string;
+        conclusion?: string | null;
+        head_sha?: string;
+        head_branch?: string | null;
+        run_attempt?: number;
+        html_url?: string;
+        event?: string;
+        created_at?: string;
+        updated_at?: string;
+        run_started_at?: string;
+        pull_requests?: CheckPullRequestRef[];
+    };
+}
+
+/** What one normalized CI delivery yields. */
+export interface NormalizedGitHubCheck {
+    envelope: IngestedEventEnvelope;
+    /** Everything the fix loop needs, minus the owner it resolves later. */
+    signal: Omit<CiCheckResultInput, 'userId'>;
+}
+
+function prHeads(refs: CheckPullRequestRef[] | undefined): CheckPullRequestHead[] {
+    return (Array.isArray(refs) ? refs : [])
+        .filter(
+            (ref): ref is CheckPullRequestRef & { number: number } =>
+                typeof ref?.number === 'number' && Number.isFinite(ref.number),
+        )
+        .map((ref) => ({ number: ref.number, headSha: nonEmpty(ref.head?.sha) ?? null }))
+        .slice(0, 20);
+}
+
+/**
+ * Normalize a `check_run` / `check_suite` / `workflow_run` delivery into
+ * a `github.check` envelope plus the fix loop's signal, or `null` when
+ * the delivery is not a CI result this platform can place.
+ *
+ * ## Identity — the whole dedupe story
+ *
+ * The spine's ONLY dedupe is `(userId, source, sourceEventId)`, so the id
+ * has to separate three things that look alike:
+ *
+ *   * a **redelivery** (GitHub retrying a delivery it got no 2xx for) —
+ *     must dedupe to nothing. Same job, same state, same id.
+ *   * a **state change** (`queued` → `completed`) — a genuinely new fact.
+ *     The status (and conclusion) are in the id.
+ *   * a **re-run** of the same commit — a new result, not a redelivery.
+ *     `check_run.id` is fresh for a re-run and `workflow_run.run_attempt`
+ *     counts them, so both are in the id. `head_sha` alone would collapse
+ *     a re-run into its predecessor.
+ *
+ * The head SHA sits BEFORE the mutable parts so a truncation at the
+ * `varchar(200)` column width trims the tail, not the part that makes the
+ * id unique — the same reasoning the push id documents.
+ */
+export function normalizeGitHubCheck(
+    eventName: string,
+    body: GitHubCheckWebhookBody,
+): NormalizedGitHubCheck | null {
+    const fullName = nonEmpty(body.repository?.full_name);
+    const [owner, repo] = (fullName ?? '').split('/');
+    if (!fullName || !owner || !repo) return null;
+
+    const actor =
+        nonEmpty(body.sender?.login) ??
+        nonEmpty(body.check_run?.app?.slug) ??
+        nonEmpty(body.check_suite?.app?.slug) ??
+        'github';
+
+    let granularity: CiCheckResultInput['granularity'];
+    let identity: string;
+    let headSha: string | undefined;
+    let headBranch: string | null = null;
+    let status: string | undefined;
+    let conclusion: string | undefined;
+    let checkName: string;
+    let occurredAtRaw: string | null | undefined;
+    let url: string | undefined;
+    let outputTitle: string | undefined;
+    let outputSummary: string | undefined;
+    let pulls: CheckPullRequestHead[];
+
+    if (eventName === 'check_run') {
+        const run = body.check_run;
+        if (!run) return null;
+        granularity = 'check_run';
+        headSha = nonEmpty(run.head_sha);
+        headBranch = nonEmpty(run.check_suite?.head_branch) ?? null;
+        status = nonEmpty(run.status);
+        conclusion = nonEmpty(run.conclusion ?? undefined);
+        checkName = nonEmpty(run.name) ?? 'check';
+        identity = `run:${run.id ?? 'unknown'}`;
+        occurredAtRaw = run.completed_at ?? run.started_at;
+        url = httpsUrl(run.html_url) ?? httpsUrl(run.details_url);
+        outputTitle = nonEmpty(run.output?.title ?? undefined);
+        // `output.text` is frequently empty and `summary` is what GitHub
+        // Actions actually fills; individual annotations are NOT in the
+        // payload (they need a second API call), so this is the whole of
+        // the failing output a webhook can carry.
+        outputSummary =
+            nonEmpty(run.output?.summary ?? undefined) ?? nonEmpty(run.output?.text ?? undefined);
+        pulls = prHeads(run.pull_requests);
+    } else if (eventName === 'check_suite') {
+        const suite = body.check_suite;
+        if (!suite) return null;
+        granularity = 'check_suite';
+        headSha = nonEmpty(suite.head_sha);
+        headBranch = nonEmpty(suite.head_branch ?? undefined) ?? null;
+        status = nonEmpty(suite.status);
+        conclusion = nonEmpty(suite.conclusion ?? undefined);
+        checkName = nonEmpty(suite.app?.slug) ?? 'check suite';
+        identity = `suite:${suite.id ?? 'unknown'}`;
+        occurredAtRaw = suite.updated_at ?? suite.created_at;
+        // A check suite payload carries no `html_url` at all — only the
+        // API link, which is not a page a human can open, so no deep link
+        // is stored rather than a misleading one.
+        pulls = prHeads(suite.pull_requests);
+    } else if (eventName === 'workflow_run') {
+        const workflow = body.workflow_run;
+        if (!workflow) return null;
+        granularity = 'workflow_run';
+        headSha = nonEmpty(workflow.head_sha);
+        headBranch = nonEmpty(workflow.head_branch ?? undefined) ?? null;
+        status = nonEmpty(workflow.status);
+        conclusion = nonEmpty(workflow.conclusion ?? undefined);
+        checkName = nonEmpty(workflow.name) ?? 'workflow';
+        identity = `workflow:${workflow.id ?? 'unknown'}#${workflow.run_attempt ?? 1}`;
+        occurredAtRaw = workflow.updated_at ?? workflow.run_started_at ?? workflow.created_at;
+        url = httpsUrl(workflow.html_url);
+        pulls = prHeads(workflow.pull_requests);
+    } else {
+        return null;
+    }
+
+    if (!headSha) return null;
+
+    const verdict: CheckVerdict = classifyCheckResult({ status, conclusion });
+    // A check that has not COMPLETED carries no verdict anybody can act
+    // on, and it is roughly half of everything GitHub sends: this repo's
+    // `ci.yml` runs ~15 job instances per pull request push, each of which
+    // announces itself `queued`, then `in_progress`, then `completed`, and
+    // the suite and workflow events restate every transition again. Each
+    // ingested envelope is a REQUIRED activity_log write plus a
+    // `saveMemory` call that is a paid embedding wherever a memory
+    // provider is configured, so ingesting the intermediate states bought
+    // tens of thousands of rows and embeddings a day, across six fleet
+    // PCs and every other repository in the installation, for a signal
+    // nothing reads. Dropped at the edge, before the spine and before any
+    // Task lookup. The `completed` results — red, green and inconclusive
+    // alike — are all still ingested, so an inbound trigger still sees
+    // every CI verdict and the board still goes red.
+    if (verdict === 'pending') return null;
+    const occurredAt = isoOrNow(occurredAtRaw);
+    const parsedReportedAt = occurredAtRaw ? new Date(occurredAtRaw) : null;
+    const reportedAt =
+        parsedReportedAt && !Number.isNaN(parsedReportedAt.getTime()) ? parsedReportedAt : null;
+    const revision = [status ?? 'unknown', conclusion].filter(Boolean).join(':');
+
+    return {
+        envelope: {
+            id: randomUUID(),
+            source: GITHUB_PLUGIN_ID,
+            sourceEventId: capped(
+                `check:${fullName}@${headSha}:${identity}:${revision}`,
+                INGESTED_EVENT_SOURCE_EVENT_ID_MAX_CHARS,
+            ),
+            kind: GITHUB_CHECK_EVENT_KIND,
+            occurredAt,
+            actor: { name: capped(actor, INGESTED_EVENT_ACTOR_MAX_CHARS) },
+            subject: {
+                type: 'check',
+                // The head commit IS the CI subject: a pull request number
+                // is absent on every fork delivery, and a branch is absent
+                // there too.
+                externalId: capped(
+                    `${fullName}@${headSha}`,
+                    INGESTED_EVENT_SUBJECT_EXTERNAL_ID_MAX_CHARS,
+                ),
+                title: capped(
+                    `${checkName}: ${conclusion ?? status ?? 'unknown'}`,
+                    INGESTED_EVENT_TITLE_MAX_CHARS,
+                ),
+            },
+            // Work routing: the repository is the container, like every
+            // other GitHub envelope. Without it a `workId`-scoped trigger
+            // never sees the event.
+            workHint: { kind: 'repo', externalId: fullName },
+            ...(url ? { sourceUrl: url } : {}),
+            payload: {
+                granularity,
+                repoFullName: fullName,
+                headSha,
+                ...(headBranch ? { headBranch } : {}),
+                ...(status ? { status } : {}),
+                ...(conclusion ? { conclusion } : {}),
+                verdict,
+                name: capped(checkName, INGESTED_EVENT_TITLE_MAX_CHARS),
+                ...(pulls.length > 0 ? { pullRequests: pulls.map((pull) => pull.number) } : {}),
+                ...(url ? { url } : {}),
+                ...(outputTitle
+                    ? { outputTitle: capped(outputTitle, INGESTED_EVENT_TITLE_MAX_CHARS) }
+                    : {}),
+                ...(outputSummary
+                    ? { outputSummary: capped(outputSummary, INGESTED_EVENT_TEXT_MAX_CHARS) }
+                    : {}),
+                occurredAt,
+            },
+        },
+        signal: {
+            owner,
+            repo,
+            headSha,
+            headBranch,
+            prNumbers: pulls.map((pull) => pull.number),
+            prHeads: pulls,
+            // The PROVIDER's own time, or null. `occurredAt` above is
+            // `isoOrNow`-substituted so the envelope is never rejected for
+            // a missing timestamp — but a substituted `now` is always the
+            // newest thing in any comparison, so handing it to the head
+            // decision would make every undated delivery look like a fresh
+            // push. The evaluator is told the truth instead.
+            observedAt: reportedAt,
+            verdict,
+            granularity,
+            checkName,
+            conclusion: conclusion ?? status ?? 'unknown',
+            url: url ?? null,
+            outputTitle: outputTitle ?? null,
+            outputSummary: outputSummary
+                ? capped(outputSummary, CHECK_OUTPUT_SUMMARY_MAX_CHARS)
+                : null,
+            failureKey:
+                verdict === 'failing'
+                    ? computeCiFailureKey({
+                          checkNames: [checkName],
+                          output: [outputTitle, outputSummary].filter(Boolean).join('\n'),
+                      })
+                    : null,
+        },
+    };
+}
+
+/**
+ * True when this delivery is a reviewer speaking about a pull request —
+ * i.e. the shape slice AB records a durable rejection for.
+ *
+ * Deliberately structural, not a re-classification: whether the author
+ * was a trusted bot, a human, or the platform's own identity is the
+ * bridge's decision and it has already been made. This only avoids
+ * pointless Task lookups for plain issue comments and for the review
+ * states (`approved`, `commented`) that record nothing.
+ */
+export function isReviewFeedbackDelivery(
+    eventName: string,
+    body: GitHubWebhookBody,
+    policy: ReviewBotPolicy,
+): boolean {
+    if (eventName === 'pull_request_review') {
+        if (body.review?.state?.toLowerCase() !== 'changes_requested') return false;
+        return isDoorbellAuthor(body.review?.user, policy);
+    }
+    if (eventName === 'pull_request_review_comment') {
+        if (body.action !== 'created' || typeof body.pull_request?.number !== 'number')
+            return false;
+        return isDoorbellAuthor(body.comment?.user, policy);
+    }
+    if (eventName === 'issue_comment') {
+        // GitHub reports PR threads as issues; only those carry
+        // `issue.pull_request`, and only they can be a Task's PR.
+        if (body.action !== 'created' || !body.issue?.pull_request) return false;
+        return isDoorbellAuthor(body.comment?.user, policy);
+    }
+    return false;
+}
+
+/**
+ * May THIS author's comment wake the fix loop?
+ *
+ * The bridge refuses `self` and `untrusted-bot` before it records
+ * anything, and this consumer has to make the same judgement rather than
+ * inherit it: a doorbell that accepts any author lets the platform's OWN
+ * status comment on the pull request start a model run on a fleet PC —
+ * the loop echoing itself, which is the exact property
+ * `classifyReviewer` exists to protect. `untrusted-bot` is dropped for
+ * the same reason it is dropped upstream: nothing it says was recorded,
+ * so there is nothing of its to act on.
+ */
+function isDoorbellAuthor(
+    user: { login?: string; type?: string } | undefined,
+    policy: ReviewBotPolicy,
+): boolean {
+    const who = classifyReviewer(user, policy);
+    return who === 'human' || who === 'trusted-bot';
+}
+
+/** The pull request number a review-shaped delivery is about. */
+function reviewPrNumber(eventName: string, body: GitHubWebhookBody): number | null {
+    const candidate =
+        eventName === 'issue_comment' ? body.issue?.number : body.pull_request?.number;
+    return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : null;
+}
+
+/**
+ * CI feedback and the autonomous fix loop (self-build slice AC, EW-806,
+ * closes finding R17) — the INBOUND half.
+ *
+ * ## The defect this closes
+ *
+ * The GitHub receiver had no handling for `check_run`, `check_suite` or
+ * `workflow_run` at all: a CI result never became an ingested event, no
+ * inbound trigger could match one, and `tasks.ciState` was written only
+ * by a two-minute poll and read only by the board. So the fleet opened a
+ * pull request, CI went red, and six PCs sat idle waiting for a human.
+ *
+ * ## Shape
+ *
+ * A registered {@link GitHubWebhookConsumer}, not a new receiver and not
+ * a dispatcher dependency: it sees deliveries on BOTH GitHub routes after
+ * the same signature verification and the same install-binding
+ * attribution the PR-review bridge gets, and the dispatcher's constructor
+ * arity (pinned by `ingest.module.spec.ts`) is untouched.
+ *
+ * Two signals, one loop, one budget:
+ *
+ *   * **CI** — the three check deliveries become `github.check` envelopes
+ *     on the ordinary spine (dedupe-insert → drain → Activity → trigger
+ *     matcher), and a completed FAILURE is offered to
+ *     {@link TaskCiAutoResumeService}.
+ *   * **Review** — a `changes_requested` review or a review comment is
+ *     ingested by nobody here (the bridge owns those and records the
+ *     durable rejection); this consumer only nudges the same evaluator to
+ *     act on the row the bridge just wrote.
+ *
+ * Every decision that can spend money lives in the evaluator, behind a
+ * durable per-attempt budget. This file's job is to normalize honestly
+ * and to hand over the coordinates.
+ */
+@Injectable()
+export class GitHubCheckIntakeService implements OnModuleInit, GitHubWebhookConsumer {
+    private readonly logger = new Logger(GitHubCheckIntakeService.name);
+
+    readonly events: readonly string[] = [...GITHUB_CHECK_EVENTS, ...GITHUB_REVIEW_EVENTS];
+
+    constructor(
+        private readonly dispatcher: GitHubWebhookDispatcherService,
+        private readonly eventIngestService: EventIngestService,
+        // @Optional() so an install without the Tasks domain (or a spec
+        // that only exercises normalization) ingests the events and
+        // resumes nothing, rather than failing the delivery.
+        @Optional() private readonly autoResume?: TaskCiAutoResumeService,
+    ) {}
+
+    onModuleInit(): void {
+        this.dispatcher.registerConsumer(this);
+    }
+
+    /** Same operator allow-lists the review bridge classifies with. */
+    private reviewBotPolicy(): ReviewBotPolicy {
+        return {
+            trusted: new Set(config.githubReviewBots.trustedLogins()),
+            self: new Set(config.githubReviewBots.selfLogins()),
+        };
+    }
+
+    async handle(
+        binding: GitHubEventsBinding,
+        eventName: string,
+        body: GitHubWebhookBody,
+    ): Promise<{ ingested: IngestResult | null; autoResume?: AutoResumeOutcome }> {
+        if (GITHUB_REVIEW_EVENTS.includes(eventName)) {
+            return {
+                ingested: null,
+                autoResume: await this.handleReview(binding, eventName, body),
+            };
+        }
+
+        const normalized = normalizeGitHubCheck(eventName, body as GitHubCheckWebhookBody);
+        if (!normalized) return { ingested: null };
+
+        const ingested = await this.eventIngestService.ingest(binding.userId, [
+            normalized.envelope,
+        ]);
+        if (ingested.inserted > 0) {
+            this.logger.log(
+                `Ingested ${GITHUB_CHECK_EVENT_KIND} ${normalized.envelope.sourceEventId} for user ${binding.userId}`,
+            );
+        }
+
+        // A confirmed redelivery is the ONE case worth short-circuiting:
+        // the spine has already seen this exact result, so re-running the
+        // Task lookup and the budget read would burn queries on a fact
+        // nothing can act on. Every other outcome — including a salience
+        // drop or a rejected envelope — still reaches the evaluator, whose
+        // own durable claim is the real idempotency guard. Gating the loop
+        // on `inserted > 0` alone would let an operator's salience filter
+        // silently switch the fix loop off.
+        if (ingested.inserted === 0 && ingested.duplicates > 0) {
+            return { ingested };
+        }
+        if (!this.autoResume) return { ingested };
+
+        const outcome = await this.autoResume.onCheckResult({
+            userId: binding.userId,
+            ...normalized.signal,
+        });
+        if (outcome.reason === 'resumed') {
+            this.logger.log(
+                `Task ${outcome.taskId}: CI red on ${normalized.signal.owner}/${normalized.signal.repo}@${normalized.signal.headSha} — resumed as run ${outcome.runId} (attempt ${outcome.attemptsUsed}/${outcome.maxAttempts}).`,
+            );
+        }
+        return { ingested, autoResume: outcome };
+    }
+
+    private async handleReview(
+        binding: GitHubEventsBinding,
+        eventName: string,
+        body: GitHubWebhookBody,
+    ): Promise<AutoResumeOutcome | undefined> {
+        if (!this.autoResume) return undefined;
+        if (!isReviewFeedbackDelivery(eventName, body, this.reviewBotPolicy())) return undefined;
+        const fullName = nonEmpty(body.repository?.full_name);
+        const [owner, repo] = (fullName ?? '').split('/');
+        const prNumber = reviewPrNumber(eventName, body);
+        if (!owner || !repo || prNumber === null) return undefined;
+        const outcome = await this.autoResume.onReviewRejection({
+            userId: binding.userId,
+            owner,
+            repo,
+            prNumber,
+        });
+        if (outcome.reason === 'resumed') {
+            this.logger.log(
+                `Task ${outcome.taskId}: reviewer rejection on ${fullName}#${prNumber} — resumed as run ${outcome.runId} (attempt ${outcome.attemptsUsed}/${outcome.maxAttempts}).`,
+            );
+        }
+        return outcome;
+    }
+}

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -887,6 +887,13 @@ describe('GitHubPrReviewBridgeService', () => {
         });
     });
 
+    /**
+     * Still true, and still `workflow_run` on purpose. Slice AC (EW-806)
+     * DOES handle that delivery — but as a registered consumer on the
+     * dispatcher (`GitHubCheckIntakeService`), never here. This bridge
+     * must keep ignoring it: it owns the review loop, and a CI result is
+     * not something to review.
+     */
     it('ignores unknown event names', async () => {
         const { service, eventIngestService } = createService();
         const result = await service.handleEvent(BINDING, 'workflow_run', {

--- a/apps/api/src/ingest/ingest.module.spec.ts
+++ b/apps/api/src/ingest/ingest.module.spec.ts
@@ -42,6 +42,22 @@ jest.mock('@ever-works/agent/plugins', () => ({
     PluginSettingsService: class PluginSettingsService {},
     UserPluginRepository: class UserPluginRepository {},
 }));
+// CI feedback + autonomous fix loop (slice AC): the check intake asks
+// TasksDomainModule for the evaluator and two pure helpers. Stubbing the
+// subpath keeps this shape-guard off the facades → agent-plugins chain,
+// exactly as the sibling GitHub specs do.
+jest.mock('@ever-works/agent/tasks-domain', () => ({
+    TasksDomainModule: class TasksDomainModule {},
+    TaskCiAutoResumeService: class TaskCiAutoResumeService {},
+    TaskGitLinkService: class TaskGitLinkService {},
+    TaskReviewRejectionService: class TaskReviewRejectionService {},
+    TaskChatService: class TaskChatService {},
+    TaskRepository: class TaskRepository {},
+    TasksService: class TasksService {},
+    TaskPriority: { P0: 'p0', P1: 'p1', P2: 'p2', P3: 'p3', P4: 'p4' },
+    classifyCheckResult: () => 'pending',
+    computeCiFailureKey: () => 'k',
+}));
 jest.mock('../ai-conversation/ai-conversation.module', () => ({
     AiConversationModule: class AiConversationModule {},
 }));
@@ -66,6 +82,7 @@ import { GitHubWebhookDispatcherService } from './github/github-webhook-dispatch
 import { SlackChatBridgeService } from './slack/slack-chat-bridge.service';
 import { GitHubAppModule } from '../integrations/github-app/github-app.module';
 import { GitHubIssueIntakeService } from './github/github-issue-intake.service';
+import { GitHubCheckIntakeService } from './github/github-check-intake.service';
 import { DependabotIncidentSource } from './incidents/dependabot-incident.source';
 import { JiraEventsController } from './jira/jira-events.controller';
 import { JiraIssueBridgeService } from './jira/jira-issue-bridge.service';
@@ -176,6 +193,7 @@ describe('IngestModule (issue + incident intake wiring)', () => {
         const provided = providers();
         for (const provider of [
             GitHubIssueIntakeService,
+            GitHubCheckIntakeService,
             DependabotIncidentSource,
             JiraIssueBridgeService,
             SentryIncidentSource,
@@ -195,6 +213,27 @@ describe('IngestModule (issue + incident intake wiring)', () => {
         expect(injected).toContain(DependabotIncidentSource);
         // …and the dispatcher itself did NOT grow a constructor dependency
         // on it (the arity pin above stays at 4).
+        expect(
+            Reflect.getMetadata('design:paramtypes', GitHubWebhookDispatcherService),
+        ).toHaveLength(4);
+    });
+
+    /**
+     * CI feedback + autonomous fix loop (slice AC, EW-806, R17). The
+     * SECOND registered consumer, and the same two hazards: dropping it
+     * from `providers` means `onModuleInit` never runs and check
+     * deliveries are silently ignored (the exact defect this slice
+     * closes); registering it twice means every delivery is handled
+     * twice, which for this consumer means paying for a model run twice.
+     */
+    it('feeds the CI check intake from the SAME dispatcher, exactly once', () => {
+        expect(providers().filter((p: unknown) => p === GitHubCheckIntakeService)).toHaveLength(1);
+        const injected = Reflect.getMetadata(
+            'design:paramtypes',
+            GitHubCheckIntakeService,
+        ) as unknown[];
+        expect(injected[0]).toBe(GitHubWebhookDispatcherService);
+        // …and, again, the dispatcher did NOT grow a dependency on it.
         expect(
             Reflect.getMetadata('design:paramtypes', GitHubWebhookDispatcherService),
         ).toHaveLength(4);

--- a/apps/api/src/ingest/ingest.module.spec.ts
+++ b/apps/api/src/ingest/ingest.module.spec.ts
@@ -55,6 +55,21 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
     TaskRepository: class TaskRepository {},
     TasksService: class TasksService {},
     TaskPriority: { P0: 'p0', P1: 'p1', P2: 'p2', P3: 'p3', P4: 'p4' },
+    // `triage-task-filer.service.ts` reads `TaskStatus.DONE` at MODULE SCOPE
+    // (`CLOSED_TASK_STATUSES`), so leaving it out of this mock is not a
+    // missing-value problem at call time — the file throws
+    // "Cannot read properties of undefined" while it is still being
+    // imported, and the whole suite fails to run. Mirrors the real enum in
+    // `task.entity.ts` exactly.
+    TaskStatus: {
+        BACKLOG: 'backlog',
+        TODO: 'todo',
+        IN_PROGRESS: 'in_progress',
+        IN_REVIEW: 'in_review',
+        BLOCKED: 'blocked',
+        DONE: 'done',
+        CANCELLED: 'cancelled',
+    },
     classifyCheckResult: () => 'pending',
     computeCiFailureKey: () => 'k',
 }));

--- a/apps/api/src/ingest/ingest.module.ts
+++ b/apps/api/src/ingest/ingest.module.ts
@@ -14,6 +14,7 @@ import { GitHubAppWebhookController } from './github/github-app-webhook.controll
 import { GitHubPrReviewBridgeService } from './github/github-pr-review-bridge.service';
 import { GitHubWebhookDispatcherService } from './github/github-webhook-dispatcher.service';
 import { GitHubIssueIntakeService } from './github/github-issue-intake.service';
+import { GitHubCheckIntakeService } from './github/github-check-intake.service';
 import { DependabotIncidentSource } from './incidents/dependabot-incident.source';
 import { JiraEventsController } from './jira/jira-events.controller';
 import { JiraIssueBridgeService } from './jira/jira-issue-bridge.service';
@@ -86,6 +87,18 @@ import { TriageTaskFilerService } from './triage/triage-task-filer.service';
  *     authenticated `SentryBindingsController`
  *     (`/api/ingest/sentry/bindings`).
  *
+ * ## CI feedback and the autonomous fix loop (§6, R17)
+ *
+ * `GitHubCheckIntakeService` is the SECOND registered consumer on the one
+ * dispatcher. `check_run` / `check_suite` / `workflow_run` deliveries —
+ * which had no handling anywhere before — become `github.check` events on
+ * the same spine, and a completed FAILURE is offered to
+ * `TaskCiAutoResumeService` (TasksDomainModule), which resumes the Task's
+ * run under a durable, per-attempt retry budget. It also sees the
+ * reviewer deliveries, purely to act on the durable rejection the review
+ * bridge has already recorded for them — the dispatcher awaits the review
+ * leg before the intake leg, so the row exists by then.
+ *
  * `TriageTaskFilerService` is a kind processor on the spine
  * (`github.issue`, `jira.issue`, `incident`): one Task per
  * `(source, external id)` in the bound Work, dedup key persisted in
@@ -120,6 +133,14 @@ import { TriageTaskFilerService } from './triage/triage-task-filer.service';
         // Issue + incident intake (§6, R2/R23).
         DependabotIncidentSource,
         GitHubIssueIntakeService,
+        // CI feedback + autonomous fix loop (slice AC, EW-806, R17) — a
+        // SECOND registered consumer on the same one dispatcher, for the
+        // `check_run` / `check_suite` / `workflow_run` deliveries nothing
+        // handled before, plus the reviewer deliveries whose durable
+        // rejection the bridge has already recorded by the time the
+        // intake leg runs. It resumes through `TaskCiAutoResumeService`
+        // (TasksDomainModule, imported above).
+        GitHubCheckIntakeService,
         JiraIssueBridgeService,
         SentryIncidentSource,
         SentryInstallBindingService,

--- a/apps/api/src/migrations/1789800000000-AddCiAutoResume.ts
+++ b/apps/api/src/migrations/1789800000000-AddCiAutoResume.ts
@@ -1,0 +1,162 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableIndex } from 'typeorm';
+
+/**
+ * CI feedback and the autonomous fix loop (self-build slice AC, EW-806,
+ * closes finding R17).
+ *
+ * ## One table — the attempt ledger, which IS the retry budget
+ *
+ * `task_ci_auto_resume_attempts` holds one row per auto-resume ATTEMPT.
+ * The `(taskId, claimKey)` index is **UNIQUE and load-bearing**: it is
+ * the only thing standing between one red pull request and a resume
+ * storm. A twelve-job matrix goes red twelve times for one push, GitHub
+ * redelivers anything it did not get a 2xx for, and two API replicas can
+ * handle one delivery concurrently — all of which resolve to the SAME
+ * `ci:<headSha>` claim key, and therefore to exactly one row and exactly
+ * one model run. Counting rows for a Task is counting attempts, never
+ * events, and it survives a crash, a redeploy and a replica swap.
+ *
+ * No foreign key to `tasks`: the ledger is the spend record and must
+ * outlive a deleted Task the same way `fleet_audit` outlives a deleted
+ * node. `idx_task_ci_auto_resume_task` serves both the budget count and
+ * the `failureKey` no-progress lookup inside one Task.
+ *
+ * ## Three additive, nullable columns on `tasks`
+ *
+ *  1. `ciHeadSha` — the head commit the provider last reported checks
+ *     against. The platform had NO such column (`baseSha` is where the
+ *     branch was cut from; the `headSha` inside `linkedPullRequests`
+ *     covers non-primary repositories only), which is precisely why
+ *     "is this check result for the head we still care about?" could not
+ *     be answered before this slice.
+ *  2. `ciHeadSeenAt` — written as a pair with it; the only thing that
+ *     orders two different head commits, so a delivery for a superseded
+ *     revision can be refused instead of resuming work on dead code.
+ *  3. `ciAutoResumeNoticedAt` — one-shot CAS marker so the "automatic
+ *     retries stopped" Inbox notice is filed once per Task rather than
+ *     once per check delivery (`InboxService.notice` has no dedup of its
+ *     own).
+ *
+ * Forward-only with existence guards so a partially applied database
+ * converges; portable `Table` / `TableColumn` DDL because CI and the e2e
+ * stack run better-sqlite3 while production runs Postgres. `down()` uses
+ * the query-runner primitives rather than raw `ALTER TABLE … DROP
+ * COLUMN`, which sqlite cannot execute for every column shape.
+ */
+export class AddCiAutoResume1789800000000 implements MigrationInterface {
+    name = 'AddCiAutoResume1789800000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+
+        if (!(await queryRunner.hasTable('task_ci_auto_resume_attempts'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'task_ci_auto_resume_attempts',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: isPostgres ? 'uuid_generate_v4()' : undefined,
+                        },
+                        { name: 'taskId', type: 'uuid' },
+                        { name: 'trigger', type: 'varchar', length: '16' },
+                        { name: 'claimKey', type: 'varchar', length: '200' },
+                        { name: 'headSha', type: 'varchar', length: '64', isNullable: true },
+                        { name: 'failureKey', type: 'varchar', length: '64', isNullable: true },
+                        { name: 'sourceRunId', type: 'uuid', isNullable: true },
+                        { name: 'resumedRunId', type: 'uuid', isNullable: true },
+                        { name: 'detail', type: 'varchar', length: '200', isNullable: true },
+                        { name: 'workId', type: 'uuid', isNullable: true },
+                        { name: 'tenantId', type: 'uuid', isNullable: true },
+                        { name: 'organizationId', type: 'uuid', isNullable: true },
+                        {
+                            name: 'createdAt',
+                            type: 'timestamp',
+                            default: 'CURRENT_TIMESTAMP',
+                        },
+                    ],
+                }),
+                true,
+            );
+        }
+
+        const attempts = await queryRunner.getTable('task_ci_auto_resume_attempts');
+        if (
+            attempts &&
+            !attempts.indices.some((index) => index.name === 'idx_task_ci_auto_resume_task')
+        ) {
+            await queryRunner.createIndex(
+                'task_ci_auto_resume_attempts',
+                new TableIndex({
+                    name: 'idx_task_ci_auto_resume_task',
+                    columnNames: ['taskId'],
+                }),
+            );
+        }
+        if (
+            attempts &&
+            !attempts.indices.some((index) => index.name === 'uq_task_ci_auto_resume_claim')
+        ) {
+            // THE guard against a resume storm. See the class doc.
+            await queryRunner.createIndex(
+                'task_ci_auto_resume_attempts',
+                new TableIndex({
+                    name: 'uq_task_ci_auto_resume_claim',
+                    columnNames: ['taskId', 'claimKey'],
+                    isUnique: true,
+                }),
+            );
+        }
+
+        const tasks = await queryRunner.getTable('tasks');
+        if (!tasks) return;
+        if (!tasks.findColumnByName('ciHeadSha')) {
+            await queryRunner.addColumn(
+                'tasks',
+                new TableColumn({
+                    name: 'ciHeadSha',
+                    type: 'varchar',
+                    length: '64',
+                    isNullable: true,
+                }),
+            );
+        }
+        // Re-read between adds: on sqlite an addColumn rebuilds the table,
+        // so metadata captured before it is stale for the next check.
+        const afterHead = await queryRunner.getTable('tasks');
+        if (afterHead && !afterHead.findColumnByName('ciHeadSeenAt')) {
+            await queryRunner.addColumn(
+                'tasks',
+                new TableColumn({ name: 'ciHeadSeenAt', type: 'timestamp', isNullable: true }),
+            );
+        }
+        const afterSeen = await queryRunner.getTable('tasks');
+        if (afterSeen && !afterSeen.findColumnByName('ciAutoResumeNoticedAt')) {
+            await queryRunner.addColumn(
+                'tasks',
+                new TableColumn({
+                    name: 'ciAutoResumeNoticedAt',
+                    type: 'timestamp',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Columns first, newest-added first, re-reading between drops for
+        // the same sqlite table-rebuild reason as `up()`.
+        for (const column of ['ciAutoResumeNoticedAt', 'ciHeadSeenAt', 'ciHeadSha']) {
+            const tasks = await queryRunner.getTable('tasks');
+            if (tasks?.findColumnByName(column)) {
+                await queryRunner.dropColumn('tasks', column);
+            }
+        }
+        if (await queryRunner.hasTable('task_ci_auto_resume_attempts')) {
+            await queryRunner.dropTable('task_ci_auto_resume_attempts', true);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddCiAutoResume.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddCiAutoResume.spec.ts
@@ -1,0 +1,184 @@
+import { DataSource, Table } from 'typeorm';
+import { AddCiAutoResume1789800000000 } from '../1789800000000-AddCiAutoResume';
+
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — schema.
+ *
+ * Same in-memory better-sqlite3 harness as the sibling migration specs.
+ * Assertions are against the PHYSICAL schema (`PRAGMA table_info`,
+ * `PRAGMA index_list`) rather than against a query that happens to
+ * succeed: a column that exists under a different name, or a unique
+ * index created as an ordinary one, would pass an insert-shaped test and
+ * still let a redelivered check event buy a second model run.
+ */
+describe('AddCiAutoResume1789800000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddCiAutoResume1789800000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        const runner = dataSource.createQueryRunner();
+        await runner.createTable(
+            new Table({
+                name: 'tasks',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'title', type: 'varchar', length: '500' },
+                    { name: 'prNumber', type: 'int', isNullable: true },
+                    { name: 'ciState', type: 'varchar', length: '16', isNullable: true },
+                ],
+            }),
+        );
+        await runner.query(
+            `INSERT INTO tasks (id, "userId", title, "prNumber", "ciState") VALUES (?, ?, ?, ?, ?)`,
+            ['task-1', 'user-1', 'Add the login button', 42, 'failing'],
+        );
+        await runner.release();
+    });
+
+    afterEach(async () => {
+        if (dataSource.isInitialized) await dataSource.destroy();
+    });
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    /** The physical column list, straight from sqlite. */
+    async function columns(table: string): Promise<Record<string, { notnull: number }>> {
+        const rows: Array<{ name: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("${table}")`,
+        );
+        return Object.fromEntries(rows.map((row) => [row.name, { notnull: row.notnull }]));
+    }
+
+    it('creates the attempt ledger with every column the entity declares', async () => {
+        await runUp();
+        const ledger = await columns('task_ci_auto_resume_attempts');
+        expect(Object.keys(ledger).sort()).toEqual(
+            [
+                'claimKey',
+                'createdAt',
+                'detail',
+                'failureKey',
+                'headSha',
+                'id',
+                'organizationId',
+                'resumedRunId',
+                'sourceRunId',
+                'taskId',
+                'tenantId',
+                'trigger',
+                'workId',
+            ].sort(),
+        );
+        // The three that carry the decision are NOT NULL; everything a
+        // delivery might not know is nullable.
+        expect(ledger.taskId.notnull).toBe(1);
+        expect(ledger.trigger.notnull).toBe(1);
+        expect(ledger.claimKey.notnull).toBe(1);
+        expect(ledger.headSha.notnull).toBe(0);
+        expect(ledger.failureKey.notnull).toBe(0);
+        expect(ledger.resumedRunId.notnull).toBe(0);
+    });
+
+    it('makes (taskId, claimKey) UNIQUE — the guard against a resume storm', async () => {
+        await runUp();
+        const indices: Array<{ name: string; unique: number }> = await dataSource.query(
+            `PRAGMA index_list("task_ci_auto_resume_attempts")`,
+        );
+        const claim = indices.find((index) => index.name === 'uq_task_ci_auto_resume_claim');
+        expect(claim).toBeDefined();
+        expect(claim?.unique).toBe(1);
+        const claimColumns: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA index_info("uq_task_ci_auto_resume_claim")`,
+        );
+        expect(claimColumns.map((column) => column.name)).toEqual(['taskId', 'claimKey']);
+
+        expect(indices.some((index) => index.name === 'idx_task_ci_auto_resume_task')).toBe(true);
+    });
+
+    it('enforces that uniqueness at the database, and scopes it to ONE Task', async () => {
+        await runUp();
+        const insert = (taskId: string, claimKey: string) =>
+            dataSource.query(
+                `INSERT INTO task_ci_auto_resume_attempts (id, "taskId", trigger, "claimKey") VALUES (?, ?, ?, ?)`,
+                [`${taskId}-${claimKey}`, taskId, 'ci', claimKey],
+            );
+
+        await insert('task-1', 'ci:abc123');
+        await expect(
+            dataSource.query(
+                `INSERT INTO task_ci_auto_resume_attempts (id, "taskId", trigger, "claimKey") VALUES (?, ?, ?, ?)`,
+                ['second', 'task-1', 'ci', 'ci:abc123'],
+            ),
+        ).rejects.toThrow(/UNIQUE/i);
+
+        // A different head, and another Task's identical head, are both fine.
+        await expect(insert('task-1', 'ci:def456')).resolves.toBeDefined();
+        await expect(insert('task-2', 'ci:abc123')).resolves.toBeDefined();
+    });
+
+    it('adds the three Task columns as nullable and leaves existing rows untouched', async () => {
+        await runUp();
+        const tasks = await columns('tasks');
+        for (const column of ['ciHeadSha', 'ciHeadSeenAt', 'ciAutoResumeNoticedAt']) {
+            expect(tasks[column]).toBeDefined();
+            expect(tasks[column].notnull).toBe(0);
+        }
+        expect(
+            await dataSource.query(
+                `SELECT "ciState", "ciHeadSha", "ciHeadSeenAt", "ciAutoResumeNoticedAt" FROM tasks WHERE id = ?`,
+                ['task-1'],
+            ),
+        ).toEqual([
+            {
+                ciState: 'failing',
+                ciHeadSha: null,
+                ciHeadSeenAt: null,
+                ciAutoResumeNoticedAt: null,
+            },
+        ]);
+    });
+
+    it('is idempotent on re-run and reversible', async () => {
+        await runUp();
+        await runUp();
+        expect(Object.keys(await columns('tasks'))).toContain('ciHeadSha');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+
+        const after = await columns('tasks');
+        for (const column of ['ciHeadSha', 'ciHeadSeenAt', 'ciAutoResumeNoticedAt']) {
+            expect(after[column]).toBeUndefined();
+        }
+        expect(Object.keys(await columns('task_ci_auto_resume_attempts'))).toHaveLength(0);
+
+        // …and a second down() is a no-op, not a crash.
+        const again = dataSource.createQueryRunner();
+        await expect(migration.down(again)).resolves.toBeUndefined();
+        await again.release();
+    });
+
+    it('is a no-op when `tasks` does not exist yet (ordering safety)', async () => {
+        const runner = dataSource.createQueryRunner();
+        await runner.dropTable('tasks');
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await runner.release();
+        // The ledger is still created — it has no dependency on `tasks`.
+        expect(Object.keys(await columns('task_ci_auto_resume_attempts')).length).toBeGreaterThan(
+            0,
+        );
+    });
+});

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -105,6 +105,12 @@ const sidebars: SidebarsConfig = {
 				// are listed together and before the money/ops pages.
 				'features/task-isolation',
 				'features/quality-gates',
+				// The half of the chain that runs AFTER the pull request is
+				// open: the provider's own check results come back in, and
+				// a red build resumes the run under a bounded budget. Reads
+				// between the gate that ran locally and the policy that
+				// lands the branch.
+				'features/ci-auto-resume',
 				'features/merge-policy',
 				// Not part of that chain — Agent Capabilities is Merge
 				// Policy's sibling matrix (same four-scope lattice,

--- a/docs/features/ci-auto-resume.md
+++ b/docs/features/ci-auto-resume.md
@@ -1,0 +1,120 @@
+---
+id: ci-auto-resume
+title: CI feedback and the autonomous fix loop
+sidebar_label: CI Auto-Fix
+---
+
+# CI feedback and the autonomous fix loop
+
+An Agent opens a pull request. Two minutes later the build goes red. Until this feature existed, that was where the platform stopped: the check result never became an event, nothing dispatched on it, and the run sat finished until a person noticed and pressed **Resume**.
+
+Now the red build is the signal. The platform ingests the provider's own check results, attaches the failing output to the Task, and resumes the run that opened the pull request — **under a hard, durable retry budget**, and with an Inbox notice when that budget is spent.
+
+:::warning This feature spends money
+Every automatic retry is a full Agent run: the same order of model spend as the run that opened the pull request in the first place. The default budget is **2 attempts per Task, for the Task's whole life** — not per push, not per day. Set `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS=0` to switch the fix loop off entirely; the check results are still ingested and the board still shows the red dot.
+:::
+
+## What arrives, and what it becomes
+
+Subscribe the GitHub App (or the repository webhook) to **Check runs**, **Check suites** and **Workflow runs** — see [Connect integrations](../guides/connect-integrations.md). Deliveries ride the existing GitHub receiver, so they are signature-verified and attributed to an account exactly like pull requests are.
+
+| Delivery       | Becomes                                                                                | Carries                                                                               |
+| -------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `check_run`    | a `github.check` event, identity `check:<repo>@<sha>:run:<id>:<status>[:<conclusion>]` | the per-job **output** (`title`, `summary`) — the only failing text a webhook carries |
+| `check_suite`  | a `github.check` event, identity `…:suite:<id>:…`                                      | the aggregate verdict; no per-job output and no page link                             |
+| `workflow_run` | a `github.check` event, identity `…:workflow:<id>#<attempt>:…`                         | the run attempt counter, which is what tells a re-run from a redelivery               |
+
+Every one routes to a Work through the repository (`workHint: repo`), so an [inbound trigger](inbound-triggers.md) can match `{ "source": "github", "kind": "github.check" }` with no extra wiring.
+
+The identity is the whole dedupe story. A byte-identical **redelivery** produces the same id and dedupes to nothing; a **re-run** of the same commit produces a new id, because a re-run is a genuinely new result.
+
+Only **completed** results are ingested. A job announcing itself as `queued` or `in_progress` carries no verdict anything can act on, and it is roughly half of everything a provider sends — a fifteen-job matrix announces three states per job, and the suite and workflow events restate every transition. Each stored event costs an activity-feed row and, where a memory provider is configured, a paid embedding, so the intermediate states are dropped at the edge. Every completed verdict — red, green and inconclusive — is still stored, so the board and inbound triggers see all of them.
+
+### Onto the Task
+
+Two Task columns are written from these deliveries rather than from the two-minute [PR status poll](tasks.md):
+
+- **`ciHeadSha` / `ciHeadSeenAt`** — the head commit CI last reported against. This is what makes "is this result for the commit we still care about?" answerable; before it, the platform stored the branch's _base_ commit and nothing else. The [PR status poll](tasks.md) writes the same pair from the pull request's own head, through the same compare-and-set, so the two writers cannot clobber each other.
+- **`ciState`** — written **red only**. A single green check is not a green gate; only the poll, which sees every check at once, may write `passing`. Red beats everything, and the loop never reports green early.
+
+## What counts as red
+
+Exactly what the board's CI dot counts as red: `failure`, `timed_out`, `action_required`, and (for workflow runs) `startup_failure`.
+
+`cancelled`, `neutral`, `skipped` and `stale` are **not** failures — a human stopping a job, or a job that decided it had nothing to do, is not something to spend a model run fixing. A check that has not completed is never actionable whatever its conclusion field says, and a completed check with no conclusion at all is treated as unsettled rather than as a pass.
+
+## The retry budget
+
+|                         |                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Setting**             | `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS`                                                                   |
+| **Default**             | `2`                                                                                                  |
+| **Range**               | `0`–`5` (`0` = the fix loop is off; an unparseable value falls back to the default)                  |
+| **Scope**               | per **Task**, for the Task's whole life                                                              |
+| **Cost of one attempt** | one `agent-task-execute` run — the same order of model spend as the run that opened the pull request |
+| **Shared with**         | the reviewer-rejection path below; both spend the same budget                                        |
+
+Two, because the first retry catches the ordinary case — a lint slip, a missing import, a snapshot the Agent forgot to update — and the second catches "the fix was almost right". A third has in practice meant the Agent does not understand the failure, and paying a third run to find that out is worse than filing the notice one run earlier.
+
+**The budget is rows, not a counter.** Each attempt is a row in `task_ci_auto_resume_attempts`, written _before_ the resume is dispatched. Counting rows is counting attempts — never events — and it survives a crash, a redeploy and a replica swap. If the ledger cannot be read, the loop **stops**: a budget nobody can count is not a budget.
+
+The count is re-read straight after the row is claimed, so two deliveries for two different commits that both read the same stale count cannot both spend a run — the one that pushed the Task past its budget refuses to dispatch. Its row stays claimed (deleting it would re-open the coordinate to the next redelivery), so a lost race costs an attempt slot and no model run. This side of the trade is deliberate: it fails toward not spending.
+
+### One resume per push, not one per failing job
+
+A twelve-job matrix goes red twelve times for one push, each job reports `created` and then `completed`, the suite and the workflow report too, and GitHub redelivers anything it did not get a `200` for — roughly thirty deliveries, doubled on a retry. The attempt row is claimed on `(task, head commit)` with a database-level unique index, so **all of it collapses into one attempt**. The losers are told the coordinate is already claimed and do nothing.
+
+Because of that, the resumed run reads the _first_ red result reported for the commit, not a full list — and the message it is seeded with says so, and tells it to read the pull request's checks before fixing.
+
+### An unchanged failure is not progress
+
+Each attempt also records a fingerprint of _what_ failed (the failing check names plus a digest of the reported output). If the same failure comes back byte-identical on a **new** commit, the Agent pushed something and the build broke the same way: the loop stops there rather than buying another run, and files the notice.
+
+## What refuses to resume
+
+| Situation                                                                      | Why                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A green, pending, cancelled or skipped result                                  | Only a completed failure is actionable. A green re-run arriving after a red one is not a failure, so it changes nothing.                                                                                                            |
+| A **superseded head** — see below                                              | CI catching up on a revision that has already been replaced would fix code nobody has.                                                                                                                                              |
+| A **merged or closed** pull request                                            | There is nothing left to push a fix to. Checked from `prState` / `branchState`, because the merged → done transition is poll-driven and can lag by minutes, and a pull request closed without merging is never transitioned at all. |
+| A repository that belongs to the Work but is **not the one its Tasks live in** | A Work owns up to three repositories; Task branches and Task pull requests are opened in the **data** repo, so a pull request `#7` in the website repo is a different pull request that happens to share a number.                  |
+| A run that is **queued or running**                                            | The fix may already be in flight.                                                                                                                                                                                                   |
+| A run **parked on a question**                                                 | That is yours to answer; resuming would consume the Inbox item with CI feedback.                                                                                                                                                    |
+| A **failed or cancelled** run                                                  | A cancel is an explicit human stop and is never undone by a webhook.                                                                                                                                                                |
+| A **done or cancelled** Task                                                   | Finished is finished.                                                                                                                                                                                                               |
+| The **global stop flag** set, or unreadable                                    | Panic controls fail closed.                                                                                                                                                                                                         |
+| A repository that is not a Work you hold                                       | The Task is resolved from platform state — the owning account, its Works, then the pull request number or branch. Nothing in a webhook body chooses an account.                                                                     |
+
+### Which commit a result is really about
+
+Two different commits are **not** ordered by their timestamps. A push's jobs finish at wildly different times, so a slow job belonging to the previous commit routinely completes _after_ the next push has already reported its first check — and a manual "Re-run jobs" on an old commit carries a brand-new timestamp by definition. Ordering by the clock would classify both as a fresh head, rewrite `ciHeadSha` backwards, and spend an attempt on a revision nobody has.
+
+Instead the delivery's own pull-request head pointer decides: every same-repository check delivery says where the pull request's head is _right now_, so a result whose commit is not that head is refused outright, with no clock involved. The clock is the fallback only when there is no pointer (a fork pull request, a push-triggered workflow run) — and a delivery that reported no usable time at all is refused rather than trusted, because a substituted "now" is always the newest thing in any comparison.
+
+### When a red result arrives at a bad moment
+
+A webhook delivery is a one-shot: refusing it (because a run was still in flight, or a question was still open) used to mean the red build was never retried at all, silently. The two-minute PR status poll is the safety net — it already walks exactly the open pull requests whose verdict has gone stale, so a gate that is _still_ red is re-offered to the same evaluator on the next tick. That cannot double-spend: the claim is keyed on the head commit, so a commit already resumed for is refused forever after.
+
+## Reviewer rejections
+
+The same loop acts on the other half of the feedback: when a human requests changes on the pull request, or an allow-listed [reviewer bot](community-pr-processing.md) leaves a finding, the review bridge records a durable rejection — and this loop resumes the run to answer it, instead of parking the row until somebody presses Resume.
+
+It reads the recorded rejection, not the delivery, so a review that recorded nothing (an approval, a plain comment) resumes nothing. The claim is keyed on the rejection row, so a redelivery cannot double it, and the attempt comes out of the same budget as a CI failure.
+
+A comment is only a doorbell — it carries no link to the row it is meant to answer — so the row it rings for is checked rather than merely fetched:
+
+- the platform's **own** identity and any **untrusted bot** never ring it, so the loop cannot wake itself on its own status comment (the same rule the review bridge applies before it records anything);
+- a `gate` row (this loop's own record of a CI failure) is never cashed in by a comment — the CI half owns those;
+- the row has to be about **this** pull request, and less than a week old. A rejection nobody consumed for a week was handled by a human or abandoned.
+
+## When the budget is spent
+
+Exactly **one** Inbox notice per Task — claimed with a compare-and-set marker on the Task itself, so the dozens of deliveries that all rediscover a spent budget cannot each file a row. It names the pull request, the last head commit seen, how many attempts were used, and whether the loop stopped because the budget ran out or because the same failure came back unchanged.
+
+Nothing further is retried automatically for that Task, and that is literal: the notice marker **is** the stop flag, so once it is claimed every later delivery for that Task is a read and nothing else. Open the pull request, read the failing check, and either fix it yourself or resume the run manually once you know what to tell the Agent.
+
+## What it looks like in the audit trail
+
+- The resumed run's `agent_run_logs` row is stamped `action: 'resume'` with `autoResume: true`, so a machine-initiated run is never mistaken for you pressing the button.
+- The failing output is persisted as a rejection on the Task (source `gate`), which is what the resumed run reads first — and what survives if the dispatch itself fails.
+- `task_ci_auto_resume_attempts` is append-only: the budget is the history.

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -108,9 +108,18 @@ Deliveries for an installation nobody has claimed are a 200 no-op that files not
 - Repeated `event_alert` deliveries for the **same issue** collapse into **one event per five minutes**. A Sentry issue is one fingerprint, so alerts inside a window are one revision of it: a flapping issue lands ~12 events an hour instead of one per occurrence, which is what keeps it out of everyone else's ingest queue. A genuinely later alert still lands as a new revision, and the newest facts (release, level, culprit) travel with whichever delivery opens a window.
 - Work routing: claim the Sentry **project slug** under **Tracker team** on the Work; `event_alert` deliveries carry only the numeric project id, so claim that too if you route alert-rule fires. Raw bodies are never logged — event alerts carry stack frames and user context.
 
+### CI check results
+
+Subscribe the GitHub App (or the repository webhook) to **Check runs**, **Check suites** and **Workflow runs**, and every result becomes a `github.check` event on the same spine, verified and attributed exactly like a pull request.
+
+- Identity carries the head commit plus the provider's own run id, status and conclusion, so an exact redelivery dedupes to nothing while a re-run of the same commit is a new result.
+- The head commit and a RED `ciState` are written onto the Task from the delivery, rather than waiting for the two-minute PR status poll. Green is never written from a webhook — one green check is not a green gate.
+- A completed **failure** can resume the Task's run automatically, under a durable per-Task retry budget (default two attempts, `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS=0` to switch it off). Read [CI Auto-Fix](ci-auto-resume.md) before turning it up: every attempt is a full Agent run.
+- Match them in a trigger with `{ "source": "github", "kind": "github.check" }`.
+
 ### The `incident` kind
 
-An incident is "something broke and somebody should look". Every incident source normalizes into the one `kind: incident` envelope with the same payload block (`provider`, `externalId`, `title`, `url`, `culprit`, `level`, `release`, `environment`, `project`, `status`, `action`), so a trigger with `eventMatcher: { kind: 'incident' }` matches all of them and `source` narrows to a vendor. Adding a source means implementing the small `IncidentSource` interface (`apps/api/src/ingest/incidents/`) behind whichever receiver verifies that vendor's signature — a CI-flake source over GitHub `workflow_run` / `check_run` deliveries is the documented next seam.
+An incident is "something broke and somebody should look". Every incident source normalizes into the one `kind: incident` envelope with the same payload block (`provider`, `externalId`, `title`, `url`, `culprit`, `level`, `release`, `environment`, `project`, `status`, `action`), so a trigger with `eventMatcher: { kind: 'incident' }` matches all of them and `source` narrows to a vendor. Adding a source means implementing the small `IncidentSource` interface (`apps/api/src/ingest/incidents/`) behind whichever receiver verifies that vendor's signature. GitHub's `check_run` / `check_suite` / `workflow_run` deliveries are handled — but as their own `github.check` kind rather than as incidents, because a red build on your own pull request is work to finish, not an incident to triage; see [CI Auto-Fix](ci-auto-resume.md). A CI-**flake** source (the same job going red and green across unrelated commits) remains the documented next seam here.
 
 ### Triage Tasks
 

--- a/docs/guides/connect-integrations.md
+++ b/docs/guides/connect-integrations.md
@@ -179,19 +179,20 @@ Self-hosting? You register your own GitHub App and wire it through environment v
     - **Payload URL**: `https://api.ever.works/api/ingest/github/events`
     - **Content type**: `application/json`
     - **Secret**: the exact value from step 2
-    - **Events**: pull requests, issue comments, pull request review comments, and pushes
+    - **Events**: pull requests, issue comments, pull request review comments, pushes, and — for the [CI auto-fix loop](../features/ci-auto-resume.md) — check runs, check suites and workflow runs
 4. Save, open a pull request, and check **Recent Deliveries** on the webhook for a `200`.
 
 Deliveries with a missing or mismatched `X-Hub-Signature-256` are rejected.
 
 ### What triggers a review, and what only gets recorded
 
-| Delivery                                                           | Result                                                                                                                         |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `pull_request` **opened** / **synchronize**                        | Ingested as `github.pr`, then reviewed. The review is keyed on the head SHA, so each pushed revision is reviewed exactly once. |
-| `@ever-works` in an issue comment or a pull-request review comment | Ingested as `github.mention`. The comment text rides along as the review instruction and the reply lands in that thread.       |
-| `push`                                                             | Ingested as `github.push` and `github.commit` — Activity only. The code has already landed, so there is nothing to review.     |
-| `pull_request` **closed** with `merged: true`                      | Ingested as `github.merge`. Also Activity only.                                                                                |
+| Delivery                                                           | Result                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pull_request` **opened** / **synchronize**                        | Ingested as `github.pr`, then reviewed. The review is keyed on the head SHA, so each pushed revision is reviewed exactly once.                                                                                                            |
+| `@ever-works` in an issue comment or a pull-request review comment | Ingested as `github.mention`. The comment text rides along as the review instruction and the reply lands in that thread.                                                                                                                  |
+| `push`                                                             | Ingested as `github.push` and `github.commit` — Activity only. The code has already landed, so there is nothing to review.                                                                                                                |
+| `pull_request` **closed** with `merged: true`                      | Ingested as `github.merge`. Also Activity only.                                                                                                                                                                                           |
+| `check_run` / `check_suite` / `workflow_run`                       | Ingested as `github.check`, and the Task's `ciHeadSha` (plus a RED `ciState`) is written from it. A completed **failure** can auto-resume the Task's run under a bounded retry budget — see [CI Auto-Fix](../features/ci-auto-resume.md). |
 
 For each review the platform matches the repository to a Work across all three repository roles, builds a byte-capped diff, adds [Knowledge Base](../features/knowledge-base.md) context and memory recall, makes one structured AI call, and posts the result. See [Community PR Processing](../features/community-pr-processing.md) for the review loop in depth.
 

--- a/packages/agent/src/agents/__tests__/run-steering-auto-resume.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-steering-auto-resume.spec.ts
@@ -1,0 +1,179 @@
+import { ConflictException } from '@nestjs/common';
+import { RunSteeringService } from '../run-steering.service';
+
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the one status
+ * `resume` learned to accept, and everything it still refuses.
+ *
+ * Why this needed a widening at all: a red build arrives MINUTES after
+ * the run that pushed the branch has ended cleanly, so the run the fix
+ * loop must continue is always `completed`. Before this, `resume` threw
+ * 409 for it, which would have made the whole slice inert.
+ *
+ * The risk of the widening is the opposite one — that the human Resume
+ * button, or a webhook, starts reviving runs nobody meant to revive. So
+ * every assertion below is about what did NOT become resumable.
+ */
+describe('RunSteeringService — auto-resume widening (slice AC)', () => {
+    const baseRun = {
+        id: 'run-old',
+        agentId: 'agent-1',
+        userId: 'user-1',
+        taskId: 'task-1',
+        workId: 'work-1',
+        status: 'completed',
+        awaitingInput: false,
+        terminalEndedReason: null as string | null,
+        cliSessionId: 'cli-abc',
+        organizationId: null,
+        tenantId: null,
+        persistent: false,
+        runnerKind: null,
+    };
+
+    let runs: any;
+    let dispatcher: any;
+
+    function makeSvc(): RunSteeringService {
+        const svc = new RunSteeringService(runs, undefined, dispatcher);
+        for (const level of ['warn', 'log'] as const) {
+            jest.spyOn(
+                (svc as never as { logger: Record<string, () => void> }).logger,
+                level,
+            ).mockImplementation(() => undefined);
+        }
+        return svc;
+    }
+
+    beforeEach(() => {
+        runs = {
+            findByIdAndUser: jest.fn().mockResolvedValue({ ...baseRun }),
+            createQueued: jest.fn().mockResolvedValue({ id: 'run-new' }),
+            seedResumeContext: jest.fn().mockResolvedValue(undefined),
+            setAwaitingInput: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trigger-1' }) };
+    });
+
+    describe('isAutoResumable', () => {
+        const shape = (over: Record<string, unknown>) => ({
+            status: 'completed',
+            awaitingInput: false,
+            terminalEndedReason: null,
+            ...over,
+        });
+
+        it('accepts a normally finished run, which plain isResumable refuses', () => {
+            const run = shape({}) as never;
+            expect(RunSteeringService.isResumable(run)).toBe(false);
+            expect(RunSteeringService.isAutoResumable(run)).toBe(true);
+        });
+
+        it('still accepts everything the human path accepts', () => {
+            for (const run of [
+                shape({ awaitingInput: true }),
+                shape({ terminalEndedReason: 'parked' }),
+            ]) {
+                expect(RunSteeringService.isAutoResumable(run as never)).toBe(true);
+            }
+        });
+
+        it('refuses a live, failed or cancelled run — a cancel is a human stop', () => {
+            for (const status of ['queued', 'running', 'failed', 'cancelled']) {
+                expect(RunSteeringService.isAutoResumable(shape({ status }) as never)).toBe(false);
+            }
+        });
+    });
+
+    it('refuses a completed run WITHOUT the flag — the human Resume button is unchanged', async () => {
+        await expect(makeSvc().resume('run-old', 'user-1')).rejects.toBeInstanceOf(
+            ConflictException,
+        );
+        expect(runs.createQueued).not.toHaveBeenCalled();
+    });
+
+    it('resumes a completed run WITH the flag, through the ordinary dispatch path', async () => {
+        const outcome = await makeSvc().resumeRun({
+            runId: 'run-old',
+            userId: 'user-1',
+            allowCompleted: true,
+        });
+        expect(outcome).toMatchObject({ runId: 'run-new', resumedFromRunId: 'run-old' });
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({ taskId: 'task-1', userId: 'user-1' }),
+        );
+        expect(dispatcher.enqueue).toHaveBeenCalledWith(
+            expect.objectContaining({ dedupKey: 'task-1:agent-1:resume:run-new' }),
+        );
+    });
+
+    it('still refuses a cancelled run even with the flag', async () => {
+        runs.findByIdAndUser.mockResolvedValue({ ...baseRun, status: 'cancelled' });
+        await expect(
+            makeSvc().resumeRun({ runId: 'run-old', userId: 'user-1', allowCompleted: true }),
+        ).rejects.toBeInstanceOf(ConflictException);
+        expect(runs.createQueued).not.toHaveBeenCalled();
+    });
+
+    it('still refuses a heartbeat run with no Task', async () => {
+        runs.findByIdAndUser.mockResolvedValue({ ...baseRun, taskId: null });
+        await expect(
+            makeSvc().resumeRun({ runId: 'run-old', userId: 'user-1', allowCompleted: true }),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('is owner-scoped: a run the acting user does not own is a 404, not a resume', async () => {
+        runs.findByIdAndUser.mockResolvedValue(null);
+        await expect(
+            makeSvc().resumeRun({ runId: 'run-old', userId: 'someone-else', allowCompleted: true }),
+        ).rejects.toThrow(/not found/);
+        expect(runs.createQueued).not.toHaveBeenCalled();
+    });
+
+    it('seeds a caller message when one is given, and nothing when it is not', async () => {
+        await makeSvc().resumeRun({
+            runId: 'run-old',
+            userId: 'user-1',
+            message: 'CI is red on lint-and-test.',
+            allowCompleted: true,
+        });
+        expect(runs.seedResumeContext).toHaveBeenCalledWith('run-new', {
+            cliSessionId: 'cli-abc',
+            pendingInput: ['CI is red on lint-and-test.'],
+        });
+
+        runs.seedResumeContext.mockClear();
+        await makeSvc().resumeRun({ runId: 'run-old', userId: 'user-1', allowCompleted: true });
+        expect(runs.seedResumeContext).toHaveBeenCalledWith('run-new', {
+            cliSessionId: 'cli-abc',
+            pendingInput: null,
+        });
+    });
+
+    it('stamps the audit row as an AUTOMATED resume', async () => {
+        const runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        const svc = new RunSteeringService(runs, runLogs as never, dispatcher);
+        jest.spyOn(
+            (svc as never as { logger: Record<string, () => void> }).logger,
+            'log',
+        ).mockImplementation(() => undefined);
+
+        await svc.resumeRun({ runId: 'run-old', userId: 'user-1', allowCompleted: true });
+        expect(runLogs.append).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({ action: 'resume', autoResume: true }),
+            }),
+        );
+
+        runLogs.append.mockClear();
+        runs.findByIdAndUser.mockResolvedValue({ ...baseRun, awaitingInput: true });
+        await svc.resume('run-old', 'user-1', 'my answer');
+        expect(runLogs.append).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({ autoResume: false }),
+            }),
+        );
+    });
+});

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -14,7 +14,10 @@ import {
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
+import { MAX_REPLAYED_REJECTIONS } from '../tasks-domain/run-steering-port';
 import type {
+    RunResumeRequest,
+    RunResumeResult,
     RunSteerInput,
     RunSteerOutcome,
     RunSteeringPort,
@@ -33,17 +36,23 @@ type ScopedRunSteerInput = RunSteerInput & { ownershipScope?: OwnershipScope };
  */
 const RESUMABLE_ENDED_REASONS = ['parked'] as const;
 
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the ONE extra
+ * status an AUTOMATED resume may act on, opted into per call via
+ * `RunResumeOptions.allowCompleted`.
+ *
+ * A red build arrives minutes AFTER the run that pushed the branch has
+ * ended cleanly, so `completed` is the only state the fix loop ever finds
+ * its target in. It is deliberately not added to
+ * {@link RESUMABLE_ENDED_REASONS}: the human "Resume" button must keep
+ * refusing a finished run (there is nothing for a person to answer), and
+ * `failed` / `cancelled` runs stay un-resumable for everyone — a cancel is
+ * a human's explicit stop and must never be undone by a webhook.
+ */
+const AUTO_RESUMABLE_STATUSES = ['completed'] as const;
+
 /** Longest steering message accepted. Matches the task-chat body cap. */
 const MAX_STEER_BYTES = 16 * 1024;
-
-/**
- * Orchestration M9 — how many pending rejections a single resume replays.
- * Bounded so a Task that accumulated a rejection storm cannot blow the
- * resumed run's first prompt; the oldest are replayed first (a comment
- * thread reads in order), and anything beyond the cap stays pending for
- * the resume after this one.
- */
-const MAX_REPLAYED_REJECTIONS = 3;
 
 /**
  * Chat-template control markers a rejection body could try to forge.
@@ -119,6 +128,18 @@ export function composeRejectionFeedbackMessage(
         lines.push('');
     }
     return lines.join('\n').trimEnd();
+}
+
+/**
+ * Per-call widening of {@link RunSteeringService.resume} (slice AC).
+ * Absent = today's behaviour, byte for byte.
+ */
+export interface RunResumeOptions {
+    /**
+     * Permit resuming a run that finished NORMALLY. Set only by the
+     * automated CI fix loop; the human Resume endpoint never sets it.
+     */
+    allowCompleted?: boolean;
 }
 
 export interface RunInterruptOutcome {
@@ -219,6 +240,21 @@ export class RunSteeringService implements RunSteeringPort {
         );
     }
 
+    /**
+     * A run a CI-driven resume may continue (slice AC): everything
+     * {@link isResumable} accepts, PLUS a run that finished normally.
+     * Never a live run, never a failed or cancelled one.
+     */
+    static isAutoResumable(
+        run: Pick<AgentRun, 'status' | 'awaitingInput' | 'terminalEndedReason'>,
+    ) {
+        if (RunSteeringService.isResumable(run)) return true;
+        return (
+            !RunSteeringService.isLive(run) &&
+            AUTO_RESUMABLE_STATUSES.includes(run.status as (typeof AUTO_RESUMABLE_STATUSES)[number])
+        );
+    }
+
     // ── steer ──────────────────────────────────────────────────────
 
     async steer(input: ScopedRunSteerInput): Promise<RunSteerOutcome> {
@@ -283,17 +319,50 @@ export class RunSteeringService implements RunSteeringPort {
 
     // ── resume ─────────────────────────────────────────────────────
 
+    /**
+     * CI feedback + autonomous fix loop (slice AC, EW-806) — the object
+     * form the `RUN_STEERING_PORT` exposes, so `TaskCiAutoResumeService`
+     * can resume without importing this module (the port file explains
+     * why the import direction is one-way).
+     *
+     * A thin adapter on purpose: every guard, the dispatch gate, the
+     * rejection replay and the audit stamp are {@link resume}'s, unchanged.
+     */
+    async resumeRun(request: RunResumeRequest): Promise<RunResumeResult> {
+        const outcome = await this.resume(
+            request.runId,
+            request.userId,
+            request.message ?? null,
+            undefined,
+            { allowCompleted: request.allowCompleted === true },
+        );
+        return {
+            runId: outcome.runId,
+            resumedFromRunId: outcome.resumedFromRunId,
+            queued: outcome.queued,
+            rejectionsReplayed: outcome.rejectionsReplayed,
+        };
+    }
+
     async resume(
         runId: string,
         userId: string,
         message?: string | null,
         ownershipScope?: OwnershipScope,
+        // Appended LAST and optional, the house positional convention:
+        // every existing call site and every positional test construction
+        // keeps its meaning.
+        options?: RunResumeOptions,
     ): Promise<RunResumeOutcome> {
         const trimmed =
             message == null || message.trim().length === 0 ? null : this.assertMessage(message);
         const run = await this.requireOwnedRun(runId, userId, ownershipScope);
 
-        if (!RunSteeringService.isResumable(run)) {
+        const resumable =
+            options?.allowCompleted === true
+                ? RunSteeringService.isAutoResumable(run)
+                : RunSteeringService.isResumable(run);
+        if (!resumable) {
             throw new ConflictException(
                 `AgentRun ${runId} is not resumable — resume applies to runs awaiting input or ` +
                     `ended with reason '${RESUMABLE_ENDED_REASONS.join("' / '")}' ` +
@@ -444,6 +513,11 @@ export class RunSteeringService implements RunSteeringPort {
             hasMessage: Boolean(trimmed),
             queued: !admission.admitted,
             rejectionsReplayed: replayed.count,
+            // Slice AC — an automated resume is auditable as one. Without
+            // this the only trace of a machine-initiated model run would be
+            // a `resume` row stamped with the Task owner, indistinguishable
+            // from the owner pressing the button.
+            autoResume: options?.allowCompleted === true,
         });
         // Streaming terminal: the fan-out path gates on `requirePersistent`,
         // but resume dispatches `agent-task-execute` directly, so without this

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -38,6 +38,15 @@ import {
     catalogCreditsMarginPercent,
     catalogPaygMaxMonthlyCapCredits,
 } from '../subscriptions/billing/stripe-catalog';
+// CI feedback + autonomous fix loop (slice AC, EW-806). Concrete file
+// import, not the tasks-domain barrel: `task-ci-auto-resume.ts` is a pure
+// leaf (its only import is `node:crypto`) and pulling the barrel here
+// would drag the Nest service graph into config resolution.
+import {
+    DEFAULT_CI_AUTO_RESUME_ATTEMPTS,
+    MAX_CI_AUTO_RESUME_ATTEMPTS,
+    clampAutoResumeAttempts,
+} from '../tasks-domain/task-ci-auto-resume';
 type AppType = 'cli' | 'api';
 
 /**
@@ -1466,6 +1475,37 @@ export const config = {
         getTaskFanoutScanLimit() {
             const raw = parseInt(process.env.TASK_FANOUT_SCAN_LIMIT || '50', 10);
             return Number.isFinite(raw) && raw > 0 ? raw : 50;
+        },
+        /**
+         * CI feedback + autonomous fix loop (self-build slice AC, EW-806) —
+         * how many times ONE Task may be auto-resumed, over its whole life,
+         * because CI went red or a reviewer rejected its pull request.
+         *
+         * 💸 THIS KNOB SPENDS MONEY. Each attempt is a full
+         * `agent-task-execute` run on a fleet PC — the same order of model
+         * spend as the run that opened the pull request. The default of
+         * TWO therefore caps what this feature can add to any one Task at
+         * two extra runs, forever, not two per push and not two per day.
+         *
+         * `0` switches the loop OFF: check results are still ingested and
+         * the board still goes red, nothing is resumed. Values are clamped
+         * to 0..5; an unparseable value falls back to the default rather
+         * than silently disabling a shipped loop.
+         *
+         * The COUNTER is not here — it is rows in
+         * `task_ci_auto_resume_attempts`. This is only the ceiling.
+         */
+        getCiAutoResumeMaxAttempts() {
+            // `clampAutoResumeAttempts` rather than the local
+            // `clampedIntEnv`: the clamp that decides how much money this
+            // loop may spend has its own unit tests next to the constants
+            // it clamps against, and those tests are only worth anything
+            // if this is the function actually shipped. `parseInt` of an
+            // absent or unparseable value yields NaN, which the clamp maps
+            // to DEFAULT_CI_AUTO_RESUME_ATTEMPTS.
+            return clampAutoResumeAttempts(
+                parseInt(process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS ?? '', 10),
+            );
         },
         /**
          * H2 kill-switch for the plan-driven concurrency ceiling

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -92,6 +92,7 @@ import { Task } from '../entities/task.entity';
 import { TaskAssignee } from '../entities/task-assignee.entity';
 import { TaskReviewer } from '../entities/task-reviewer.entity';
 import { TaskReviewRejection } from '../entities/task-review-rejection.entity';
+import { TaskCiAutoResumeAttempt } from '../entities/task-ci-auto-resume-attempt.entity';
 import { TaskApprover } from '../entities/task-approver.entity';
 import { TaskBlock } from '../entities/task-block.entity';
 import { TaskRelation } from '../entities/task-relation.entity';
@@ -253,6 +254,9 @@ export const ENTITIES = [
     TaskReviewer,
     // Orchestration M9 - durable rejection feedback for resume.
     TaskReviewRejection,
+    // CI feedback + autonomous fix loop (slice AC, EW-806) - the durable
+    // auto-resume attempt ledger, which IS the retry budget.
+    TaskCiAutoResumeAttempt,
     TaskApprover,
     TaskBlock,
     TaskRelation,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -159,6 +159,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'TaskAttachment',
     'TaskBlock',
     'TaskChatMessage',
+    'TaskCiAutoResumeAttempt',
     'TaskKbMention',
     'TaskRelation',
     'TaskReviewRejection',

--- a/packages/agent/src/database/repositories/__tests__/task-ci-auto-resume-attempt.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/task-ci-auto-resume-attempt.repository.spec.ts
@@ -1,0 +1,111 @@
+import { DataSource, Repository } from 'typeorm';
+import {
+    TaskCiAutoResumeAttempt,
+    type TaskAutoResumeTrigger,
+} from '../../../entities/task-ci-auto-resume-attempt.entity';
+import { TaskCiAutoResumeAttemptRepository } from '../task-ci-auto-resume-attempt.repository';
+
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the attempt
+ * ledger against a REAL better-sqlite3 schema carrying the REAL unique
+ * index, because that index is the only thing standing between one red
+ * pull request and a resume storm.
+ *
+ * Only this one entity is registered: the ledger has no foreign keys (it
+ * is the spend record and must outlive a deleted Task), so it needs no
+ * other table, and keeping the DataSource this small keeps the suite off
+ * the agent-plugins import chain.
+ */
+describe('TaskCiAutoResumeAttemptRepository (better-sqlite3, real unique index)', () => {
+    const TASK = '11111111-1111-4111-8111-111111111111';
+    let dataSource: DataSource;
+    let rows: Repository<TaskCiAutoResumeAttempt>;
+    let attempts: TaskCiAutoResumeAttemptRepository;
+
+    const claim = (claimKey: string, extra: Partial<{ failureKey: string }> = {}) =>
+        attempts.claim({
+            taskId: TASK,
+            trigger: 'ci' as TaskAutoResumeTrigger,
+            claimKey,
+            headSha: 'a'.repeat(40),
+            ...extra,
+        });
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [TaskCiAutoResumeAttempt],
+            synchronize: true,
+            logging: false,
+        });
+        await dataSource.initialize();
+        rows = dataSource.getRepository(TaskCiAutoResumeAttempt);
+        attempts = new TaskCiAutoResumeAttemptRepository(rows);
+    });
+
+    afterAll(async () => {
+        if (dataSource?.isInitialized) await dataSource.destroy();
+    });
+
+    beforeEach(async () => {
+        jest.restoreAllMocks();
+        await rows.clear();
+    });
+
+    it('claims a coordinate once and refuses the redelivery', async () => {
+        expect(await claim('ci:abc')).not.toBeNull();
+        expect(await claim('ci:abc')).toBeNull();
+        expect(await attempts.countForTask(TASK)).toBe(1);
+    });
+
+    /**
+     * THE regression.
+     *
+     * `claim()` is check-then-insert, so the pre-read absorbs the ordinary
+     * redelivery and the UNIQUE INDEX is the real guard — the one that has
+     * to hold when two API replicas handle the same delivery in the same
+     * instant. That path was never exercised by any test (every existing
+     * case short-circuits on the pre-read), and it was broken: the
+     * violation matcher compared the driver code to the exact string
+     * `SQLITE_CONSTRAINT`, while better-sqlite3 — the driver CI, the e2e
+     * stack and every spec in this repo run on — reports the EXTENDED code
+     * `SQLITE_CONSTRAINT_UNIQUE`. `claim()` therefore THREW instead of
+     * returning null, which `TaskCiAutoResumeService` reports as `error`.
+     *
+     * Stubbing the pre-read to miss is exactly what losing the race looks
+     * like from inside the loser: the row was not there when it looked.
+     */
+    it('returns null (never throws) when the UNIQUE INDEX is what stops it', async () => {
+        expect(await claim('ci:race')).not.toBeNull();
+        // The loser of the race: its pre-read ran before the winner's
+        // insert committed, so it goes straight at the index.
+        jest.spyOn(rows, 'findOne').mockResolvedValueOnce(null);
+
+        await expect(claim('ci:race')).resolves.toBeNull();
+        expect(await attempts.countForTask(TASK)).toBe(1);
+    });
+
+    it('rethrows anything that is NOT a unique violation — a broken ledger must not read as a lost race', async () => {
+        jest.spyOn(rows, 'findOne').mockResolvedValueOnce(null);
+        jest.spyOn(rows, 'save').mockRejectedValueOnce(
+            Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' }),
+        );
+        await expect(claim('ci:busy')).rejects.toThrow('database is locked');
+    });
+
+    it('counts attempts per Task, and answers the no-progress question', async () => {
+        await claim('ci:one', { failureKey: 'f1' });
+        await claim('ci:two', { failureKey: 'f2' });
+        expect(await attempts.countForTask(TASK)).toBe(2);
+        expect(await attempts.hasFailureKey(TASK, 'f1')).toBe(true);
+        expect(await attempts.hasFailureKey(TASK, 'nope')).toBe(false);
+        // An empty fingerprint is never "already tried".
+        expect(await attempts.hasFailureKey(TASK, '')).toBe(false);
+    });
+
+    it('caps an oversized claim key at the column width instead of failing the insert', async () => {
+        const claimed = await claim(`ci:${'z'.repeat(500)}`);
+        expect(claimed!.claimKey).toHaveLength(200);
+    });
+});

--- a/packages/agent/src/database/repositories/task-ci-auto-resume-attempt.repository.ts
+++ b/packages/agent/src/database/repositories/task-ci-auto-resume-attempt.repository.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+    TASK_AUTO_RESUME_CLAIM_KEY_MAX_CHARS,
+    TaskCiAutoResumeAttempt,
+    type TaskAutoResumeTrigger,
+} from '../../entities/task-ci-auto-resume-attempt.entity';
+
+export interface ClaimAutoResumeAttemptInput {
+    taskId: string;
+    trigger: TaskAutoResumeTrigger;
+    /** Idempotency coordinate — UNIQUE per Task. See the entity doc. */
+    claimKey: string;
+    headSha?: string | null;
+    failureKey?: string | null;
+    sourceRunId?: string | null;
+    detail?: string | null;
+    workId?: string | null;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+/**
+ * CI feedback and the autonomous fix loop (slice AC, EW-806) — the
+ * attempt ledger's four operations, and no more.
+ *
+ * Every method here is on the money path: `countForTask` IS the retry
+ * budget, `claim` IS the idempotency guard, and both are allowed to
+ * throw. That is deliberate and the caller depends on it — a budget that
+ * cannot be read must STOP the loop, and a claim that cannot be written
+ * must not be treated as won. Nothing in this file swallows an error into
+ * a permissive default.
+ */
+@Injectable()
+export class TaskCiAutoResumeAttemptRepository {
+    constructor(
+        @InjectRepository(TaskCiAutoResumeAttempt)
+        private readonly repository: Repository<TaskCiAutoResumeAttempt>,
+    ) {}
+
+    /**
+     * How many auto-resume attempts this Task has already spent.
+     *
+     * Rows, not events: one row is one dispatched (or attempted)
+     * resume. THROWS on a read failure — see the class doc.
+     */
+    async countForTask(taskId: string): Promise<number> {
+        return this.repository.count({ where: { taskId } });
+    }
+
+    /**
+     * Has this Task already been retried against this exact failure
+     * fingerprint, on any head?
+     *
+     * The no-progress guard: a failure that comes back byte-identical
+     * after a fix attempt is evidence the retry did not work, and
+     * spending another model run on it is the doom loop this slice
+     * exists to avoid. THROWS on a read failure.
+     */
+    async hasFailureKey(taskId: string, failureKey: string): Promise<boolean> {
+        if (!failureKey) return false;
+        const count = await this.repository.count({ where: { taskId, failureKey } });
+        return count > 0;
+    }
+
+    /**
+     * Claim ONE attempt, or lose the race.
+     *
+     * Returns the row this caller inserted, or `null` when the
+     * `(taskId, claimKey)` unique index says an attempt for this
+     * coordinate already exists — which is the outcome for every GitHub
+     * redelivery, every extra failing job on the same push, and the
+     * loser of two API replicas handling one delivery.
+     *
+     * Check-then-insert is not atomic, so the constraint violation is
+     * the real guard and the pre-read is only there to save an INSERT in
+     * the common case (same convention as
+     * `IngestedEventRepository.createIfNew`).
+     */
+    async claim(input: ClaimAutoResumeAttemptInput): Promise<TaskCiAutoResumeAttempt | null> {
+        const claimKey = input.claimKey.slice(0, TASK_AUTO_RESUME_CLAIM_KEY_MAX_CHARS);
+        const existing = await this.repository.findOne({
+            where: { taskId: input.taskId, claimKey },
+        });
+        if (existing) return null;
+        try {
+            return await this.repository.save(
+                this.repository.create({
+                    taskId: input.taskId,
+                    trigger: input.trigger,
+                    claimKey,
+                    headSha: input.headSha ?? null,
+                    failureKey: input.failureKey ?? null,
+                    sourceRunId: input.sourceRunId ?? null,
+                    detail: input.detail ?? null,
+                    workId: input.workId ?? null,
+                    tenantId: input.tenantId ?? null,
+                    organizationId: input.organizationId ?? null,
+                }),
+            );
+        } catch (error) {
+            if (this.isUniqueViolation(error)) return null;
+            throw error;
+        }
+    }
+
+    /**
+     * Record which run the claimed attempt actually produced.
+     *
+     * Best-effort by contract: the attempt is already spent by the time
+     * this runs, and losing the pointer costs reporting, not safety.
+     */
+    async stampResumedRun(id: string, resumedRunId: string): Promise<void> {
+        await this.repository.update({ id }, { resumedRunId });
+    }
+
+    /**
+     * Attempts for one Task, oldest first. Reporting and tests.
+     *
+     * `id` is a tie-break because `createdAt` has SECOND resolution on
+     * sqlite, so two attempts claimed in the same second would otherwise
+     * come back in an undefined order. Nothing on the decision path ranks
+     * by this list — the budget is decided by {@link countForTask}, which
+     * needs no ordering at all.
+     */
+    async listForTask(taskId: string): Promise<TaskCiAutoResumeAttempt[]> {
+        return this.repository.find({
+            where: { taskId },
+            order: { createdAt: 'ASC', id: 'ASC' },
+        });
+    }
+
+    private isUniqueViolation(error: unknown): boolean {
+        if (!error || typeof error !== 'object') return false;
+        const driverCode = (error as { driverError?: { code?: string } }).driverError?.code;
+        const topCode = (error as { code?: string }).code;
+        // Postgres 23505 / MySQL ER_DUP_ENTRY / SQLite SQLITE_CONSTRAINT*.
+        //
+        // The sqlite arm is a PREFIX match, not the exact `SQLITE_CONSTRAINT`
+        // that several older repositories in this package compare against:
+        // better-sqlite3 — the driver CI, the e2e stack and every spec in
+        // this repo run on — reports the EXTENDED result code, so a real
+        // unique-index hit arrives as `SQLITE_CONSTRAINT_UNIQUE` and an
+        // exact comparison misses it. `claim()` then THROWS instead of
+        // returning null, and the check-then-insert race this ledger exists
+        // to lose gracefully becomes an `error` outcome. Same reasoning (and
+        // same `startsWith`) as `isWorkCustomDomainUniqueConstraintError`.
+        const codes = ['23505', 'ER_DUP_ENTRY'];
+        for (const code of [driverCode, topCode]) {
+            if (typeof code !== 'string') continue;
+            if (codes.includes(code) || code.startsWith('SQLITE_CONSTRAINT')) return true;
+        }
+        return false;
+    }
+}

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -347,6 +347,67 @@ export class TaskRepository {
             })
             .where('id = :taskId', { taskId })
             .andWhere('prNumber = :prNumber', { prNumber })
+     * CI feedback loop (slice AC, EW-806) — record the head commit the
+     * provider is reporting checks against, and the red verdict that came
+     * with it.
+     *
+     * MONOTONIC by construction: the head pair is only written when the
+     * row still carries the head this caller read (or none at all), so two
+     * deliveries racing on one push cannot leave the newer commit
+     * overwritten by the older one. Returns whether this caller's head
+     * write landed.
+     *
+     * Query-builder update for the same reason `updatePrStatusCache` uses
+     * one: it must NOT bump `updatedAt`, or a busy CI would reshuffle the
+     * updatedAt-ordered board on every job.
+     *
+     * `ciState` is only ever written RED here. A single green check is not
+     * a green gate — only the poll, which sees every check at once, may
+     * write `passing` (see `deriveCiState`: red beats everything, never
+     * green early).
+     */
+    async recordCiHead(input: {
+        taskId: string;
+        expectedHeadSha: string | null;
+        headSha: string;
+        seenAt: Date;
+        failing?: boolean;
+    }): Promise<boolean> {
+        const patch: Partial<Task> = { ciHeadSha: input.headSha, ciHeadSeenAt: input.seenAt };
+        if (input.failing) {
+            patch.ciState = 'failing';
+            patch.ciCheckedAt = input.seenAt;
+        }
+        const qb = this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set(patch)
+            .where('id = :taskId', { taskId: input.taskId });
+        if (input.expectedHeadSha === null) {
+            qb.andWhere('ciHeadSha IS NULL');
+        } else {
+            qb.andWhere('ciHeadSha = :expected', { expected: input.expectedHeadSha });
+        }
+        const result = await qb.execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * CI feedback loop (slice AC) — claim the right to file the ONE
+     * "automatic retries stopped" Inbox notice for this Task.
+     *
+     * Compare-and-set from NULL in a single statement, so exactly one of N
+     * concurrent deliveries that all discover a spent budget files the
+     * notice and the rest are told they lost. Same shape as
+     * `FleetNodeRepository.casTripDailyCeiling`.
+     */
+    async casMarkCiAutoResumeNoticed(taskId: string, at: Date): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set({ ciAutoResumeNoticedAt: at })
+            .where('id = :taskId', { taskId })
+            .andWhere('ciAutoResumeNoticedAt IS NULL')
             .execute();
         return (result.affected ?? 0) > 0;
     }

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -347,67 +347,6 @@ export class TaskRepository {
             })
             .where('id = :taskId', { taskId })
             .andWhere('prNumber = :prNumber', { prNumber })
-     * CI feedback loop (slice AC, EW-806) — record the head commit the
-     * provider is reporting checks against, and the red verdict that came
-     * with it.
-     *
-     * MONOTONIC by construction: the head pair is only written when the
-     * row still carries the head this caller read (or none at all), so two
-     * deliveries racing on one push cannot leave the newer commit
-     * overwritten by the older one. Returns whether this caller's head
-     * write landed.
-     *
-     * Query-builder update for the same reason `updatePrStatusCache` uses
-     * one: it must NOT bump `updatedAt`, or a busy CI would reshuffle the
-     * updatedAt-ordered board on every job.
-     *
-     * `ciState` is only ever written RED here. A single green check is not
-     * a green gate — only the poll, which sees every check at once, may
-     * write `passing` (see `deriveCiState`: red beats everything, never
-     * green early).
-     */
-    async recordCiHead(input: {
-        taskId: string;
-        expectedHeadSha: string | null;
-        headSha: string;
-        seenAt: Date;
-        failing?: boolean;
-    }): Promise<boolean> {
-        const patch: Partial<Task> = { ciHeadSha: input.headSha, ciHeadSeenAt: input.seenAt };
-        if (input.failing) {
-            patch.ciState = 'failing';
-            patch.ciCheckedAt = input.seenAt;
-        }
-        const qb = this.repository
-            .createQueryBuilder()
-            .update(Task)
-            .set(patch)
-            .where('id = :taskId', { taskId: input.taskId });
-        if (input.expectedHeadSha === null) {
-            qb.andWhere('ciHeadSha IS NULL');
-        } else {
-            qb.andWhere('ciHeadSha = :expected', { expected: input.expectedHeadSha });
-        }
-        const result = await qb.execute();
-        return (result.affected ?? 0) > 0;
-    }
-
-    /**
-     * CI feedback loop (slice AC) — claim the right to file the ONE
-     * "automatic retries stopped" Inbox notice for this Task.
-     *
-     * Compare-and-set from NULL in a single statement, so exactly one of N
-     * concurrent deliveries that all discover a spent budget files the
-     * notice and the rest are told they lost. Same shape as
-     * `FleetNodeRepository.casTripDailyCeiling`.
-     */
-    async casMarkCiAutoResumeNoticed(taskId: string, at: Date): Promise<boolean> {
-        const result = await this.repository
-            .createQueryBuilder()
-            .update(Task)
-            .set({ ciAutoResumeNoticedAt: at })
-            .where('id = :taskId', { taskId })
-            .andWhere('ciAutoResumeNoticedAt IS NULL')
             .execute();
         return (result.affected ?? 0) > 0;
     }
@@ -730,5 +669,71 @@ export class TaskRepository {
                 nextOccurrenceAt: LessThanOrEqual(olderThan),
             },
         });
+    }
+
+    /**
+     * CI feedback loop (slice AC, EW-806) — record the head commit the
+     * provider is reporting checks against, and the red verdict that came
+     * with it.
+     *
+     * MONOTONIC by construction: the head pair is only written when the
+     * row still carries the head this caller read (or none at all), so two
+     * deliveries racing on one push cannot leave the newer commit
+     * overwritten by the older one. Returns whether this caller's head
+     * write landed.
+     *
+     * Query-builder update for the same reason `updatePrStatusCache` uses
+     * one: it must NOT bump `updatedAt`, or a busy CI would reshuffle the
+     * updatedAt-ordered board on every job.
+     *
+     * `ciState` is only ever written RED here. A single green check is not
+     * a green gate — only the poll, which sees every check at once, may
+     * write `passing` (see `deriveCiState`: red beats everything, never
+     * green early).
+     */
+    async recordCiHead(input: {
+        taskId: string;
+        expectedHeadSha: string | null;
+        headSha: string;
+        seenAt: Date;
+        failing?: boolean;
+    }): Promise<boolean> {
+        const patch: Partial<Task> = { ciHeadSha: input.headSha, ciHeadSeenAt: input.seenAt };
+        if (input.failing) {
+            patch.ciState = 'failing';
+            patch.ciCheckedAt = input.seenAt;
+        }
+        const qb = this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set(patch)
+            .where('id = :taskId', { taskId: input.taskId });
+        if (input.expectedHeadSha === null) {
+            qb.andWhere('ciHeadSha IS NULL');
+        } else {
+            qb.andWhere('ciHeadSha = :expected', { expected: input.expectedHeadSha });
+        }
+        const result = await qb.execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * CI feedback loop (slice AC) — claim the right to file the ONE
+     * "automatic retries stopped" Inbox notice for this Task.
+     *
+     * Compare-and-set from NULL in a single statement, so exactly one of N
+     * concurrent deliveries that all discover a spent budget files the
+     * notice and the rest are told they lost. Same shape as
+     * `FleetNodeRepository.casTripDailyCeiling`.
+     */
+    async casMarkCiAutoResumeNoticed(taskId: string, at: Date): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set({ ciAutoResumeNoticedAt: at })
+            .where('id = :taskId', { taskId })
+            .andWhere('ciAutoResumeNoticedAt IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
     }
 }

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -73,6 +73,7 @@ export * from './task.entity';
 export * from './task-assignee.entity';
 export * from './task-reviewer.entity';
 export * from './task-review-rejection.entity';
+export * from './task-ci-auto-resume-attempt.entity';
 export * from './task-approver.entity';
 export * from './task-block.entity';
 export * from './task-relation.entity';

--- a/packages/agent/src/entities/task-ci-auto-resume-attempt.entity.ts
+++ b/packages/agent/src/entities/task-ci-auto-resume-attempt.entity.ts
@@ -1,0 +1,130 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * What produced an auto-resume attempt.
+ *
+ * - `ci`     — a completed, FAILING check result arrived from the git
+ *              provider (`check_run` / `check_suite` / `workflow_run`).
+ * - `review` — a durable reviewer rejection was recorded for the Task
+ *              (a human `changes_requested`, or a trusted reviewer bot's
+ *              finding — slice AB) and nothing has consumed it yet.
+ */
+export type TaskAutoResumeTrigger = 'ci' | 'review';
+
+export const TASK_AUTO_RESUME_TRIGGERS: readonly TaskAutoResumeTrigger[] = ['ci', 'review'];
+
+/** `claimKey` is `varchar(200)`; every writer caps before persisting. */
+export const TASK_AUTO_RESUME_CLAIM_KEY_MAX_CHARS = 200;
+
+/**
+ * CI feedback and the autonomous fix loop (self-build slice AC, EW-806) —
+ * the **attempt ledger**, and the only durable retry budget the loop has.
+ *
+ * ## Why a ledger and not a counter column
+ *
+ * A single pull request emits DOZENS of `check_run` deliveries per push
+ * (created + completed per job, more while jobs queue), GitHub redelivers
+ * anything it did not get a 2xx for, and each spurious resume is a whole
+ * model run on one of six fleet PCs. So the budget cannot be "increment a
+ * number when an event arrives" — an event is not an attempt.
+ *
+ * One row here IS one attempt. The row is inserted BEFORE the resume is
+ * dispatched and its `(taskId, claimKey)` unique index is the claim: the
+ * loser of a race (and every redelivery) hits the constraint, is told the
+ * attempt already exists, and resumes nothing. Counting rows for a Task
+ * is therefore counting attempts, never events, and it survives a crash,
+ * a redeploy and a replica swap because it is a row and not memory.
+ *
+ * `claimKey` is what makes a resume idempotent for a given
+ * (task, head commit, failure):
+ *
+ *   * `ci:<headSha>`        — one attempt per Task per HEAD COMMIT. This is
+ *                             deliberately stronger than one-per-failing-
+ *                             check: a 12-job matrix goes red 12 times for
+ *                             one push and that is ONE thing to fix.
+ *   * `review:<rejectionId>` — one attempt per durable rejection row. The
+ *                             row's own `consumedByRunId` CAS is the second
+ *                             guard behind this one.
+ *
+ * `failureKey` is a fingerprint of WHAT failed (the failing check names
+ * plus a digest of the reported output). It is not part of the claim; it
+ * answers a different question — "has this Task already been retried
+ * against this exact failure?" — so a failure that recurs byte-identical
+ * on a NEW head stops the loop instead of buying another attempt.
+ * Retrying an unchanged failure is not progress.
+ *
+ * Append-only. Nothing ever updates a row except the best-effort
+ * `resumedRunId` stamp, and nothing deletes one: the budget is the
+ * history.
+ */
+@Entity({ name: 'task_ci_auto_resume_attempts' })
+// The budget read: how many attempts has this Task spent?  Also the
+// no-progress lookup, which filters `failureKey` inside the same Task.
+@Index('idx_task_ci_auto_resume_task', ['taskId'])
+// The claim. UNIQUE is load-bearing: it is what makes a redelivered
+// check event, or two API replicas racing on one delivery, resolve to
+// exactly ONE resume instead of two model runs.
+@Index('uq_task_ci_auto_resume_claim', ['taskId', 'claimKey'], { unique: true })
+export class TaskCiAutoResumeAttempt {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    taskId: string;
+
+    /** `ci` | `review` — which signal bought this attempt. */
+    @Column({ type: 'varchar', length: 16 })
+    trigger: TaskAutoResumeTrigger;
+
+    /**
+     * The idempotency coordinate. UNIQUE per Task — see the class doc.
+     * Untrusted provider values (a head SHA) are capped and never
+     * interpolated anywhere but here.
+     */
+    @Column({ type: 'varchar', length: TASK_AUTO_RESUME_CLAIM_KEY_MAX_CHARS })
+    claimKey: string;
+
+    /** Head commit the failing checks were reported against. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    headSha?: string | null;
+
+    /**
+     * Fingerprint of the failure this attempt answered — failing check
+     * names + a digest of the reported output. NULL for `review`
+     * attempts, whose "what" is the rejection text itself.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    failureKey?: string | null;
+
+    /** The run this attempt resumed FROM (already terminal). */
+    @Column({ type: 'uuid', nullable: true })
+    sourceRunId?: string | null;
+
+    /**
+     * The run the resume created. NULL when the row was claimed but the
+     * dispatch then failed — deliberately: a burned attempt that bought
+     * nothing still costs budget, because the alternative is a claim that
+     * can be retried forever by a redelivery.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    resumedRunId?: string | null;
+
+    /** Short machine-readable note (`check_run:lint-and-test`, …). */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    detail?: string | null;
+
+    /** Denormalized Work scope, for per-Work reporting. */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    // Tier C scope denormalization (EW-657). No @ManyToOne — cycle
+    // avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -310,6 +310,47 @@ export class Task {
     /** Stable refusal code of that refusal (or `not-merged` when untyped). */
     @Column({ type: 'varchar', length: 64, nullable: true })
     mergeRefusedCode?: string | null;
+    // ── CI feedback + autonomous fix loop (slice AC, EW-806) ─────────
+    // Written from the git provider's OWN `check_run` / `check_suite` /
+    // `workflow_run` deliveries, not from the every-2-minutes poll that
+    // fills the three columns above. They sit here for the same reason
+    // those do: the pull request belongs to the Task's branch, which
+    // outlives any single run.
+
+    /**
+     * Head commit the last CI result was reported against, straight from
+     * the provider delivery.
+     *
+     * This is the column that makes "is this check result for the head we
+     * still care about?" answerable at all — `baseSha` is where the branch
+     * was cut FROM, and the per-entry `headSha` inside
+     * `linkedPullRequests` only covers non-primary repositories. Without
+     * it the fix loop could not tell a fresh red from CI catching up on a
+     * revision that has already been force-pushed away.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    ciHeadSha?: string | null;
+
+    /**
+     * When `ciHeadSha` was observed. Written as a PAIR with it, and used
+     * only to order two different head commits — a delivery reporting a
+     * commit older than this one is stale and never resumes anything.
+     */
+    @PortableDateColumn({ nullable: true })
+    ciHeadSeenAt?: Date | null;
+
+    /**
+     * One-shot marker for the "automatic retries stopped" Inbox notice.
+     *
+     * Compare-and-set from NULL exactly once per Task
+     * (`TaskRepository.casMarkCiAutoResumeNoticed`), the same shape
+     * `fleet_nodes.dailyCostTrippedOn` uses: a single pull request emits
+     * dozens of check deliveries and every one of them re-discovers a
+     * spent budget, so without this marker the owner would get one Inbox
+     * row per delivery instead of one per Task.
+     */
+    @PortableDateColumn({ nullable: true })
+    ciAutoResumeNoticedAt?: Date | null;
 
     // ── Latest-run denorm (kanban run cockpit, Wave 2) ───────────────
     // Maintained by `TaskRunDenormService` on queued creation, claim and

--- a/packages/agent/src/tasks-domain/__tests__/task-ci-auto-resume.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-ci-auto-resume.spec.ts
@@ -1,0 +1,378 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { config } from '../../config';
+import {
+    DEFAULT_CI_AUTO_RESUME_ATTEMPTS,
+    MAX_CI_AUTO_RESUME_ATTEMPTS,
+    ciAutoResumeClaimKey,
+    clampAutoResumeAttempts,
+    classifyCheckResult,
+    composeBudgetSpentNotice,
+    composeCiFailureFeedback,
+    computeCiFailureKey,
+    decideCiHead,
+    isPullRequestFinished,
+    reviewAutoResumeClaimKey,
+} from '../task-ci-auto-resume';
+
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the pure rules.
+ *
+ * These four functions decide, between them, whether a webhook delivery
+ * is allowed to spend a model run. Each is unit-tested here so the
+ * end-to-end suite can concentrate on the wiring rather than on
+ * enumerating conclusions.
+ */
+describe('classifyCheckResult', () => {
+    it('reds only the conclusions the board rollup treats as failures', () => {
+        for (const conclusion of ['failure', 'timed_out', 'action_required', 'startup_failure']) {
+            expect(classifyCheckResult({ status: 'completed', conclusion })).toBe('failing');
+        }
+    });
+
+    it('does NOT red a cancelled, neutral, skipped or stale check', () => {
+        for (const conclusion of ['cancelled', 'neutral', 'skipped', 'stale']) {
+            expect(classifyCheckResult({ status: 'completed', conclusion })).toBe('inconclusive');
+        }
+    });
+
+    it('treats an unfinished check as pending whatever its conclusion field says', () => {
+        expect(classifyCheckResult({ status: 'in_progress', conclusion: 'failure' })).toBe(
+            'pending',
+        );
+        expect(classifyCheckResult({ status: 'queued', conclusion: null })).toBe('pending');
+        expect(classifyCheckResult({})).toBe('pending');
+    });
+
+    it('never launders a completed-with-no-conclusion result into a pass', () => {
+        expect(classifyCheckResult({ status: 'completed', conclusion: null })).toBe('inconclusive');
+        expect(classifyCheckResult({ status: 'completed', conclusion: 'success' })).toBe('passing');
+    });
+
+    it('is case-insensitive on both fields', () => {
+        expect(classifyCheckResult({ status: 'COMPLETED', conclusion: 'FAILURE' })).toBe('failing');
+    });
+});
+
+describe('the retry budget', () => {
+    const original = process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS;
+    afterEach(() => {
+        if (original === undefined) delete process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS;
+        else process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = original;
+    });
+
+    it('defaults to two attempts per Task, for its whole life', () => {
+        delete process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS;
+        expect(config.agents.getCiAutoResumeMaxAttempts()).toBe(DEFAULT_CI_AUTO_RESUME_ATTEMPTS);
+        expect(DEFAULT_CI_AUTO_RESUME_ATTEMPTS).toBe(2);
+    });
+
+    it('accepts 0 as "switch the loop off", and clamps above the ceiling', () => {
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = '0';
+        expect(config.agents.getCiAutoResumeMaxAttempts()).toBe(0);
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = '999';
+        expect(config.agents.getCiAutoResumeMaxAttempts()).toBe(MAX_CI_AUTO_RESUME_ATTEMPTS);
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = '-4';
+        expect(config.agents.getCiAutoResumeMaxAttempts()).toBe(0);
+    });
+
+    it('falls back to the default on a typo rather than silently disabling the loop', () => {
+        process.env.TASK_CI_AUTO_RESUME_MAX_ATTEMPTS = 'two';
+        expect(config.agents.getCiAutoResumeMaxAttempts()).toBe(DEFAULT_CI_AUTO_RESUME_ATTEMPTS);
+        expect(clampAutoResumeAttempts(Number.NaN)).toBe(DEFAULT_CI_AUTO_RESUME_ATTEMPTS);
+        expect(clampAutoResumeAttempts(undefined)).toBe(DEFAULT_CI_AUTO_RESUME_ATTEMPTS);
+    });
+
+    it('truncates a fraction into the range instead of rounding up', () => {
+        expect(clampAutoResumeAttempts(3.9)).toBe(3);
+    });
+});
+
+describe('claim keys', () => {
+    it('keys a CI attempt on the HEAD COMMIT, not on the failing job', () => {
+        expect(ciAutoResumeClaimKey('abc123')).toBe('ci:abc123');
+        // Twelve red jobs on one push are one thing to fix, so they must
+        // all produce the SAME key.
+        expect(ciAutoResumeClaimKey('abc123')).toBe(ciAutoResumeClaimKey('abc123'));
+        expect(ciAutoResumeClaimKey('def456')).not.toBe(ciAutoResumeClaimKey('abc123'));
+    });
+
+    it('keys a review attempt on the rejection row', () => {
+        expect(reviewAutoResumeClaimKey('rej-1')).toBe('review:rej-1');
+        expect(reviewAutoResumeClaimKey('rej-1')).not.toBe(ciAutoResumeClaimKey('rej-1'));
+    });
+});
+
+/**
+ * The policy file is the ONE place every money-spending rule of this
+ * slice lives — the claim keys, the failure fingerprint, the budget
+ * clamp, the head-staleness rule. It shipped with a RAW NUL byte (0x00)
+ * written as a literal control character inside the fingerprint template
+ * literal instead of a unicode escape, which makes git classify the
+ * file as binary: `git diff` prints "Binary files … differ" instead of
+ * the content, `grep` answers "Binary file … matches" and prints nothing,
+ * and the code that decides how much a red pull request is allowed to
+ * cost becomes unreviewable in the GitHub diff. Nothing else in the file
+ * would have gone red.
+ */
+describe('the policy file itself', () => {
+    it('contains no raw control characters, so git treats it as text', () => {
+        const source = readFileSync(join(__dirname, '..', 'task-ci-auto-resume.ts'));
+        const offenders: Array<{ offset: number; byte: string }> = [];
+        for (let index = 0; index < source.length; index += 1) {
+            const byte = source[index];
+            const isAllowedWhitespace = byte === 0x09 || byte === 0x0a || byte === 0x0d;
+            if (byte < 0x20 && !isAllowedWhitespace) {
+                offenders.push({ offset: index, byte: `0x${byte.toString(16)}` });
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it('still fingerprints with a NUL separator — the escape is byte-identical', () => {
+        // The separator marks where the joined NAMES end and the output
+        // begins, so a name that swallows the head of an output cannot
+        // hash the same as the pair it came from. Switching the literal
+        // control character to an escape must not change that, or any
+        // failure fingerprint already in the ledger stops matching.
+        expect(computeCiFailureKey({ checkNames: ['lint'], output: 'x' })).not.toBe(
+            computeCiFailureKey({ checkNames: ['lintx'], output: '' }),
+        );
+        expect(computeCiFailureKey({ checkNames: ['lint'], output: 'boom' })).toBe(
+            createHash('sha256')
+                .update(['lint', 'boom'].join(String.fromCharCode(0)))
+                .digest('hex')
+                .slice(0, 32),
+        );
+    });
+});
+
+describe('computeCiFailureKey', () => {
+    it('is stable for the same failure and independent of job order or case', () => {
+        expect(computeCiFailureKey({ checkNames: ['Lint', 'Unit'], output: 'boom' })).toBe(
+            computeCiFailureKey({ checkNames: ['unit', 'lint'], output: 'boom' }),
+        );
+    });
+
+    it('collapses whitespace, so a reflowed summary is still the same failure', () => {
+        expect(computeCiFailureKey({ checkNames: ['lint'], output: 'a  b\n c' })).toBe(
+            computeCiFailureKey({ checkNames: ['lint'], output: 'a b c' }),
+        );
+    });
+
+    it('differs when the reported output differs — a NEW failure buys a new attempt', () => {
+        expect(computeCiFailureKey({ checkNames: ['lint'], output: 'file A' })).not.toBe(
+            computeCiFailureKey({ checkNames: ['lint'], output: 'file B' }),
+        );
+    });
+
+    it('fits the varchar(64) column', () => {
+        expect(computeCiFailureKey({ checkNames: ['lint'], output: 'x' })).toHaveLength(32);
+    });
+});
+
+describe('decideCiHead', () => {
+    const seenAt = new Date('2026-09-06T10:00:00Z');
+
+    it('adopts the first head it ever sees', () => {
+        expect(decideCiHead(null, { headSha: 'aaa', reportedAt: seenAt })).toBe('first-seen');
+        expect(decideCiHead({ ciHeadSha: null }, { headSha: 'aaa', reportedAt: seenAt })).toBe(
+            'first-seen',
+        );
+    });
+
+    it('calls the same commit current', () => {
+        expect(
+            decideCiHead(
+                { ciHeadSha: 'aaa', ciHeadSeenAt: seenAt },
+                { headSha: 'aaa', reportedAt: seenAt },
+            ),
+        ).toBe('current');
+    });
+
+    describe('when the delivery carries the pull request head (the ordinary case)', () => {
+        it('advances to the commit the provider says the pull request is at', () => {
+            expect(
+                decideCiHead(
+                    { ciHeadSha: 'aaa', ciHeadSeenAt: seenAt },
+                    { headSha: 'bbb', prHeadSha: 'bbb', reportedAt: seenAt },
+                ),
+            ).toBe('advanced');
+        });
+
+        /**
+         * THE regression. A push's jobs finish at wildly different times,
+         * so an old commit's slow job routinely completes AFTER the next
+         * push has already reported its first check — and ordering by
+         * timestamp then classified the dead commit as a new head, wrote
+         * it back over `tasks.ciHeadSha`, and spent one of the Task's two
+         * lifetime attempts fixing code nobody has any more. The pull
+         * request's own head pointer settles it with no clock involved.
+         */
+        it('refuses a superseded commit whose slow job finished LATER than the new head was seen', () => {
+            expect(
+                decideCiHead(
+                    // Commit B landed at 10:01 and was recorded then…
+                    { ciHeadSha: 'bbb', ciHeadSeenAt: new Date('2026-09-06T10:01:00Z') },
+                    {
+                        // …and commit A's e2e shard, started before the
+                        // push, only completed at 10:25.
+                        headSha: 'aaa',
+                        prHeadSha: 'bbb',
+                        reportedAt: new Date('2026-09-06T10:25:00Z'),
+                    },
+                ),
+            ).toBe('stale');
+        });
+
+        it('refuses a manual re-run of an old commit, however fresh its timestamp', () => {
+            expect(
+                decideCiHead(
+                    { ciHeadSha: 'bbb', ciHeadSeenAt: seenAt },
+                    {
+                        headSha: 'aaa',
+                        prHeadSha: 'bbb',
+                        reportedAt: new Date('2026-09-09T00:00:00Z'),
+                    },
+                ),
+            ).toBe('stale');
+        });
+    });
+
+    describe('when there is no pull request head to check (forks, push-triggered runs)', () => {
+        it('falls back to the provider clock', () => {
+            expect(
+                decideCiHead(
+                    { ciHeadSha: 'aaa', ciHeadSeenAt: seenAt },
+                    { headSha: 'bbb', reportedAt: new Date('2026-09-06T11:00:00Z') },
+                ),
+            ).toBe('advanced');
+        });
+
+        it('refuses a commit reported no later than the recorded one', () => {
+            for (const reportedAt of [
+                new Date('2026-09-06T09:00:00Z'),
+                new Date('2026-09-06T10:00:00Z'),
+            ]) {
+                expect(
+                    decideCiHead(
+                        { ciHeadSha: 'aaa', ciHeadSeenAt: seenAt },
+                        { headSha: 'bbb', reportedAt },
+                    ),
+                ).toBe('stale');
+            }
+        });
+
+        /**
+         * `isoOrNow` substitutes `now` for a missing or unparseable
+         * provider timestamp so the ingest envelope is never rejected.
+         * Handing that substitute to the head decision made every undated
+         * delivery the newest thing in the comparison, i.e. ALWAYS
+         * `advanced` — a permanent fail-open. The evaluator is given
+         * `null` instead, and `null` is not evidence.
+         */
+        it('refuses a delivery that reported no usable time at all', () => {
+            for (const reportedAt of [null, undefined, new Date('nonsense')]) {
+                expect(
+                    decideCiHead({ ciHeadSha: 'aaa', ciHeadSeenAt: seenAt }, {
+                        headSha: 'bbb',
+                        reportedAt,
+                    } as never),
+                ).toBe('stale');
+            }
+        });
+
+        it('lets the newer sighting win when the recorded pair is half-written', () => {
+            // Only reachable from a hand-edited row: this loop always
+            // writes the sha and the time together. Refusing forever would
+            // wedge the Task, so the new sighting is adopted.
+            expect(
+                decideCiHead(
+                    { ciHeadSha: 'aaa', ciHeadSeenAt: null },
+                    { headSha: 'bbb', reportedAt: seenAt },
+                ),
+            ).toBe('advanced');
+        });
+    });
+});
+
+describe('isPullRequestFinished', () => {
+    it('is true for a merged or closed pull request, and for a landed branch', () => {
+        expect(isPullRequestFinished({ prState: 'merged' })).toBe(true);
+        expect(isPullRequestFinished({ prState: 'closed' })).toBe(true);
+        expect(isPullRequestFinished({ branchState: 'merged' })).toBe(true);
+        expect(isPullRequestFinished({ branchState: 'discarded' })).toBe(true);
+    });
+
+    it('is FALSE for a draft or open pull request — a red draft is exactly the case', () => {
+        expect(isPullRequestFinished({ prState: 'draft' })).toBe(false);
+        expect(isPullRequestFinished({ prState: 'open', branchState: 'pr-open' })).toBe(false);
+        expect(isPullRequestFinished({})).toBe(false);
+    });
+});
+
+describe('the text the model and the human read', () => {
+    it('names the commit, the check and the limit of what the webhook knows', () => {
+        const message = composeCiFailureFeedback({
+            repoFullName: 'octo/site',
+            headSha: 'abc123',
+            checkName: 'lint-and-test',
+            conclusion: 'failure',
+            prNumber: 42,
+            url: 'https://github.com/octo/site/runs/1',
+            outputTitle: '1 failing test',
+            outputSummary: 'login.spec.ts › renders',
+        });
+        expect(message).toContain('Continuous integration is RED for octo/site at commit abc123.');
+        expect(message).toContain('Failing check: lint-and-test (failure).');
+        expect(message).toContain('Pull request: #42.');
+        expect(message).toContain('login.spec.ts');
+        // Honest about its blind spot — a delivery carries the first red
+        // result for a commit, not the full list.
+        expect(message).toContain('not a full list');
+        // …and closes the obvious wrong fix.
+        expect(message).toContain('Do not disable, skip or weaken a check');
+    });
+
+    it('caps the stored feedback so one CI dump cannot blow the prompt', () => {
+        const message = composeCiFailureFeedback({
+            repoFullName: 'octo/site',
+            headSha: 'abc123',
+            checkName: 'lint',
+            conclusion: 'failure',
+            outputSummary: 'x'.repeat(50_000),
+        });
+        expect(message.length).toBeLessThanOrEqual(4000);
+    });
+
+    it('says which of the two stopping conditions ended the loop', () => {
+        const spent = composeBudgetSpentNotice({
+            taskTitle: 'Add the login button',
+            reason: 'budget-spent',
+            attemptsUsed: 2,
+            maxAttempts: 2,
+            repoFullName: 'octo/site',
+            prNumber: 42,
+            headSha: 'abc123',
+        });
+        expect(spent.title).toContain('Add the login button');
+        expect(spent.body).toContain('2 of 2 attempts used');
+        expect(spent.body).toContain('octo/site#42');
+
+        const repeat = composeBudgetSpentNotice({
+            taskTitle: 'Add the login button',
+            reason: 'repeat-failure',
+            attemptsUsed: 1,
+            maxAttempts: 2,
+        });
+        expect(repeat.body).toContain('came back unchanged');
+        // Both reasons promise a hard stop, and the evaluator now keeps
+        // that promise (the notice marker IS the stop flag). The count is
+        // stated either way so the owner can see how much of the budget
+        // was actually spent.
+        expect(repeat.body).toContain('1 of 2 attempts used');
+        expect(repeat.body).toContain('Nothing further will be retried automatically');
+        expect(spent.body).toContain('Nothing further will be retried automatically');
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-git-link.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-git-link.service.spec.ts
@@ -16,6 +16,24 @@ describe('TaskGitLinkService (git activity ingestion)', () => {
 
     const task = { id: 'task-1', slug: 'T-42', workId: 'work-1', prNumber: 42 };
 
+    /**
+     * CI feedback + autonomous fix loop (slice AC, EW-806) added two
+     * fields to every link: WHICH of the Work's repo roles the delivery's
+     * repository fills, and whether that is the repository this Work's
+     * Tasks actually live in (the DATA repo — see `WORK_TASK_REPO_ROLE`).
+     * The default fixture below declares only a `work` repo, so a
+     * consumer that ACTS on the Task it resolved must refuse this link;
+     * the git-activity consumer, which only decorates an ingested event,
+     * goes on ignoring both fields.
+     */
+    const WORK_REPO_LINK = {
+        workId: 'work-1',
+        taskId: 'task-1',
+        taskSlug: 'T-42',
+        repoRoles: ['work'],
+        isTaskRepo: false,
+    };
+
     function makeSvc(): TaskGitLinkService {
         const svc = new TaskGitLinkService(tasks, works);
         jest.spyOn(
@@ -56,7 +74,7 @@ describe('TaskGitLinkService (git activity ingestion)', () => {
                     repo: 'widgets',
                     branch: 'ever/task-t-42',
                 }),
-            ).resolves.toEqual({ workId: 'work-1', taskId: 'task-1', taskSlug: 'T-42' });
+            ).resolves.toEqual(WORK_REPO_LINK);
             expect(works.findByUser).toHaveBeenCalledWith('u1');
             expect(tasks.findByWorkAndBranchRef).toHaveBeenCalledWith('work-1', 'ever/task-t-42');
         });
@@ -98,6 +116,113 @@ describe('TaskGitLinkService (git activity ingestion)', () => {
         });
     });
 
+    describe('the repo role a link came from', () => {
+        it('marks a link found through the Work’s DATA repo as the Task repository', async () => {
+            works.findByUser = jest.fn().mockResolvedValue([
+                {
+                    id: 'work-1',
+                    getRepoOwner: () => 'acme',
+                    getMainRepo: () => 'widgets-main',
+                    getWebsiteRepo: () => 'widgets-www',
+                    getDataRepo: () => 'widgets',
+                },
+            ]);
+            await expect(
+                makeSvc().findByPullRequest({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    prNumber: 42,
+                }),
+            ).resolves.toMatchObject({ repoRoles: ['data'], isTaskRepo: true });
+        });
+
+        it('reports EVERY role a repository fills, because two can be the same repo', async () => {
+            works.findByUser = jest.fn().mockResolvedValue([
+                {
+                    id: 'work-1',
+                    getRepoOwner: () => 'acme',
+                    getMainRepo: () => 'widgets',
+                    getWebsiteRepo: () => 'widgets-www',
+                    getDataRepo: () => 'widgets',
+                },
+            ]);
+            await expect(
+                makeSvc().findByPullRequest({
+                    userId: 'u1',
+                    owner: 'acme',
+                    repo: 'widgets',
+                    prNumber: 42,
+                }),
+            ).resolves.toMatchObject({ repoRoles: ['work', 'data'], isTaskRepo: true });
+        });
+    });
+
+    describe('findByPullRequests (one Works scan for a whole delivery)', () => {
+        beforeEach(() => {
+            works.findByUser = jest.fn().mockResolvedValue([
+                {
+                    id: 'work-1',
+                    getRepoOwner: () => 'acme',
+                    getMainRepo: () => 'widgets-main',
+                    getWebsiteRepo: () => null,
+                    getDataRepo: () => 'widgets',
+                },
+            ]);
+        });
+
+        /**
+         * A commit can head several pull requests (a stacked chain, a
+         * shared branch) and a check delivery lists all of them, capped at
+         * 20. Resolving each through `findByPullRequest` re-loaded the
+         * owner's ENTIRE Works list every time and threw away every scan
+         * before the matching one — on a webhook hot path, for the busiest
+         * account on the platform, on every one of the ~30 deliveries a
+         * single push produces.
+         */
+        it('loads the owner’s Works exactly once however many PR numbers are reported', async () => {
+            tasks.findByWorkAndPrNumber = jest
+                .fn()
+                .mockImplementation(async (_workId: string, prNumber: number) =>
+                    prNumber === 9 ? { id: 'task-1', slug: 'T-42' } : null,
+                );
+
+            await expect(
+                makeSvc().findByPullRequests(
+                    { userId: 'u1', owner: 'acme', repo: 'widgets' },
+                    [3, 5, 7, 9],
+                ),
+            ).resolves.toMatchObject({ taskId: 'task-1', prNumber: 9, isTaskRepo: true });
+            expect(works.findByUser).toHaveBeenCalledTimes(1);
+            expect(tasks.findByWorkAndPrNumber).toHaveBeenCalledTimes(4);
+        });
+
+        it('tries the numbers in the order it was given and stops at the first hit', async () => {
+            tasks.findByWorkAndPrNumber = jest
+                .fn()
+                .mockResolvedValue({ id: 'task-1', slug: 'T-42' });
+            await expect(
+                makeSvc().findByPullRequests(
+                    { userId: 'u1', owner: 'acme', repo: 'widgets' },
+                    [42, 7],
+                ),
+            ).resolves.toMatchObject({ prNumber: 42 });
+            expect(tasks.findByWorkAndPrNumber).toHaveBeenCalledTimes(1);
+        });
+
+        it('touches nothing for an empty or non-integer list', async () => {
+            await expect(
+                makeSvc().findByPullRequests({ userId: 'u1', owner: 'acme', repo: 'widgets' }, []),
+            ).resolves.toBeNull();
+            await expect(
+                makeSvc().findByPullRequests({ userId: 'u1', owner: 'acme', repo: 'widgets' }, [
+                    Number.NaN,
+                ]),
+            ).resolves.toBeNull();
+            expect(works.findByUser).not.toHaveBeenCalled();
+        });
+    });
+
     describe('findByPullRequest', () => {
         it('resolves the PR number to its Work and Task', async () => {
             await expect(
@@ -107,7 +232,7 @@ describe('TaskGitLinkService (git activity ingestion)', () => {
                     repo: 'widgets',
                     prNumber: 42,
                 }),
-            ).resolves.toEqual({ workId: 'work-1', taskId: 'task-1', taskSlug: 'T-42' });
+            ).resolves.toEqual(WORK_REPO_LINK);
             expect(tasks.findByWorkAndPrNumber).toHaveBeenCalledWith('work-1', 42);
         });
 

--- a/packages/agent/src/tasks-domain/__tests__/task-pr-status.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-pr-status.service.spec.ts
@@ -7,6 +7,7 @@ import type { WorkRepository } from '../../database/repositories/work.repository
 import type { GitFacadeService } from '../../facades/git.facade';
 import type { TaskTransitionService } from '../task-transition.service';
 import type { TaskMergeGateService } from '../task-merge-gate.service';
+import type { TaskCiAutoResumeService } from '../task-ci-auto-resume.service';
 
 /**
  * PR insights (kanban run cockpit, plan 04 M5/M6/M7) — the sync + read
@@ -34,7 +35,9 @@ describe('TaskPrStatusService', () => {
         findDuePrStatusSync: jest.Mock;
         updatePrStatusCache: jest.Mock;
         updateById: jest.Mock;
+        recordCiHead: jest.Mock;
     };
+    let autoResume: { onCheckResult: jest.Mock };
     let works: { findById: jest.Mock };
     let git: {
         getPullRequestStatus: jest.Mock;
@@ -81,6 +84,10 @@ describe('TaskPrStatusService', () => {
             findDuePrStatusSync: jest.fn().mockResolvedValue([]),
             updatePrStatusCache: jest.fn().mockResolvedValue(undefined),
             updateById: jest.fn().mockResolvedValue(undefined),
+            // CI feedback + autonomous fix loop (slice AC, EW-806): the
+            // poll is the second writer of the head pair, through the same
+            // monotonic compare-and-set the webhook uses.
+            recordCiHead: jest.fn().mockResolvedValue(true),
         };
         works = {
             findById: jest.fn().mockResolvedValue({
@@ -117,12 +124,14 @@ describe('TaskPrStatusService', () => {
                 .fn()
                 .mockResolvedValue({ action: 'skipped', reason: 'no-agent' }),
         };
+        autoResume = { onCheckResult: jest.fn().mockResolvedValue({ reason: 'already-claimed' }) };
         service = new TaskPrStatusService(
             tasks as unknown as TaskRepository,
             works as unknown as WorkRepository,
             git as unknown as GitFacadeService,
             transitions as unknown as TaskTransitionService,
             mergeGate as unknown as TaskMergeGateService,
+            autoResume as unknown as TaskCiAutoResumeService,
         );
     });
 
@@ -393,6 +402,115 @@ describe('TaskPrStatusService', () => {
         const summary = await service.syncDuePrStatuses();
 
         expect(summary).toMatchObject({ scanned: 2, refreshed: 1, failed: 1 });
+    });
+
+    /**
+     * CI feedback + autonomous fix loop (slice AC, EW-806) — the SAFETY
+     * NET behind the webhook.
+     *
+     * The webhook is a one-shot. A red result refused for a TRANSIENT
+     * reason — `run-in-flight`, because the run that pushed the branch is
+     * still posting the PR link when CI reports — was refused FOREVER:
+     * every envelope for that push is already ingested, so a GitHub
+     * redelivery short-circuits as a duplicate, and when the run finally
+     * ends there is no further CI event to arrive. Nothing re-evaluated a
+     * refusal, so the Task's red build was never retried, silently, with
+     * no Inbox notice. This sweep already runs every two minutes over
+     * exactly the right population and already holds the provider's check
+     * list, so it re-offers a still-red gate.
+     */
+    describe('re-offering a still-red gate to the fix loop', () => {
+        const redStatus = {
+            ...openStatus,
+            ciState: 'failing' as const,
+            headSha: 'deadbeef',
+            checks: [
+                { name: 'build', status: 'completed' as const, conclusion: 'success' as const },
+                {
+                    name: 'lint-and-test',
+                    status: 'completed' as const,
+                    conclusion: 'failure' as const,
+                },
+            ],
+        };
+
+        it('offers the red gate with the pull request’s own head, from platform state only', async () => {
+            git.getPullRequestStatus.mockResolvedValue(redStatus);
+            tasks.findDuePrStatusSync.mockResolvedValue([makeTask({ ciHeadSha: 'old' })]);
+
+            await service.syncDuePrStatuses();
+
+            expect(autoResume.onCheckResult).toHaveBeenCalledTimes(1);
+            const offered = autoResume.onCheckResult.mock.calls[0][0];
+            expect(offered).toMatchObject({
+                userId: USER,
+                owner: 'acme',
+                repo: 'widgets',
+                headSha: 'deadbeef',
+                verdict: 'failing',
+                checkName: 'lint-and-test',
+                conclusion: 'failure',
+                prNumbers: [41],
+                // The poll reads the PULL REQUEST, so its head IS the pull
+                // request's head by construction — the staleness rule can
+                // never mistake this for a superseded commit.
+                prHeads: [{ number: 41, headSha: 'deadbeef' }],
+            });
+            expect(offered.failureKey).toEqual(expect.any(String));
+            // …and the fresh head was written through the monotonic CAS.
+            expect(tasks.recordCiHead).toHaveBeenCalledWith(
+                expect.objectContaining({ expectedHeadSha: 'old', headSha: 'deadbeef' }),
+            );
+        });
+
+        it('offers nothing for a green or pending gate', async () => {
+            for (const ciState of ['passing', 'pending', 'unknown'] as const) {
+                autoResume.onCheckResult.mockClear();
+                git.getPullRequestStatus.mockResolvedValue({ ...redStatus, ciState });
+                tasks.findDuePrStatusSync.mockResolvedValue([makeTask()]);
+                await service.syncDuePrStatuses();
+                expect(autoResume.onCheckResult).not.toHaveBeenCalled();
+            }
+        });
+
+        it('offers nothing for a MERGED pull request — that landing is its own path', async () => {
+            git.getPullRequestStatus.mockResolvedValue({
+                ...redStatus,
+                state: 'merged' as const,
+                merged: true,
+            });
+            tasks.findDuePrStatusSync.mockResolvedValue([makeTask({ prState: 'open' })]);
+
+            await service.syncDuePrStatuses();
+
+            expect(autoResume.onCheckResult).not.toHaveBeenCalled();
+        });
+
+        it('never lets the fix loop sink the sweep', async () => {
+            git.getPullRequestStatus.mockResolvedValue(redStatus);
+            autoResume.onCheckResult.mockRejectedValue(new Error('evaluator exploded'));
+            tasks.findDuePrStatusSync.mockResolvedValue([makeTask()]);
+
+            await expect(service.syncDuePrStatuses()).resolves.toMatchObject({
+                scanned: 1,
+                refreshed: 1,
+                failed: 0,
+            });
+        });
+
+        it('does nothing at all when the fix loop is not bound in this runtime', async () => {
+            const withoutLoop = new TaskPrStatusService(
+                tasks as unknown as TaskRepository,
+                works as unknown as WorkRepository,
+                git as unknown as GitFacadeService,
+                transitions as unknown as TaskTransitionService,
+            );
+            git.getPullRequestStatus.mockResolvedValue(redStatus);
+            tasks.findDuePrStatusSync.mockResolvedValue([makeTask()]);
+
+            await expect(withoutLoop.syncDuePrStatuses()).resolves.toMatchObject({ refreshed: 1 });
+            expect(autoResume.onCheckResult).not.toHaveBeenCalled();
+        });
     });
 
     it('does nothing at all when no git facade is bound in this runtime', async () => {

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -61,6 +61,19 @@ export * from './task-review-rejection.service';
 // Merge approval (self-build slice AE, EW-805).
 export * from './task-review-approval.service';
 export * from './task-merge-gate.service';
+// CI feedback + autonomous fix loop (slice AC, EW-806) — the pure policy
+// helpers and the decision layer the GitHub check receiver calls.
+export * from './task-ci-auto-resume';
+export * from './task-ci-auto-resume.service';
+export {
+    TaskCiAutoResumeAttempt,
+    TASK_AUTO_RESUME_TRIGGERS,
+    type TaskAutoResumeTrigger,
+} from '../entities/task-ci-auto-resume-attempt.entity';
+export {
+    TaskCiAutoResumeAttemptRepository,
+    type ClaimAutoResumeAttemptInput,
+} from '../database/repositories/task-ci-auto-resume-attempt.repository';
 // Git activity ingestion (audit item j) — branch/PR → Task resolver.
 export * from './task-git-link.service';
 export {

--- a/packages/agent/src/tasks-domain/run-steering-port.ts
+++ b/packages/agent/src/tasks-domain/run-steering-port.ts
@@ -35,8 +35,68 @@ export interface RunSteerOutcome {
     queuedCount?: number;
 }
 
+/**
+ * CI feedback + autonomous fix loop (slice AC, EW-806) — the object form
+ * of `RunSteeringService.resume`, so a tasks-domain service can ask for a
+ * resume through the SAME token `TaskChatService` already steers through,
+ * without importing `../agents` (which imports this file — the one-way
+ * rule at the top of this doc).
+ */
+export interface RunResumeRequest {
+    /** The terminal / parked run to resume from. Runs are immutable. */
+    runId: string;
+    /**
+     * Acting owner. For an automated resume this MUST come from platform
+     * state (the Task's own `userId`), never from a webhook body — the
+     * implementation loads the run with `findByIdAndUser`, so a wrong
+     * owner is indistinguishable from a missing run.
+     */
+    userId: string;
+    message?: string | null;
+    /**
+     * Widen the resumable set by exactly one status: a run that finished
+     * NORMALLY (`completed`). A human "Resume" never sets this — it exists
+     * because CI goes red AFTER the run that pushed the branch has already
+     * completed cleanly, and that run is the only conversation there is to
+     * continue. `cancelled` and `failed` runs stay un-resumable either way.
+     */
+    allowCompleted?: boolean;
+}
+
+/**
+ * How many pending reviewer rejections ONE resume replays into the new
+ * run's first turn (`RunSteeringService.claimRejectionFeedback`).
+ *
+ * It lives on the port, not in the implementation, because the CI fix
+ * loop has to reason about it from the other side of the import boundary:
+ * `TaskCiAutoResumeService` writes the red build as a rejection row and
+ * has to know whether that row will actually be inside the replay window
+ * (rows are claimed OLDEST first, and its row is the newest). When it
+ * will not be, the loop hands the same text to `resume` as its message
+ * instead — otherwise a Task carrying three older unconsumed reviewer
+ * findings would spend a full model run and never be told CI is red.
+ */
+export const MAX_REPLAYED_REJECTIONS = 3;
+
+export interface RunResumeResult {
+    /** The NEW run's id. */
+    runId: string;
+    resumedFromRunId: string;
+    /** True when the dispatch gate parked the new run instead of enqueuing it. */
+    queued: boolean;
+    /** Durable reviewer rejections replayed into the new run's first input. */
+    rejectionsReplayed: number;
+}
+
 export interface RunSteeringPort {
     steer(input: RunSteerInput): Promise<RunSteerOutcome>;
+    /**
+     * OPTIONAL on the port so the pre-existing consumers and their test
+     * stubs (which only ever steer) keep compiling untouched. The bound
+     * implementation always has it; a caller must check before calling and
+     * treat its absence as "this install cannot resume".
+     */
+    resumeRun?(request: RunResumeRequest): Promise<RunResumeResult>;
 }
 
 export const RUN_STEERING_PORT = 'RUN_STEERING_PORT' as const;

--- a/packages/agent/src/tasks-domain/task-ci-auto-resume.service.ts
+++ b/packages/agent/src/tasks-domain/task-ci-auto-resume.service.ts
@@ -1,0 +1,842 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { config } from '../config';
+import { TaskStatus, type Task } from '../entities/task.entity';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { TaskCiAutoResumeAttemptRepository } from '../database/repositories/task-ci-auto-resume-attempt.repository';
+import { TaskReviewRejectionRepository } from '../database/repositories/task-review-rejection.repository';
+import { RUN_KILL_SWITCH, type RunKillSwitch } from '../agents/run-kill-switch';
+import { INBOX_PRODUCER, type InboxProducer } from '../inbox/inbox-producer.port';
+import {
+    MAX_REPLAYED_REJECTIONS,
+    RUN_STEERING_PORT,
+    type RunSteeringPort,
+} from './run-steering-port';
+import { TaskGitLinkService } from './task-git-link.service';
+import {
+    ciAutoResumeClaimKey,
+    composeBudgetSpentNotice,
+    composeCiFailureFeedback,
+    decideCiHead,
+    isPullRequestFinished,
+    reviewAutoResumeClaimKey,
+    type AutoResumeOutcome,
+    type AutoResumeOutcomeReason,
+    type CheckVerdict,
+    type CiHeadDecision,
+} from './task-ci-auto-resume';
+import type { TaskAutoResumeTrigger } from '../entities/task-ci-auto-resume-attempt.entity';
+
+/** One completed (or in-flight) check result, already normalized. */
+export interface CiCheckResultInput {
+    /**
+     * The platform user the VERIFIED install binding resolved to. Used
+     * ONLY to scope the repo→Work→Task walk. The owner the resume runs
+     * as is `task.userId`, read back from the Task row — never anything
+     * the webhook body said.
+     */
+    userId: string;
+    owner: string;
+    repo: string;
+    /** Head commit the provider reported these checks against. */
+    headSha: string;
+    /** `null` for fork pull requests — the PR numbers then carry the link. */
+    headBranch?: string | null;
+    /** `check_run.pull_requests[].number`; empty for forks. */
+    prNumbers?: readonly number[];
+    /**
+     * `pull_requests[]`, each with the head the PROVIDER says that pull
+     * request is at RIGHT NOW. This is what makes head staleness decidable
+     * without commit ancestry — see {@link decideCiHead}. Empty for forks
+     * and for push-triggered workflow runs.
+     */
+    prHeads?: readonly { number: number; headSha: string | null }[];
+    /**
+     * When the PROVIDER says this result happened, or `null` when the
+     * delivery carried no usable timestamp.
+     *
+     * Deliberately nullable: the ingest layer substitutes `now` for a
+     * missing provider timestamp so the envelope is never rejected, and a
+     * substituted `now` is always the newest thing in any comparison — a
+     * delivery that reported no time at all would otherwise read as a
+     * brand-new push every single time.
+     */
+    observedAt: Date | null;
+    verdict: CheckVerdict;
+    /** Which vendor delivery this came from, for the audit trail. */
+    granularity: 'check_run' | 'check_suite' | 'workflow_run';
+    checkName: string;
+    conclusion: string;
+    url?: string | null;
+    outputTitle?: string | null;
+    outputSummary?: string | null;
+    /** Fingerprint of the failure — see `computeCiFailureKey`. */
+    failureKey?: string | null;
+}
+
+/**
+ * How many pending rejections the reviewer doorbell scans before giving
+ * up. `findPendingForTask` returns them oldest-first and caps at 20; the
+ * doorbell wants the oldest row that is genuinely about this delivery, so
+ * it has to look past the ones that are not.
+ */
+export const REVIEW_PENDING_SCAN = 20;
+
+/**
+ * How stale an unconsumed reviewer rejection may be and still buy a
+ * resume when a later comment rings the doorbell.
+ *
+ * Seven days. A rejection that nothing consumed for a week was answered
+ * by a human, or abandoned; replaying it costs a full model run and tells
+ * the agent to fix something that is very likely already fixed.
+ */
+export const REVIEW_PENDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** A provider-side review that slice AB has ALREADY recorded a row for. */
+export interface ReviewRejectionSignalInput {
+    userId: string;
+    owner: string;
+    repo: string;
+    prNumber: number;
+}
+
+/**
+ * CI feedback and the autonomous fix loop (self-build slice AC, EW-806,
+ * closes finding R17) — the decision layer.
+ *
+ * ## The defect
+ *
+ * The fleet opened a pull request, CI went red, and six PCs sat idle
+ * waiting for a human who might not be watching. Check results were not
+ * ingested at all (the webhook receiver had no `check_run` /
+ * `check_suite` / `workflow_run` handling), `tasks.ciState` was written
+ * by a poll and read only by the board, and nothing anywhere resumed a
+ * run without a person pressing a button.
+ *
+ * ## The failure this class is shaped around: a RESUME STORM
+ *
+ * One push to a twelve-job matrix emits roughly thirty deliveries
+ * (`created` + `completed` per job, plus suite and workflow events), and
+ * GitHub redelivers everything it did not get a 2xx for. Each spurious
+ * resume is a full model run on one of six PCs — real money, real machine
+ * time. So:
+ *
+ *  1. **The budget is rows, not a counter, and not events.** One row in
+ *     `task_ci_auto_resume_attempts` is one attempt. `countForTask` IS the
+ *     budget read, and it is durable across crashes and replicas.
+ *  2. **The claim is the unique index**, keyed `ci:<headSha>` — one
+ *     attempt per Task per HEAD COMMIT. Twelve red jobs and every
+ *     redelivery of them collapse into the one thing there is to fix.
+ *  3. **If the ledger cannot be read, the loop STOPS.** A budget nobody
+ *     can count is not a budget; continuing would be unbounded spend.
+ *  4. **An unchanged failure is not progress.** A failure fingerprint
+ *     that has already bought an attempt refuses the next one even on a
+ *     new head, and files the notice instead.
+ *
+ * ## What refuses to resume, and why
+ *
+ *  * a **green / pending / cancelled** result — only a completed failure
+ *    is actionable, and a green re-run arriving after a red one refuses
+ *    because it is not a failure;
+ *  * a **stale head** — CI catching up on a revision that has already been
+ *    replaced would fix code nobody has;
+ *  * a **superseded run** — the target is always the Task's LATEST run, so
+ *    an older one is never resumed, and a run that is queued or running
+ *    means the fix may already be in flight;
+ *  * a run **parked on a question** — that is the owner's to answer, and
+ *    resuming would consume their Inbox item with CI feedback;
+ *  * a **done or cancelled** Task, checked here because the cloud dispatch
+ *    path has no such guard of its own (only the fleet planner does);
+ *  * the **global stop flag**, read fail-closed.
+ *
+ * ## Tenancy
+ *
+ * The Task comes from `TaskGitLinkService`, which walks the binding
+ * owner's Works with the shared repo matcher; the resume then runs as
+ * `task.userId` and `RunSteeringService` re-scopes the run by that owner.
+ * Nothing in a webhook body chooses an account.
+ *
+ * ## Cost
+ *
+ * `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS` (default **2**, `0` = off) is the
+ * per-Task lifetime ceiling. Each attempt is one `agent-task-execute`
+ * run — the same order of model spend as the run that opened the pull
+ * request. See `docs/features/ci-auto-resume.md`.
+ */
+@Injectable()
+export class TaskCiAutoResumeService {
+    private readonly logger = new Logger(TaskCiAutoResumeService.name);
+
+    constructor(
+        private readonly tasks: TaskRepository,
+        private readonly attempts: TaskCiAutoResumeAttemptRepository,
+        private readonly links: TaskGitLinkService,
+        private readonly runs: AgentRunRepository,
+        private readonly rejections: TaskReviewRejectionRepository,
+        // Every collaborator below is @Optional() and appended in a stable
+        // order — the house positional convention, so hand-rolled
+        // positional test constructions keep working.
+        //
+        // Without the steering port there is no dispatch path and the loop
+        // refuses rather than inventing one.
+        @Optional()
+        @Inject(RUN_STEERING_PORT)
+        private readonly steering?: RunSteeringPort,
+        @Optional()
+        @Inject(INBOX_PRODUCER)
+        private readonly inbox?: InboxProducer,
+        // The GLOBAL STOP FLAG. Read fail-closed: a stopped (or
+        // unreadable) platform resumes nothing.
+        @Optional()
+        @Inject(RUN_KILL_SWITCH)
+        private readonly killSwitch?: RunKillSwitch,
+    ) {}
+
+    /**
+     * A check result arrived from the provider.
+     *
+     * Never throws: the caller is a webhook consumer that must answer 200
+     * fast, and every refusal is an ordinary outcome with a machine-
+     * readable reason.
+     */
+    async onCheckResult(input: CiCheckResultInput): Promise<AutoResumeOutcome> {
+        try {
+            return await this.handleCheckResult(input);
+        } catch (error) {
+            // Fail CLOSED on anything unexpected: stop the loop, say so.
+            this.logger.warn(
+                `CI auto-resume aborted for ${input.owner}/${input.repo}@${input.headSha}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { reason: 'error' };
+        }
+    }
+
+    /**
+     * A reviewer rejection was recorded for a pull request (slice AB
+     * already wrote the durable row; this acts on it).
+     *
+     * Reads the recorded STATE rather than the delivery: if the Task has
+     * no unconsumed rejection there is nothing to answer, whatever the
+     * payload said.
+     */
+    async onReviewRejection(input: ReviewRejectionSignalInput): Promise<AutoResumeOutcome> {
+        try {
+            return await this.handleReviewRejection(input);
+        } catch (error) {
+            this.logger.warn(
+                `Review auto-resume aborted for ${input.owner}/${input.repo}#${input.prNumber}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { reason: 'error' };
+        }
+    }
+
+    // ── entry points ───────────────────────────────────────────────
+
+    private async handleCheckResult(input: CiCheckResultInput): Promise<AutoResumeOutcome> {
+        const headSha = (input.headSha ?? '').trim();
+        if (!headSha) return { reason: 'no-task' };
+
+        const resolved = await this.resolveTask(input);
+        if (!resolved) return { reason: 'no-task' };
+        const { task, prNumber } = resolved;
+
+        const failing = input.verdict === 'failing';
+        const decision = decideCiHead(task, {
+            headSha,
+            // The pull request THIS Task owns, never simply the first entry
+            // in the delivery: a commit that heads two pull requests lists
+            // both, and the other one's head says nothing about this Task.
+            prHeadSha: this.prHeadFor(input, prNumber ?? task.prNumber ?? null),
+            reportedAt: input.observedAt,
+        });
+
+        // ── the ingest half: the provider's own verdict, onto the Task ──
+        // Runs for every delivery whose head is not stale, red or green,
+        // and BEFORE any budget question. Recording the head on a GREEN
+        // push is what makes the staleness rule work at all: without it a
+        // later red on the previous commit would still look current.
+        if (decision !== 'stale') {
+            await this.recordHead(task, headSha, input.observedAt ?? new Date(), failing, decision);
+        }
+
+        if (!failing) return { reason: 'not-a-failure', taskId: task.id };
+        if (decision === 'stale') return { reason: 'stale-head', taskId: task.id };
+
+        const feedback = composeCiFailureFeedback({
+            repoFullName: `${input.owner}/${input.repo}`,
+            headSha,
+            checkName: input.checkName,
+            conclusion: input.conclusion,
+            prNumber: prNumber ?? task.prNumber ?? null,
+            url: input.url ?? null,
+            outputTitle: input.outputTitle ?? null,
+            outputSummary: input.outputSummary ?? null,
+        });
+
+        return this.evaluate({
+            task,
+            trigger: 'ci',
+            claimKey: ciAutoResumeClaimKey(headSha),
+            headSha,
+            failureKey: input.failureKey ?? null,
+            detail: `${input.granularity}:${input.checkName}`,
+            feedback: {
+                text: feedback,
+                reviewerLabel: input.checkName,
+                prNumber: prNumber ?? task.prNumber ?? null,
+                prUrl: input.url ?? null,
+            },
+            notice: {
+                repoFullName: `${input.owner}/${input.repo}`,
+                prNumber: prNumber ?? task.prNumber ?? null,
+                headSha,
+            },
+        });
+    }
+
+    private async handleReviewRejection(
+        input: ReviewRejectionSignalInput,
+    ): Promise<AutoResumeOutcome> {
+        const link = await this.links.findByPullRequest({
+            userId: input.userId,
+            owner: input.owner,
+            repo: input.repo,
+            prNumber: input.prNumber,
+        });
+        // Only the repository this Work's Tasks live in — see `resolveTask`.
+        if (!link || link.isTaskRepo === false) return { reason: 'no-task' };
+        const task = await this.tasks.findById(link.taskId);
+        if (!task) return { reason: 'no-task' };
+
+        // The durable state, not the payload: slice AB has already
+        // decided whether this delivery was a rejection worth keeping.
+        //
+        // But a delivery is only a DOORBELL — `issue_comment` carries no
+        // link to the row it is meant to answer — so the row it rings for
+        // has to be checked, not merely fetched. Taking `findPendingForTask
+        // (task.id, 1)` at face value let any created comment on the pull
+        // request cash in whatever unconsumed row happened to be oldest:
+        // a months-old `task-review` rejection a human recorded in the web
+        // UI, or a `gate` row THIS service left pending after its own
+        // dispatch failed — a full model run replaying a CI failure that no
+        // longer exists. Three filters, all of them about the row rather
+        // than the delivery:
+        const oldest = (await this.rejections.findPendingForTask(task.id, REVIEW_PENDING_SCAN))
+            .filter((row) => {
+                //  1. a `gate` row is this loop's OWN CI failure record. The
+                //     CI half owns it, and it is replayed by `resume`
+                //     anyway; the reviewer doorbell must never spend an
+                //     attempt on one.
+                if (row.source === 'gate') return false;
+                //  2. it has to be about THIS pull request. A row that names
+                //     a different PR belongs to a different conversation.
+                if (typeof row.prNumber === 'number' && row.prNumber !== input.prNumber) {
+                    return false;
+                }
+                //  3. and it has to be recent enough to still be what the
+                //     reviewer is waiting on. A rejection nobody consumed
+                //     for a week was handled by a human, or abandoned.
+                const createdAt = row.createdAt instanceof Date ? row.createdAt.getTime() : null;
+                if (createdAt !== null && Date.now() - createdAt > REVIEW_PENDING_MAX_AGE_MS) {
+                    return false;
+                }
+                return true;
+            })
+            .at(0);
+        if (!oldest) return { reason: 'no-feedback', taskId: task.id };
+
+        return this.evaluate({
+            task,
+            trigger: 'review',
+            claimKey: reviewAutoResumeClaimKey(oldest.id),
+            headSha: task.ciHeadSha ?? null,
+            failureKey: null,
+            detail: `review:${oldest.reviewerLabel ?? 'reviewer'}`.slice(0, 200),
+            // Nothing to record — the row EXISTS, and `resume` claims it.
+            feedback: null,
+            notice: {
+                repoFullName: `${input.owner}/${input.repo}`,
+                prNumber: input.prNumber,
+                headSha: task.ciHeadSha ?? null,
+            },
+        });
+    }
+
+    // ── the one decision path both entry points share ──────────────
+
+    private async evaluate(ctx: {
+        task: Task;
+        trigger: TaskAutoResumeTrigger;
+        claimKey: string;
+        headSha: string | null;
+        failureKey: string | null;
+        detail: string;
+        feedback: {
+            text: string;
+            reviewerLabel: string;
+            prNumber: number | null;
+            prUrl: string | null;
+        } | null;
+        notice: { repoFullName: string; prNumber: number | null; headSha: string | null };
+    }): Promise<AutoResumeOutcome> {
+        const { task } = ctx;
+        const maxAttempts = config.agents.getCiAutoResumeMaxAttempts();
+        if (maxAttempts <= 0) {
+            return { reason: 'disabled', taskId: task.id, maxAttempts };
+        }
+        if (task.status === TaskStatus.DONE || task.status === TaskStatus.CANCELLED) {
+            return { reason: 'task-finished', taskId: task.id };
+        }
+        // The loop already gave up on this Task and told the owner so.
+        // Read from the row the caller already holds, so the terminal
+        // steady state stays a pure READ: a Task's pull request keeps
+        // receiving check deliveries for as long as it is open, and
+        // re-issuing the notice CAS for every one of them was a
+        // guaranteed-zero-row UPDATE against the busiest table in the
+        // schema, forever, per Task, across six machines.
+        if (task.ciAutoResumeNoticedAt) {
+            return { reason: 'stopped', taskId: task.id, maxAttempts };
+        }
+        // A merged or closed pull request has nothing left to push a fix
+        // to. `TaskStatus` alone does not cover this: the merged -> DONE
+        // transition is poll-driven, conditional (only from in_progress /
+        // in_review) and up to two minutes late, and a pull request the
+        // owner closed WITHOUT merging is never transitioned at all — so
+        // without this guard every red straggler on a dead PR keeps
+        // resuming until the budget is gone.
+        if (isPullRequestFinished(task)) {
+            return { reason: 'pr-closed', taskId: task.id };
+        }
+        if (await this.isHalted()) {
+            return { reason: 'halted', taskId: task.id };
+        }
+        if (!this.steering?.resumeRun) {
+            this.logger.warn(
+                `Task ${task.id}: CI is red but no run-steering port is bound on this install — nothing resumed.`,
+            );
+            return { reason: 'no-steering', taskId: task.id };
+        }
+
+        // ── the budget, from durable state, counted per ATTEMPT ──────
+        let attemptsUsed: number;
+        try {
+            attemptsUsed = await this.attempts.countForTask(task.id);
+        } catch (error) {
+            // A budget nobody can count is not a budget. STOP.
+            this.logger.warn(
+                `Task ${task.id}: auto-resume budget unreadable — stopping the loop: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { reason: 'budget-unreadable', taskId: task.id };
+        }
+
+        if (attemptsUsed >= maxAttempts) {
+            return {
+                reason: 'budget-spent',
+                taskId: task.id,
+                attemptsUsed,
+                maxAttempts,
+                noticeFiled: await this.fileStopNotice(
+                    ctx,
+                    'budget-spent',
+                    attemptsUsed,
+                    maxAttempts,
+                ),
+            };
+        }
+
+        if (ctx.failureKey) {
+            let repeated: boolean;
+            try {
+                repeated = await this.attempts.hasFailureKey(task.id, ctx.failureKey);
+            } catch (error) {
+                this.logger.warn(
+                    `Task ${task.id}: failure-fingerprint lookup failed — stopping the loop: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                return { reason: 'budget-unreadable', taskId: task.id };
+            }
+            if (repeated) {
+                return {
+                    reason: 'repeat-failure',
+                    taskId: task.id,
+                    attemptsUsed,
+                    maxAttempts,
+                    noticeFiled: await this.fileStopNotice(
+                        ctx,
+                        'repeat-failure',
+                        attemptsUsed,
+                        maxAttempts,
+                    ),
+                };
+            }
+        }
+
+        // ── which run, and is it ours to touch? ─────────────────────
+        const run = await this.runs.findLatestForTask(task.id);
+        if (!run) return { reason: 'no-run', taskId: task.id };
+        // Status literals rather than `RunSteeringService.isLive`: this
+        // package's import direction is agents → tasks-domain, never back.
+        if (run.status === 'queued' || run.status === 'running') {
+            return { reason: 'run-in-flight', taskId: task.id };
+        }
+        if (run.awaitingInput === true) {
+            // Parked on a QUESTION. Resuming would clear `awaitingInput`
+            // and spend the owner's Inbox item on CI feedback.
+            return { reason: 'awaiting-human', taskId: task.id };
+        }
+        if (run.status !== 'completed') {
+            return { reason: 'run-not-resumable', taskId: task.id };
+        }
+
+        // ── the claim. Everything above is a read; this is the act. ──
+        const claimed = await this.attempts.claim({
+            taskId: task.id,
+            trigger: ctx.trigger,
+            claimKey: ctx.claimKey,
+            headSha: ctx.headSha,
+            failureKey: ctx.failureKey,
+            sourceRunId: run.id,
+            detail: ctx.detail,
+            workId: task.workId ?? null,
+            tenantId: task.tenantId ?? null,
+            organizationId: task.organizationId ?? null,
+        });
+        if (!claimed) {
+            // A redelivery, another failing job on the same push, or the
+            // loser of two replicas racing one delivery.
+            return { reason: 'already-claimed', taskId: task.id, attemptsUsed, maxAttempts };
+        }
+
+        // ── the budget race ────────────────────────────────────────
+        // The count above and the claim just made are two statements, so
+        // deliveries for DIFFERENT heads can all read "1 of 2 used" and
+        // all claim: their coordinates genuinely differ, so the unique
+        // index cannot help, and the overshoot would be paid in model
+        // runs. Re-reading the ledger AFTER the claim settles it — the
+        // row is in the count now, so a claim that pushed the Task past
+        // its budget refuses to dispatch.
+        //
+        // The claimed row is deliberately left in place: deleting it
+        // would re-open the coordinate to the next redelivery, which is
+        // the far more expensive mistake. So a lost race costs one
+        // attempt slot and no model run — this fails toward NOT spending,
+        // which is the direction that matters here.
+        let settled: number;
+        try {
+            settled = await this.attempts.countForTask(task.id);
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: budget unreadable after claiming attempt ${claimed.id} — not dispatching: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return { reason: 'budget-unreadable', taskId: task.id };
+        }
+        if (settled > maxAttempts) {
+            this.logger.warn(
+                `Task ${task.id}: auto-resume attempt ${claimed.id} lost the budget race (${settled} claimed, budget ${maxAttempts}) — not dispatching.`,
+            );
+            return {
+                reason: 'budget-spent',
+                taskId: task.id,
+                attemptsUsed: settled,
+                maxAttempts,
+                noticeFiled: await this.fileStopNotice(ctx, 'budget-spent', settled, maxAttempts),
+            };
+        }
+
+        // Persist the failure as durable rejection feedback so `resume`'s
+        // existing replay path seeds it into the new run's FIRST turn —
+        // and so it survives if the dispatch fails. If the write fails,
+        // fall back to handing the same text to `resume` as its message:
+        // a resumed run that does not know what broke is the one outcome
+        // worth avoiding here.
+        let fallbackMessage: string | null = null;
+        if (ctx.feedback) {
+            // Will `resume` actually replay it?  `claimRejectionFeedback`
+            // takes the MAX_REPLAYED_REJECTIONS OLDEST unconsumed rows, and
+            // the row about to be written is the newest — so a Task already
+            // carrying that many unconsumed reviewer findings would spend a
+            // full model run seeded with three stale review comments and
+            // never be told CI is red at all. When the row will fall
+            // outside the window, hand the same text to `resume` as its
+            // message instead (it is appended after the replayed block, so
+            // nothing is lost or reordered).
+            let replayWindowHasRoom = true;
+            try {
+                const alreadyPending = await this.rejections.findPendingForTask(
+                    task.id,
+                    MAX_REPLAYED_REJECTIONS,
+                );
+                replayWindowHasRoom = alreadyPending.length < MAX_REPLAYED_REJECTIONS;
+            } catch {
+                // Cannot tell — assume it will NOT be replayed. Duplicating
+                // the failure text costs prompt tokens; losing it costs a
+                // whole run that does not know what broke.
+                replayWindowHasRoom = false;
+            }
+            if (!replayWindowHasRoom) fallbackMessage = ctx.feedback.text;
+            try {
+                await this.rejections.record({
+                    taskId: task.id,
+                    source: 'gate',
+                    feedback: ctx.feedback.text,
+                    workId: task.workId ?? null,
+                    runId: run.id,
+                    reviewerLabel: ctx.feedback.reviewerLabel,
+                    reviewerKind: 'bot',
+                    // A red gate blocks the merge; nothing about it is a nit.
+                    severity: 'critical',
+                    prNumber: ctx.feedback.prNumber,
+                    prUrl: ctx.feedback.prUrl,
+                    organizationId: task.organizationId ?? null,
+                });
+            } catch (error) {
+                this.logger.warn(
+                    `Task ${task.id}: could not persist CI failure feedback, seeding it directly: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                fallbackMessage = ctx.feedback.text;
+            }
+        }
+
+        try {
+            const outcome = await this.steering.resumeRun({
+                runId: run.id,
+                // Platform state, never the webhook body.
+                userId: task.userId,
+                message: fallbackMessage,
+                allowCompleted: true,
+            });
+            await this.attempts
+                .stampResumedRun(claimed.id, outcome.runId)
+                .catch((error: unknown) =>
+                    this.logger.warn(
+                        `Task ${task.id}: attempt ${claimed.id} resumed as ${outcome.runId} but the pointer did not stamp: ${error}`,
+                    ),
+                );
+            this.logger.log(
+                `Task ${task.id}: auto-resumed as run ${outcome.runId} (${ctx.trigger}, attempt ${
+                    attemptsUsed + 1
+                }/${maxAttempts}).`,
+            );
+            return {
+                reason: 'resumed',
+                taskId: task.id,
+                runId: outcome.runId,
+                attemptsUsed: attemptsUsed + 1,
+                maxAttempts,
+            };
+        } catch (error) {
+            // The attempt stays spent. That is the deliberate trade: a
+            // claim that could be retried by a redelivery is exactly the
+            // resume storm this ledger exists to stop.
+            this.logger.warn(
+                `Task ${task.id}: auto-resume dispatch failed (attempt spent): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return {
+                reason: 'dispatch-failed',
+                taskId: task.id,
+                attemptsUsed: attemptsUsed + 1,
+                maxAttempts,
+            };
+        }
+    }
+
+    // ── internals ──────────────────────────────────────────────────
+
+    /**
+     * Repo + PR number (or branch) → the Task, through platform state only.
+     *
+     * Two rules that are easy to get wrong and expensive when they are:
+     *
+     *  * **The Work's TASK repository only.** A Work declares up to three
+     *    repositories (`work`, `website`, `data`) and the shared matcher
+     *    matches all three, but Task worktrees and Task pull requests are
+     *    opened in the DATA repo (`TaskWorkspaceService`), so
+     *    `tasks.prNumber` and `tasks.branchRef` are only unique there.
+     *    Without the role check, a red check on pull request #7 of the
+     *    Work's WEBSITE repo resolves to whatever Task opened #7 in the
+     *    data repo, overwrites that Task's `ciHeadSha` with a commit from
+     *    another repository, and spends an attempt telling an agent to
+     *    fix a repository the failure is not in.
+     *  * **One Works scan per delivery.** A commit that heads several pull
+     *    requests lists all of them, and resolving each through
+     *    `findByPullRequest` re-loaded the owner's entire Works list every
+     *    time. The Task's own `prNumber` is tried FIRST so a stacked chain
+     *    resolves to this Task rather than to whichever entry GitHub
+     *    happened to order first.
+     */
+    private async resolveTask(
+        input: CiCheckResultInput,
+    ): Promise<{ task: Task; prNumber: number | null } | null> {
+        const base = { userId: input.userId, owner: input.owner, repo: input.repo };
+        const prNumbers = [...(input.prNumbers ?? [])];
+        if (prNumbers.length > 0) {
+            const link = await this.links.findByPullRequests(base, prNumbers);
+            if (link) {
+                if (link.isTaskRepo === false) return null;
+                const task = await this.tasks.findById(link.taskId);
+                return task ? { task, prNumber: link.prNumber } : null;
+            }
+        }
+        // Fork pull requests report an EMPTY `pull_requests[]`, so the
+        // branch is the only remaining coordinate — and it is `null` for
+        // forks too, which is why both are tried and neither is assumed.
+        const branch = (input.headBranch ?? '').trim();
+        if (!branch) return null;
+        const link = await this.links.findByBranch({ ...base, branch });
+        if (!link || link.isTaskRepo === false) return null;
+        const task = await this.tasks.findById(link.taskId);
+        return task ? { task, prNumber: null } : null;
+    }
+
+    /**
+     * The head the provider says THIS Task's pull request is at, from the
+     * delivery's own `pull_requests[]`.
+     *
+     * Prefers the entry for the pull request the Task resolved through;
+     * falls back to the Task's recorded `prNumber`, and finally to a lone
+     * entry. Never guesses between two entries — an unrelated pull
+     * request's head is not evidence about this one, so `null` (fall back
+     * to the clock) is the honest answer.
+     */
+    private prHeadFor(input: CiCheckResultInput, prNumber: number | null): string | null {
+        const heads = input.prHeads ?? [];
+        if (heads.length === 0) return null;
+        const wanted = prNumber;
+        const match =
+            (wanted !== null ? heads.find((entry) => entry.number === wanted) : undefined) ??
+            (heads.length === 1 ? heads[0] : undefined);
+        const sha = (match?.headSha ?? '').trim();
+        return sha.length > 0 ? sha : null;
+    }
+
+    /**
+     * Write the provider's head commit (and a RED verdict) onto the Task.
+     *
+     * Best-effort: this is the board's decoration plus the input to the
+     * staleness rule, and losing one write costs freshness, not safety.
+     */
+    private async recordHead(
+        task: Task,
+        headSha: string,
+        seenAt: Date,
+        failing: boolean,
+        decision: CiHeadDecision,
+    ): Promise<void> {
+        // Nothing new to say: same head, still not red.
+        if (decision === 'current' && !failing) return;
+        try {
+            await this.tasks.recordCiHead({
+                taskId: task.id,
+                expectedHeadSha: decision === 'first-seen' ? null : (task.ciHeadSha ?? null),
+                headSha,
+                seenAt,
+                failing,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: CI head write failed (ignored): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * File the ONE "automatic retries stopped" Inbox notice for this Task.
+     *
+     * The CAS marker on the Task is claimed BEFORE the notice is filed, so
+     * exactly one of the dozens of deliveries that all rediscover a spent
+     * budget can file — `InboxService.notice` has no dedup of its own and
+     * would happily insert one row per `check_run`. At-most-once is the
+     * deliberate direction: a marker that cannot be written files nothing
+     * rather than everything.
+     */
+    private async fileStopNotice(
+        ctx: {
+            task: Task;
+            notice: { repoFullName: string; prNumber: number | null; headSha: string | null };
+        },
+        reason: Extract<AutoResumeOutcomeReason, 'budget-spent' | 'repeat-failure'>,
+        attemptsUsed: number,
+        maxAttempts: number,
+    ): Promise<boolean> {
+        // Already stopped — nothing to claim and nothing to file. Checked
+        // against the row in hand so the post-stop steady state issues no
+        // write at all (`evaluate` short-circuits on the same field; this
+        // is the belt for callers that reach here another way).
+        if (ctx.task.ciAutoResumeNoticedAt) return false;
+        let won: boolean;
+        try {
+            won = await this.tasks.casMarkCiAutoResumeNoticed(ctx.task.id, new Date());
+        } catch (error) {
+            this.logger.warn(
+                `Task ${ctx.task.id}: notice marker CAS failed, filing nothing: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+        if (!won) return false;
+        // The marker IS the stop flag, so it is claimed whether or not an
+        // Inbox producer is bound: an install with no Inbox must still stop
+        // the loop rather than re-deciding the same terminal condition on
+        // every future delivery.
+        ctx.task.ciAutoResumeNoticedAt = new Date();
+        if (!this.inbox) return false;
+
+        const { title, body } = composeBudgetSpentNotice({
+            taskTitle: ctx.task.title,
+            reason,
+            attemptsUsed,
+            maxAttempts,
+            repoFullName: ctx.notice.repoFullName,
+            prNumber: ctx.notice.prNumber,
+            headSha: ctx.notice.headSha,
+        });
+        try {
+            await this.inbox.notice(ctx.task.userId, {
+                title,
+                body,
+                taskId: ctx.task.id,
+                workId: ctx.task.workId ?? null,
+                organizationId: ctx.task.organizationId ?? null,
+            });
+            return true;
+        } catch (error) {
+            this.logger.warn(
+                `Task ${ctx.task.id}: auto-resume stop notice could not be filed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+
+    /** Fail-closed read of the global stop flag, mirroring the fan-out driver. */
+    private async isHalted(): Promise<boolean> {
+        if (!this.killSwitch) return false;
+        try {
+            return await this.killSwitch.shouldHaltDispatch();
+        } catch (error) {
+            this.logger.warn(
+                `CI auto-resume: global stop flag unreadable — refusing to resume (fail-closed): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return true;
+        }
+    }
+}

--- a/packages/agent/src/tasks-domain/task-ci-auto-resume.ts
+++ b/packages/agent/src/tasks-domain/task-ci-auto-resume.ts
@@ -1,0 +1,451 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * CI feedback and the autonomous fix loop (self-build slice AC, EW-806) —
+ * the PURE half.
+ *
+ * Everything here is side-effect free and takes plain shapes, so the
+ * service, the API-side webhook consumer and the tests share one set of
+ * rules instead of each re-deriving "is this red?", "is this the head we
+ * care about?" and "have we already tried exactly this?".
+ */
+
+// ── the retry budget ────────────────────────────────────────────────
+
+/**
+ * Bounds on the auto-resume budget.
+ *
+ * `0` is a real, supported value and means the loop is OFF: nothing is
+ * ever auto-resumed, the ingest half still runs, and the board still
+ * shows the red dot. The ceiling exists because the value arrives from
+ * an environment variable and one resume is one full model run on one
+ * fleet PC — an out-of-range number must never buy an unbounded spend.
+ */
+export const MIN_CI_AUTO_RESUME_ATTEMPTS = 0;
+export const MAX_CI_AUTO_RESUME_ATTEMPTS = 5;
+
+/**
+ * Attempts per Task, over the Task's whole life, when nothing is set.
+ *
+ * TWO. The first retry catches the ordinary case — a lint slip, a
+ * missing import, a snapshot the agent forgot to update — and the second
+ * catches "the fix was almost right". A third has, in practice, meant the
+ * agent does not understand the failure, and paying a third model run to
+ * find that out is worse than filing the Inbox notice one run earlier.
+ *
+ * Cost: see `docs/features/ci-auto-resume.md`. A resumed run is a normal
+ * `agent-task-execute` run — the same order of model spend as the run
+ * that opened the pull request in the first place — so the DEFAULT
+ * exposure this feature adds to a Task is at most two extra runs.
+ */
+export const DEFAULT_CI_AUTO_RESUME_ATTEMPTS = 2;
+
+/**
+ * Clamp a configured budget into `0..5`.
+ *
+ * An unparseable value falls back to the DEFAULT rather than to zero:
+ * silently switching a shipped loop off because of a typo is the harder
+ * failure to notice, and the default is itself bounded.
+ */
+export function clampAutoResumeAttempts(raw: unknown): number {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+        return DEFAULT_CI_AUTO_RESUME_ATTEMPTS;
+    }
+    return Math.min(
+        MAX_CI_AUTO_RESUME_ATTEMPTS,
+        Math.max(MIN_CI_AUTO_RESUME_ATTEMPTS, Math.trunc(raw)),
+    );
+}
+
+// ── reading a provider check result ─────────────────────────────────
+
+/**
+ * The four verdicts a single check result can carry, in the same
+ * vocabulary `deriveCiState` uses for the board's CI dot.
+ *
+ * `failing` is the ONLY one that can buy a resume.
+ */
+export type CheckVerdict = 'failing' | 'passing' | 'pending' | 'inconclusive';
+
+/**
+ * Conclusions that count as RED.
+ *
+ * Deliberately the same set `packages/plugin`'s `deriveCiState` treats as
+ * failures, plus `startup_failure`, which only `workflow_run` reports.
+ * `cancelled`, `neutral`, `skipped` and `stale` are NOT failures — a
+ * human stopping a job, or a job that decided it had nothing to do, is
+ * not something to spend a model run fixing.
+ */
+export const FAILING_CHECK_CONCLUSIONS: readonly string[] = [
+    'failure',
+    'timed_out',
+    'action_required',
+    'startup_failure',
+];
+
+/**
+ * Verdict of ONE reported check.
+ *
+ * A check that has not completed is `pending` whatever its conclusion
+ * field says, so a red arriving before the job finished (or a payload
+ * with a stale conclusion on an `in_progress` re-run) can never trigger
+ * the loop. A completed check with no conclusion at all is
+ * `inconclusive`, never laundered into a pass — same rule as the board
+ * rollup.
+ */
+export function classifyCheckResult(input: {
+    status?: string | null;
+    conclusion?: string | null;
+}): CheckVerdict {
+    const status = (input.status ?? '').toLowerCase();
+    if (status !== 'completed') return 'pending';
+    const conclusion = (input.conclusion ?? '').toLowerCase();
+    if (!conclusion) return 'inconclusive';
+    if (FAILING_CHECK_CONCLUSIONS.includes(conclusion)) return 'failing';
+    if (conclusion === 'success') return 'passing';
+    return 'inconclusive';
+}
+
+// ── idempotency coordinates ─────────────────────────────────────────
+
+/**
+ * The claim key for a CI failure: ONE attempt per Task per head commit.
+ *
+ * Stronger than one-per-failing-check on purpose. A 12-job matrix goes
+ * red twelve times for one push, GitHub redelivers on any non-2xx, and
+ * every one of those is the same single thing to fix. Keying the claim on
+ * the head commit collapses the whole storm into one attempt.
+ */
+export function ciAutoResumeClaimKey(headSha: string): string {
+    return `ci:${headSha}`;
+}
+
+/** The claim key for a recorded reviewer rejection: one per rejection row. */
+export function reviewAutoResumeClaimKey(rejectionId: string): string {
+    return `review:${rejectionId}`;
+}
+
+/**
+ * Fingerprint of WHAT failed — failing check names plus a digest of the
+ * output the provider reported.
+ *
+ * Used only by the no-progress guard, never by the claim: two different
+ * failures on one head still get one attempt, but the SAME failure coming
+ * back unchanged on a new head stops the loop instead of buying another
+ * model run. Names are lower-cased and sorted so job ordering cannot
+ * change the fingerprint; the output is whitespace-collapsed for the same
+ * reason.
+ */
+export function computeCiFailureKey(input: {
+    checkNames: readonly string[];
+    output?: string | null;
+}): string {
+    const names = [...new Set(input.checkNames.map((name) => name.trim().toLowerCase()))]
+        .filter((name) => name.length > 0)
+        .sort();
+    const output = (input.output ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+    return createHash('sha256')
+        .update(`${names.join(',')}\u0000${output}`)
+        .digest('hex')
+        .slice(0, 32);
+}
+
+// ── head-commit staleness ───────────────────────────────────────────
+
+/**
+ * What a delivery's head commit is, relative to the head the platform
+ * last saw for this Task.
+ *
+ *  - `first-seen` — the Task has no recorded head yet; adopt this one.
+ *  - `current`    — same commit; act on it.
+ *  - `advanced`   — a different commit that the provider says is the pull
+ *                   request's head RIGHT NOW: a new push superseded the
+ *                   old head. Adopt and act.
+ *  - `stale`      — a different commit the pull request has already moved
+ *                   past, or one this platform cannot prove is newer.
+ *                   Refuse: this is CI catching up on a revision that has
+ *                   been replaced, and resuming on it would fix code
+ *                   nobody has any more.
+ */
+export type CiHeadDecision = 'first-seen' | 'current' | 'advanced' | 'stale';
+
+/** What one delivery tells us about which commit it is really about. */
+export interface CiHeadEvidence {
+    /** The commit the CHECK ran against. */
+    headSha: string;
+    /**
+     * The commit the provider says the PULL REQUEST is at, from the
+     * delivery's own `pull_requests[].head.sha`. This is the authoritative
+     * signal and it is checked FIRST — see the ordering note below.
+     * `null` when the delivery named no pull request (a fork, or a
+     * push-triggered workflow run).
+     */
+    prHeadSha?: string | null;
+    /**
+     * The provider's OWN timestamp for this result, or `null` when the
+     * delivery carried none (or an unparseable one). Deliberately not
+     * defaulted to `now`: a synthesized timestamp is always the newest
+     * thing in the comparison, which would make every undated delivery
+     * look like a fresh push.
+     */
+    reportedAt?: Date | null;
+}
+
+/**
+ * Which commit a delivery is really about, relative to the Task's
+ * recorded head.
+ *
+ * ## Why wall-clock ordering is the FALLBACK, not the rule
+ *
+ * The obvious implementation — "the later timestamp wins" — is wrong, and
+ * wrong in the expensive direction. A push's jobs have wildly different
+ * durations (this repo's `ci.yml` runs ~15 job instances per PR push), so
+ * a slow job belonging to commit A routinely COMPLETES after commit B has
+ * already landed and reported its first queued check. Ordering by
+ * timestamp classifies that late result as a new head, rewrites
+ * `tasks.ciHeadSha` backwards to A, and buys a full model run against a
+ * revision nobody has any more. A manual "Re-run jobs" on an old commit
+ * does the same thing. Both are ordinary, not exotic.
+ *
+ * So the decision is evidence-ordered:
+ *
+ *  1. **The pull request's own head pointer.** Every `check_run`,
+ *     `check_suite` and `workflow_run` delivery for a same-repository pull
+ *     request carries `pull_requests[].head.sha`, which is the PR's head
+ *     at delivery time. If it disagrees with the check's own head, the
+ *     check is for a commit the branch has moved past — `stale`, with no
+ *     clock involved. If it agrees, this IS the current head — `advanced`.
+ *  2. **Wall clock, only when there is no pointer** (fork pull requests,
+ *     push-triggered workflow runs). Then a strictly later PROVIDER-
+ *     REPORTED time is the only evidence available, and a delivery with no
+ *     provider timestamp at all is refused rather than trusted.
+ *
+ * Fails toward `stale`, i.e. toward NOT spending a model run: the whole
+ * budget of this feature is two runs per Task, and burning them on dead
+ * commits is the failure that leaves the fleet stalled at exactly the
+ * moment the loop exists to prevent.
+ */
+export function decideCiHead(
+    stored: { ciHeadSha?: string | null; ciHeadSeenAt?: Date | null } | null | undefined,
+    event: CiHeadEvidence,
+): CiHeadDecision {
+    // Commit ids are compared case-insensitively: they are hex, providers
+    // are not consistent about case, and a mismatch that is only casing
+    // would read as a different commit and wedge the Task on `stale`
+    // forever.
+    const sha = (value: string | null | undefined) => (value ?? '').trim().toLowerCase();
+    const storedSha = sha(stored?.ciHeadSha);
+    const eventSha = sha(event.headSha);
+    if (!storedSha) return 'first-seen';
+    if (storedSha === eventSha) return 'current';
+
+    // (1) The provider's own pointer to the pull request head. Decisive
+    //     in both directions, and available on every same-repo delivery.
+    const prHeadSha = sha(event.prHeadSha);
+    if (prHeadSha) return prHeadSha === eventSha ? 'advanced' : 'stale';
+
+    // (2) No pointer. Fall back to the clock, and only to a real one.
+    const reportedAt = event.reportedAt ?? null;
+    if (!(reportedAt instanceof Date) || Number.isNaN(reportedAt.getTime())) return 'stale';
+    const seenAt = stored?.ciHeadSeenAt ?? null;
+    // A recorded head with no recorded sighting time can only come from a
+    // hand-edited row (this loop always writes the pair together). There
+    // is nothing to order against, and refusing forever would wedge the
+    // Task, so the newer sighting wins.
+    if (!(seenAt instanceof Date) || Number.isNaN(seenAt.getTime())) return 'advanced';
+    return reportedAt.getTime() > seenAt.getTime() ? 'advanced' : 'stale';
+}
+
+/**
+ * Pull-request states that mean "there is nothing left to push a fix to".
+ *
+ * `tasks.prState` is the poll's cache of the provider's own verdict and
+ * `tasks.branchState` is the branch chip; both are durable platform state
+ * on the row the evaluator already holds, and either one reaching a
+ * terminal value is enough. Deliberately NOT `draft`: a draft pull
+ * request is still being worked on, and a red build on one is exactly
+ * what the loop is for.
+ */
+export const FINISHED_PR_STATES: readonly string[] = ['merged', 'closed'];
+export const FINISHED_BRANCH_STATES: readonly string[] = ['merged', 'discarded'];
+
+/**
+ * Has this Task's pull request already landed (or been abandoned)?
+ *
+ * Checked separately from `TaskStatus` because the merged -> DONE
+ * transition is poll-driven, runs on a two-minute cron, and only fires
+ * from `in_progress` / `in_review` — so a Task sitting in `blocked` with a
+ * merged pull request stays non-DONE indefinitely, and every Task has a
+ * window after merge. A pull request the owner closed without merging is
+ * never transitioned at all.
+ */
+export function isPullRequestFinished(task: {
+    prState?: string | null;
+    branchState?: string | null;
+}): boolean {
+    const prState = (task.prState ?? '').toLowerCase();
+    if (prState && FINISHED_PR_STATES.includes(prState)) return true;
+    const branchState = (task.branchState ?? '').toLowerCase();
+    return Boolean(branchState) && FINISHED_BRANCH_STATES.includes(branchState);
+}
+
+// ── why a resume did or did not happen ──────────────────────────────
+
+/**
+ * Every terminal reason the evaluator can report. Exhaustive on purpose:
+ * the service returns one of these for EVERY delivery, the specs assert
+ * on them, and "we did nothing and cannot say why" is not an option for
+ * something that spends money when it says yes.
+ */
+export type AutoResumeOutcomeReason =
+    /** A run was created. */
+    | 'resumed'
+    /** `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS=0`. */
+    | 'disabled'
+    /** The delivery is not a completed failure (green, pending, cancelled…). */
+    | 'not-a-failure'
+    /** The global stop flag is set, or could not be read. */
+    | 'halted'
+    /** The repo/branch/PR resolved to no Task this owner holds. */
+    | 'no-task'
+    /** A review delivery arrived but the Task has no unconsumed rejection. */
+    | 'no-feedback'
+    /** The Task is `done` or `cancelled`. */
+    | 'task-finished'
+    /**
+     * The pull request is `merged` or `closed` (or the branch is merged /
+     * discarded). There is nothing left to push a fix to.
+     */
+    | 'pr-closed'
+    /**
+     * The loop already gave up on this Task and said so in the Inbox. A
+     * terminal, durable state — no further delivery is evaluated.
+     */
+    | 'stopped'
+    /** The delivery reports a head the Task has already moved past. */
+    | 'stale-head'
+    /** The ledger could not be read — the loop STOPS rather than guesses. */
+    | 'budget-unreadable'
+    /** Every attempt in the budget has been spent. */
+    | 'budget-spent'
+    /** This exact failure has already been retried once. */
+    | 'repeat-failure'
+    /** Another delivery (or replica) already claimed this coordinate. */
+    | 'already-claimed'
+    /** The Task has no run to resume. */
+    | 'no-run'
+    /** A run is queued or running — the fix may already be in flight. */
+    | 'run-in-flight'
+    /** The run is parked on a QUESTION; that is the human's to answer. */
+    | 'awaiting-human'
+    /** The latest run ended in a state an automated resume must not touch. */
+    | 'run-not-resumable'
+    /** The steering port is not bound on this install. */
+    | 'no-steering'
+    /** The dispatch itself failed; the attempt is spent. */
+    | 'dispatch-failed'
+    /**
+     * Something unexpected threw. The loop STOPS on it rather than
+     * continuing — the caller is a webhook that must answer 200, and an
+     * error is never permission to spend a model run.
+     */
+    | 'error';
+
+export interface AutoResumeOutcome {
+    reason: AutoResumeOutcomeReason;
+    /** The Task the delivery resolved to, when it resolved to one. */
+    taskId?: string;
+    /** The run the resume created. */
+    runId?: string;
+    /** Attempts spent for this Task INCLUDING this one. */
+    attemptsUsed?: number;
+    /** The budget in force. */
+    maxAttempts?: number;
+    /** True when this call filed the one-and-only Inbox notice. */
+    noticeFiled?: boolean;
+}
+
+// ── the message the resumed run reads ───────────────────────────────
+
+/** Longest failure body persisted as rejection feedback. */
+export const CI_FAILURE_FEEDBACK_MAX_CHARS = 4000;
+
+/**
+ * Compose the durable rejection text for a red gate.
+ *
+ * Written in the same register as the gate's own iterate message so an
+ * agent that has learned to read one reads the other, and deliberately
+ * honest about its own blind spot: the delivery carries the FIRST failure
+ * observed for this commit, not necessarily the only one, and the run
+ * that reads this has a git provider it can ask.
+ *
+ * Every interpolated value is provider-reported and therefore untrusted;
+ * `RunSteeringService` neutralizes chat-template markers when it splices
+ * the stored row into a prompt, and the caller caps the length.
+ */
+export function composeCiFailureFeedback(input: {
+    repoFullName: string;
+    headSha: string;
+    checkName: string;
+    conclusion: string;
+    prNumber?: number | null;
+    url?: string | null;
+    outputTitle?: string | null;
+    outputSummary?: string | null;
+}): string {
+    const lines: string[] = [
+        `Continuous integration is RED for ${input.repoFullName} at commit ${input.headSha}.`,
+        '',
+        `Failing check: ${input.checkName} (${input.conclusion}).`,
+    ];
+    if (input.prNumber) lines.push(`Pull request: #${input.prNumber}.`);
+    if (input.url) lines.push(`Details: ${input.url}`);
+    if (input.outputTitle) lines.push('', `Reported title: ${input.outputTitle}`);
+    if (input.outputSummary) lines.push('', 'Reported output:', input.outputSummary);
+    lines.push(
+        '',
+        'Other checks on this commit may also be failing — this is the first red result reported for it, not a full list. Read the pull request checks, fix the cause, and push to the same branch. Do not disable, skip or weaken a check to make it pass.',
+    );
+    return lines.join('\n').slice(0, CI_FAILURE_FEEDBACK_MAX_CHARS);
+}
+
+/**
+ * Title + body of the ONE Inbox notice filed when the loop gives up.
+ *
+ * Both reasons are TERMINAL for the Task — `TaskCiAutoResumeService`
+ * treats the notice marker itself as the stop flag, so the body's promise
+ * that "nothing further will be retried automatically" is literally true
+ * for whichever of the two conditions fires first. It used to be filed
+ * for `repeat-failure` while the loop happily carried on resuming any
+ * DIFFERENT failure inside the remaining budget, which meant the owner
+ * read a hard stop that had not happened and the real budget-spent event
+ * then filed nothing (the one-shot marker was already burned).
+ */
+export function composeBudgetSpentNotice(input: {
+    taskTitle: string;
+    reason: Extract<AutoResumeOutcomeReason, 'budget-spent' | 'repeat-failure'>;
+    attemptsUsed: number;
+    maxAttempts: number;
+    repoFullName?: string | null;
+    prNumber?: number | null;
+    headSha?: string | null;
+}): { title: string; body: string } {
+    const why =
+        input.reason === 'repeat-failure'
+            ? `the same failure came back unchanged after an automatic retry, so retrying it again would not be progress (${input.attemptsUsed} of ${input.maxAttempts} attempts used)`
+            : `the automatic retry budget for this task is spent (${input.attemptsUsed} of ${input.maxAttempts} attempts used)`;
+    const where = input.repoFullName
+        ? `${input.repoFullName}${input.prNumber ? `#${input.prNumber}` : ''}`
+        : 'the pull request';
+    return {
+        title: `CI is still red on ${input.taskTitle} — automatic retries stopped`,
+        body: [
+            `The build for ${where} is failing and ${why}.`,
+            input.headSha ? `Last head commit seen: ${input.headSha}.` : null,
+            '',
+            'Nothing further will be retried automatically for this task. Open the pull request, read the failing check, and either fix it yourself or resume the run manually once you know what to tell the agent.',
+        ]
+            .filter((line): line is string => line !== null)
+            .join('\n'),
+    };
+}

--- a/packages/agent/src/tasks-domain/task-git-link.service.ts
+++ b/packages/agent/src/tasks-domain/task-git-link.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { TaskRepository } from '../database/repositories/task.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
-import { matchWorkByRepo } from '../works/work-repo-match';
+import {
+    WORK_TASK_REPO_ROLE,
+    matchWorkRepoRole,
+    type WorkRepoRole,
+} from '../works/work-repo-match';
 
 /** What a git ref resolved to inside the platform, when it resolved at all. */
 export interface TaskGitLink {
@@ -9,6 +13,23 @@ export interface TaskGitLink {
     taskId: string;
     /** The Task's human slug — cheap context for the Activity row. */
     taskSlug?: string | null;
+    /**
+     * WHICH of the Work's repo roles the delivery's repository fills —
+     * all of them, since two roles can resolve to the same repository.
+     */
+    repoRoles?: readonly WorkRepoRole[];
+    /**
+     * True when the repository is the one this Work's TASKS live in (the
+     * data repo — see {@link WORK_TASK_REPO_ROLE}), i.e. the one
+     * `tasks.prNumber` and `tasks.branchRef` are unique within.
+     *
+     * A consumer that merely decorates an ingested event can ignore this.
+     * A consumer that ACTS on the Task it resolved — rewriting its CI
+     * head, resuming its run — must not, or a pull request #7 in the
+     * Work's website repo resolves to the Task that opened #7 in the data
+     * repo.
+     */
+    isTaskRepo?: boolean;
 }
 
 /** Coordinates every lookup starts from: the repo the delivery named. */
@@ -61,6 +82,55 @@ export class TaskGitLinkService {
         );
     }
 
+    /**
+     * The Task behind ANY of several pull request numbers reported for one
+     * commit, resolving the owner's Works exactly ONCE.
+     *
+     * A commit can head several pull requests (a stacked chain, a shared
+     * branch), and a provider delivery lists all of them. Calling
+     * {@link findByPullRequest} per number re-loads the owner's entire
+     * Works list every time — on a webhook hot path, for the busiest
+     * account on the platform, discarding every scan before the matching
+     * one. This does the repo→Work walk once and then asks only the Task
+     * query per number.
+     *
+     * `prNumbers` is tried in order and the first hit wins; the caller
+     * should put its preferred number first. Returns the matched number
+     * alongside the link so the caller can line the result up with the
+     * delivery's per-pull-request data.
+     */
+    async findByPullRequests(
+        base: TaskGitLookupBase,
+        prNumbers: readonly number[],
+    ): Promise<(TaskGitLink & { prNumber: number }) | null> {
+        const wanted = prNumbers.filter((n) => Number.isInteger(n));
+        if (wanted.length === 0) return null;
+        const matched = await this.matchWork(base);
+        if (!matched) return null;
+        try {
+            for (const prNumber of wanted) {
+                const task = await this.tasks.findByWorkAndPrNumber(matched.work.id, prNumber);
+                if (task) {
+                    return {
+                        workId: matched.work.id,
+                        taskId: task.id,
+                        taskSlug: task.slug ?? null,
+                        repoRoles: matched.roles,
+                        isTaskRepo: matched.roles.includes(WORK_TASK_REPO_ROLE),
+                        prNumber,
+                    };
+                }
+            }
+        } catch (error) {
+            this.logger.warn(
+                `Task link lookup failed for ${base.owner}/${base.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        return null;
+    }
+
     /** The Task whose isolated worktree branch is `branch`, or null. */
     async findByBranch(input: TaskGitLookupBase & { branch: string }): Promise<TaskGitLink | null> {
         const branch = (input.branch ?? '').trim();
@@ -81,17 +151,39 @@ export class TaskGitLinkService {
         base: TaskGitLookupBase,
         findTask: (workId: string) => Promise<{ id: string; slug?: string | null } | null>,
     ): Promise<TaskGitLink | null> {
-        if (!base.userId || !base.owner || !base.repo) return null;
+        const matched = await this.matchWork(base);
+        if (!matched) return null;
         try {
-            const candidates = await this.works.findByUser(base.userId);
-            const work = matchWorkByRepo(candidates ?? [], base.owner, base.repo);
-            if (!work) return null;
-            const task = await findTask(work.id);
+            const task = await findTask(matched.work.id);
             if (!task) return null;
-            return { workId: work.id, taskId: task.id, taskSlug: task.slug ?? null };
+            return {
+                workId: matched.work.id,
+                taskId: task.id,
+                taskSlug: task.slug ?? null,
+                repoRoles: matched.roles,
+                isTaskRepo: matched.roles.includes(WORK_TASK_REPO_ROLE),
+            };
         } catch (error) {
             this.logger.warn(
                 `Task link lookup failed for ${base.owner}/${base.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
+    }
+
+    /** Owner-scoped repo→Work walk. One `findByUser` per call, never more. */
+    private async matchWork(
+        base: TaskGitLookupBase,
+    ): Promise<{ work: { id: string }; roles: readonly WorkRepoRole[] } | null> {
+        if (!base.userId || !base.owner || !base.repo) return null;
+        try {
+            const candidates = await this.works.findByUser(base.userId);
+            return matchWorkRepoRole(candidates ?? [], base.owner, base.repo);
+        } catch (error) {
+            this.logger.warn(
+                `Work lookup failed for ${base.owner}/${base.repo}: ${
                     error instanceof Error ? error.message : String(error)
                 }`,
             );

--- a/packages/agent/src/tasks-domain/task-pr-status.service.ts
+++ b/packages/agent/src/tasks-domain/task-pr-status.service.ts
@@ -8,6 +8,8 @@ import { WorkRepository } from '../database/repositories/work.repository';
 import { GitFacadeService } from '../facades/git.facade';
 import { TaskTransitionService } from './task-transition.service';
 import { TaskMergeGateService } from './task-merge-gate.service';
+import { TaskCiAutoResumeService } from './task-ci-auto-resume.service';
+import { classifyCheckResult, computeCiFailureKey } from './task-ci-auto-resume';
 
 /**
  * PR insights (kanban run cockpit, plan 04 M5 + M6 + the merged half of
@@ -110,6 +112,12 @@ export class TaskPrStatusService {
         // positional-spec arity rule; absent, this service behaves exactly
         // as it did before the slice (refresh the cache, land merged PRs).
         @Optional() private readonly mergeGate?: TaskMergeGateService,
+        // CI feedback + autonomous fix loop (slice AC, EW-806). Appended
+        // LAST and @Optional(), the house positional convention: every
+        // existing call site and positional test construction keeps its
+        // meaning, and an install without the fix loop polls exactly as
+        // it did before.
+        @Optional() private readonly autoResume?: TaskCiAutoResumeService,
     ) {}
 
     // ── Read paths ────────────────────────────────────────────────────
@@ -256,6 +264,8 @@ export class TaskPrStatusService {
                 if (after.prState === 'merged' && before !== 'merged') {
                     summary.merged += 1;
                     if (await this.completeOnMerge(after)) summary.completed += 1;
+                } else {
+                    await this.offerRedGateToFixLoop(after);
                 }
             } catch (error) {
                 summary.failed += 1;
@@ -268,6 +278,80 @@ export class TaskPrStatusService {
         }
 
         return summary;
+    }
+
+    /**
+     * CI feedback + autonomous fix loop (slice AC, EW-806) — the SAFETY
+     * NET behind the webhook.
+     *
+     * The webhook is a one-shot: a red result refused for a TRANSIENT
+     * reason (`run-in-flight`, because the run that pushed the branch is
+     * still posting the PR link when CI reports; `awaiting-human`, until
+     * the owner answers) is refused forever, because nothing re-delivers
+     * it. Every envelope for that push has already been ingested, so a
+     * GitHub redelivery short-circuits as a duplicate, and when the run
+     * finally ends there is no further CI event to arrive. The Task's red
+     * build was then never retried — silently, with no Inbox notice.
+     *
+     * This sweep already runs every two minutes over exactly the right
+     * population (open pull requests whose verdict has gone stale, never
+     * a merged or closed one) and already has the provider's full check
+     * list in hand, so re-offering a still-red gate here costs one extra
+     * call on a Task that was going to be polled anyway.
+     *
+     * It cannot double-spend: the evaluator's claim key is
+     * `ci:<headSha>`, so a head the webhook already resumed for is
+     * `already-claimed` on every tick thereafter, forever.
+     */
+    private async offerRedGateToFixLoop(task: Task): Promise<void> {
+        if (!this.autoResume?.onCheckResult) return;
+        if (task.ciState !== 'failing' || !task.workId || !task.prNumber) return;
+        const failing = (Array.isArray(task.prChecks) ? task.prChecks : []).filter(
+            (check) =>
+                classifyCheckResult({
+                    status: check.status,
+                    conclusion: check.conclusion ?? null,
+                }) === 'failing',
+        );
+        if (failing.length === 0) return;
+        try {
+            const target = await this.resolveRepo(task, task.userId);
+            const headSha = (task.ciHeadSha ?? '').trim();
+            if (!headSha) return;
+            await this.autoResume.onCheckResult({
+                // Platform state throughout — this path has no webhook
+                // body to be tempted by.
+                userId: task.userId,
+                owner: target.owner,
+                repo: target.repo,
+                headSha,
+                headBranch: task.branchRef ?? null,
+                prNumbers: [task.prNumber],
+                // The poll reads the PULL REQUEST, so the head it reports
+                // IS the pull request's head by construction.
+                prHeads: [{ number: task.prNumber, headSha }],
+                observedAt: task.ciCheckedAt ?? null,
+                verdict: 'failing',
+                granularity: 'check_suite',
+                checkName: failing[0].name,
+                conclusion: failing[0].conclusion ?? 'failure',
+                url: failing[0].detailsUrl ?? task.prUrl ?? null,
+                outputTitle: null,
+                outputSummary: null,
+                failureKey: computeCiFailureKey({
+                    checkNames: failing.map((check) => check.name),
+                    output: null,
+                }),
+            });
+        } catch (error) {
+            // Never a sweep failure: the fix loop is an extra, and this
+            // Task's PR status has already been refreshed successfully.
+            this.logger.warn(
+                `CI fix-loop re-offer failed for task ${task.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     // ── Internals ─────────────────────────────────────────────────────
@@ -299,6 +383,30 @@ export class TaskPrStatusService {
             }
             const patch = this.toCachePatch(status, checkedAt);
             await this.tasks.updatePrStatusCache(task.id, patch);
+            // CI feedback + autonomous fix loop (slice AC, EW-806): the
+            // provider's answer includes the pull request's CURRENT head,
+            // which is the most authoritative statement of it anywhere —
+            // better than any single check delivery, and available even on
+            // an install whose webhook is not subscribed to check events at
+            // all. Written through the same monotonic CAS the webhook uses,
+            // so the two writers cannot clobber each other; a lost CAS just
+            // means the webhook got there first and the in-memory copy is
+            // left alone.
+            const providerHead = (status.headSha ?? '').trim();
+            if (providerHead && providerHead !== task.ciHeadSha) {
+                const landed = await this.tasks
+                    .recordCiHead({
+                        taskId: task.id,
+                        expectedHeadSha: task.ciHeadSha ?? null,
+                        headSha: providerHead,
+                        seenAt: checkedAt,
+                        failing: false,
+                    })
+                    .catch(() => false);
+                if (landed) {
+                    Object.assign(task, { ciHeadSha: providerHead, ciHeadSeenAt: checkedAt });
+                }
+            }
             // Keep the branch chip honest too — a landed PR is a merged branch.
             if (status.state === 'merged' && task.branchState !== 'merged') {
                 await this.tasks

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -12,6 +12,7 @@ import { TaskWatcher } from '../entities/task-watcher.entity';
 import { TaskKbMention } from '../entities/task-kb-mention.entity';
 import { TaskTemplate } from '../entities/task-template.entity';
 import { TaskTemplateStep } from '../entities/task-template-step.entity';
+import { TaskCiAutoResumeAttempt } from '../entities/task-ci-auto-resume-attempt.entity';
 import { UserTaskCounter } from '../entities/user-task-counter.entity';
 import { WorkKnowledgeUpload } from '../entities/work-knowledge-upload.entity';
 import { AgentRepoAttachment } from '../entities/agent-repo-attachment.entity';
@@ -21,6 +22,7 @@ import { Team } from '../entities/team.entity';
 import { Goal } from '../entities/goal.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
 import { TaskRepository } from '../database/repositories/task.repository';
+import { TaskCiAutoResumeAttemptRepository } from '../database/repositories/task-ci-auto-resume-attempt.repository';
 import { AgentRepoAttachmentRepository } from '../database/repositories/agent-repo-attachment.repository';
 import { TaskTemplateRepository } from '../database/repositories/task-template.repository';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
@@ -54,6 +56,7 @@ import { TaskMergeGateService } from './task-merge-gate.service';
 import { TaskGitLinkService } from './task-git-link.service';
 import { TaskWorkspaceService } from './task-workspace.service';
 import { TaskPrStatusService } from './task-pr-status.service';
+import { TaskCiAutoResumeService } from './task-ci-auto-resume.service';
 import { FacadesModule } from '../facades/facades.module';
 import { PolicyModule } from '../policy/policy.module';
 import { MergeApprovalModule } from '../agent-approvals/merge-approval.module';
@@ -87,6 +90,11 @@ import { DatabaseModule } from '../database/database.module';
             // `_entities-inventory.ts` (no autoLoadEntities in this repo).
             TaskTemplate,
             TaskTemplateStep,
+            // CI feedback + autonomous fix loop (slice AC, EW-806) — the
+            // durable attempt ledger that IS the retry budget. ALSO
+            // registered in `_entities-inventory.ts` (no autoLoadEntities
+            // in this repo) and in `_entity-names.ts`.
+            TaskCiAutoResumeAttempt,
             UserTaskCounter,
             WorkKnowledgeUpload,
             Work,
@@ -128,6 +136,7 @@ import { DatabaseModule } from '../database/database.module';
     ],
     providers: [
         TaskRepository,
+        TaskCiAutoResumeAttemptRepository,
         AgentRepoAttachmentRepository,
         TaskAssigneeRepository,
         TaskReviewerRepository,
@@ -178,6 +187,15 @@ import { DatabaseModule } from '../database/database.module';
         // diff reads. Uses the git facade (FacadesModule, imported above)
         // and TaskTransitionService for the merged-PR -> done landing.
         TaskPrStatusService,
+        // CI feedback + autonomous fix loop (slice AC, EW-806) — the
+        // decision layer behind the GitHub check receiver. Reads the
+        // attempt ledger above, `AgentRunRepository` +
+        // `TaskReviewRejectionRepository` (AgentsModule, imported above)
+        // and `TaskGitLinkService`; resumes through the RUN_STEERING_PORT
+        // the api-side @Global() AgentsModule binds. Every one of those
+        // tokens is @Optional() at the injection site, so an install
+        // without them files nothing and resumes nothing.
+        TaskCiAutoResumeService,
         // Wave 3 M2 — acceptance-check runner (quality gates). Needs only
         // AgentRunRepository (exported by AgentsModule above) to persist
         // per-run gate results.
@@ -190,6 +208,7 @@ import { DatabaseModule } from '../database/database.module';
     ],
     exports: [
         TaskRepository,
+        TaskCiAutoResumeAttemptRepository,
         TaskAssigneeRepository,
         TaskReviewerRepository,
         TaskApproverRepository,
@@ -218,6 +237,7 @@ import { DatabaseModule } from '../database/database.module';
         TaskMergeGateService,
         TaskGitLinkService,
         TaskPrStatusService,
+        TaskCiAutoResumeService,
         TaskGateRunnerService,
         TaskGateJudgeService,
     ],

--- a/packages/agent/src/works/work-repo-match.ts
+++ b/packages/agent/src/works/work-repo-match.ts
@@ -37,12 +37,47 @@ export function matchWorkByRepo<T extends Work>(
     owner: string,
     repo: string,
 ): T | null {
+    return matchWorkRepoRole(works, owner, repo)?.work ?? null;
+}
+
+/**
+ * The repo role a Task's own branch and pull request live in.
+ *
+ * `data`, not `work`: `TaskWorkspaceService` clones `work.getDataRepo()`
+ * for every isolated Task worktree and opens the pull request there, and
+ * `TaskPrStatusService.resolveRepo` polls the same repository. So
+ * `tasks.branchRef` and `tasks.prNumber` are only unique inside the DATA
+ * repository — a pull request #7 in the Work's `work` or `website` repo
+ * is a different pull request that happens to share a number.
+ */
+export const WORK_TASK_REPO_ROLE: WorkRepoRole = 'data';
+
+/**
+ * The same match, but it also says WHICH repo roles hit — all of them,
+ * because a Work whose `relatedRepositories` does not name a role falls
+ * back to a default name and two roles can legitimately resolve to the
+ * SAME repository (see `markdown-generator.service.ts`: "`getMainRepo()`
+ * and `work.getDataRepo()` can be the SAME repo").
+ *
+ * Callers that merely decorate an ingested event do not care. Callers
+ * that key on a Task's own coordinates — `tasks.prNumber`,
+ * `tasks.branchRef` — must check for {@link WORK_TASK_REPO_ROLE}, or a
+ * pull request #7 in the Work's website repo resolves to whatever Task
+ * opened #7 in the data repo, and anything done on that Task's behalf
+ * (rewriting its CI head, resuming its run) lands on the wrong Task and
+ * the wrong repository. `matchWorkByRepo` keeps the role-blind behaviour
+ * its existing callers were written against.
+ */
+export function matchWorkRepoRole<T extends Work>(
+    works: readonly T[],
+    owner: string,
+    repo: string,
+): { work: T; roles: readonly WorkRepoRole[] } | null {
     const target = `${owner}/${repo}`.trim().toLowerCase();
     if (!target || target === '/') return null;
     for (const work of works) {
-        for (const role of WORK_REPO_ROLES) {
-            if (getWorkRepoFullName(work, role) === target) return work;
-        }
+        const roles = WORK_REPO_ROLES.filter((role) => getWorkRepoFullName(work, role) === target);
+        if (roles.length > 0) return { work, roles };
     }
     return null;
 }

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -121,7 +121,7 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 				type: 'string',
 				title: 'Webhook secret',
 				description:
-					'Shared secret used to verify GitHub webhook deliveries sent to the platform ingest receiver (POST /api/ingest/github/events). Set the same value on the GitHub webhook configuration; deliveries with a missing or mismatched X-Hub-Signature-256 are rejected. Leave blank to keep the receiver disabled for your account.',
+					'Shared secret used to verify GitHub webhook deliveries sent to the platform ingest receiver (POST /api/ingest/github/events). Set the same value on the GitHub webhook configuration; deliveries with a missing or mismatched X-Hub-Signature-256 are rejected. Subscribe the webhook to pull requests, issue comments, pull request review comments, pushes, issues, and — for the CI auto-fix loop — check runs, check suites and workflow runs. Leave blank to keep the receiver disabled for your account.',
 				'x-secret': true,
 				'x-scope': 'user',
 				'x-widget': 'password'


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AC**. Refs **EW-806**, closes finding R17. Depends on slice AB, merged.

**The self-build loop stopped at the first red build.** The fleet opened a pull request, CI went red, and six machines sat idle waiting for a human who may not be watching.

### The defect, verified at HEAD before any code was written

- No `check_run`, `check_suite` or `workflow_run` handler existed **anywhere**. The only textual hits were a comment, an unrelated `workflow_runs` migration, and a spec using `workflow_run` as its example of an *unknown* event.
- `autoResume` and `retryBudget` returned nothing.
- `tasks.ciState` was written by a poll and read only by the web app.
- `tasks` had no head-SHA column at all.

### What changes

The three check deliveries become ordinary envelopes on the **existing** spine, so they dedupe, drain, reach the Activity feed and match triggers like every other event. A completed **failure** is then offered to the auto-resume service, alongside the recorded review rejections slice AB already produces.

### The hard part is not starting a run, it is starting exactly one

A single push emits a check event per job and several per job as they queue then complete; GitHub redelivers; and **each spurious resume is a full model run on somebody's desk**. So:

- Attempts live in a durable ledger with `UNIQUE (taskId, claimKey)`, and the key is `ci:<headSha>` — which collapses a whole matrix to one row.
- The budget is counted **per attempt, not per event**, and re-read after the claim so two replicas racing cannot both spend the last one.
- **If the budget cannot be read, the loop stops** rather than continuing.
- A no-progress fingerprint refuses to retry a failure that has not changed.
- Green, pending, cancelled, a stale head, an in-flight or parked or failed run, a done or cancelled Task, and an unresolvable repository all refuse, each with its own reason.
- The Inbox notice is CAS-guarded on the Task, so a spent budget files **one** notice, not one per delivery.

**The integration spec drives 52 real deliveries** — a twelve-job matrix's `created` and `completed`, plus suite and workflow events, then the whole lot redelivered — through the real handler over a real schema, and asserts **one** resume, one ledger row, one rejection row. It was **mutation-checked**: making the claim key non-deterministic reds exactly that test.

### Cost, stated plainly

Default budget is **2 attempts per Task for its whole life**. One attempt is one `agent-task-execute` run, the same order of spend as the run that opened the pull request. `TASK_CI_AUTO_RESUME_MAX_ATTEMPTS=0` switches it off. `docs/features/ci-auto-resume.md` says all of that and lists every refusal.

### Known, and stated rather than hidden

The resumed run is seeded with the **first** red result for a commit, not all of them. Collapsing the claim to one row per head is what stops the storm, so later failing jobs on the same push are ingested but add no rejection row. The seeded message says so and tells the agent to read the pull request's checks.

### Verified locally

| Check | Result |
| --- | --- |
| `packages/agent` tasks-domain, database, entities, events, agents | 180 suites / 2570 tests |
| `apps/api` ingest + migrations | 646 tests, 0 failures |
| `node-contract-gate` (merged since this branch started) | 2 suites / 82 tests |
| `packages/contracts` whole suite | 34 files / 1721 tests, no type errors |
| `tsc --noEmit` | clean in both packages |
| `prettier --check` over all changed files | clean |
| conflict markers / NUL bytes | none |

**Wiring checked explicitly**, because the previous slice nearly shipped an API that could not boot: the new repository is provided *and* exported by `TasksDomainModule` rather than assumed to come from `DatabaseModule` (it is not in `_repository-inventory.ts`, and should not be), and `AgentRunRepository` and `TaskReviewRejectionRepository` come from `AgentsModule`, which the module imports and which exports them. The new consumer injects the service `@Optional()`, so an install without the Tasks domain ingests the events and resumes nothing rather than failing the delivery.

### Not verified locally

- **Six `apps/api` suites cannot load here** — `@ever-works/agent-plugins` has no build output in this checkout. They run in CI.
- **ESLint could not run**: no `eslint` binary in this checkout and no `lint` script in `apps/api/package.json`. Formatting was normalised with Prettier per package instead.
- Real GitHub delivery ordering and volume are simulated from fixtures, not observed against a live repository.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub Check runs, suites, and workflow results now update task CI status and can automatically resume failed agent runs.
  - Automatic retries use bounded budgets, prevent duplicate or stale resumes, and provide failure feedback and retry-limit notices.
  - Reviewer rejections can also trigger eligible task resumes.
  - GitHub integrations now support the required CI webhook events.

- **Documentation**
  - Added CI auto-resume feature documentation and updated integration setup and event-handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->