### PR TITLE
release: promote develop to stage (slice AI, the release promotion lane)

### DIFF
--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -22,9 +22,21 @@ name: Promotion Gate
 # the `override-e2e-gate` label to proceed. The override is deliberate,
 # attributable, and visible in the PR timeline.
 
+# On BOTH rungs of the cascade, not just the last one (self-build slice AI,
+# EW-808). `develop -> stage` used to run nothing at all, so the release
+# promotion lane had no verdict to read for the first rung and treated it
+# as `absent`, which is not a pass — a lane that could never advance.
+#
+# What each rung actually gets, stated plainly because it is easy to
+# over-read: on a PR into `stage` the `e2e-result` job below SKIPS (its
+# `if:` requires a `stage` head), so a green gate there means the NODE
+# CONTRACT held and nothing more. That is not an oversight: e2e.yml runs on
+# push to `develop` only, so the develop -> stage PR shows zero e2e shards
+# BY DESIGN and there is no e2e signal to gate on. The first e2e result for
+# a batch arrives on `stage` and is what the SECOND rung gates on.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, stage]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
@@ -38,7 +50,16 @@ jobs:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     timeout-minutes: 10
     # Only gate promotions from stage. Hotfix branches targeting main directly
-    # are a different conversation and are not covered here.
+    # are a different conversation and are not covered here, and so is the
+    # develop -> stage rung, which has no e2e result to consult (e2e.yml runs
+    # on push to `develop` only).
+    #
+    # This job SKIPS in both those cases, and a skipped job reports as SUCCESS
+    # in branch protection. The release promotion lane does not read job
+    # conclusions for that exact reason — it reads this WORKFLOW's run
+    # conclusion, and treats `skipped`, `cancelled` and `absent` as
+    # not-a-pass. `node-contract` below has no `if:`, so the run always has at
+    # least one job that really evaluated.
     if: github.event.pull_request.head.ref == 'stage'
 
     steps:
@@ -209,7 +230,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v3
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v3
         with:
           version: 10.33.3
 

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -56,6 +56,7 @@ import { AgentPluginsApiModule } from './agent-plugins/agent-plugins.module';
 import { McpConnectionsModule } from './mcp-connections/mcp-connections.module';
 import { RepoConnectionsModule } from './repo-connections/repo-connections.module';
 import { TasksModule } from './tasks/tasks.module';
+import { ReleaseModule } from './release/release.module';
 import { TaskTemplatesModule } from './task-templates/task-templates.module';
 import { WorkflowsModule } from './workflows/workflows.module';
 import { TerminalModule } from './terminal/terminal.module';
@@ -208,6 +209,13 @@ import { DatabaseModule } from '@ever-works/agent/database';
         TasksModule,
         // Tasks upgrades — workflow Task Templates (CRUD + instantiate).
         TaskTemplatesModule,
+        // Release promotion lane (self-build slice AI, EW-808) — the
+        // operator surface for develop -> stage -> main, and the import
+        // that BINDS the @Global() PROMOTION_MERGE_GUARD /
+        // PROMOTION_LANE_WATCHER tokens `TaskMergeGateService` and
+        // `TaskPrStatusService` consume. Removing it does not open a hole:
+        // the merge gate refuses a promotion Task whose guard is unbound.
+        ReleaseModule,
         // Saved workflow graphs (judgment layer G5) — the persistence and
         // CRUD surface for graphs the executor could already run but
         // nothing could keep.

--- a/apps/api/src/migrations/1790000000000-CreateReleasePromotions.ts
+++ b/apps/api/src/migrations/1790000000000-CreateReleasePromotions.ts
@@ -1,0 +1,211 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableColumn,
+    TableForeignKey,
+    TableIndex,
+} from 'typeorm';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the
+ * `release_promotions` table plus the one column on `works` that says
+ * which branches a promotion is allowed to touch.
+ *
+ * Entities:
+ *   `packages/agent/src/entities/release-promotion.entity.ts`
+ *   `packages/agent/src/entities/work.entity.ts` (`releaseLadder`)
+ *
+ * ## `works.releaseLadder`
+ *
+ * The `integration → staging → production` triple, as platform state.
+ * NULL on every existing row, which is the correct history and the
+ * correct default: a Work whose ladder nobody has declared has no release
+ * lane, and `POST /works/:id/promotions` refuses rather than guessing
+ * `main`. `simple-json` to match the other JSON columns on `works`
+ * (`communityPrState`, `worksConfigSnapshot`), and read back only through
+ * `sanitizeReleaseLadder` — the branch names end up in a pull request's
+ * `head`/`base`.
+ *
+ * ## `release_promotions.laneKey` — THE load-bearing constraint
+ *
+ * UNIQUE `(workId, rung, laneKey)` is what stops two merges to `develop`
+ * seconds apart opening two competing `develop → stage` pull requests,
+ * and what stops a re-run opening a second one.
+ *
+ * The constraint we actually want is "at most one OPEN promotion per
+ * (Work, rung)". Postgres can say that directly (`CREATE UNIQUE INDEX …
+ * WHERE state = 'open'`); better-sqlite3 — which CI and the e2e stack run
+ * — cannot, and a constraint that behaves differently on the two
+ * databases is a race that only ever reproduces in production. So it is
+ * carried in a VALUE instead: every live promotion writes the literal
+ * `'open'` into `laneKey` and therefore collides, and every terminal one
+ * writes `'<state>:<id>'` and therefore does not. One index, identical
+ * semantics on both drivers.
+ *
+ * FKs: `userId` → `users.id` and `workId` → `works.id` CASCADE (a
+ * promotion is meaningless without either). `taskId` → `tasks.id` SET
+ * NULL rather than CASCADE: deleting the reporting Task must not delete
+ * the record that a promotion was opened, and a promotion row with a
+ * dangling `taskId` would let the merge guard resolve a promotion for
+ * somebody else's Task.
+ *
+ * Forward-only + idempotent (`hasTable` / `findColumnByName` guards), and
+ * portable `Table`/`TableColumn` DDL rather than raw SQL, because
+ * production runs Postgres while CI runs better-sqlite3.
+ */
+export class CreateReleasePromotions1790000000000 implements MigrationInterface {
+    name = 'CreateReleasePromotions1790000000000';
+
+    private static readonly WORK_COLUMN = new TableColumn({
+        name: 'releaseLadder',
+        type: 'text',
+        isNullable: true,
+    });
+
+    private static readonly LANE_INDEX = new TableIndex({
+        name: 'uq_release_promotions_lane',
+        columnNames: ['workId', 'rung', 'laneKey'],
+        isUnique: true,
+    });
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const works = await queryRunner.getTable('works');
+        if (works && !works.findColumnByName('releaseLadder')) {
+            await queryRunner.addColumn('works', CreateReleasePromotions1790000000000.WORK_COLUMN);
+        }
+
+        if (await queryRunner.hasTable('release_promotions')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'release_promotions',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'workId', type: 'uuid' },
+                    { name: 'taskId', type: 'uuid', isNullable: true },
+                    { name: 'rung', type: 'varchar', length: '32' },
+                    { name: 'headBranch', type: 'varchar', length: '128' },
+                    { name: 'baseBranch', type: 'varchar', length: '128' },
+                    { name: 'headSha', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'headRecordedAt', type: 'timestamp', isNullable: true },
+                    { name: 'prNumber', type: 'int', isNullable: true },
+                    { name: 'prUrl', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'state', type: 'varchar', length: '16', default: "'open'" },
+                    { name: 'laneKey', type: 'varchar', length: '64', default: "'open'" },
+                    { name: 'gateWorkflow', type: 'varchar', length: '128' },
+                    { name: 'gateVerdict', type: 'varchar', length: '16', isNullable: true },
+                    { name: 'gateVerdictSha', type: 'varchar', length: '64', isNullable: true },
+                    // Was the gate's E2E leg WAIVED rather than green for
+                    // `gateVerdictSha`? `promotion-gate.yml` exits 0 on the
+                    // `override-e2e-gate` label, and GitHub folds that back
+                    // into a plain `success` run conclusion — so without
+                    // this the lane cannot tell a human that the leg was
+                    // overridden rather than green.
+                    { name: 'gateOverridden', type: 'boolean', default: false },
+                    { name: 'gateCheckedAt', type: 'timestamp', isNullable: true },
+                    { name: 'gateRunUrl', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'refusalCode', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'inboxFiledForSha', type: 'varchar', length: '64', isNullable: true },
+                    // The (commit, reading) pair the one Inbox notice was
+                    // filed for. Both halves, because keying on the commit
+                    // alone let a `pending` reading past the grace window
+                    // consume the slot and suppress the verdict that
+                    // actually decided the promotion.
+                    { name: 'inboxFiledVerdict', type: 'varchar', length: '16', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // At most one OPEN promotion per (Work, rung) — see the header.
+        await queryRunner.createIndex(
+            'release_promotions',
+            CreateReleasePromotions1790000000000.LANE_INDEX,
+        );
+
+        // "Which promotion does this Task report?" — one row, but a plain
+        // index: a Task's promotion is looked up on every PR-status
+        // refresh, and history rows keep pointing at their Tasks.
+        await queryRunner.createIndex(
+            'release_promotions',
+            new TableIndex({ name: 'idx_release_promotions_task', columnNames: ['taskId'] }),
+        );
+
+        // "Is there an open promotion for this Work?" for the operator list.
+        await queryRunner.createIndex(
+            'release_promotions',
+            new TableIndex({
+                name: 'idx_release_promotions_work_state',
+                columnNames: ['workId', 'state'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'release_promotions',
+            new TableForeignKey({
+                name: 'fk_release_promotions_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'release_promotions',
+            new TableForeignKey({
+                name: 'fk_release_promotions_work',
+                columnNames: ['workId'],
+                referencedTableName: 'works',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'release_promotions',
+            new TableForeignKey({
+                name: 'fk_release_promotions_task',
+                columnNames: ['taskId'],
+                referencedTableName: 'tasks',
+                referencedColumnNames: ['id'],
+                // SET NULL, not CASCADE: deleting the reporting Task must
+                // not erase the record that a promotion happened, and a
+                // dangling taskId would let the merge guard resolve this
+                // promotion for whatever Task later took that id.
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('release_promotions')) {
+            await queryRunner.dropTable('release_promotions', true);
+        }
+
+        const works = await queryRunner.getTable('works');
+        if (works) {
+            // `dropColumn` rather than a raw `ALTER TABLE … DROP COLUMN`:
+            // the query runner rebuilds the table on drivers that cannot
+            // drop a column in place, which is exactly the driver CI uses.
+            const column = works.findColumnByName('releaseLadder');
+            if (column) {
+                await queryRunner.dropColumn('works', column);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateReleasePromotions.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateReleasePromotions.spec.ts
@@ -1,0 +1,224 @@
+import { DataSource } from 'typeorm';
+import { CreateReleasePromotions1790000000000 } from '../1790000000000-CreateReleasePromotions';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — migration test for
+ * `release_promotions` + `works.releaseLadder`, run against an in-memory
+ * better-sqlite3 DataSource (same harness as
+ * `CreateExternalIssueLinks.spec.ts`).
+ *
+ * The load-bearing assertion is the UNIQUE `(workId, rung, laneKey)` index,
+ * exercised the way the service uses it rather than by reading its
+ * definition: two OPEN promotions for the same (Work, rung) must collide,
+ * and everything else must not. That constraint is the whole anti-duplicate
+ * guarantee — without it two merges to `develop` seconds apart open two
+ * competing promotion pull requests.
+ *
+ * Schema shape is asserted against the PHYSICAL table (`PRAGMA table_info`),
+ * never by watching an INSERT fail: a column that silently does not exist
+ * makes an INSERT fail for the wrong reason.
+ *
+ * The inserts pass `createdAt`/`updatedAt` explicitly: the table's `now()` /
+ * `uuid_generate_v4()` defaults are Postgres functions (the shape every
+ * migration in this folder ships), and sqlite is used here only as a cheap
+ * DDL harness.
+ */
+describe('CreateReleasePromotions1790000000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateReleasePromotions1790000000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`CREATE TABLE "users" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "users" ("id") VALUES ('u-a'), ('u-b')`);
+        await dataSource.query(
+            `CREATE TABLE "works" ("id" varchar PRIMARY KEY NOT NULL, "slug" varchar)`,
+        );
+        await dataSource.query(
+            `INSERT INTO "works" ("id", "slug") VALUES ('w-1', 'one'), ('w-2', 'two')`,
+        );
+        await dataSource.query(`CREATE TABLE "tasks" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "tasks" ("id") VALUES ('t-1'), ('t-2')`);
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function up(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function down(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+    }
+
+    async function columnNames(table: string): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("${table}")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    const COLUMNS =
+        '"id", "userId", "workId", "taskId", "rung", "headBranch", "baseBranch", "state", "laneKey", "gateWorkflow", "createdAt", "updatedAt"';
+    const STAMPS = `'2026-09-06 00:00:00', '2026-09-06 00:00:00'`;
+
+    function insert(
+        id: string,
+        opts: {
+            workId?: string;
+            rung?: string;
+            laneKey?: string;
+            state?: string;
+            taskId?: string | null;
+        } = {},
+    ): Promise<unknown> {
+        const workId = opts.workId ?? 'w-1';
+        const rung = opts.rung ?? 'develop-to-stage';
+        const state = opts.state ?? 'open';
+        const laneKey = opts.laneKey ?? 'open';
+        const taskId =
+            opts.taskId === undefined ? `'t-1'` : opts.taskId ? `'${opts.taskId}'` : 'NULL';
+        return dataSource.query(
+            `INSERT INTO "release_promotions" (${COLUMNS}) VALUES ('${id}', 'u-a', '${workId}', ${taskId}, '${rung}', 'develop', 'stage', '${state}', '${laneKey}', 'promotion-gate.yml', ${STAMPS})`,
+        );
+    }
+
+    it('creates the table with the lane, pull-request and gate columns', async () => {
+        await up();
+        expect(await columnNames('release_promotions')).toEqual(
+            expect.arrayContaining([
+                'id',
+                'userId',
+                'workId',
+                'taskId',
+                'rung',
+                'headBranch',
+                'baseBranch',
+                'headSha',
+                'headRecordedAt',
+                'prNumber',
+                'prUrl',
+                'state',
+                'laneKey',
+                'gateWorkflow',
+                'gateVerdict',
+                'gateVerdictSha',
+                'gateOverridden',
+                'gateCheckedAt',
+                'gateRunUrl',
+                'refusalCode',
+                'inboxFiledForSha',
+                'inboxFiledVerdict',
+                'tenantId',
+                'organizationId',
+                'createdAt',
+                'updatedAt',
+            ]),
+        );
+    });
+
+    it('adds works.releaseLadder as a nullable column', async () => {
+        await up();
+        expect(await columnNames('works')).toContain('releaseLadder');
+        const rows: Array<{ name: string; notnull: number }> = await dataSource.query(
+            `PRAGMA table_info("works")`,
+        );
+        const ladder = rows.find((row) => row.name === 'releaseLadder');
+        // Nullable, because every existing Work legitimately has no
+        // release lane and must not be given a guessed one.
+        expect(ladder?.notnull).toBe(0);
+    });
+
+    it('leaves existing Works with a NULL ladder — no lane is the correct history', async () => {
+        await up();
+        const rows: Array<{ releaseLadder: string | null }> = await dataSource.query(
+            `SELECT "releaseLadder" FROM "works" WHERE "id" = 'w-1'`,
+        );
+        expect(rows[0].releaseLadder).toBeNull();
+    });
+
+    it('refuses a SECOND open promotion for the same Work and rung', async () => {
+        await up();
+        await insert('p-1');
+        // THE constraint. Two merges to develop seconds apart both try to
+        // claim (w-1, develop-to-stage, 'open'); exactly one survives.
+        await expect(insert('p-2')).rejects.toThrow(/UNIQUE/i);
+    });
+
+    it('allows an open promotion on each rung of the same Work', async () => {
+        await up();
+        await insert('p-1', { rung: 'develop-to-stage' });
+        await expect(
+            insert('p-2', { rung: 'stage-to-main', taskId: 't-2' }),
+        ).resolves.toBeDefined();
+    });
+
+    it('allows an open promotion on the same rung of a DIFFERENT Work', async () => {
+        await up();
+        await insert('p-1', { workId: 'w-1' });
+        await expect(insert('p-2', { workId: 'w-2', taskId: 't-2' })).resolves.toBeDefined();
+    });
+
+    it('frees the lane once the previous promotion goes terminal', async () => {
+        await up();
+        await insert('p-1');
+        // What `promotionLaneKey('merged', id)` writes.
+        await dataSource.query(
+            `UPDATE "release_promotions" SET "state" = 'merged', "laneKey" = 'merged:p-1' WHERE "id" = 'p-1'`,
+        );
+        await expect(insert('p-2', { taskId: 't-2' })).resolves.toBeDefined();
+    });
+
+    it('allows many terminal promotions for one lane', async () => {
+        await up();
+        await insert('p-1', { state: 'merged', laneKey: 'merged:p-1' });
+        await insert('p-2', { state: 'merged', laneKey: 'merged:p-2', taskId: 't-2' });
+        await insert('p-3', { state: 'refused', laneKey: 'refused:p-3', taskId: null });
+        const rows: Array<{ n: number }> = await dataSource.query(
+            `SELECT COUNT(*) AS n FROM "release_promotions"`,
+        );
+        expect(Number(rows[0].n)).toBe(3);
+    });
+
+    it('is idempotent — a second up() over an applied schema is a no-op', async () => {
+        await up();
+        await insert('p-1');
+        await up();
+        const rows: Array<{ n: number }> = await dataSource.query(
+            `SELECT COUNT(*) AS n FROM "release_promotions"`,
+        );
+        expect(Number(rows[0].n)).toBe(1);
+        expect(await columnNames('works')).toContain('releaseLadder');
+    });
+
+    it('down() drops the table and the works column via the query runner', async () => {
+        await up();
+        await down();
+        const tables: Array<{ name: string }> = await dataSource.query(
+            `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'release_promotions'`,
+        );
+        expect(tables).toEqual([]);
+        // Physical schema, not a failing INSERT: `dropColumn` rebuilds the
+        // table on this driver, and a rebuild that silently kept the column
+        // would still pass an INSERT-based check.
+        expect(await columnNames('works')).not.toContain('releaseLadder');
+        // The rest of `works` survived the rebuild.
+        expect(await columnNames('works')).toEqual(expect.arrayContaining(['id', 'slug']));
+    });
+
+    it('down() is safe on a database where up() never ran', async () => {
+        await expect(down()).resolves.toBeUndefined();
+    });
+});

--- a/apps/api/src/release/promotion-gate-workflow.contract.spec.ts
+++ b/apps/api/src/release/promotion-gate-workflow.contract.spec.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PROMOTION_GATE_OVERRIDE_LABEL, PROMOTION_GATE_WORKFLOW_FILE } from '@ever-works/contracts';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the contract
+ * between the platform and the workflow it waits on.
+ *
+ * `ReleasePromotionService` reads ONE named workflow file for the head
+ * commit of a promotion pull request. Two things about that file are not
+ * the platform's to change silently, and neither is visible to `tsc`:
+ *
+ *   1. **The file name.** `PROMOTION_GATE_WORKFLOW_FILE` is what the
+ *      platform asks GitHub for. Rename the workflow and every promotion
+ *      reads `absent` — which is correctly not-a-pass, but silently means
+ *      no promotion can ever advance again.
+ *   2. **The trigger.** Before this slice the workflow ran only on pull
+ *      requests into `main`, so the `develop → stage` rung had no verdict
+ *      to read at all and the lane could not advance past the first step.
+ *
+ * The `if:` condition on `e2e-result` is pinned too, but as a REMINDER
+ * rather than a requirement: that job skips on a `develop → stage`
+ * promotion, and a skipped job reports as SUCCESS in branch protection.
+ * The lane reads the WORKFLOW RUN's conclusion for exactly that reason,
+ * and `node-contract` — which has no `if:` — is what makes the run's
+ * conclusion mean something on the first rung.
+ */
+describe('promotion-gate.yml — the workflow the release lane waits on', () => {
+    const path = join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        '.github',
+        'workflows',
+        PROMOTION_GATE_WORKFLOW_FILE,
+    );
+    const source = readFileSync(path, 'utf8');
+
+    it('exists at the file name the platform asks the provider for', () => {
+        expect(PROMOTION_GATE_WORKFLOW_FILE).toBe('promotion-gate.yml');
+        expect(source).toContain('name: Promotion Gate');
+    });
+
+    it('runs on BOTH rungs of the ladder', () => {
+        // `branches: [main]` alone is what made the develop -> stage rung
+        // vacuous: no run for the commit, so `absent`, so never a pass.
+        const trigger = source.slice(source.indexOf('on:'), source.indexOf('permissions:'));
+        expect(trigger).toMatch(/branches:\s*\[main,\s*stage\]/);
+        expect(trigger).toMatch(/pull_request:/);
+    });
+
+    it('keeps a job that runs on EVERY promotion, so a run conclusion means something', () => {
+        // If every job could skip, the run itself would conclude `skipped`
+        // and the lane would refuse every promotion forever.
+        const nodeContract = source.slice(source.indexOf('  node-contract:'));
+        const firstJobBody = nodeContract.slice(0, nodeContract.indexOf('    steps:'));
+        expect(firstJobBody).not.toMatch(/^\s{4}if:/m);
+    });
+
+    it('still gates the stage E2E result on a stage head only', () => {
+        // Kept deliberately: `develop -> stage` has no e2e signal to
+        // consult (e2e.yml runs on push to `develop` only), so a green
+        // gate on the FIRST rung means the node contract held and nothing
+        // more. The runbook says so in the same words.
+        expect(source).toMatch(/if:\s*github\.event\.pull_request\.head\.ref == 'stage'/);
+    });
+
+    it('keeps the override an explicit, attributable label rather than a default', () => {
+        expect(source).toContain(PROMOTION_GATE_OVERRIDE_LABEL);
+        // The workflow reads the label off the pull request; the shared
+        // constant is the platform's copy of the SAME string. The two must
+        // agree byte-for-byte, so the label is spelled once in contracts
+        // and referenced from both sides.
+        expect(PROMOTION_GATE_OVERRIDE_LABEL).toBe('override-e2e-gate');
+    });
+
+    it('is read by the lane as a WARNING, never as a grant', () => {
+        // CONTRACT REVERSED, deliberately, and this comment is the record
+        // of why. This test used to assert the lane's source did not
+        // mention the override at all — "the lane must not encode it".
+        // That was the wrong shape of the right idea, and it hid a real
+        // defect: the workflow exits 0 on the label in all four of its
+        // failure branches, GitHub folds that into a plain `success` run
+        // conclusion, and the lane then told the person deciding a
+        // production release "Promotion gate PASSED" when what actually
+        // happened is that somebody with repository write applied a label.
+        //
+        // The property that is actually wanted is narrower: the label may
+        // never GRANT anything, and it must be reported. So the lane now
+        // reads it and words the notice accordingly, and what is pinned
+        // here is that it is spelled through the shared constant (never a
+        // second copy of the literal, which could drift from the workflow)
+        // and that the pass rule is still `isPromotionGatePass` alone.
+        const laneSource = readFileSync(
+            join(
+                __dirname,
+                '..',
+                '..',
+                '..',
+                '..',
+                'packages',
+                'agent',
+                'src',
+                'tasks-domain',
+                'release-promotion.service.ts',
+            ),
+            'utf8',
+        );
+        // No second copy of the literal — one spelling, in contracts.
+        // Comments are stripped first: prose is allowed to NAME the label
+        // (and does, next to the explanation of why it is read at all);
+        // what must not exist is a second string constant that could drift
+        // from the workflow's own spelling.
+        const code = laneSource
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .split('\n')
+            .filter((line) => !line.trim().startsWith('//'))
+            .join('\n');
+        expect(code).not.toMatch(/['"`]override-e2e-gate['"`]/);
+        expect(code).toContain('PROMOTION_GATE_OVERRIDE_LABEL');
+        // And it is not part of any decision: the only thing that makes a
+        // verdict a pass is `isPromotionGatePass`, and an overridden
+        // reading is fed to the same rule as any other.
+        expect(code).not.toMatch(/isPromotionGateOverridden\([^)]*\)\s*(\?|&&|\|\|)/);
+    });
+});

--- a/apps/api/src/release/release-promotions.controller.spec.ts
+++ b/apps/api/src/release/release-promotions.controller.spec.ts
@@ -1,0 +1,235 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { ReleasePromotionsController } from './release-promotions.controller';
+import { ReleaseModule } from './release.module';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the operator
+ * surface.
+ *
+ * The assertions worth having here are about what the surface CANNOT do:
+ * it cannot merge, it cannot cascade, it cannot name its own branches, and
+ * it cannot read or write another owner's Work. The happy path is one
+ * test.
+ */
+describe('ReleasePromotionsController', () => {
+    const USER = { userId: 'user-1' } as never;
+    const OTHER = { userId: 'someone-else' } as never;
+    const WORK = '11111111-1111-4111-8111-111111111111';
+
+    const promotion = {
+        id: 'rp-1',
+        rung: 'develop-to-stage',
+        state: 'open',
+        headBranch: 'develop',
+        baseBranch: 'stage',
+        headSha: 'a'.repeat(40),
+        prNumber: 42,
+        prUrl: 'https://github.com/ever-works/ever-works/pull/42',
+        taskId: 'task-1',
+        gateWorkflow: 'promotion-gate.yml',
+        gateVerdict: 'pending',
+        gateVerdictSha: 'a'.repeat(40),
+        gateCheckedAt: new Date('2026-09-06T00:00:00Z'),
+        gateRunUrl: null,
+        refusalCode: null,
+        laneKey: 'open',
+        createdAt: new Date('2026-09-06T00:00:00Z'),
+    };
+
+    function build(over: { work?: Record<string, unknown> | null; open?: unknown } = {}) {
+        const works = {
+            findById: jest.fn().mockResolvedValue(
+                over.work === null
+                    ? null
+                    : {
+                          id: WORK,
+                          userId: 'user-1',
+                          releaseLadder: {
+                              integration: 'develop',
+                              staging: 'stage',
+                              production: 'main',
+                          },
+                          ...over.work,
+                      },
+            ),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        const promotions = {
+            openPromotion: jest.fn().mockResolvedValue(
+                over.open ?? {
+                    outcome: 'opened',
+                    promotion,
+                    task: { id: 'task-1', slug: 'T-9' },
+                },
+            ),
+            listForWork: jest.fn().mockResolvedValue([promotion]),
+        };
+        return {
+            controller: new ReleasePromotionsController(promotions as never, works as never),
+            works,
+            promotions,
+        };
+    }
+
+    // ── Opening ───────────────────────────────────────────────────────
+
+    it('passes the RUNG through and nothing else — no branches, no repository, no owner', async () => {
+        const { controller, promotions } = build();
+
+        const result = await controller.open(USER, WORK, {
+            rung: 'develop-to-stage',
+            agentId: 'agent-1',
+        });
+
+        expect(promotions.openPromotion).toHaveBeenCalledWith({
+            userId: 'user-1',
+            workId: WORK,
+            rung: 'develop-to-stage',
+            agentId: 'agent-1',
+        });
+        expect(result).toMatchObject({ outcome: 'opened', taskId: 'task-1' });
+    });
+
+    it('reports an already-open lane as a CONFLICT, not a success', async () => {
+        // Making this a 200 is how a UI ends up reporting "promoted" twice
+        // for one pull request.
+        const { controller } = build({ open: { outcome: 'already-open', promotion } });
+
+        await expect(
+            controller.open(USER, WORK, { rung: 'develop-to-stage', agentId: 'agent-1' }),
+        ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('surfaces a refusal as a 400 carrying the code the operator needs', async () => {
+        const { controller } = build({
+            open: {
+                outcome: 'refused',
+                code: 'ladder-not-configured',
+                reason: 'Work has no usable release ladder.',
+            },
+        });
+
+        await expect(
+            controller.open(USER, WORK, { rung: 'stage-to-main', agentId: 'agent-1' }),
+        ).rejects.toMatchObject({
+            response: { code: 'ladder-not-configured' },
+        });
+    });
+
+    it('surfaces an unreachable Work as a 404', async () => {
+        const { controller } = build({
+            open: { outcome: 'refused', code: 'work-not-found', reason: 'Work not found.' },
+        });
+
+        await expect(
+            controller.open(USER, WORK, { rung: 'develop-to-stage', agentId: 'agent-1' }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('never exposes the lane key, which is an index implementation detail', async () => {
+        const { controller } = build();
+        const result = (await controller.open(USER, WORK, {
+            rung: 'develop-to-stage',
+            agentId: 'agent-1',
+        })) as { promotion: Record<string, unknown> };
+        expect(result.promotion).not.toHaveProperty('laneKey');
+        expect(result.promotion.gate).toMatchObject({
+            workflow: 'promotion-gate.yml',
+            verdict: 'pending',
+            forCommit: 'a'.repeat(40),
+        });
+    });
+
+    // ── The ladder ────────────────────────────────────────────────────
+
+    it('stores a sanitised ladder as platform state', async () => {
+        const { controller, works } = build();
+
+        await controller.setLadder(USER, WORK, {
+            integration: ' develop ',
+            staging: 'stage',
+            production: 'main',
+        });
+
+        expect(works.update).toHaveBeenCalledWith(WORK, {
+            releaseLadder: { integration: 'develop', staging: 'stage', production: 'main' },
+        });
+    });
+
+    it.each([
+        ['a repeated branch', { integration: 'develop', staging: 'develop', production: 'main' }],
+        ['a path escape', { integration: '../main', staging: 'stage', production: 'main' }],
+        ['an option-shaped name', { integration: '--force', staging: 'stage', production: 'main' }],
+        ['a refspec', { integration: 'develop', staging: 'stage:stage', production: 'main' }],
+    ])('refuses %s and writes nothing', async (_label, body) => {
+        const { controller, works } = build();
+
+        await expect(controller.setLadder(USER, WORK, body as never)).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+        expect(works.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses to read or write another owner’s ladder, with the same words as a missing Work', async () => {
+        const { controller, works } = build({ work: { userId: 'someone-else' } });
+
+        await expect(controller.getLadder(USER, WORK)).rejects.toBeInstanceOf(NotFoundException);
+        await expect(
+            controller.setLadder(USER, WORK, {
+                integration: 'develop',
+                staging: 'stage',
+                production: 'main',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(works.update).not.toHaveBeenCalled();
+    });
+
+    it('reads a stored ladder back through the sanitiser, not raw', async () => {
+        // The column is `simple-json` and holds whatever was written to it;
+        // the branch names end up in a pull request's head/base.
+        const { controller } = build({ work: { releaseLadder: { integration: '../evil' } } });
+        await expect(controller.getLadder(USER, WORK)).resolves.toEqual({
+            workId: WORK,
+            releaseLadder: null,
+        });
+    });
+
+    // ── The listing ───────────────────────────────────────────────────
+
+    it('scopes the listing to the caller', async () => {
+        const { controller, promotions } = build();
+        await controller.list(OTHER, WORK, '5');
+        expect(promotions.listForWork).toHaveBeenCalledWith(WORK, 'someone-else', 5);
+    });
+
+    it('ignores a non-numeric limit rather than passing NaN to the store', async () => {
+        const { controller, promotions } = build();
+        await controller.list(USER, WORK, 'all');
+        expect(promotions.listForWork).toHaveBeenCalledWith(WORK, 'user-1', undefined);
+    });
+
+    // ── What the surface deliberately lacks ───────────────────────────
+
+    it('exposes no merge and no cascade route', () => {
+        // Landing a promotion is an Inbox approval (slice AE), and the next
+        // rung is a separate deliberate act. Neither is reachable here.
+        const routes = Object.getOwnPropertyNames(ReleasePromotionsController.prototype).filter(
+            (name) => name !== 'constructor',
+        );
+        expect(routes.sort()).toEqual(['getLadder', 'list', 'open', 'setLadder']);
+        expect(routes.some((name) => /merge|approve|cascade|promoteAll/i.test(name))).toBe(false);
+    });
+
+    it('is mounted by a module that binds the promotion tokens app-wide', () => {
+        const imports = (Reflect.getMetadata('imports', ReleaseModule) ?? []).map(
+            (entry: { name?: string }) => entry?.name,
+        );
+        // Dropping this import does not open a hole — the merge gate
+        // refuses a promotion Task whose guard is unbound — but it does
+        // silently disable the lane, so it is pinned.
+        expect(imports).toContain('ReleasePromotionModule');
+        expect(Reflect.getMetadata('controllers', ReleaseModule)).toEqual([
+            ReleasePromotionsController,
+        ]);
+    });
+});

--- a/apps/api/src/release/release-promotions.controller.ts
+++ b/apps/api/src/release/release-promotions.controller.ts
@@ -1,0 +1,202 @@
+import {
+    BadRequestException,
+    Body,
+    ConflictException,
+    Controller,
+    Get,
+    NotFoundException,
+    Param,
+    ParseUUIDPipe,
+    Post,
+    Put,
+    Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { sanitizeReleaseLadder } from '@ever-works/contracts';
+import { ReleasePromotionService } from '@ever-works/agent/tasks-domain';
+import { WorkRepository } from '@ever-works/agent/database';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { OpenPromotionDto, SetReleaseLadderDto } from './release-promotions.dto';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the operator's
+ * entry point to `develop → stage → main`.
+ *
+ * ## The whole surface, and what it deliberately lacks
+ *
+ * There is no "merge" endpoint here, and no "promote everything" endpoint.
+ * Opening a promotion is one deliberate act per rung; landing it is a
+ * `merge_pull_request` approval in the Inbox, decided by a human and
+ * re-verified against the head commit at merge time (slice AE). Nothing
+ * here can merge anything, and nothing here opens the second rung when
+ * the first one lands.
+ *
+ * ## Why `POST` is rate-limited hard
+ *
+ * A promotion opens a pull request on a real repository and starts a CI
+ * lane measured at 215–243 minutes. Six a minute is already far more than
+ * a human performs; the lane's UNIQUE index is the real duplicate guard,
+ * and this is the cheap one in front of it.
+ */
+@ApiTags('release')
+@Controller('api/works/:workId')
+export class ReleasePromotionsController {
+    constructor(
+        private readonly promotions: ReleasePromotionService,
+        private readonly works: WorkRepository,
+    ) {}
+
+    @Put('release-ladder')
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Declare this Work’s develop → stage → main branch ladder',
+        description:
+            'PLATFORM STATE. Set once by the owner; every later promotion reads it. A promotion request can never name its own branches.',
+    })
+    async setLadder(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+        @Body() body: SetReleaseLadderDto,
+    ) {
+        const work = await this.works.findById(workId);
+        if (!work || work.userId !== user.userId) {
+            // Same answer for "no such Work" and "not yours".
+            throw new NotFoundException(`Work ${workId} not found.`);
+        }
+        const ladder = sanitizeReleaseLadder(body);
+        if (!ladder) {
+            throw new BadRequestException(
+                'A release ladder needs three DISTINCT plain branch names for integration, staging and production.',
+            );
+        }
+        await this.works.update(workId, { releaseLadder: ladder });
+        return { workId, releaseLadder: ladder };
+    }
+
+    @Get('release-ladder')
+    @ApiOperation({ summary: 'Read this Work’s release ladder (null when none is configured)' })
+    async getLadder(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+    ) {
+        const work = await this.works.findById(workId);
+        if (!work || work.userId !== user.userId) {
+            throw new NotFoundException(`Work ${workId} not found.`);
+        }
+        return { workId, releaseLadder: sanitizeReleaseLadder(work.releaseLadder) };
+    }
+
+    @Post('promotions')
+    @Throttle({ long: { limit: 6, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Open ONE rung of the release ladder as a pull request',
+        description:
+            'Opens the promotion pull request and files the Task that reports the promotion-gate verdict. It does NOT merge it, and it does NOT open the next rung when this one lands.',
+    })
+    async open(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+        @Body() body: OpenPromotionDto,
+    ) {
+        const result = await this.promotions.openPromotion({
+            userId: user.userId,
+            workId,
+            rung: body.rung,
+            agentId: body.agentId,
+        });
+
+        if (result.outcome === 'opened') {
+            return {
+                outcome: 'opened' as const,
+                promotion: view(result.promotion),
+                taskId: result.task.id,
+                taskSlug: result.task.slug,
+            };
+        }
+        if (result.outcome === 'already-open') {
+            // 409, not 200: the caller asked for a NEW promotion and got
+            // somebody else's. Making that a success is how a UI ends up
+            // reporting "promoted" twice for one pull request. The live
+            // promotion is in the body so the caller can link to it.
+            throw new ConflictException({
+                message: `A ${body.rung} promotion is already open for this Work.`,
+                promotion: view(result.promotion),
+            });
+        }
+        if (result.code === 'work-not-found') {
+            throw new NotFoundException(result.reason);
+        }
+        throw new BadRequestException({ code: result.code, message: result.reason });
+    }
+
+    @Get('promotions')
+    @ApiOperation({ summary: 'This Work’s promotion history, newest first' })
+    async list(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+        @Query('limit') limit?: string,
+    ) {
+        const parsed = limit ? Number.parseInt(limit, 10) : undefined;
+        const rows = await this.promotions.listForWork(
+            workId,
+            user.userId,
+            Number.isFinite(parsed) ? parsed : undefined,
+        );
+        return { promotions: rows.map(view) };
+    }
+}
+
+/**
+ * The read model. `laneKey` is deliberately NOT exposed — it is an index
+ * implementation detail, and a caller that learned to read it would be
+ * one edit away from writing it.
+ */
+function view(promotion: {
+    id: string;
+    rung: string;
+    state: string;
+    headBranch: string;
+    baseBranch: string;
+    headSha?: string | null;
+    prNumber?: number | null;
+    prUrl?: string | null;
+    taskId?: string | null;
+    gateWorkflow: string;
+    gateVerdict?: string | null;
+    gateVerdictSha?: string | null;
+    gateCheckedAt?: Date | null;
+    gateRunUrl?: string | null;
+    gateOverridden?: boolean | null;
+    refusalCode?: string | null;
+    createdAt: Date;
+}) {
+    return {
+        id: promotion.id,
+        rung: promotion.rung,
+        state: promotion.state,
+        headBranch: promotion.headBranch,
+        baseBranch: promotion.baseBranch,
+        headSha: promotion.headSha ?? null,
+        prNumber: promotion.prNumber ?? null,
+        prUrl: promotion.prUrl ?? null,
+        taskId: promotion.taskId ?? null,
+        gate: {
+            workflow: promotion.gateWorkflow,
+            verdict: promotion.gateVerdict ?? null,
+            forCommit: promotion.gateVerdictSha ?? null,
+            checkedAt: promotion.gateCheckedAt ?? null,
+            runUrl: promotion.gateRunUrl ?? null,
+            // A `success` whose E2E leg was WAIVED by the
+            // `override-e2e-gate` label rather than green. GitHub folds an
+            // overridden run back into a plain `success` conclusion, so
+            // without this field a caller cannot tell the two apart — and
+            // this lane exists so a human can read the verdict before
+            // promoting.
+            overridden: promotion.gateOverridden === true,
+        },
+        refusalCode: promotion.refusalCode ?? null,
+        createdAt: promotion.createdAt,
+    };
+}

--- a/apps/api/src/release/release-promotions.dto.ts
+++ b/apps/api/src/release/release-promotions.dto.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString, IsUUID, MaxLength } from 'class-validator';
+import {
+    PROMOTION_RUNGS,
+    RELEASE_BRANCH_MAX_LENGTH,
+    type PromotionRung,
+} from '@ever-works/contracts';
+
+// Why every field carries `@ApiProperty`: the API build runs no
+// `@nestjs/swagger` CLI plugin, so a DTO field without an explicit
+// decorator is simply absent from the OpenAPI document — and the MCP
+// server derives its tool schemas from that document.
+
+/**
+ * Everything a caller may say about a promotion.
+ *
+ * Note what is NOT here: no branch names, no repository, no owner. Those
+ * come from the Work's `releaseLadder` and its source repository. A
+ * request that could name its own branches could open
+ * `their-branch → main` and call it a release, so it cannot.
+ *
+ * The RUNG is the caller's only choice, and it is a closed enum. That is
+ * the deliberate act the founder performs per batch: `develop → stage`
+ * now, `stage → main` later, after reading the end-to-end verdict.
+ */
+export class OpenPromotionDto {
+    @ApiProperty({
+        enum: PROMOTION_RUNGS as unknown as string[],
+        description:
+            'Which rung of the release ladder to promote. The BRANCHES come from the Work, never from this request.',
+    })
+    @IsIn(PROMOTION_RUNGS as unknown as string[])
+    rung: PromotionRung;
+
+    @ApiProperty({
+        format: 'uuid',
+        description:
+            'Agent the promotion Task is attributed to. Must be owned by the caller — the Inbox merge approval this Task later raises is decidable only by that owner.',
+    })
+    @IsUUID()
+    agentId: string;
+}
+
+/**
+ * The release ladder, set as PLATFORM STATE on the Work.
+ *
+ * Deliberately a separate, deliberate configuration act from asking for a
+ * promotion: the owner declares the ladder once, and every later promotion
+ * reads it. Re-validated with `sanitizeReleaseLadder` server-side, which
+ * refuses anything that is not three distinct plain branch names.
+ */
+export class SetReleaseLadderDto {
+    @ApiProperty({ maxLength: RELEASE_BRANCH_MAX_LENGTH, example: 'develop' })
+    @IsString()
+    @MaxLength(RELEASE_BRANCH_MAX_LENGTH)
+    integration: string;
+
+    @ApiProperty({ maxLength: RELEASE_BRANCH_MAX_LENGTH, example: 'stage' })
+    @IsString()
+    @MaxLength(RELEASE_BRANCH_MAX_LENGTH)
+    staging: string;
+
+    @ApiProperty({ maxLength: RELEASE_BRANCH_MAX_LENGTH, example: 'main' })
+    @IsString()
+    @MaxLength(RELEASE_BRANCH_MAX_LENGTH)
+    production: string;
+}

--- a/apps/api/src/release/release.module.spec.ts
+++ b/apps/api/src/release/release.module.spec.ts
@@ -1,0 +1,104 @@
+import { Global, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ENTITIES, WorkCustomDomainRepository, WorkRepository } from '@ever-works/agent/database';
+import {
+    PluginRegistryService,
+    PluginSettingsService,
+    WorkPluginRepository,
+} from '@ever-works/agent/plugins';
+import { PluginUsageService } from '@ever-works/agent/usage';
+import { BudgetGuardService } from '@ever-works/agent/budgets';
+import { EverWorksK8sDeployProvider } from '@ever-works/agent/ever-works-providers';
+import { ReleasePromotionService } from '@ever-works/agent/tasks-domain';
+import { PROMOTION_LANE_WATCHER, PROMOTION_MERGE_GUARD } from '@ever-works/agent/policy';
+import { ReleaseModule } from './release.module';
+import { ReleasePromotionsController } from './release-promotions.controller';
+
+/**
+ * `ReleaseModule` against a REAL Nest container.
+ *
+ * The api-side half of the same guard `release-promotion.module.spec.ts`
+ * applies in `packages/agent`, and it exists for the same reason: a module
+ * whose controller injects something the module does not import passes
+ * every unit spec — `release-promotions.controller.spec.ts` constructs the
+ * controller positionally — and then the API refuses to boot. Reading
+ * `Reflect.getMetadata('imports', …)` does not catch it either; that only
+ * proves a name is in a list, never that the graph resolves.
+ *
+ * MUTATION CHECK, executed rather than assumed: removing `DatabaseModule`
+ * from `ReleaseModule`'s imports makes `WorkRepository` — which
+ * `ReleasePromotionsController` injects to read and write the Work's
+ * release ladder — unresolvable, and this file fails. Before it existed,
+ * that change left `apps/api` entirely green.
+ *
+ * The `@Global()` stub below stands in for the providers the running API
+ * supplies from its ROOT module, which `FacadesModule`'s graph reaches
+ * transitively. Nothing the release lane itself depends on is stubbed.
+ */
+const APP_ROOT_PROVIDERS = [
+    PluginRegistryService,
+    PluginSettingsService,
+    WorkPluginRepository,
+    PluginUsageService,
+    BudgetGuardService,
+    WorkCustomDomainRepository,
+    EverWorksK8sDeployProvider,
+];
+
+@Global()
+@Module({
+    providers: APP_ROOT_PROVIDERS.map((token) => ({ provide: token, useValue: {} })),
+    exports: APP_ROOT_PROVIDERS,
+})
+class AppRootStubModule {}
+
+describe('ReleaseModule — dependency injection', () => {
+    async function compile() {
+        return Test.createTestingModule({
+            imports: [
+                AppRootStubModule,
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                }),
+                ReleaseModule,
+            ],
+        }).compile();
+    }
+
+    it('resolves the controller with BOTH of its constructor dependencies', async () => {
+        const moduleRef = await compile();
+
+        const controller = moduleRef.get(ReleasePromotionsController);
+        expect(controller).toBeInstanceOf(ReleasePromotionsController);
+        // The two things the controller cannot work without: the promotion
+        // service (opens a rung, lists history) and WorkRepository (reads
+        // and writes the release ladder — the platform state a caller can
+        // never supply itself).
+        expect(moduleRef.get(ReleasePromotionService, { strict: false })).toBeInstanceOf(
+            ReleasePromotionService,
+        );
+        expect(moduleRef.get(WorkRepository, { strict: false })).toBeInstanceOf(WorkRepository);
+
+        await moduleRef.close();
+    });
+
+    it('BINDS both promotion tokens app-wide, which is what makes the lane live', async () => {
+        // Importing `ReleasePromotionModule` here is what binds
+        // `PROMOTION_MERGE_GUARD` and `PROMOTION_LANE_WATCHER` for the
+        // whole app: it is `@Global()`, and `TaskPrStatusService` /
+        // `TaskMergeGateService` inject both `@Optional()`. Dropping the
+        // import does not open a hole — the merge gate refuses a promotion
+        // Task whose guard is unbound — but it silently disables the lane.
+        const moduleRef = await compile();
+
+        const service = moduleRef.get(ReleasePromotionService, { strict: false });
+        expect(moduleRef.get(PROMOTION_MERGE_GUARD, { strict: false })).toBe(service);
+        expect(moduleRef.get(PROMOTION_LANE_WATCHER, { strict: false })).toBe(service);
+
+        await moduleRef.close();
+    });
+});

--- a/apps/api/src/release/release.module.ts
+++ b/apps/api/src/release/release.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { ReleasePromotionModule } from '@ever-works/agent/tasks-domain';
+import { ReleasePromotionsController } from './release-promotions.controller';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the api-side
+ * mount for `develop → stage → main`.
+ *
+ * Importing `ReleasePromotionModule` here is what BINDS
+ * `PROMOTION_MERGE_GUARD` and `PROMOTION_LANE_WATCHER` for the whole app:
+ * that module is `@Global()`, so `TaskPrStatusService` and
+ * `TaskMergeGateService` — which inject both tokens `@Optional()` — pick
+ * them up without `TasksDomainModule` having to import the module that
+ * imports it.
+ *
+ * The consequence, stated because it is a safety property rather than an
+ * accident: DROP this import and the platform does not silently start
+ * merging promotions through the ordinary agent path. `TaskMergeGateService`
+ * recognises a promotion Task off its own labels and stands down when the
+ * guard is unbound, so the lane fails closed rather than open.
+ *
+ * `DatabaseModule` is imported for `WorkRepository`, which the controller
+ * uses to read and write the Work's release ladder.
+ */
+@Module({
+    imports: [DatabaseModule, ReleasePromotionModule],
+    controllers: [ReleasePromotionsController],
+})
+export class ReleaseModule {}

--- a/docs/runbooks/RELEASE_PROMOTION.md
+++ b/docs/runbooks/RELEASE_PROMOTION.md
@@ -1,0 +1,398 @@
+# Release promotion lane — `develop → stage → main`
+
+Self-build slice AI (EW-808), epic EW-762. Closes finding R20.
+
+Companion to [`MERGE_APPROVAL.md`](./MERGE_APPROVAL.md), which this lane
+reuses wholesale for landing, and to
+[`FLEET_BREAK_GLASS.md`](./FLEET_BREAK_GLASS.md), whose manual `gh pr create`
+cascade this replaces for the platform's own repository.
+
+---
+
+## 1. What this fixes
+
+Once a pull request merged to `develop`, the work stopped. Nothing opened
+the two promotion pull requests the house release flow requires; there was
+no promotion Task kind and no code path anywhere that opened a
+`develop → stage` or `stage → main` pull request. The platform's own deploy
+surface could not help either — a Repository Work is explicitly
+non-deployable and is refused before a provider resolves.
+
+The lane makes promotion **possible and legible**. It does not make it
+automatic, and the rest of this document is mostly about that distinction.
+
+---
+
+## 2. What a promotion Task does
+
+1. **Opens ONE pull request**, from the branch the Work's release ladder
+   names to the branch the ladder names. Nothing about which branches is
+   taken from the caller.
+2. **Waits on `promotion-gate.yml`** for the pull request's head commit and
+   records what it said, stamped with the commit it was about.
+3. **Reports each stage into the Task** (its chat thread) and **files ONE
+   Inbox item** per head commit, so a human can see the gate result and
+   decide.
+
+The Task is filed `in_review` with the labels `release:promotion` and
+`release:promotion:<rung>`, priority P1, bound to the Work and to the Agent
+you named.
+
+## 3. What it will NEVER do on its own
+
+- **It will never merge.** `ReleasePromotionService` contains no merge call
+  at all — asserted by a test that reads its own source. Landing a
+  promotion pull request goes through the SAME path as every other agent
+  merge: a `merge_pull_request` proposal in your Inbox, decided by a real
+  human identity, re-verified against the live head commit at merge time.
+  All twelve merge-time conditions in `MERGE_APPROVAL.md` apply unchanged.
+- **It will never cascade.** Merging the `develop → stage` promotion frees
+  the lane and stops. Opening `stage → main` is a separate, separately
+  approved act that you perform when you are ready. There is no
+  "next rung" function anywhere in the contracts, and a test fails if one
+  appears.
+- **It will never widen the merge gate.** The promotion guard can only ever
+  say NO. A promotion whose gate is anything other than an explicit
+  `success` is refused before an approval is even raised.
+
+Why: the stage e2e gate has been unreliable for weeks, and a bad promotion
+is a multi-hour outage on a build lane measured at **215–243 minutes**. Two
+promotions is most of a working day. The decision is yours, per batch,
+after reading the end-to-end verdict.
+
+---
+
+## 4. Setting the lane up (once per Work)
+
+The ladder is **platform state**, declared once by the Work's owner:
+
+```
+PUT /api/works/:workId/release-ladder
+{ "integration": "develop", "staging": "stage", "production": "main" }
+```
+
+Rules, all fail-closed:
+
+- Three **distinct** branch names. `develop → develop` is not a promotion.
+- Plain names only: no `..`, no leading `-` or `/`, no whitespace, no
+  `~^:?*[\`, no trailing `/` or `.lock`, max 128 characters. A branch name
+  ends up as a pull request's `head`/`base`.
+- A Work with **no ladder has no lane**. `POST …/promotions` refuses with
+  `ladder-not-configured` rather than guessing `main`.
+
+`GET /api/works/:workId/release-ladder` reads it back — through the
+sanitiser, not raw.
+
+---
+
+## 5. Running a promotion
+
+```
+POST /api/works/:workId/promotions
+{ "rung": "develop-to-stage", "agentId": "<an Agent you own>" }
+```
+
+`rung` is the only choice you make. It is a closed enum — there is no
+`develop-to-main`, because skipping `stage` is the mistake the lane exists
+to make hard.
+
+`agentId` must be an Agent **you own**: the Inbox merge approval this Task
+will later raise is decidable only by the proposal's own owner, and
+`TasksService.create` refuses an Agent that is not yours.
+
+### Responses
+
+| Result                                           | Meaning                                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `201` `{ outcome: "opened", promotion, taskId }` | The pull request is open and the Task is filed.                                             |
+| `409` `{ message, promotion }`                   | A promotion for this rung is **already open**. Not a new one — the live one is in the body. |
+| `400` `{ code, message }`                        | Refused. See the codes below.                                                               |
+| `404`                                            | The Work does not exist, or is not yours. Same words for both.                              |
+
+### Refusal codes at open time
+
+| Code                                          | What happened                                                                          | What to do                                                                             |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `ladder-not-configured`                       | No ladder, or one that is not three distinct plain branch names.                       | `PUT …/release-ladder` first.                                                          |
+| `head-branch-missing` / `base-branch-missing` | The ladder names a branch the repository does not have.                                | Fix the ladder, or create the branch.                                                  |
+| `head-sha-unknown`                            | The branch tip could not be read (often a token without repo scope).                   | Fix credentials; nothing was created.                                                  |
+| `no-git-provider`                             | No git provider wired in this deployment.                                              | Deployment problem, not a lane problem.                                                |
+| `pull-request-failed`                         | The provider refused (commonly "no commits between" — the branches are already level). | Nothing to promote, or read the provider error.                                        |
+| `branches-not-as-claimed`                     | The provider opened a pull request between DIFFERENT branches than we asked for.       | **The pull request is disowned. Close it by hand.** Nothing in the lane will merge it. |
+| `promotion-not-recorded`                      | The pull request IS open on the provider, but the platform could not record it.        | Retry. The retry **adopts** the open pull request rather than opening a second one.    |
+
+Every refusal frees the lane, so a retry is a clean retry — including the
+crash window between claiming the lane and binding the pull request: an
+`open` row with no `prNumber` older than ten minutes is wreckage nothing
+else can free, and the next claimant retires it. A refusal that happens
+_after_ the Task was filed **cancels that Task** and leaves the reason on
+its chat thread. That matters: a promotion-labelled Task sitting in
+`in_review` with no pull request behind it is indistinguishable on the board
+from a real promotion, and each retry would add another.
+
+### The pull request that is already open
+
+The founder performs this promotion by hand today, so an open
+`develop → stage` is the normal state of the world the first time the lane
+runs — and GitHub answers a second request for the same pair with a 422.
+`openPromotion` therefore **looks for the open `head → base` pull request
+first and adopts it**, exactly as `openPullRequestForBranch` already does
+for Task branches. A pull request between other branches is never adopted.
+
+### The head the promotion reports
+
+The branch tip is read before the lane is claimed (so a missing branch
+refuses before anything exists), but the commit the promotion **reports** is
+read back from the pull request itself once it exists. Two merges to
+`develop` seconds apart would otherwise have the lane publish a commit that
+is not what gets promoted. If that read-back fails, the branch tip is used
+and the Task thread says so.
+
+### What is NOT written to the Task
+
+`task.branchRef` is deliberately left NULL. It is the slot the platform
+treats as a **disposable task branch**: `DELETE /api/tasks/:id/branch` and
+the nightly branch-GC sweep both hand it to `gitFacade.deleteBranch`, and an
+agent run provisions its workspace onto it. A promotion owns no branch — it
+moves two that already exist — so writing `develop` there would aim the
+branch reaper at the integration branch. The pull request is bound through
+`prNumber`, which is what `findDuePrStatusSync` selects on.
+
+---
+
+## 6. Watching a promotion
+
+The promotion is refreshed on the same two-minute `task-pr-status-sync`
+sweep that drives every other Task's pull request, and immediately on
+`GET /api/tasks/:id/pr-status?refresh=true`.
+
+The promotion is identified by its **row**, keyed on `taskId` — never by
+the Task's labels. Labels are free-form and any owner can rewrite them
+through `PATCH /api/tasks/:id`; keying the lane on them meant one request
+could freeze a live promotion and disarm its gate while the row still said
+`open`. Labels survive only as the fail-closed answer for a Task that
+claims to be a promotion with no row behind it.
+
+Each refresh, in order:
+
+1. **Refuses if the Task's pull request has been rebound**
+   (`pull-request-rebound`) — the status being read must be the promotion's
+   own pull request, or every step below would be about someone else's.
+2. Re-reads the pull request and **refuses if the branches moved**
+   (`branches-moved`) — the promotion must be for the branches it claims.
+3. Adopts a new head if the branch advanced, and **drops the recorded gate
+   verdict**. A verdict is about a commit. Any human approval dies with it
+   automatically, because the approval subject key contains the head SHA.
+4. Reads `promotion-gate.yml` for that exact commit and records the verdict.
+   A run that names pull requests **not including this one** is treated as
+   `absent`: a run is keyed by commit, and one commit can head more than one
+   pull request.
+5. Reports a **change** into the Task thread (never a repeat — the change is
+   the database's own answer to "did this row differ?", so two replicas
+   cannot both narrate it), and files the one Inbox item.
+
+`GET /api/works/:workId/promotions` lists the history, newest first.
+
+### The gate verdicts, and which one is a pass
+
+**Only `success` is a pass.** Every other reading — including "cannot
+tell" — is not.
+
+| Verdict      | Meaning                                                                             | Pass?   |
+| ------------ | ----------------------------------------------------------------------------------- | ------- |
+| `success`    | The run completed and concluded `success`.                                          | **YES** |
+| `failure`    | It ran and failed (`failure`, `timed_out`, `action_required`).                      | no      |
+| `pending`    | A run exists and has not finished.                                                  | no      |
+| `cancelled`  | Somebody stopped it. There is no verdict and none is coming.                        | no      |
+| `skipped`    | It finished without evaluating (`skipped`, `neutral`, `stale`).                     | no      |
+| `absent`     | No run of that workflow exists for that commit.                                     | no      |
+| `unreadable` | The lookup failed, or the provider cannot answer. **A broken gate, not a verdict.** | no      |
+
+Two of these deserve emphasis, because the platform's ordinary CI roll-up
+gets them wrong:
+
+- **`skipped` renders GREEN in branch protection.** `deriveCiState` treats
+  `skipped`, `neutral`, `stale` and `cancelled` as non-blocking — correct
+  for the board's CI dot, unusable as a release gate. The lane reads the
+  named workflow's own run instead, and refuses all four.
+- **`absent` is invisible in a roll-up.** A commit with other green checks
+  rolls up `passing` while the gate never ran at all.
+
+`pending`, `absent` and `unreadable` do not raise an Inbox item until they
+have stayed that way for **20 minutes** (past `node-contract`'s own budget
+plus queue time). A run does not exist the instant a pull request opens.
+
+The one Inbox item is keyed on **(commit, reading)**, not on the commit
+alone. `pending` past twenty minutes is routine on this gate, and keyed on
+the commit alone that first post-grace reading consumed the slot and the
+verdict that actually decided the promotion — including a FAILURE — was
+never filed. Every undecided reading shares one token (`stuck`), so a
+`pending → unreadable → pending` flap is still one item; each decided
+verdict gets its own.
+
+### What a green gate actually means, per rung
+
+`promotion-gate.yml` runs on pull requests into **both** `stage` and `main`
+(slice AI widened it; before, the first rung had no verdict at all). But the
+two rungs get different coverage, and conflating them is dangerous:
+
+| Rung              | `e2e-result`                                  | `node-contract` | A `success` means                                                                                    |
+| ----------------- | --------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `develop → stage` | **skips** (its `if:` requires a `stage` head) | runs            | **the node contract held, and nothing more**                                                         |
+| `stage → main`    | runs                                          | runs            | stage's e2e result was green, or a human applied `override-e2e-gate`, **and** the node contract held |
+
+The first rung genuinely has no e2e signal: `e2e.yml` runs on push to
+`develop` only, so the `develop → stage` pull request shows zero e2e shards
+**by design**. The first e2e result for a batch arrives on `stage`, which is
+what the second rung gates on. **Do not read a green `develop → stage`
+promotion as "e2e passed".**
+
+Because the two rungs differ, the Inbox item **says which legs actually
+evaluated**. A `develop → stage` notice reads "the node wire contract ONLY
+… NO end-to-end result was consulted here"; a `stage → main` notice names
+both. The operator deciding a release reads the Inbox item, not this
+runbook.
+
+### The override
+
+`override-e2e-gate` is a real, attributable, visible-in-the-timeline escape
+on the `e2e-result` job, and it is used. `node-contract` has no override at
+all.
+
+The workflow exits 0 on the label in **all four** of its failure branches —
+a broken lookup, no run found, a run still going, and a red run — and
+GitHub then folds the whole thing back into a plain `success` run
+conclusion. Read from the run alone, "the E2E was green" and "somebody with
+repository write applied a label" are byte-for-byte identical.
+
+So the lane reads the label off the pull request beside the run, records it
+(`release_promotions.gateOverridden`, surfaced as `gate.overridden` on the
+API read model), and **says so in the words the human reads**: the Inbox
+title becomes `Promotion gate PASSED — E2E WAIVED, not green — for …` and
+the body carries a `WAIVED, NOT GREEN` line naming the label. Applying the
+label to a red gate therefore files a SECOND Inbox item rather than being
+swallowed as "we already told them about this commit".
+
+It does **not** change the verdict: an overridden run still has to conclude
+`success` before anything is offered for merge, and refusing a documented
+escape hatch would only get the lane routed around within a week. What
+changes is that the override can no longer be laundered into an unqualified
+pass.
+
+---
+
+## 7. Landing a promotion
+
+Nothing here is new. On the refresh after the gate goes `success`, and only
+if the pull request is open, its CI roll-up is `passing`, its check read was
+complete, and the promotion guard allows it:
+
+1. `TaskMergeGateService` raises a `merge_pull_request` proposal bound to
+   `merge:<taskId>:<prNumber>:<headSha>`.
+2. It appears in your Inbox as
+   `Merge PR #N into stage in ever-works/ever-works for T-9 (@ <sha12>)`,
+   with Approve / Reject. **"Approve all" cannot approve it** — a merge is
+   decided one pull request at a time.
+3. You approve. On the NEXT refresh (≈2 minutes, or immediately with
+   `?refresh=true`) the merge is attempted, pinned to the head commit you
+   approved.
+4. `GitFacadeService.mergePullRequest` re-verifies the approval, re-reads
+   live provider state, and applies the merge policy matrix before touching
+   the provider.
+
+Then the promotion goes `merged`, the lane is freed, and **that is the end
+of it**. If you want `stage → main`, you open it — after reading the
+end-to-end verdict.
+
+### Every path that could reach a promotion merge
+
+| Path                                                                    | Gated by                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TaskMergeGateService` on a PR-status refresh (cron or `?refresh=true`) | promotion guard → gate `success` for the live head AND for the promotion's own pull request; then the full slice-AE approval + `GitFacadeService.mergePullRequest` re-verification                                                                                                                                                                                                                  |
+| The same, under a policy with `requireHumanApproval: false`             | **A promotion always takes the approval path anyway.** `requireHumanApproval: false` is a legitimate operator choice for ordinary agent work and is not a choice about releases; the gate raises the proposal regardless, and `attemptMergeForOpenPullRequest` also RAISES the requirement inside the facade so the property does not rest on one branch. Ordinary Tasks are unaffected.            |
+| A deployment where the promotion guard is not bound                     | `TaskMergeGateService` recognises a promotion Task off its own labels and **stands down** — the refusal does not depend on the missing service                                                                                                                                                                                                                                                      |
+| Running the promotion Task with an agent (`POST /api/tasks/:id/run`)    | The run pushes a Task branch (never `develop`/`stage` — `branchRef` is NULL on a promotion) and opens its OWN pull request, replacing `tasks.prNumber`. The next refresh sees `status.number !== promotion.prNumber` and **refuses the promotion** (`pull-request-rebound`), freeing the lane; the guard independently refuses with `promotion-pull-request-mismatch`. Neither pull request merges. |
+| Stripping the promotion labels off the Task (`PATCH /api/tasks/:id`)    | Nothing changes. Both the watcher and the guard resolve the promotion by its **row**, keyed on `taskId`; the labels are consulted only when no row resolves, and then only to refuse.                                                                                                                                                                                                               |
+| Anything else                                                           | There is nothing else. `ReleasePromotionService` has no merge call, the controller has no merge route, and the guard has no verdict that permits a merge the ordinary path would refuse.                                                                                                                                                                                                            |
+
+There are exactly two entries into `TaskWorkspaceService.attemptMergeForOpenPullRequest`,
+both inside `TaskMergeGateService`, and both sit behind the promotion guard.
+There is exactly one `gitFacade.mergePullRequest(...)` call in the whole
+platform. Grep for either if you want to re-verify this table.
+
+**The branch the approval names is the branch that gets merged into.** A
+promotion carries its own `baseBranch` through the guard verdict into both
+the `merge_pull_request` proposal title (`Merge PR #N into main in …`) and
+the merge policy's `targetBranch`. Every other Task pull request still uses
+the Work's `taskIsolationBaseBranch`, exactly as before. This is not
+cosmetic: `GitFacadeService` uses `targetBranch` verbatim and only reads the
+pull request's real base when it is absent, so a promotion reported as
+targeting `develop` would have `protectedBranches` evaluated against a
+branch it is not merging into — and an operator who removes `develop` from
+`protectedBranches` so Task pull requests can land there would silently
+unprotect `main` for promotions at the same time.
+
+Note also the platform default: `PLATFORM_DEFAULT_MERGE_POLICY` has
+`allowAgentMerge: false` and `protectedBranches: ['main','master','develop','stage']`.
+Out of the box the platform will therefore raise the approval and then
+refuse the merge with `agent-merge-disabled` (or `protected-branch` if
+agent merges are enabled but the branch is still protected). That is a
+**policy configuration** decision, not a lane defect: an operator who wants
+the platform to land its own promotions must widen the policy for that
+scope deliberately, and it is still an approval-per-merge.
+
+---
+
+## 8. Duplicates and races
+
+At most **one open promotion per (Work, rung)**, enforced by a UNIQUE
+database index on `(workId, rung, laneKey)` rather than by a read-then-write.
+
+- Two merges to `develop` seconds apart → one pull request; the loser is
+  told `already-open`.
+- The cron worker racing an operator's retry → same.
+- Re-running the request → same.
+- The OTHER rung may be open at the same time. Different Works never
+  collide.
+
+`laneKey` carries the constraint as a value (`'open'` while live,
+`'<state>:<id>'` once terminal) because Postgres can express a partial
+unique index and better-sqlite3 — which CI and the e2e stack run — cannot,
+and a constraint that behaves differently on the two databases is a race
+that only reproduces in production.
+
+---
+
+## 9. Where to look when something is wrong
+
+| Symptom                                                         | Where                                                                                                                                                                                                                   |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It opened nothing."                                            | The `400`/`409` body. Every refusal has a code and frees the lane.                                                                                                                                                      |
+| "The gate says absent forever."                                 | Is `promotion-gate.yml` on the head branch? It has to exist on the commit being promoted.                                                                                                                               |
+| "The gate says unreadable."                                     | Token scope: reading workflow runs needs `actions:read`. A broken lookup never reports as `absent`.                                                                                                                     |
+| "It went green but nothing merged."                             | Expected. Check your Inbox for the merge approval. Then check the merge refusal recorded on the Task (`mergeRefusedCode`) — most likely `agent-merge-disabled` or `protected-branch` under the platform default policy. |
+| "It merged and nothing happened next."                          | Also expected. The next rung is yours to open.                                                                                                                                                                          |
+| "Two pull requests."                                            | Shouldn't be possible via the lane. Check whether one was opened by hand, or disowned with `branches-not-as-claimed`. A pull request opened by hand for the same `head → base` is ADOPTED, not duplicated.              |
+| "Every retry says `already-open` and there is no pull request." | The claim/bind crash window. The row retires itself after ten minutes with no `prNumber`; retry after that, and the retry adopts any pull request that did get opened.                                                  |
+| "The Inbox says PASSED but the e2e was red."                    | Read the title. An overridden gate reads `PASSED — E2E WAIVED, not green`, and `gate.overridden` is `true` on `GET …/promotions`. A `develop → stage` notice also names the legs — that rung has no e2e signal at all.  |
+
+Deploy, after `stage → main` lands: `k8s-build` → ghcr `:prod` → ArgoCD.
+It queues rather than cancels and is measured at 215–243 minutes. Plan the
+outage around that number.
+
+---
+
+## 10. Files
+
+| Concern                                     | File                                                                                                                          |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Ladder, rungs, labels, lane key             | `packages/contracts/src/release/promotion.types.ts`                                                                           |
+| Gate verdict vocabulary + the one pass rule | `packages/contracts/src/release/promotion-gate.types.ts`                                                                      |
+| Provider capability                         | `packages/plugin/src/contracts/capabilities/git-provider.interface.ts` (`getWorkflowRunForCommit`)                            |
+| GitHub implementation                       | `packages/plugins/github/src/github-api.service.ts`                                                                           |
+| Facade seam                                 | `packages/agent/src/facades/git.facade.ts`                                                                                    |
+| The lane                                    | `packages/agent/src/tasks-domain/release-promotion.service.ts`                                                                |
+| The extra refusal                           | `packages/agent/src/policy/promotion-merge-guard.port.ts`                                                                     |
+| Storage                                     | `packages/agent/src/entities/release-promotion.entity.ts`, `apps/api/src/migrations/1790000000000-CreateReleasePromotions.ts` |
+| Operator surface                            | `apps/api/src/release/`                                                                                                       |
+| The workflow                                | `.github/workflows/promotion-gate.yml`                                                                                        |

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -160,6 +160,7 @@ import { AgentPluginPackage } from '../entities/agent-plugin-package.entity';
 import { AgentPluginPackageAllowlist } from '../entities/agent-plugin-package-allowlist.entity';
 import { RepoConnection } from '../entities/repo-connection.entity';
 import { AgentRepoAttachment } from '../entities/agent-repo-attachment.entity';
+import { ReleasePromotion } from '../entities/release-promotion.entity';
 
 import {
     PluginEntity,
@@ -402,4 +403,9 @@ export const ENTITIES = [
     AgentPluginPackageAllowlist,
     RepoConnection,
     AgentRepoAttachment,
+    // Release promotion lane (self-build slice AI, EW-808) — one row per
+    // attempt to move a Work one rung along develop -> stage -> main. The
+    // UNIQUE (workId, rung, laneKey) index on it is what stops two merges
+    // to develop opening two competing promotion pull requests.
+    ReleasePromotion,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -144,6 +144,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'PlanEntitlement',
     'PluginUsageEvent',
     'RefreshToken',
+    // Release promotion lane (self-build slice AI, EW-808).
+    'ReleasePromotion',
     // Repository registry (Feature G) — account-level repo records.
     'RepoConnection',
     // Skills family (PR #1019) ──

--- a/packages/agent/src/database/repositories/release-promotion.repository.ts
+++ b/packages/agent/src/database/repositories/release-promotion.repository.ts
@@ -1,0 +1,366 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+    PROMOTION_LANE_OPEN,
+    promotionLaneKey,
+    type PromotionGateVerdict,
+    type PromotionRung,
+    type PromotionState,
+} from '@ever-works/contracts';
+import { ReleasePromotion } from '../../entities/release-promotion.entity';
+
+/** What a lane claim resolved to. */
+export interface PromotionLaneClaim {
+    /** True when THIS caller created the row. */
+    claimed: boolean;
+    /** The live promotion for the lane — this caller's, or the winner's. */
+    promotion: ReleasePromotion;
+}
+
+export interface ClaimPromotionLaneInput {
+    userId: string;
+    workId: string;
+    rung: PromotionRung;
+    headBranch: string;
+    baseBranch: string;
+    gateWorkflow: string;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+/**
+ * How long an OPEN promotion may hold its lane with NO pull request
+ * bound to it before the next claimant treats it as abandoned.
+ *
+ * The lane is claimed BEFORE the provider is touched — deliberately, so a
+ * race loses in the database rather than on GitHub — which leaves a
+ * window spanning one `createPullRequest` round trip. A process that dies
+ * inside that window (deploy, OOM, node crash) used to leave the row
+ * `open` with `prNumber` NULL forever: nothing sweeps it (the PR-status
+ * sweep selects on `prNumber IS NOT NULL`), there is no abandon endpoint,
+ * and the UNIQUE index then works against the operator — every later
+ * promotion for that rung is refused `already-open` until somebody edits
+ * the database.
+ *
+ * Ten minutes is far longer than opening a pull request can legitimately
+ * take and far shorter than a human's patience. Reclaiming is safe rather
+ * than duplicating because `openPromotion` ADOPTS an already-open
+ * head → base pull request instead of asking for a second one.
+ */
+export const PROMOTION_LANE_ABANDON_MS = 10 * 60 * 1000;
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the store for
+ * `release_promotions`.
+ *
+ * DELIBERATELY NOT in `_repository-inventory.ts`. That file is the
+ * DatabaseModule-owned set; this repository belongs to the promotion lane
+ * and is listed in `ReleasePromotionModule`'s own providers, the same way
+ * `MergeApprovalModule` lists `TaskRepository`. Adding it to the inventory
+ * would export it to every module in the platform for the benefit of one.
+ */
+@Injectable()
+export class ReleasePromotionRepository {
+    constructor(
+        @InjectRepository(ReleasePromotion)
+        private readonly repository: Repository<ReleasePromotion>,
+    ) {}
+
+    /**
+     * Take the `(workId, rung)` lane, or report who already has it.
+     *
+     * THE anti-duplicate guarantee, and the reason it is an INSERT rather
+     * than a read-then-write: two merges to `develop` seconds apart, or a
+     * cron worker racing an operator's retry, both see "no open promotion"
+     * if you look first. Only the UNIQUE `(workId, rung, laneKey)` index
+     * can decide, so the insert IS the decision and the loser reads the
+     * winner back.
+     *
+     * Modelled on `MergeApprovalService.requestMergeApproval`, including
+     * the pre-read: skipping it would make the ordinary "already open"
+     * case log a constraint violation on every sweep.
+     */
+    async claimLane(input: ClaimPromotionLaneInput): Promise<PromotionLaneClaim> {
+        const existing = await this.findOpenForLane(input.workId, input.rung);
+        if (existing) {
+            // An open row that never got a pull request bound to it, older
+            // than the abandon window, is wreckage from a process that died
+            // between the claim and `recordPullRequest` — see
+            // {@link PROMOTION_LANE_ABANDON_MS}. Nothing else can ever free
+            // it: the PR-status sweep only looks at Tasks that HAVE a pull
+            // request. Retire it and let this caller through.
+            if (!isAbandonedLane(existing)) return { claimed: false, promotion: existing };
+            await this.closeLane(existing.id, 'refused', 'abandoned-before-pull-request');
+        }
+
+        try {
+            const created = await this.repository.save(
+                this.repository.create({
+                    userId: input.userId,
+                    workId: input.workId,
+                    rung: input.rung,
+                    headBranch: input.headBranch,
+                    baseBranch: input.baseBranch,
+                    gateWorkflow: input.gateWorkflow,
+                    state: 'open',
+                    laneKey: PROMOTION_LANE_OPEN,
+                    tenantId: input.tenantId ?? null,
+                    organizationId: input.organizationId ?? null,
+                }),
+            );
+            return { claimed: true, promotion: created };
+        } catch {
+            // Lost the race (or a genuine write failure). Re-read: a
+            // winner means "already open", and no winner means the write
+            // really failed and the caller must not proceed.
+            const winner = await this.findOpenForLane(input.workId, input.rung);
+            if (!winner) throw new Error('Could not claim the promotion lane.');
+            return { claimed: false, promotion: winner };
+        }
+    }
+
+    /** The live promotion for one lane, if there is one. */
+    async findOpenForLane(workId: string, rung: PromotionRung): Promise<ReleasePromotion | null> {
+        return this.repository.findOne({
+            where: { workId, rung, laneKey: PROMOTION_LANE_OPEN },
+        });
+    }
+
+    /**
+     * The promotion a Task reports, if it reports one.
+     *
+     * One Task files one promotion, so in practice this is a single row.
+     * The OPEN row is asked for FIRST anyway, deliberately: this is the
+     * lookup the merge guard runs, and "there is a live promotion for this
+     * Task" must never lose a sort to a terminal one. Ordering the two
+     * together by `laneKey` would do exactly that — `'closed:…'` and
+     * `'merged:…'` both sort before `'open'`.
+     *
+     * `null` is a normal outcome; most Tasks are not promotions.
+     */
+    async findByTaskId(taskId: string): Promise<ReleasePromotion | null> {
+        const open = await this.repository.findOne({
+            where: { taskId, laneKey: PROMOTION_LANE_OPEN },
+        });
+        if (open) return open;
+        return this.repository.findOne({ where: { taskId }, order: { createdAt: 'DESC' } });
+    }
+
+    /**
+     * The LIVE promotion a Task reports, if it has one.
+     *
+     * THE identity lookup for both halves of the lane, and one query
+     * rather than {@link findByTaskId}'s two, because it runs for every
+     * Task on every PR-status sweep and for every green pull request the
+     * merge gate considers. It is asked BEFORE anything looks at a Task's
+     * labels: labels are free-form and any owner can rewrite them through
+     * `PATCH /api/tasks/:id`, so a lane whose identity came from them
+     * could be disarmed by one request while the promotion row still said
+     * `open`. Hits `idx_release_promotions_task`.
+     */
+    async findOpenByTaskId(taskId: string): Promise<ReleasePromotion | null> {
+        return this.repository.findOne({ where: { taskId, laneKey: PROMOTION_LANE_OPEN } });
+    }
+
+    async findById(id: string): Promise<ReleasePromotion | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    /** Owner-scoped history for one Work, newest first. */
+    async listForWork(workId: string, userId: string, limit = 20): Promise<ReleasePromotion[]> {
+        return this.repository.find({
+            where: { workId, userId },
+            order: { createdAt: 'DESC' },
+            take: Math.max(1, Math.min(limit, 100)),
+        });
+    }
+
+    /** Bind the reporting Task to the claimed lane. */
+    async attachTask(id: string, taskId: string): Promise<void> {
+        await this.repository.update({ id }, { taskId });
+    }
+
+    /** Record the opened pull request and the head it was opened at. */
+    async recordPullRequest(
+        id: string,
+        patch: {
+            prNumber: number;
+            prUrl: string | null;
+            headSha: string | null;
+            headRecordedAt: Date;
+        },
+    ): Promise<void> {
+        await this.repository.update(
+            { id },
+            {
+                prNumber: patch.prNumber,
+                prUrl: patch.prUrl,
+                headSha: patch.headSha,
+                headRecordedAt: patch.headRecordedAt,
+            },
+        );
+    }
+
+    /**
+     * Adopt a NEW head commit for a live promotion.
+     *
+     * Clears the gate verdict in the same write: a verdict is about a
+     * commit, and this one has not been judged. Leaving it would let a
+     * `success` recorded for an old commit authorise a merge of a new one.
+     */
+    async recordHeadMoved(id: string, headSha: string, at: Date): Promise<void> {
+        await this.repository.update(
+            { id },
+            {
+                headSha,
+                headRecordedAt: at,
+                gateVerdict: null,
+                gateVerdictSha: null,
+                gateRunUrl: null,
+                // The waiver went with the verdict: a label applied to an
+                // older commit's run says nothing about this one.
+                gateOverridden: false,
+            },
+        );
+    }
+
+    /**
+     * Record one reading of the gate, stamped with the commit it was
+     * about, and report whether it CHANGED anything.
+     *
+     * A compare-and-set rather than a read-then-write, for the same reason
+     * {@link claimInboxNotice} is one: the two-minute PR-status sweep and
+     * an on-demand `?refresh=true` run in different processes, so two
+     * callers holding the same stale in-memory row would both compute
+     * "this is new" and both narrate it into the Task thread. `changed`
+     * comes from the database's own answer to "did this row actually
+     * differ?", so exactly one caller narrates a given transition.
+     *
+     * `gateCheckedAt` is written either way — the operator surface shows
+     * when the gate was last LOOKED at, which is a different fact from
+     * when it last changed.
+     */
+    async recordGateVerdict(
+        id: string,
+        patch: {
+            gateVerdict: PromotionGateVerdict;
+            gateVerdictSha: string;
+            gateCheckedAt: Date;
+            gateRunUrl?: string | null;
+            /**
+             * Was the gate's E2E leg waived by the `override-e2e-gate`
+             * label rather than green? Part of the compare-and-set, not a
+             * side note: a label applied to a live pull request re-runs the
+             * gate and flips a red run to `success`, and the human has to
+             * be told that transition happened.
+             */
+            gateOverridden: boolean;
+        },
+    ): Promise<{ changed: boolean }> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                gateVerdict: patch.gateVerdict,
+                gateVerdictSha: patch.gateVerdictSha,
+                gateCheckedAt: patch.gateCheckedAt,
+                gateRunUrl: patch.gateRunUrl ?? null,
+                gateOverridden: patch.gateOverridden,
+            })
+            .where('id = :id', { id })
+            .andWhere(
+                '(gateVerdict IS NULL OR gateVerdict != :verdict OR gateVerdictSha IS NULL OR gateVerdictSha != :sha OR gateOverridden IS NULL OR gateOverridden != :overridden)',
+                {
+                    verdict: patch.gateVerdict,
+                    sha: patch.gateVerdictSha,
+                    overridden: patch.gateOverridden,
+                },
+            )
+            .execute();
+        if ((result.affected ?? 0) > 0) return { changed: true };
+
+        // Unchanged reading: keep the "last looked at" stamp honest and
+        // say nothing.
+        await this.repository.update(
+            { id },
+            { gateCheckedAt: patch.gateCheckedAt, gateRunUrl: patch.gateRunUrl ?? null },
+        );
+        return { changed: false };
+    }
+
+    /**
+     * Take a promotion terminal and FREE its lane, so the next one can be
+     * opened by a human when they decide to.
+     *
+     * `laneKey` is computed by the shared helper rather than written here,
+     * so the value the unique index sees can never drift from the value
+     * the claim path expects.
+     */
+    async closeLane(
+        id: string,
+        state: Exclude<PromotionState, 'open'>,
+        refusalCode?: string | null,
+    ): Promise<void> {
+        await this.repository.update(
+            { id },
+            {
+                state,
+                laneKey: promotionLaneKey(state, id),
+                ...(refusalCode === undefined ? {} : { refusalCode }),
+            },
+        );
+    }
+
+    /**
+     * Claim the right to file the ONE Inbox notice for this (head commit,
+     * reading) pair.
+     *
+     * Compare-and-set, not a read-then-write: the two-minute PR-status
+     * sweep and an on-demand `?refresh=true` run in different processes
+     * and would otherwise both file one. `true` means this caller won and
+     * must file; `false` means somebody already filed THIS reading for
+     * THIS commit.
+     *
+     * The `token` half is load-bearing and was missing. Keyed on the
+     * commit alone, the first reading to clear the grace window took the
+     * slot — and `pending` past twenty minutes is routine on this gate,
+     * because `node-contract` has a 20-minute budget plus self-hosted ARC
+     * queue time, and a single transient 403/5xx (recorded `unreadable`)
+     * does the same. The verdict that actually decided the promotion,
+     * including a FAILURE, was then never filed at all. Callers pass
+     * `'stuck'` for every undecided reading, so a `pending → unreadable →
+     * pending` flap is still ONE notice, and `success` / `failure` /
+     * `cancelled` / `skipped` each get theirs.
+     */
+    async claimInboxNotice(id: string, headSha: string, token: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({ inboxFiledForSha: headSha, inboxFiledVerdict: token })
+            .where('id = :id', { id })
+            .andWhere(
+                '(inboxFiledForSha IS NULL OR inboxFiledForSha != :headSha OR inboxFiledVerdict IS NULL OR inboxFiledVerdict != :token)',
+                { headSha, token },
+            )
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+}
+
+/**
+ * An open lane nobody can ever free: no pull request bound, and older
+ * than {@link PROMOTION_LANE_ABANDON_MS}.
+ *
+ * Reads `createdAt` rather than `updatedAt`: nothing touches such a row
+ * after the claim, so the two are the same value — and `createdAt` cannot
+ * be pushed forward by an unrelated write.
+ */
+function isAbandonedLane(promotion: ReleasePromotion): boolean {
+    if (promotion.prNumber !== null && promotion.prNumber !== undefined) return false;
+    const created = promotion.createdAt ? new Date(promotion.createdAt).getTime() : Number.NaN;
+    // No usable creation time is NOT a licence to retire the row: an
+    // unreadable clock must not become a way to steal a live lane.
+    if (Number.isNaN(created)) return false;
+    return Date.now() - created >= PROMOTION_LANE_ABANDON_MS;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -190,3 +190,6 @@ export * from './agent-plugin-package.entity';
 export * from './agent-plugin-package-allowlist.entity';
 export * from './repo-connection.entity';
 export * from './agent-repo-attachment.entity';
+// Release promotion lane (self-build slice AI, EW-808) — one row per
+// attempt to move a Work one rung along develop -> stage -> main.
+export * from './release-promotion.entity';

--- a/packages/agent/src/entities/release-promotion.entity.ts
+++ b/packages/agent/src/entities/release-promotion.entity.ts
@@ -1,0 +1,244 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import type { PromotionGateVerdict, PromotionRung, PromotionState } from '@ever-works/contracts';
+import { PortableDateColumn } from './_types';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — one row per
+ * attempt to move a Work's code one rung along `develop → stage → main`.
+ *
+ * ## Why this exists as its own row
+ *
+ * The Task carries the pull request (`prNumber`, `prUrl`, `prHeadSha`)
+ * and is what a human looks at. It cannot carry the two things a
+ * promotion needs that a Task has no shape for:
+ *
+ *   1. **Lane occupancy.** "There is already an open `develop → stage`
+ *      promotion for this Work" has to be a DATABASE fact, not a query
+ *      result, or two merges to `develop` seconds apart open two
+ *      competing pull requests. See {@link ReleasePromotion.laneKey}.
+ *   2. **A gate verdict bound to a commit.** The Task caches a rolled-up
+ *      `ciState` over every check; a promotion needs ONE named workflow's
+ *      answer, stamped with the commit it was about, so a verdict cannot
+ *      outlive the head it was given for.
+ *
+ * ## What a row does NOT do
+ *
+ * It does not merge anything, and it does not know about the next rung.
+ * A promotion that reaches `merged` frees its lane and stops. Opening
+ * `stage → main` after a `develop → stage` lands is a separate,
+ * separately-approved human act — there is deliberately no column here
+ * that could hold "and then".
+ *
+ * Merging a promotion pull request goes through the SAME path as every
+ * other agent merge: the Task's `merge_pull_request` Inbox approval
+ * (slice AE), verified against the live head at merge time. This row only
+ * ever NARROWS that: `gateVerdict` must be an explicit `success` for the
+ * exact head being merged, or the merge gate stands down.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1790000000000-CreateReleasePromotions`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` and
+ * `_entity-names.ts` — this repo has no `autoLoadEntities`, so a
+ * forFeature'd-but-unregistered entity throws EntityMetadataNotFoundError
+ * on first query.
+ */
+@Entity({ name: 'release_promotions' })
+@Index('uq_release_promotions_lane', ['workId', 'rung', 'laneKey'], { unique: true })
+@Index('idx_release_promotions_task', ['taskId'])
+@Index('idx_release_promotions_work_state', ['workId', 'state'])
+export class ReleasePromotion {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner of the Work, the Task and the pull request. Scopes every read. */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    /** The Work whose repository and release ladder this promotion used. */
+    @Column({ type: 'uuid' })
+    workId: string;
+
+    /**
+     * The Task that reports this promotion's progress and carries the
+     * pull request the merge gate acts on. NULL only in the window
+     * between claiming the lane and filing the Task.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    taskId?: string | null;
+
+    /** Which rung: `develop-to-stage` or `stage-to-main`. */
+    @Column({ type: 'varchar', length: 32 })
+    rung: PromotionRung;
+
+    /**
+     * The branches this promotion CLAIMS, resolved from the Work's ladder
+     * at open time and never from the caller.
+     *
+     * Recorded rather than re-derived on every refresh so that a ladder
+     * edited underneath a live promotion is caught: the refresh compares
+     * the provider's live `head`/`base` against THESE, and refuses if
+     * either moved.
+     */
+    @Column({ type: 'varchar', length: 128 })
+    headBranch: string;
+
+    @Column({ type: 'varchar', length: 128 })
+    baseBranch: string;
+
+    /**
+     * The commit the promotion currently reports — the head branch's tip
+     * when the pull request was opened, and thereafter whatever the
+     * provider says the pull request's head is.
+     *
+     * When this changes, {@link gateVerdict} is CLEARED: a verdict is
+     * about a commit, and the new one has not been judged. Any human
+     * approval is invalidated at the same time for free, because the AE
+     * subject key (`merge:<taskId>:<prNumber>:<headSha>`) contains it.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    headSha?: string | null;
+
+    /** When {@link headSha} was last set to a NEW value — the grace clock. */
+    @PortableDateColumn({ nullable: true })
+    headRecordedAt?: Date | null;
+
+    @Column({ type: 'int', nullable: true })
+    prNumber?: number | null;
+
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    prUrl?: string | null;
+
+    /** `open` | `merged` | `closed` | `refused`. */
+    @Column({ type: 'varchar', length: 16, default: 'open' })
+    state: PromotionState;
+
+    /**
+     * The third column of the UNIQUE `(workId, rung, laneKey)` index, and
+     * the whole anti-duplicate guarantee.
+     *
+     * Postgres could express "at most one open promotion per (Work, rung)"
+     * as a partial unique index; better-sqlite3 — which CI and the e2e
+     * stack run — cannot, and a constraint that behaves differently on the
+     * two databases is a race that only reproduces in production. So the
+     * constraint is carried in a VALUE: every live promotion writes the
+     * literal `'open'` and therefore collides, and every terminal one
+     * writes `'<state>:<id>'` and therefore does not.
+     *
+     * Written only through `promotionLaneKey()`. Never edited by hand.
+     */
+    @Column({ type: 'varchar', length: 64, default: 'open' })
+    laneKey: string;
+
+    /** Workflow file whose verdict this promotion waits on. */
+    @Column({ type: 'varchar', length: 128 })
+    gateWorkflow: string;
+
+    /**
+     * The last reading of {@link gateWorkflow}: `success` | `failure` |
+     * `pending` | `cancelled` | `skipped` | `absent` | `unreadable`.
+     *
+     * NULL means "not read yet". Only an explicit `success` is a pass,
+     * and only while {@link gateVerdictSha} equals the head being merged.
+     */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    gateVerdict?: PromotionGateVerdict | null;
+
+    /**
+     * The commit {@link gateVerdict} was read for.
+     *
+     * Kept beside the verdict rather than assumed equal to
+     * {@link headSha}, so a verdict can never be silently re-used for a
+     * commit it was not about: the merge guard compares this against the
+     * LIVE head and refuses when they differ.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    gateVerdictSha?: string | null;
+
+    /**
+     * Was the gate's E2E leg WAIVED rather than green for
+     * {@link gateVerdictSha}?
+     *
+     * `promotion-gate.yml` exits 0 on the `override-e2e-gate` label in
+     * every one of its failure branches — a broken lookup, no run, a run
+     * still going and a red run — and GitHub then folds the whole thing
+     * back into a plain `success` conclusion. Read from the run alone,
+     * "the E2E was green" and "somebody with repository write applied a
+     * label" are byte-for-byte identical, and the person deciding a
+     * production release would be told the first when the second happened.
+     *
+     * So the label is read off the pull request beside the run and
+     * recorded here. It does not change the verdict — the override is a
+     * deliberate, documented escape hatch and refusing it would only get
+     * the lane routed around — it changes what the human is TOLD.
+     *
+     * `false` also means "no label on the read we did", which is why it
+     * only ever adds a warning and never grants anything.
+     */
+    @Column({ type: 'boolean', default: false })
+    gateOverridden: boolean;
+
+    @PortableDateColumn({ nullable: true })
+    gateCheckedAt?: Date | null;
+
+    /** Deep link to the gate run, for the operator who has to read the log. */
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    gateRunUrl?: string | null;
+
+    /**
+     * Why this promotion was refused, when `state` is `refused`.
+     * Free-form short code (`ladder-not-configured`, `branches-moved`,
+     * `head-branch-missing`, …) reported into the Task verbatim.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    refusalCode?: string | null;
+
+    /**
+     * The head commit an Inbox notice has already been filed for.
+     *
+     * Claimed with a compare-and-set so the two-minute PR-status sweep and
+     * an on-demand `?refresh=true` cannot both file one, and so a new head
+     * legitimately gets a new notice.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    inboxFiledForSha?: string | null;
+
+    /**
+     * WHAT the last Inbox notice for {@link inboxFiledForSha} said —
+     * `'stuck'` for an undecided reading past the grace window, otherwise
+     * the verdict itself.
+     *
+     * Half of the compare-and-set, and not an optimisation. Keying the
+     * one-notice-per-commit slot on the SHA alone meant the first reading
+     * to clear the grace window (routinely `pending`: the gate's
+     * `node-contract` job has a 20-minute budget plus self-hosted ARC
+     * queue time) consumed the slot, and the verdict that actually decides
+     * the promotion — including a FAILURE — was then suppressed for that
+     * commit. The human was told the gate was stuck and never told what it
+     * concluded.
+     */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    inboxFiledVerdict?: string | null;
+
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -26,6 +26,8 @@ import type {
     SourceRepository as ContractSourceRepository,
     WorksConfigSnapshot as ContractWorksConfigSnapshot,
 } from '@ever-works/contracts/api';
+// Release promotion lane (self-build slice AI, EW-808).
+import type { ReleaseLadder } from '@ever-works/contracts';
 import type { PRUpdate } from '@src/generators/data-generator';
 import { WorkGenerationHistory } from './work-generation-history.entity';
 import { TimestampColumn } from './_types';
@@ -428,6 +430,27 @@ export class Work {
     /** `'on-merge' | 'manual'` — when the Task branch is deleted. */
     @Column({ type: 'varchar', length: 16, default: 'on-merge' })
     taskBranchCleanup: string;
+
+    // ── Release promotion lane (self-build slice AI, EW-808) ─────────
+
+    /**
+     * The `integration → staging → production` branch ladder this Work's
+     * releases move along, as PLATFORM STATE.
+     *
+     * NULL — the default, and the value on every existing Work — means
+     * this Work has no release lane and `POST /promotions` refuses. That
+     * is deliberate: a Work whose ladder nobody has declared has no
+     * business opening a pull request into a branch the platform guessed.
+     * `taskIsolationBaseBranch` above is a DIFFERENT thing (where Task
+     * branches fork from and merge back to) and is not a substitute — it
+     * names one branch and a ladder needs three.
+     *
+     * Read through `sanitizeReleaseLadder` on every use, never raw: the
+     * column is `simple-json` and therefore holds whatever was written to
+     * it, and the branch names end up in a pull request's `head`/`base`.
+     */
+    @Column('simple-json', { nullable: true })
+    releaseLadder?: ReleaseLadder | null;
 
     // ── Memory recall (memory upgrades M3) ───────────────────────────
 

--- a/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
@@ -382,6 +382,65 @@ describe('GitFacadeService.mergePullRequest — merge approval gate (slice AE)',
         });
     });
 
+    // Release promotion lane (slice AI). `AgentMergeActor.requireHumanApproval`
+    // is a caller-side RAISE, in one direction only. It exists because "an
+    // operator turned approvals off for this scope" must not extend to a
+    // release promotion, and it is enforced HERE as well as in
+    // `TaskMergeGateService` so the property does not rest on one caller
+    // remembering.
+    describe('a caller may RAISE the approval requirement, never clear it', () => {
+        it('requires an approval under a policy that does not, when the actor asks', async () => {
+            const { facade, verifier, plugin } = makeFacade({
+                policy: NO_APPROVAL_NEEDED,
+                verdict: {
+                    approved: false,
+                    code: 'approval-missing',
+                    reason: 'No human approval is on record.',
+                },
+            });
+            await expect(
+                facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, {
+                    ...ACTOR,
+                    requireHumanApproval: true,
+                }),
+            ).rejects.toMatchObject({ code: 'approval-missing' });
+            expect(verifier.verifyMergeApproval).toHaveBeenCalled();
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+
+        it('merges once the approval it insisted on verifies', async () => {
+            const { facade, plugin } = makeFacade({ policy: NO_APPROVAL_NEEDED });
+            await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, {
+                ...ACTOR,
+                requireHumanApproval: true,
+            });
+            expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            ['false', false],
+            ['undefined', undefined],
+        ])('cannot CLEAR the requirement with %s', async (_label, value) => {
+            // The direction that must not work: a policy that demands an
+            // approval still demands one whatever the caller says.
+            const { facade, plugin } = makeFacade({
+                policy: NEEDS_APPROVAL,
+                verdict: {
+                    approved: false,
+                    code: 'approval-missing',
+                    reason: 'No human approval is on record.',
+                },
+            });
+            await expect(
+                facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, {
+                    ...ACTOR,
+                    requireHumanApproval: value,
+                }),
+            ).rejects.toMatchObject({ code: 'approval-missing' });
+            expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+        });
+    });
+
     // An INCOMPLETE check read is not green. `ciState` is documented as
     // the roll-up for the whole head commit while `checks` is a bounded
     // display sample; a provider that says it could not read the full set

--- a/packages/agent/src/facades/__tests__/git.facade.workflow-run.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.workflow-run.spec.ts
@@ -1,0 +1,229 @@
+import type { GitCheckConclusion, GitCheckStatus, GitWorkflowRun } from '@ever-works/plugin';
+import {
+    promotionGateVerdictFromRun,
+    type PromotionGateRunReading,
+    type PromotionGateVerdict,
+} from '@ever-works/contracts';
+import { GitFacadeService, GitOperationNotSupportedError } from '../git.facade';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — facade-side
+ * contract for `getWorkflowRunForCommit`.
+ *
+ * Same absence rules as the PR-insights capabilities beside it: the method
+ * is OPTIONAL on `IGitProviderPlugin`, and the lazy-plugin proxy in this
+ * codebase over-reports optional methods, so the facade materialises it
+ * off the resolved plugin and raises a typed error rather than letting a
+ * TypeError become an unmapped 500.
+ *
+ * The consequence for the lane is deliberate and worth stating: a provider
+ * that cannot read workflow runs makes the gate `unreadable`, and
+ * `unreadable` is not a pass. The lane fails closed on a provider it
+ * cannot interrogate.
+ */
+
+const OPTIONS = { providerId: 'github', userId: 'user-1', workId: 'work-1' } as const;
+
+const RUN = {
+    id: 1001,
+    workflowPath: '.github/workflows/promotion-gate.yml',
+    headSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+    status: 'completed' as const,
+    conclusion: 'success' as const,
+    url: 'https://github.com/ever-works/ever-works/actions/runs/1001',
+};
+
+function makeFacade(plugin: Record<string, unknown>) {
+    const facade = new GitFacadeService(
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+    );
+    (
+        facade as unknown as {
+            resolvePluginAndToken: () => Promise<{ plugin: unknown; token: string }>;
+        }
+    ).resolvePluginAndToken = jest
+        .fn()
+        .mockResolvedValue({ plugin: { id: 'github', ...plugin }, token: 'tok' });
+    return facade;
+}
+
+describe('GitFacadeService.getWorkflowRunForCommit', () => {
+    it('delegates to the provider with the resolved token', async () => {
+        const getWorkflowRunForCommit = jest.fn().mockResolvedValue(RUN);
+        const facade = makeFacade({ getWorkflowRunForCommit });
+
+        await expect(
+            facade.getWorkflowRunForCommit(
+                'ever-works',
+                'ever-works',
+                'promotion-gate.yml',
+                RUN.headSha,
+                OPTIONS,
+            ),
+        ).resolves.toEqual(RUN);
+        expect(getWorkflowRunForCommit).toHaveBeenCalledWith(
+            'ever-works',
+            'ever-works',
+            'promotion-gate.yml',
+            RUN.headSha,
+            'tok',
+        );
+    });
+
+    it('passes a provider `null` (no run for this commit) straight through', async () => {
+        // `null` is a real answer — "the gate never ran on this commit" —
+        // and the lane renders it differently from a broken lookup.
+        const facade = makeFacade({
+            getWorkflowRunForCommit: jest.fn().mockResolvedValue(null),
+        });
+        await expect(
+            facade.getWorkflowRunForCommit(
+                'acme',
+                'widgets',
+                'promotion-gate.yml',
+                'abc1234',
+                OPTIONS,
+            ),
+        ).resolves.toBeNull();
+    });
+
+    it('lets a provider error propagate rather than reporting the gate absent', async () => {
+        const facade = makeFacade({
+            getWorkflowRunForCommit: jest.fn().mockRejectedValue(new Error('403 actions:read')),
+        });
+        await expect(
+            facade.getWorkflowRunForCommit(
+                'acme',
+                'widgets',
+                'promotion-gate.yml',
+                'abc1234',
+                OPTIONS,
+            ),
+        ).rejects.toThrow('403 actions:read');
+    });
+
+    it('raises GitOperationNotSupportedError when the provider omits it', async () => {
+        const facade = makeFacade({});
+        await expect(
+            facade.getWorkflowRunForCommit(
+                'acme',
+                'widgets',
+                'promotion-gate.yml',
+                'abc1234',
+                OPTIONS,
+            ),
+        ).rejects.toBeInstanceOf(GitOperationNotSupportedError);
+    });
+
+    it('raises it for a proxy that reports a non-function member', async () => {
+        const facade = makeFacade({ getWorkflowRunForCommit: undefined });
+        await expect(
+            facade.getWorkflowRunForCommit(
+                'acme',
+                'widgets',
+                'promotion-gate.yml',
+                'abc1234',
+                OPTIONS,
+            ),
+        ).rejects.toBeInstanceOf(GitOperationNotSupportedError);
+    });
+});
+
+/**
+ * THE vocabulary agreement, asserted here because this is one of the very
+ * few places both types are importable: `GitWorkflowRun` lives in
+ * `@ever-works/plugin` and `PromotionGateRunReading` in
+ * `@ever-works/contracts`, which has no dependencies and therefore cannot
+ * import the provider types it is structurally compatible with.
+ *
+ * `promotion-gate.types.ts` says this file does exactly this. It did not,
+ * until now — the comment named a guard that was not there, which is worse
+ * than no comment at all.
+ */
+describe('GitWorkflowRun ↔ PromotionGateRunReading — one vocabulary, not two', () => {
+    const CHECK_STATUSES = ['queued', 'in_progress', 'completed', 'unknown'] as const;
+    const CHECK_CONCLUSIONS = [
+        'success',
+        'failure',
+        'neutral',
+        'cancelled',
+        'timed_out',
+        'action_required',
+        'skipped',
+        'stale',
+    ] as const;
+
+    it('pins the two string sets, so adding a member without a verdict fails here', () => {
+        // Assignment in BOTH directions: the arrays are exhaustive over the
+        // union (a member added to the type and not to the array leaves the
+        // `satisfies` unsatisfied in spirit — the compile-time half — and a
+        // member in the array that is not in the union fails `tsc`).
+        const statuses: readonly GitCheckStatus[] = CHECK_STATUSES;
+        const conclusions: readonly GitCheckConclusion[] = CHECK_CONCLUSIONS;
+        expect(statuses).toHaveLength(4);
+        expect(conclusions).toHaveLength(8);
+    });
+
+    it('reads a GitWorkflowRun as a PromotionGateRunReading, with no adapter in between', () => {
+        // The structural claim `promotion-gate.types.ts` makes. If either
+        // side renamed or re-typed `status` / `conclusion`, this stops
+        // compiling — and the lane would otherwise have read every gate as
+        // `unreadable` with no test failing.
+        const run: GitWorkflowRun = {
+            id: 1001,
+            workflowPath: '.github/workflows/promotion-gate.yml',
+            headSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+            status: 'completed',
+            conclusion: 'success',
+        };
+        const reading: PromotionGateRunReading = run;
+        expect(promotionGateVerdictFromRun(reading)).toBe('success');
+    });
+
+    it.each(CHECK_STATUSES.filter((status) => status !== 'completed'))(
+        'maps the non-terminal status %s to pending',
+        (status) => {
+            const run: GitWorkflowRun = { ...RUN, status, conclusion: null };
+            expect(promotionGateVerdictFromRun(run)).toBe('pending');
+        },
+    );
+
+    it.each([
+        ['success', 'success'],
+        ['failure', 'failure'],
+        ['timed_out', 'failure'],
+        ['action_required', 'failure'],
+        ['cancelled', 'cancelled'],
+        ['neutral', 'skipped'],
+        ['skipped', 'skipped'],
+        ['stale', 'skipped'],
+    ] as ReadonlyArray<readonly [GitCheckConclusion, PromotionGateVerdict]>)(
+        'maps the completed conclusion %s to %s',
+        (conclusion, expected) => {
+            // EVERY member of `GitCheckConclusion`, so a new one added to
+            // the provider vocabulary without a verdict here is caught by
+            // the exhaustiveness assertion above rather than silently
+            // becoming `unreadable` in production.
+            const run: GitWorkflowRun = { ...RUN, status: 'completed', conclusion };
+            expect(promotionGateVerdictFromRun(run)).toBe(expected);
+        },
+    );
+
+    it('covers every conclusion the provider vocabulary defines', () => {
+        const mapped = [
+            'success',
+            'failure',
+            'timed_out',
+            'action_required',
+            'cancelled',
+            'neutral',
+            'skipped',
+            'stale',
+        ];
+        expect([...CHECK_CONCLUSIONS].sort()).toEqual([...mapped].sort());
+    });
+});

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -33,6 +33,8 @@ import type {
     GitDiffOptions,
     GitDiffResult,
     GitPullRequestStatus,
+    // Release promotion lane (self-build slice AI, EW-808).
+    GitWorkflowRun,
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
@@ -226,8 +228,32 @@ export interface AgentMergeActor {
      * looks it up through the provider. If it still cannot be determined
      * and the policy protects any branch, the merge is REFUSED rather than
      * performed blind.
+     *
+     * MUST be the branch this pull request actually merges into. Passing
+     * a Work-level default here (the caller's usual base) makes the
+     * protected-branch rule evaluate a branch that is not being merged
+     * into — see the release promotion lane, whose pull requests are the
+     * first on this platform whose base is not `taskIsolationBaseBranch`.
      */
     targetBranch?: string | null;
+    /**
+     * Release promotion lane (self-build slice AI, EW-808) — a caller-side
+     * RAISE of the approval requirement.
+     *
+     * One direction only, enforced at the read: `true` forces the approval
+     * gate on even where the resolved policy sets `requireHumanApproval:
+     * false`; `false` / omitted changes nothing. A caller can therefore
+     * never lower the bar, only insist on a higher one.
+     *
+     * It exists because "an operator turned approvals off for this scope"
+     * must not extend to a release promotion. A promotion moves a whole
+     * batch onto `stage` or into production off a build lane measured at
+     * 215-243 minutes, and this slice's whole premise is that a human
+     * reads the gate verdict and decides. `TaskMergeGateService` sets it
+     * for promotions, and it is asserted HERE too so the property does not
+     * depend on one caller remembering.
+     */
+    requireHumanApproval?: boolean;
 }
 
 export type { GitProviderInfo };
@@ -926,7 +952,13 @@ export class GitFacadeService implements IGitFacade {
         if (typeof this.mergePolicy.resolve === 'function') {
             try {
                 const resolved = await this.mergePolicy.resolve(scope);
-                requiresApproval = resolved.policy.requireHumanApproval;
+                // OR, never assignment: `agentActor.requireHumanApproval`
+                // can only RAISE the bar (release promotion lane, slice
+                // AI). A caller that could clear it would be able to
+                // answer the question the gate exists to ask.
+                requiresApproval =
+                    resolved.policy.requireHumanApproval ||
+                    agentActor.requireHumanApproval === true;
                 policySource = resolved.source;
             } catch (error) {
                 this.logger.warn(
@@ -1246,6 +1278,46 @@ export class GitFacadeService implements IGitFacade {
             throw new GitOperationNotSupportedError('getPullRequestDiff', plugin.id);
         }
         return impl.call(plugin, owner, repo, prNumber, diffOptions, token);
+    }
+
+    // ── Release promotion lane (self-build slice AI, EW-808) ──────────
+
+    /**
+     * The verdict of ONE named workflow file for ONE commit.
+     *
+     * Separate from `getPullRequestStatus` on purpose. That read rolls up
+     * every check on the head commit and treats `skipped` / `cancelled` /
+     * `neutral` / `stale` as non-blocking, which is right for the board's
+     * dot and wrong for a release gate — `promotion-gate.yml` SKIPS its
+     * e2e job by design on any head that is not `stage`, and a skipped job
+     * renders green. It also cannot answer "did the gate run at all?",
+     * because the `checks[]` it returns is a capped sample.
+     *
+     * Three outcomes, all distinct and all meaningful to the caller:
+     *   - a run          → the caller maps its status/conclusion to a verdict;
+     *   - `null`         → the workflow has no run for this commit;
+     *   - a THROW        → the lookup is broken (no capability, no scope,
+     *                      provider down). Never collapsed into `null`.
+     *
+     * The promotion lane refuses on all three except an explicit success,
+     * but it tells the operator a different story for each.
+     */
+    async getWorkflowRunForCommit(
+        owner: string,
+        repo: string,
+        workflowPath: string,
+        headSha: string,
+        options: GitFacadeOptions,
+    ): Promise<GitWorkflowRun | null> {
+        const { plugin, token } = await this.resolvePluginAndToken(options);
+        // The lazy-plugin proxy over-reports optional methods, so the
+        // method is materialised off the resolved plugin before it is
+        // called (same rule as the PR-insights reads above).
+        const impl = plugin.getWorkflowRunForCommit;
+        if (typeof impl !== 'function') {
+            throw new GitOperationNotSupportedError('getWorkflowRunForCommit', plugin.id);
+        }
+        return impl.call(plugin, owner, repo, workflowPath, headSha, token);
     }
 
     /** Same, for a pushed branch that has not opened a PR yet. */

--- a/packages/agent/src/policy/index.ts
+++ b/packages/agent/src/policy/index.ts
@@ -8,6 +8,10 @@ export * from './merge-policy.enforcer';
 // Merge approval (self-build slice AE) — token + contract for the
 // "is there a real, current, human approval for this merge?" question.
 export * from './merge-approval.port';
+// Release promotion lane (self-build slice AI) — token + contract for the
+// extra refusal a promotion pull request carries on top of slice AE. It
+// can only ever say NO.
+export * from './promotion-merge-guard.port';
 export * from './merge-policy.repository';
 export * from './merge-policy.service';
 // Quality gates — the PR gate every non-worker `createPullRequest` caller

--- a/packages/agent/src/policy/promotion-merge-guard.port.ts
+++ b/packages/agent/src/policy/promotion-merge-guard.port.ts
@@ -1,0 +1,167 @@
+import type { GitPullRequestStatus } from '@ever-works/plugin';
+import type { Task } from '../entities/task.entity';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the NARROWING
+ * the merge gate applies to a promotion pull request.
+ *
+ * ## What this is for
+ *
+ * Slice AE made every agent merge go through one path: green provider CI,
+ * a `merge_pull_request` Inbox approval decided by an entitled human, and
+ * a re-verification against the live head at merge time. A promotion pull
+ * request goes through exactly that path — this port does not replace any
+ * of it and cannot satisfy any of it.
+ *
+ * What it adds is one extra refusal, because the CI roll-up AE consults
+ * cannot answer the question a release gate asks. `deriveCiState` treats
+ * `skipped`, `cancelled`, `neutral` and `stale` as non-blocking, and
+ * `promotion-gate.yml` SKIPS its e2e job by design on any head that is not
+ * `stage`. So a promotion whose gate never evaluated rolls up `passing`,
+ * and without this port the merge gate would raise a human approval on a
+ * green badge the platform manufactured.
+ *
+ * ## Direction of travel
+ *
+ * This port can only ever say NO. There is no verdict here that permits a
+ * merge the ordinary path would refuse, and `{ promotion: false }` — "not
+ * a promotion" — leaves the ordinary path exactly as it was.
+ *
+ * ## Unbound means NO for a promotion
+ *
+ * Deliberately inverting the usual `@Optional()` convention, the same way
+ * `MERGE_APPROVAL_VERIFIER` does: a deployment that cannot evaluate
+ * promotions must not merge them through the ordinary agent path. The
+ * merge gate detects that case off the Task's own labels (which it has
+ * already loaded) and stands down, so the refusal does not depend on the
+ * very service that is missing.
+ */
+
+/** What the merge gate knows about the Task it is considering. */
+export interface PromotionMergeSubject {
+    readonly taskId: string;
+    /**
+     * The Task's labels.
+     *
+     * A HINT, not the identity. Labels are free-form and any owner can
+     * rewrite them through `PATCH /api/tasks/:id`, so an implementation
+     * that decided "is this a promotion?" off them alone would let a
+     * single request disarm the gate on a live release pull request. The
+     * authority is the promotion row keyed by `taskId`; these are used to
+     * fail CLOSED when no row resolves, and by the merge gate itself to
+     * stand down when no guard is bound at all.
+     */
+    readonly labels: readonly string[] | null | undefined;
+    /**
+     * The pull request the merge gate is about to act on.
+     *
+     * Carried so the guard can refuse when it is not the pull request the
+     * promotion opened. The two CAN diverge — an agent run on the
+     * promotion Task overwrites `tasks.prNumber` with its own pull
+     * request — and a verdict about one pull request must never authorise
+     * a merge of another.
+     */
+    readonly prNumber: number;
+    /**
+     * The head commit as read from the provider MOMENTS AGO — not from a
+     * cache, and not from the caller's memory of what it pushed. The
+     * recorded gate verdict is compared against THIS.
+     */
+    readonly headSha: string;
+}
+
+/** Why a promotion may not be merged right now. */
+export type PromotionMergeRefusalCode =
+    /** The Task says it is a promotion but no promotion row resolves. */
+    | 'promotion-row-missing'
+    /** The promotion is merged, closed or refused; nothing left to do. */
+    | 'promotion-not-open'
+    /**
+     * The recorded verdict is for a DIFFERENT commit than the one being
+     * merged. A verdict is about a commit; it is never inherited.
+     */
+    | 'promotion-gate-stale'
+    /**
+     * The gate did not say `success` for this commit. `reason` carries the
+     * actual reading — pending, cancelled, skipped, absent, unreadable or
+     * failure — because the operator's next action differs for each.
+     */
+    | 'promotion-gate-not-success'
+    /**
+     * The pull request the merge gate is holding is not the one this
+     * promotion opened. Reachable when something rebinds `tasks.prNumber`
+     * — an agent run on the promotion Task does exactly that — and the
+     * recorded verdict is then about a pull request nobody is merging.
+     */
+    | 'promotion-pull-request-mismatch';
+
+export type PromotionMergeVerdict =
+    /** Not a promotion Task. The ordinary merge path is unchanged. */
+    | { readonly promotion: false }
+    /**
+     * A promotion whose gate said `success` for exactly this commit, on
+     * exactly this pull request.
+     *
+     * Carries the promotion's OWN branches, because the merge path's
+     * default answer to "what is this pull request's base?" is the Work's
+     * `taskIsolationBaseBranch` — right for every Task pull request and
+     * wrong for every promotion. The protected-branch rule and the string
+     * the approving human reads are both computed from it.
+     */
+    | {
+          readonly promotion: true;
+          readonly allowed: true;
+          readonly promotionId: string;
+          readonly headBranch: string;
+          readonly baseBranch: string;
+          readonly prNumber: number;
+      }
+    /** A promotion that may not be merged. */
+    | {
+          readonly promotion: true;
+          readonly allowed: false;
+          readonly promotionId?: string;
+          readonly code: PromotionMergeRefusalCode;
+          readonly reason: string;
+      };
+
+export interface PromotionMergeGuard {
+    /**
+     * May this Task's pull request be considered for a merge?
+     *
+     * Implementations MUST NOT throw for "no" — a throw is treated as a
+     * refusal by the caller, but a refusal carries a reason a human can
+     * read and a throw does not.
+     */
+    assessPromotionForMerge(subject: PromotionMergeSubject): Promise<PromotionMergeVerdict>;
+}
+
+/** DI token. Bound by `ReleasePromotionModule`. */
+export const PROMOTION_MERGE_GUARD = 'PROMOTION_MERGE_GUARD' as const;
+
+/**
+ * The other half of the lane: the thing that WATCHES a promotion.
+ *
+ * Split from the guard because they have different callers and very
+ * different postures. The watcher runs on every PR-status refresh
+ * regardless of what CI says — a promotion has to be legible even when it
+ * can never merge — and it is best-effort by contract. The guard is
+ * consulted only at the merge decision and can only ever refuse.
+ *
+ * Both are tokens rather than concrete classes for the same reason
+ * `INBOX_PRODUCER` is: the implementation lives in a module that imports
+ * `TasksDomainModule` (it files Tasks), so `TasksDomainModule` cannot
+ * import it back. A `@Global()` binding at the app root closes the loop
+ * without a cycle.
+ */
+export interface PromotionLaneWatcher {
+    /**
+     * Called after every successful provider read for a Task, with the
+     * LIVE status. Implementations MUST NOT throw: the caller's job is to
+     * keep a PR-status cache honest for every Task behind this one.
+     */
+    onPullRequestStatusRefreshed(task: Task, status: GitPullRequestStatus): Promise<unknown>;
+}
+
+/** DI token. Bound by `ReleasePromotionModule`. */
+export const PROMOTION_LANE_WATCHER = 'PROMOTION_LANE_WATCHER' as const;

--- a/packages/agent/src/tasks-domain/__tests__/release-promotion.module.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/release-promotion.module.spec.ts
@@ -1,0 +1,219 @@
+import { Global, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReleasePromotionRepository } from '@src/database/repositories/release-promotion.repository';
+import {
+    PROMOTION_LANE_WATCHER,
+    PROMOTION_MERGE_GUARD,
+} from '@src/policy/promotion-merge-guard.port';
+import { ENTITIES } from '@src/database/database.config';
+import { PluginRegistryService } from '@src/plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '@src/plugins/services/plugin-settings.service';
+import { PluginUsageService } from '@src/usage/plugin-usage.service';
+import { BudgetGuardService } from '@src/budgets/budget-guard.service';
+import { WorkPluginRepository } from '@src/plugins/repositories/work-plugin.repository';
+import { WorkCustomDomainRepository } from '@src/database/repositories/work-custom-domain.repository';
+import { EverWorksK8sDeployProvider } from '@src/ever-works-providers/ever-works-k8s-deploy.provider';
+import { ReleasePromotionModule } from '../release-promotion.module';
+import { ReleasePromotionService } from '../release-promotion.service';
+import { TasksDomainModule } from '../tasks.module';
+
+/**
+ * The promotion lane's wiring, against a REAL Nest container compiling the
+ * REAL `ReleasePromotionModule`.
+ *
+ * This exists because of the failure mode this repo has now paid for
+ * twice: `_repository-inventory.ts` is NOT "every repository". Several are
+ * deliberately absent, and a module that injects one it did not provide
+ * passes every unit spec — the service's own spec constructs it
+ * positionally, which proves the logic and says nothing about wiring — and
+ * then the API refuses to boot.
+ *
+ * ## Why the module itself, and not a replica of its provider list
+ *
+ * An earlier version of this file hand-copied the module's providers into
+ * `Test.createTestingModule` and asserted THAT compiled. It proved
+ * nothing about the module: deleting
+ * `TypeOrmModule.forFeature([ReleasePromotion])` — the only thing
+ * providing the `Repository<ReleasePromotion>` token that
+ * `ReleasePromotionRepository` injects, and therefore an API that cannot
+ * boot — left the whole suite green, because the replica supplied its own
+ * `forFeature` and the metadata block only checked `imports.map(e =>
+ * e?.name)`, which is `undefined` for every dynamic module.
+ *
+ * So the module is imported for real. `ReleasePromotionModule` pulls in
+ * `TasksDomainModule` and `FacadesModule`, whose graph reaches a handful
+ * of providers that the API supplies from its ROOT rather than from any of
+ * these modules; those — and only those — are stubbed through a `@Global()`
+ * module below, which is the same shape the real application uses. Nothing
+ * the promotion lane actually depends on is stubbed: the repository, the
+ * entity registration, `TasksService`, `GitFacadeService` and the two
+ * token bindings all come from the real graph.
+ *
+ * MUTATION CHECK, executed rather than assumed, against this file:
+ *
+ *   - deleting `TypeOrmModule.forFeature([ReleasePromotion])` from the
+ *     module fails with "Nest can't resolve dependencies of the
+ *     ReleasePromotionRepository (?)";
+ *   - deleting `ReleasePromotionRepository` from the module's `providers`
+ *     fails to compile as well.
+ *
+ * Both used to pass.
+ */
+
+/**
+ * The app-root providers `FacadesModule`'s graph expects to find in the
+ * global scope. In the running API they come from the root module; here
+ * they are inert, because nothing under test calls them.
+ */
+const APP_ROOT_PROVIDERS = [
+    PluginRegistryService,
+    PluginSettingsService,
+    PluginUsageService,
+    BudgetGuardService,
+    WorkPluginRepository,
+    WorkCustomDomainRepository,
+    EverWorksK8sDeployProvider,
+];
+
+@Global()
+@Module({
+    providers: APP_ROOT_PROVIDERS.map((token) => ({ provide: token, useValue: {} })),
+    exports: APP_ROOT_PROVIDERS,
+})
+class AppRootStubModule {}
+
+describe('ReleasePromotionModule — dependency injection', () => {
+    async function compile() {
+        return Test.createTestingModule({
+            imports: [
+                AppRootStubModule,
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                }),
+                ReleasePromotionModule,
+            ],
+        }).compile();
+    }
+
+    it('compiles the REAL module and resolves the service and BOTH tokens to one instance', async () => {
+        const moduleRef = await compile();
+
+        const service = moduleRef.get(ReleasePromotionService);
+        expect(service).toBeInstanceOf(ReleasePromotionService);
+        // ONE instance behind both tokens, and that matters: the guard
+        // reads state the watcher wrote.
+        expect(moduleRef.get(PROMOTION_MERGE_GUARD)).toBe(service);
+        expect(moduleRef.get(PROMOTION_LANE_WATCHER)).toBe(service);
+
+        await moduleRef.close();
+    });
+
+    it('registers the entity with the DataSource, so the first query does not throw', async () => {
+        // A forFeature'd-but-uninventoried entity throws
+        // EntityMetadataNotFoundError on the FIRST query, not at compile —
+        // so compiling is not enough, something has to ask.
+        const moduleRef = await compile();
+
+        const promotions = moduleRef.get(ReleasePromotionRepository);
+        await expect(promotions.findOpenForLane('work-1', 'develop-to-stage')).resolves.toBeNull();
+        await expect(promotions.findOpenByTaskId('task-1')).resolves.toBeNull();
+
+        await moduleRef.close();
+    });
+
+    it('exposes the lane to the rest of the app without TasksDomainModule importing it back', async () => {
+        // The whole point of the @Global() binding: `TaskPrStatusService`
+        // and `TaskMergeGateService` live INSIDE `TasksDomainModule` and
+        // inject the two tokens `@Optional()`. If the binding were not
+        // global, they would resolve to `undefined` and the lane would be
+        // silently inert — which fails closed for merges but also means no
+        // promotion is ever watched.
+        const moduleRef = await compile();
+
+        const fromTasksDomain = moduleRef.select(TasksDomainModule);
+        expect(fromTasksDomain.get(PROMOTION_MERGE_GUARD, { strict: false })).toBe(
+            moduleRef.get(ReleasePromotionService),
+        );
+
+        await moduleRef.close();
+    });
+});
+
+describe('ReleasePromotionModule — module shape', () => {
+    const imports = () => Reflect.getMetadata('imports', ReleasePromotionModule) ?? [];
+    const providers = () => Reflect.getMetadata('providers', ReleasePromotionModule) ?? [];
+    const exports_ = () => Reflect.getMetadata('exports', ReleasePromotionModule) ?? [];
+
+    it('is @Global(), which is what lets TasksDomainModule consume the tokens without a cycle', () => {
+        // `ReleasePromotionService` files a Task, so it imports
+        // `TasksDomainModule`. Two services INSIDE that module need it
+        // back. A module cycle is a boot failure, so the consumers inject
+        // TOKENS and a @Global() binding closes the loop — the same shape
+        // `INBOX_PRODUCER` already uses.
+        expect(Reflect.getMetadata('__module:global__', ReleasePromotionModule)).toBe(true);
+    });
+
+    it('imports the modules that own its cross-module collaborators', () => {
+        const names = imports().map((entry: { name?: string }) => entry?.name);
+        // TasksService (files the Task) + TaskRepository / WorkRepository /
+        // TaskChatMessageRepository.
+        expect(names).toContain(TasksDomainModule.name);
+        // GitFacadeService (opens the PR, reads branch tips and the gate).
+        expect(names).toContain('FacadesModule');
+    });
+
+    it('registers its own entity with forFeature', () => {
+        // A dynamic module has no `.name`, so the check above cannot see
+        // it. Named explicitly because dropping it is an API that does not
+        // boot — the DI test above is the real guard, this one names the
+        // line so the failure reads clearly.
+        const dynamic = imports().filter(
+            (entry: { module?: unknown; name?: string }) =>
+                typeof entry === 'object' && entry !== null && 'module' in entry,
+        );
+        expect(dynamic.length).toBeGreaterThan(0);
+    });
+
+    it('provides its own feature repository rather than expecting DatabaseModule to', () => {
+        // `_repository-inventory.ts` is the DatabaseModule-owned set.
+        // Adding a feature repository to it would export it to the whole
+        // platform for the benefit of one module.
+        expect(providers()).toContain(ReleasePromotionRepository);
+        expect(providers()).toContain(ReleasePromotionService);
+    });
+
+    it('binds both tokens with useExisting, so consumers depend on the contract', () => {
+        const bindings = providers().filter(
+            (entry: { provide?: unknown }) => typeof entry === 'object' && entry?.provide,
+        );
+        const guard = bindings.find(
+            (entry: { provide: unknown }) => entry.provide === PROMOTION_MERGE_GUARD,
+        );
+        const watcher = bindings.find(
+            (entry: { provide: unknown }) => entry.provide === PROMOTION_LANE_WATCHER,
+        );
+        expect(guard).toEqual({
+            provide: PROMOTION_MERGE_GUARD,
+            useExisting: ReleasePromotionService,
+        });
+        expect(watcher).toEqual({
+            provide: PROMOTION_LANE_WATCHER,
+            useExisting: ReleasePromotionService,
+        });
+    });
+
+    it('exports the service and both tokens', () => {
+        expect(exports_()).toEqual(
+            expect.arrayContaining([
+                ReleasePromotionRepository,
+                ReleasePromotionService,
+                PROMOTION_MERGE_GUARD,
+                PROMOTION_LANE_WATCHER,
+            ]),
+        );
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/release-promotion.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/release-promotion.service.spec.ts
@@ -1,0 +1,1593 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DataSource, Repository } from 'typeorm';
+import type { GitPullRequestStatus } from '@ever-works/plugin';
+import {
+    PROMOTION_GATE_DECISION_GRACE_MS,
+    PROMOTION_GATE_OVERRIDE_LABEL,
+    PROMOTION_TASK_LABEL,
+} from '@ever-works/contracts';
+import { ReleasePromotion } from '@src/entities/release-promotion.entity';
+import { ReleasePromotionRepository } from '@src/database/repositories/release-promotion.repository';
+import { TaskStatus } from '@src/entities/task.entity';
+import { ReleasePromotionService } from '../release-promotion.service';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808).
+ *
+ * The REAL `ReleasePromotionRepository` over a real (in-memory sqlite)
+ * `release_promotions` table, so the UNIQUE `(workId, rung, laneKey)`
+ * index — the whole anti-duplicate guarantee — is exercised rather than
+ * mocked. Only the things at the edges of the process are stubbed: the git
+ * provider, the Task writer and the Inbox.
+ *
+ * What this file is mostly about is REFUSALS. The happy path is three
+ * tests; everything else is a way the lane must say no.
+ */
+describe('ReleasePromotionService', () => {
+    let dataSource: DataSource;
+    let rows: Repository<ReleasePromotion>;
+    let promotions: ReleasePromotionRepository;
+
+    const USER = 'user-1';
+    const WORK = 'work-1';
+    const AGENT = 'agent-1';
+    const HEAD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const NEXT_HEAD = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    const LADDER = { integration: 'develop', staging: 'stage', production: 'main' };
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [ReleasePromotion],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        rows = dataSource.getRepository(ReleasePromotion);
+        promotions = new ReleasePromotionRepository(rows);
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    beforeEach(async () => {
+        await rows.clear();
+    });
+
+    // ── Harness ───────────────────────────────────────────────────────
+
+    function makeWork(overrides: Record<string, unknown> = {}) {
+        return {
+            id: WORK,
+            slug: 'ever-works',
+            userId: USER,
+            gitProvider: 'github',
+            tenantId: null,
+            organizationId: null,
+            releaseLadder: LADDER,
+            getRepoOwner: () => 'ever-works',
+            getDataRepo: () => 'ever-works',
+            ...overrides,
+        };
+    }
+
+    function makeTask(overrides: Record<string, unknown> = {}) {
+        return {
+            id: 'task-1',
+            slug: 'T-7',
+            userId: USER,
+            agentId: AGENT,
+            workId: WORK,
+            labels: [PROMOTION_TASK_LABEL, 'release:promotion:develop-to-stage'],
+            tenantId: null,
+            organizationId: null,
+            prNumber: 42,
+            ...overrides,
+        };
+    }
+
+    function build(
+        opts: {
+            work?: Record<string, unknown> | null;
+            branches?: Array<{ name: string; commit: string }>;
+            pullRequest?: Record<string, unknown>;
+            livePullRequest?: Record<string, unknown> | null;
+            workflowRun?: Record<string, unknown> | null;
+            createPullRequestError?: Error;
+            listBranchesError?: Error;
+            workflowRunError?: Error;
+            noGitFacade?: boolean;
+            noInbox?: boolean;
+            createTaskError?: Error;
+            /** Pull requests already open on the provider, for the ADOPT path. */
+            openPullRequests?: Array<Record<string, unknown>>;
+            /** What `getPullRequestStatus` reports as the pull request's own head. */
+            confirmedHead?: string | null;
+            /** Make the writes that BIND the pull request to the Task fail. */
+            bindError?: Error;
+        } = {},
+    ) {
+        const created = makeTask();
+        const works = {
+            findById: jest.fn().mockResolvedValue(opts.work === null ? null : makeWork(opts.work)),
+        };
+        const tasks = {
+            updateById: opts.bindError
+                ? jest.fn().mockImplementation((_id: string, patch: Record<string, unknown>) =>
+                      // Only the PR binding fails; the CANCELLED write that
+                      // follows must still work, or the test would be
+                      // asserting two failures at once.
+                      'prNumber' in patch
+                          ? Promise.reject(opts.bindError)
+                          : Promise.resolve(undefined),
+                  )
+                : jest.fn().mockResolvedValue(undefined),
+        };
+        const tasksService = {
+            create: opts.createTaskError
+                ? jest.fn().mockRejectedValue(opts.createTaskError)
+                : jest.fn().mockResolvedValue(created),
+        };
+        const chat = { create: jest.fn().mockResolvedValue(undefined) };
+        const gitFacade = {
+            listBranches: opts.listBranchesError
+                ? jest.fn().mockRejectedValue(opts.listBranchesError)
+                : jest.fn().mockResolvedValue(
+                      opts.branches ?? [
+                          { name: 'develop', commit: HEAD, isDefault: true },
+                          {
+                              name: 'stage',
+                              commit: 'cccccccccccccccccccccccccccccccccccccccc',
+                              isDefault: false,
+                          },
+                          {
+                              name: 'main',
+                              commit: 'dddddddddddddddddddddddddddddddddddddddd',
+                              isDefault: false,
+                          },
+                      ],
+                  ),
+            createPullRequest: opts.createPullRequestError
+                ? jest.fn().mockRejectedValue(opts.createPullRequestError)
+                : jest.fn().mockImplementation((prOptions: { head: string; base: string }) => ({
+                      number: 42,
+                      url: 'https://github.com/ever-works/ever-works/pull/42',
+                      // A well-behaved provider echoes what it was asked
+                      // for. `opts.pullRequest` is how a test makes it
+                      // misbehave.
+                      head: prOptions.head,
+                      base: prOptions.base,
+                      state: 'open',
+                      title: `release: ${prOptions.head} -> ${prOptions.base}`,
+                      createdAt: '',
+                      updatedAt: '',
+                      ...opts.pullRequest,
+                  })),
+            getPullRequest: jest.fn().mockResolvedValue(
+                opts.livePullRequest === null
+                    ? null
+                    : {
+                          number: 42,
+                          head: 'develop',
+                          base: 'stage',
+                          state: 'open',
+                          labels: [],
+                          ...opts.livePullRequest,
+                      },
+            ),
+            // The ADOPT path: what is already open on the provider.
+            listPullRequests: jest.fn().mockResolvedValue(opts.openPullRequests ?? []),
+            // `GitPullRequest` carries no head SHA; this read is what
+            // confirms the commit the pull request actually heads.
+            getPullRequestStatus: jest.fn().mockResolvedValue(
+                opts.confirmedHead === null
+                    ? null
+                    : {
+                          number: 42,
+                          state: 'open',
+                          headSha: opts.confirmedHead ?? HEAD,
+                      },
+            ),
+            getWorkflowRunForCommit: opts.workflowRunError
+                ? jest.fn().mockRejectedValue(opts.workflowRunError)
+                : jest.fn().mockResolvedValue(opts.workflowRun ?? null),
+        };
+        const inbox = { notice: jest.fn().mockResolvedValue(undefined) };
+
+        const service = new ReleasePromotionService(
+            works as never,
+            tasks as never,
+            promotions,
+            tasksService as never,
+            chat as never,
+            opts.noGitFacade ? undefined : (gitFacade as never),
+            opts.noInbox ? undefined : (inbox as never),
+        );
+        return { service, works, tasks, tasksService, chat, gitFacade, inbox, created };
+    }
+
+    function status(overrides: Partial<GitPullRequestStatus> = {}): GitPullRequestStatus {
+        return {
+            number: 42,
+            state: 'open',
+            merged: false,
+            mergeable: true,
+            headSha: HEAD,
+            reviewDecision: null,
+            ciState: 'passing',
+            checks: [],
+            checksComplete: true,
+            url: 'https://github.com/ever-works/ever-works/pull/42',
+            title: 'release: develop -> stage',
+            ...overrides,
+        } as GitPullRequestStatus;
+    }
+
+    // ── Opening ───────────────────────────────────────────────────────
+
+    describe('openPromotion', () => {
+        it('opens the pull request the LADDER names, not one the caller does', async () => {
+            const { service, gitFacade } = build();
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+
+            expect(result.outcome).toBe('opened');
+            expect(gitFacade.createPullRequest).toHaveBeenCalledTimes(1);
+            const [prOptions] = gitFacade.createPullRequest.mock.calls[0];
+            expect(prOptions).toMatchObject({
+                owner: 'ever-works',
+                repo: 'ever-works',
+                head: 'develop',
+                base: 'stage',
+            });
+        });
+
+        it('resolves the other rung off the same ladder', async () => {
+            const { service, gitFacade } = build();
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'stage-to-main',
+                agentId: AGENT,
+            });
+            expect(gitFacade.createPullRequest.mock.calls[0][0]).toMatchObject({
+                head: 'stage',
+                base: 'main',
+            });
+        });
+
+        it('files the Task IN_REVIEW so the TODO fan-out can never dispatch a run against it', async () => {
+            const { service, tasksService } = build();
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const [, input] = tasksService.create.mock.calls[0];
+            expect(input.status).toBe(TaskStatus.IN_REVIEW);
+            expect(input.labels).toContain(PROMOTION_TASK_LABEL);
+            expect(input.workId).toBe(WORK);
+            expect(input.agentId).toBe(AGENT);
+        });
+
+        it('binds the pull request to the Task, which is what puts it on the slice-AE merge path', async () => {
+            const { service, tasks } = build();
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(tasks.updateById).toHaveBeenCalledWith('task-1', {
+                prNumber: 42,
+                prUrl: 'https://github.com/ever-works/ever-works/pull/42',
+            });
+        });
+
+        it('NEVER writes the release branch into task.branchRef — that slot is the branch reaper’s', async () => {
+            // `branchRef` is what `discardBranch` (DELETE
+            // /api/tasks/:id/branch) and the nightly
+            // `findBranchCleanupCandidates` sweep hand to
+            // `gitFacade.deleteBranch`, and what `runWorkspace` provisions
+            // an agent run onto. Writing `develop` there aimed the branch
+            // reaper at the integration branch and let a run push straight
+            // to it with no pull request. A promotion owns no branch: it
+            // moves two that already exist.
+            const { service, tasks } = build();
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            for (const [, patch] of tasks.updateById.mock.calls) {
+                expect(patch).not.toHaveProperty('branchRef');
+                expect(patch).not.toHaveProperty('branchState');
+            }
+            // And the row therefore cannot match the GC query, whose first
+            // clause is `task.branchRef IS NOT NULL`.
+            const written = tasks.updateById.mock.calls.map(
+                ([, patch]: [string, Record<string, unknown>]) => patch.branchRef,
+            );
+            expect(written.some((value: unknown) => value === 'develop')).toBe(false);
+        });
+
+        it('records the head it opened at', async () => {
+            const { service } = build();
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const stored = await rows.findOne({
+                where: { id: (result as { promotion: ReleasePromotion }).promotion.id },
+            });
+            expect(stored?.headSha).toBe(HEAD);
+            expect(stored?.headBranch).toBe('develop');
+            expect(stored?.baseBranch).toBe('stage');
+            expect(stored?.state).toBe('open');
+        });
+
+        // ── Duplicates and races ──────────────────────────────────────
+
+        it('refuses a SECOND promotion for the same rung — a re-run does not duplicate one', async () => {
+            const { service, gitFacade } = build();
+            const first = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const second = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+
+            expect(first.outcome).toBe('opened');
+            expect(second.outcome).toBe('already-open');
+            expect((second as { promotion: ReleasePromotion }).promotion.id).toBe(
+                (first as { promotion: ReleasePromotion }).promotion.id,
+            );
+            // The load-bearing assertion: no second pull request.
+            expect(gitFacade.createPullRequest).toHaveBeenCalledTimes(1);
+        });
+
+        it('opens ONE pull request when two merges to develop race', async () => {
+            // Two callers, two service instances, one database — the shape
+            // of the cron worker racing an operator. Only the UNIQUE index
+            // can decide this; a read-then-write would open two.
+            const a = build();
+            const b = build({
+                branches: [
+                    { name: 'develop', commit: NEXT_HEAD },
+                    { name: 'stage', commit: HEAD },
+                ],
+            });
+            const [first, second] = await Promise.all([
+                a.service.openPromotion({
+                    userId: USER,
+                    workId: WORK,
+                    rung: 'develop-to-stage',
+                    agentId: AGENT,
+                }),
+                b.service.openPromotion({
+                    userId: USER,
+                    workId: WORK,
+                    rung: 'develop-to-stage',
+                    agentId: AGENT,
+                }),
+            ]);
+
+            const outcomes = [first.outcome, second.outcome].sort();
+            expect(outcomes).toEqual(['already-open', 'opened']);
+            const opened =
+                a.gitFacade.createPullRequest.mock.calls.length +
+                b.gitFacade.createPullRequest.mock.calls.length;
+            expect(opened).toBe(1);
+            expect(await rows.count()).toBe(1);
+        });
+
+        it('allows the OTHER rung to be open at the same time', async () => {
+            const { service } = build();
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const other = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'stage-to-main',
+                agentId: AGENT,
+            });
+            expect(other.outcome).toBe('opened');
+        });
+
+        // ── Refusals ──────────────────────────────────────────────────
+
+        it('refuses a Work with no ladder rather than guessing main', async () => {
+            const { service, gitFacade } = build({ work: { releaseLadder: null } });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'stage-to-main',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'ladder-not-configured' });
+            expect(gitFacade.createPullRequest).not.toHaveBeenCalled();
+            expect(await rows.count()).toBe(0);
+        });
+
+        it('refuses a ladder that is not three distinct plain branch names', async () => {
+            for (const ladder of [
+                { integration: 'develop', staging: 'develop', production: 'main' },
+                { integration: '../evil', staging: 'stage', production: 'main' },
+                { integration: 'develop', staging: 'stage' },
+            ]) {
+                const { service } = build({ work: { releaseLadder: ladder } });
+                const result = await service.openPromotion({
+                    userId: USER,
+                    workId: WORK,
+                    rung: 'develop-to-stage',
+                    agentId: AGENT,
+                });
+                expect(result).toMatchObject({ outcome: 'refused', code: 'ladder-not-configured' });
+            }
+            expect(await rows.count()).toBe(0);
+        });
+
+        it('refuses a Work owned by somebody else, with the same words as a missing one', async () => {
+            const { service } = build({ work: { userId: 'someone-else' } });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'work-not-found' });
+        });
+
+        it('refuses when the head branch does not exist', async () => {
+            const { service, gitFacade } = build({ branches: [{ name: 'stage', commit: HEAD }] });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'head-branch-missing' });
+            expect(gitFacade.createPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('refuses when the base branch does not exist', async () => {
+            const { service } = build({ branches: [{ name: 'develop', commit: HEAD }] });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'base-branch-missing' });
+        });
+
+        it('refuses when the head commit cannot be read', async () => {
+            const { service } = build({
+                branches: [
+                    { name: 'develop', commit: 'not-a-sha' },
+                    { name: 'stage', commit: HEAD },
+                ],
+            });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'head-sha-unknown' });
+        });
+
+        it('refuses when the branch listing itself fails, and claims no lane', async () => {
+            const { service } = build({ listBranchesError: new Error('403 no scope') });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'head-sha-unknown' });
+            expect(await rows.count()).toBe(0);
+        });
+
+        it('refuses when no git provider is wired', async () => {
+            const { service } = build({ noGitFacade: true });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'no-git-provider' });
+        });
+
+        it('frees the lane when the pull request could not be opened', async () => {
+            const { service } = build({
+                createPullRequestError: new Error('422 no commits between'),
+            });
+            const first = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(first).toMatchObject({ outcome: 'refused', code: 'pull-request-failed' });
+            // A failed attempt must not hold the lane hostage.
+            const retry = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(retry.outcome).toBe('refused');
+            const stored = await rows.find();
+            expect(stored.every((row) => row.state === 'refused')).toBe(true);
+        });
+
+        it('leaves NO promotion-labelled Task behind when the pull request could not be opened', async () => {
+            // The Task is filed before the pull request exists (the pull
+            // request body names it). A failure used to leave it in
+            // `in_review` wearing the promotion labels with nothing behind
+            // it — indistinguishable on the board from a real promotion,
+            // and one more per retry.
+            const { service, tasks } = build({
+                createPullRequestError: new Error('422 already exists'),
+            });
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(tasks.updateById).toHaveBeenCalledWith('task-1', {
+                status: TaskStatus.CANCELLED,
+            });
+        });
+
+        // ── Adopting what a human already opened ──────────────────────
+
+        it('ADOPTS the pull request already open for head → base instead of asking for a second', async () => {
+            // The founder performs this promotion by hand today, so an open
+            // `develop -> stage` is the NORMAL state of the world the first
+            // time the lane runs. GitHub answers a second request for the
+            // same pair with a 422.
+            const { service, gitFacade } = build({
+                openPullRequests: [
+                    {
+                        number: 99,
+                        url: 'https://github.com/ever-works/ever-works/pull/99',
+                        head: 'develop',
+                        base: 'stage',
+                        state: 'open',
+                    },
+                ],
+            });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+
+            expect(result.outcome).toBe('opened');
+            expect(gitFacade.createPullRequest).not.toHaveBeenCalled();
+            expect((await rows.find())[0].prNumber).toBe(99);
+        });
+
+        it('does not adopt an open pull request between OTHER branches', async () => {
+            const { service, gitFacade } = build({
+                openPullRequests: [
+                    { number: 99, head: 'feature/x', base: 'stage', state: 'open' },
+                    { number: 98, head: 'develop', base: 'main', state: 'open' },
+                ],
+            });
+            await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(gitFacade.createPullRequest).toHaveBeenCalledTimes(1);
+        });
+
+        // ── The head it claims is the head it has ─────────────────────
+
+        it('records the PULL REQUEST’s head, not the branch tip it read a round trip earlier', async () => {
+            // Two merges to `develop` seconds apart: the tip read before the
+            // lane was claimed is already stale by the time the pull request
+            // exists. Publishing the older commit names something that is
+            // not what gets promoted, and costs a spurious "head moved"
+            // report plus a fresh 20-minute grace window on the next sweep.
+            const { service } = build({ confirmedHead: NEXT_HEAD });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const stored = await rows.findOne({
+                where: { id: (result as { promotion: ReleasePromotion }).promotion.id },
+            });
+            expect(stored?.headSha).toBe(NEXT_HEAD);
+        });
+
+        it('falls back to the branch tip when the head cannot be confirmed, and SAYS it did', async () => {
+            const { service, chat } = build({ confirmedHead: null });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            const stored = await rows.findOne({
+                where: { id: (result as { promotion: ReleasePromotion }).promotion.id },
+            });
+            expect(stored?.headSha).toBe(HEAD);
+            expect(chat.create.mock.calls.at(-1)?.[0].body).toMatch(/could not be read back/);
+        });
+
+        it('frees the lane — and adopts on retry — when the pull request opened but could not be recorded', async () => {
+            // The window this used to wedge: a real pull request is open and
+            // the platform cannot watch it, the lane is held by a row with
+            // no `prNumber`, and nothing sweeps such a row.
+            const { service, gitFacade } = build({ bindError: new Error('db gone') });
+            const first = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(first).toMatchObject({ outcome: 'refused', code: 'promotion-not-recorded' });
+            expect((await rows.find()).every((row) => row.state === 'refused')).toBe(true);
+
+            // The lane is free, and a retry that can see the pull request
+            // adopts it rather than opening a second one.
+            const retry = build({
+                openPullRequests: [{ number: 42, head: 'develop', base: 'stage', state: 'open' }],
+            });
+            const second = await retry.service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(second.outcome).toBe('opened');
+            expect(retry.gitFacade.createPullRequest).not.toHaveBeenCalled();
+            expect(gitFacade.createPullRequest).toHaveBeenCalledTimes(1);
+        });
+
+        it('frees the lane when the Task could not be filed', async () => {
+            const { service, gitFacade } = build({
+                createTaskError: new Error('Agent not found.'),
+            });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result.outcome).toBe('refused');
+            expect(gitFacade.createPullRequest).not.toHaveBeenCalled();
+            expect((await rows.find())[0].state).toBe('refused');
+        });
+
+        it('DISOWNS a pull request the provider opened between different branches', async () => {
+            // PROMOTING THE WRONG THING. The provider is the authority on
+            // what it created; if it is not the promotion we asked for, the
+            // lane refuses instead of adopting it.
+            const { service, chat } = build({ pullRequest: { head: 'develop', base: 'main' } });
+            const result = await service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            expect(result).toMatchObject({ outcome: 'refused', code: 'branches-not-as-claimed' });
+            expect((await rows.find())[0].refusalCode).toBe('branches-not-as-claimed');
+            expect(chat.create.mock.calls.at(-1)?.[0].body).toMatch(
+                /NOT managed by this promotion/,
+            );
+        });
+
+        it('accepts a provider head qualified as owner:branch, and refuses a fork head', async () => {
+            const same = build({ pullRequest: { head: 'ever-works:develop', base: 'stage' } });
+            await expect(
+                same.service.openPromotion({
+                    userId: USER,
+                    workId: WORK,
+                    rung: 'develop-to-stage',
+                    agentId: AGENT,
+                }),
+            ).resolves.toMatchObject({ outcome: 'opened' });
+
+            await rows.clear();
+            const fork = build({ pullRequest: { head: 'attacker:develop-x', base: 'stage' } });
+            await expect(
+                fork.service.openPromotion({
+                    userId: USER,
+                    workId: WORK,
+                    rung: 'develop-to-stage',
+                    agentId: AGENT,
+                }),
+            ).resolves.toMatchObject({ outcome: 'refused', code: 'branches-not-as-claimed' });
+        });
+    });
+
+    // ── Watching ──────────────────────────────────────────────────────
+
+    describe('onPullRequestStatusRefreshed', () => {
+        async function openOne(harness: ReturnType<typeof build>) {
+            const result = await harness.service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            return (result as { promotion: ReleasePromotion; task: { id: string } }).promotion;
+        }
+
+        it('ignores a Task that is not a promotion', async () => {
+            const harness = build();
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask({ labels: ['chore'] }) as never,
+                status(),
+            );
+            expect(outcome).toEqual({ action: 'not-a-promotion' });
+            expect(harness.gitFacade.getWorkflowRunForCommit).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['a completed success', { status: 'completed', conclusion: 'success' }, 'success'],
+            ['a running gate', { status: 'in_progress', conclusion: null }, 'pending'],
+            ['a failure', { status: 'completed', conclusion: 'failure' }, 'failure'],
+            ['a cancelled run', { status: 'completed', conclusion: 'cancelled' }, 'cancelled'],
+            ['a skipped run', { status: 'completed', conclusion: 'skipped' }, 'skipped'],
+        ])(
+            'records %s as %s, stamped with the commit it was about',
+            async (_label, run, expected) => {
+                const harness = build({
+                    workflowRun: {
+                        id: 1,
+                        workflowPath: '.github/workflows/promotion-gate.yml',
+                        headSha: HEAD,
+                        ...run,
+                    },
+                });
+                const promotion = await openOne(harness);
+                await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+
+                const stored = await rows.findOne({ where: { id: promotion.id } });
+                expect(stored?.gateVerdict).toBe(expected);
+                expect(stored?.gateVerdictSha).toBe(HEAD);
+            },
+        );
+
+        it('records an ABSENT gate when the workflow has no run for the commit', async () => {
+            const harness = build({ workflowRun: null });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'absent',
+            );
+        });
+
+        it('records an UNREADABLE gate when the lookup throws — a broken gate is not a missing run', async () => {
+            const harness = build({ workflowRunError: new Error('403 actions:read') });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'unreadable',
+            );
+        });
+
+        it('asks the provider for the NAMED workflow and the LIVE head', async () => {
+            const harness = build();
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.gitFacade.getWorkflowRunForCommit).toHaveBeenCalledWith(
+                'ever-works',
+                'ever-works',
+                'promotion-gate.yml',
+                HEAD,
+                expect.objectContaining({ providerId: 'github', workId: WORK }),
+            );
+        });
+
+        it('DROPS a recorded verdict when the head moves', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+            });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'success',
+            );
+
+            // New commit pushed to develop. The gate has not judged it.
+            harness.gitFacade.getWorkflowRunForCommit.mockResolvedValue(null);
+            await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ headSha: NEXT_HEAD }),
+            );
+            const after = await rows.findOne({ where: { id: promotion.id } });
+            expect(after?.headSha).toBe(NEXT_HEAD);
+            expect(after?.gateVerdict).toBe('absent');
+            expect(after?.gateVerdictSha).toBe(NEXT_HEAD);
+        });
+
+        it('REFUSES the promotion when the pull request is no longer between the branches it claims', async () => {
+            const harness = build();
+            const promotion = await openOne(harness);
+            harness.gitFacade.getPullRequest.mockResolvedValue({
+                number: 42,
+                head: 'develop',
+                base: 'main',
+                state: 'open',
+            });
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status(),
+            );
+            expect(outcome).toEqual({ action: 'refused', code: 'branches-moved' });
+            const stored = await rows.findOne({ where: { id: promotion.id } });
+            expect(stored?.state).toBe('refused');
+            expect(stored?.refusalCode).toBe('branches-moved');
+        });
+
+        it('records UNREADABLE when the pull request cannot be re-read, rather than trusting the cache', async () => {
+            const harness = build({ livePullRequest: null });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'unreadable',
+            );
+        });
+
+        it('never throws — a provider hiccup must not fail the PR-status sweep', async () => {
+            const harness = build();
+            await openOne(harness);
+            harness.gitFacade.getPullRequest.mockRejectedValue(new Error('socket hang up'));
+            await expect(
+                harness.service.onPullRequestStatusRefreshed(makeTask() as never, status()),
+            ).resolves.toMatchObject({ action: 'observed' });
+        });
+
+        // ── THE no-cascade property ───────────────────────────────────
+
+        it('frees the lane on merge and opens NOTHING — stage → main is a separate human act', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+            });
+            const promotion = await openOne(harness);
+            harness.gitFacade.createPullRequest.mockClear();
+            harness.tasksService.create.mockClear();
+
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'merged', merged: true }),
+            );
+
+            expect(outcome).toEqual({ action: 'closed', state: 'merged' });
+            // THE assertion this slice exists for.
+            expect(harness.gitFacade.createPullRequest).not.toHaveBeenCalled();
+            expect(harness.tasksService.create).not.toHaveBeenCalled();
+            expect(await rows.count()).toBe(1);
+
+            const stored = await rows.findOne({ where: { id: promotion.id } });
+            expect(stored?.state).toBe('merged');
+            // The lane is free for a human to open the next rung — later,
+            // by hand.
+            expect(stored?.laneKey).not.toBe('open');
+            expect(harness.chat.create.mock.calls.at(-1)?.[0].body).toMatch(
+                /not opened automatically/i,
+            );
+        });
+
+        it('frees the lane when the promotion pull request is closed unmerged', async () => {
+            const harness = build();
+            const promotion = await openOne(harness);
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'closed' }),
+            );
+            expect(outcome).toEqual({ action: 'closed', state: 'closed' });
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.state).toBe('closed');
+        });
+
+        // ── The one Inbox item ────────────────────────────────────────
+
+        it('files ONE Inbox notice per head, however many times the sweep runs', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+            });
+            await openOne(harness);
+            for (let i = 0; i < 5; i += 1) {
+                await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            }
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(1);
+            const [userId, item] = harness.inbox.notice.mock.calls[0];
+            expect(userId).toBe(USER);
+            expect(item.title).toMatch(/PASSED/);
+            expect(item.taskId).toBe('task-1');
+            expect(item.body).toMatch(/Nothing merges until you approve it/);
+        });
+
+        it('files a NEW notice for a NEW head', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'failure', headSha: HEAD },
+            });
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ headSha: NEXT_HEAD }),
+            );
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(2);
+        });
+
+        it('says plainly that a non-success gate blocks the merge', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'skipped', headSha: HEAD },
+            });
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            const [, item] = harness.inbox.notice.mock.calls[0];
+            expect(item.title).toMatch(/SKIPPED/);
+            expect(item.body).toMatch(/will NOT be offered for merge/);
+        });
+
+        it('waits out the grace window before crying "no gate run"', async () => {
+            const harness = build({ workflowRun: null });
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            // A run does not exist the instant a pull request opens.
+            expect(harness.inbox.notice).not.toHaveBeenCalled();
+        });
+
+        it('does tell the human once an ABSENT gate has stayed absent past the grace window', async () => {
+            const harness = build({ workflowRun: null });
+            const promotion = await openOne(harness);
+            await rows.update(
+                { id: promotion.id },
+                { headRecordedAt: new Date(Date.now() - PROMOTION_GATE_DECISION_GRACE_MS - 1000) },
+            );
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(1);
+            expect(harness.inbox.notice.mock.calls[0][1].title).toMatch(/ABSENT/);
+        });
+
+        it('still files the DECIDING verdict after a stuck reading already used the commit’s slot', async () => {
+            // The composition of the two tests above, which is where the
+            // bug lived: keyed on the commit ALONE, the first post-grace
+            // `pending`/`absent` consumed the one-notice slot and the
+            // verdict that actually decided the promotion — including a
+            // FAILURE — was suppressed for that commit. `pending` past
+            // twenty minutes is routine on this gate (`node-contract` has a
+            // 20-minute budget plus self-hosted ARC queue time), and one
+            // transient 403 recorded as `unreadable` does the same.
+            const harness = build({ workflowRun: null });
+            const promotion = await openOne(harness);
+            await rows.update(
+                { id: promotion.id },
+                { headRecordedAt: new Date(Date.now() - PROMOTION_GATE_DECISION_GRACE_MS - 1000) },
+            );
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.inbox.notice.mock.calls[0][1].title).toMatch(/ABSENT/);
+
+            harness.gitFacade.getWorkflowRunForCommit.mockResolvedValue({
+                id: 1,
+                status: 'completed',
+                conclusion: 'failure',
+                headSha: HEAD,
+            });
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(2);
+            expect(harness.inbox.notice.mock.calls[1][1].title).toMatch(/FAILURE/);
+        });
+
+        it('collapses a pending → unreadable → pending flap into ONE notice', async () => {
+            // The other half of the same key: every undecided reading
+            // shares the `'stuck'` token, so a flapping gate is one item
+            // rather than one per sweep.
+            const harness = build({
+                workflowRun: { id: 1, status: 'in_progress', conclusion: null, headSha: HEAD },
+            });
+            const promotion = await openOne(harness);
+            await rows.update(
+                { id: promotion.id },
+                { headRecordedAt: new Date(Date.now() - PROMOTION_GATE_DECISION_GRACE_MS - 1000) },
+            );
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            harness.gitFacade.getWorkflowRunForCommit.mockRejectedValueOnce(new Error('503'));
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            harness.gitFacade.getWorkflowRunForCommit.mockResolvedValue({
+                id: 1,
+                status: 'queued',
+                conclusion: null,
+                headSha: HEAD,
+            });
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(1);
+        });
+
+        // ── An overridden gate is not a green one ─────────────────────
+
+        it('says the E2E leg was WAIVED when the override label is on the pull request', async () => {
+            // `promotion-gate.yml` exits 0 on `override-e2e-gate` in all
+            // four of its failure branches, and GitHub folds that into a
+            // plain `success` run conclusion. Read from the run alone,
+            // "green" and "somebody applied a label" are identical — and
+            // this notice is the one artefact the founder reads before
+            // deciding a production release.
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+                livePullRequest: { labels: [PROMOTION_GATE_OVERRIDE_LABEL] },
+            });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+
+            const [, item] = harness.inbox.notice.mock.calls[0];
+            expect(item.title).toMatch(/WAIVED/);
+            expect(item.title).not.toMatch(/^Promotion gate PASSED for/);
+            expect(item.body).toMatch(/WAIVED, NOT GREEN/);
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateOverridden).toBe(
+                true,
+            );
+        });
+
+        it('files a SECOND notice when a red gate is overridden into a pass on the same commit', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'failure', headSha: HEAD },
+            });
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.inbox.notice.mock.calls[0][1].title).toMatch(/FAILURE/);
+
+            // A maintainer applies the label; the `labeled` trigger re-runs
+            // the gate and it now concludes success.
+            harness.gitFacade.getWorkflowRunForCommit.mockResolvedValue({
+                id: 2,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            harness.gitFacade.getPullRequest.mockResolvedValue({
+                number: 42,
+                head: 'develop',
+                base: 'stage',
+                state: 'open',
+                labels: [PROMOTION_GATE_OVERRIDE_LABEL],
+            });
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+
+            expect(harness.inbox.notice).toHaveBeenCalledTimes(2);
+            expect(harness.inbox.notice.mock.calls[1][1].title).toMatch(/WAIVED/);
+        });
+
+        it('says which legs the rung actually evaluated, and the two rungs differ', async () => {
+            // On `develop -> stage` the gate's `e2e-result` job SKIPS by
+            // design (its `if:` requires a `stage` head), so the run
+            // concludes `success` off `node-contract` alone. "PASSED" then
+            // means something materially narrower than it does on the
+            // second rung, and the operator reads the Inbox item, not the
+            // runbook.
+            const first = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+            });
+            await openOne(first);
+            await first.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(first.inbox.notice.mock.calls[0][1].body).toMatch(
+                /node wire contract ONLY[\s\S]*NO end-to-end result was consulted/,
+            );
+
+            await rows.clear();
+            const second = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'success', headSha: HEAD },
+                livePullRequest: { head: 'stage', base: 'main' },
+            });
+            await second.service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'stage-to-main',
+                agentId: AGENT,
+            });
+            await second.service.onPullRequestStatusRefreshed(
+                makeTask({
+                    labels: [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main'],
+                }) as never,
+                status(),
+            );
+            expect(second.inbox.notice.mock.calls[0][1].body).toMatch(
+                /node wire contract AND stage’s own end-to-end result/,
+            );
+        });
+
+        // ── The row, not the label, is the identity ───────────────────
+
+        it('keeps watching a live promotion whose Task labels have been stripped', async () => {
+            // Same PATCH as the guard test: clearing the labels used to
+            // freeze the lane — no more gate readings, no more Inbox items
+            // — while the row still said `open`.
+            const harness = build({
+                workflowRun: { id: 1, status: 'completed', conclusion: 'failure', headSha: HEAD },
+            });
+            const promotion = await openOne(harness);
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask({ labels: [] }) as never,
+                status(),
+            );
+            expect(outcome).toMatchObject({ action: 'observed', verdict: 'failure' });
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'failure',
+            );
+        });
+
+        it('REFUSES when the Task’s pull request has been rebound away from the promotion', async () => {
+            // An agent run on the promotion Task opens its own pull request
+            // and overwrites `tasks.prNumber`. Everything downstream — the
+            // head, the gate verdict, the merged/closed decision — comes
+            // from the status read for THAT pull request, so the promotion
+            // would end up recording promotion-gate.yml's answer about
+            // somebody else's work.
+            const harness = build();
+            const promotion = await openOne(harness);
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask({ prNumber: 77 }) as never,
+                status({ number: 77 }),
+            );
+            expect(outcome).toEqual({ action: 'refused', code: 'pull-request-rebound' });
+            const stored = await rows.findOne({ where: { id: promotion.id } });
+            expect(stored?.state).toBe('refused');
+            expect(stored?.refusalCode).toBe('pull-request-rebound');
+        });
+
+        it('ignores a gate run that belongs to a DIFFERENT pull request on the same commit', async () => {
+            // A workflow run is keyed by COMMIT, and one commit can head
+            // more than one pull request. The override label is per pull
+            // request, so adopting the wrong run is exactly the case that
+            // matters.
+            const harness = build({
+                workflowRun: {
+                    id: 1,
+                    status: 'completed',
+                    conclusion: 'success',
+                    headSha: HEAD,
+                    pullRequestNumbers: [4242],
+                },
+            });
+            const promotion = await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.gateVerdict).toBe(
+                'absent',
+            );
+        });
+
+        it('reports a verdict CHANGE into the Task, and does not repeat itself', async () => {
+            const harness = build({
+                workflowRun: { id: 1, status: 'in_progress', conclusion: null, headSha: HEAD },
+            });
+            await openOne(harness);
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            const afterFirst = harness.chat.create.mock.calls.length;
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.chat.create.mock.calls.length).toBe(afterFirst);
+
+            harness.gitFacade.getWorkflowRunForCommit.mockResolvedValue({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            expect(harness.chat.create.mock.calls.length).toBe(afterFirst + 1);
+            expect(harness.chat.create.mock.calls.at(-1)?.[0].body).toMatch(/PASSED/);
+        });
+    });
+
+    // ── The guard ─────────────────────────────────────────────────────
+
+    describe('assessPromotionForMerge', () => {
+        async function openAndObserve(run: Record<string, unknown> | null) {
+            const harness = build({ workflowRun: run });
+            const opened = await harness.service.openPromotion({
+                userId: USER,
+                workId: WORK,
+                rung: 'develop-to-stage',
+                agentId: AGENT,
+            });
+            await harness.service.onPullRequestStatusRefreshed(makeTask() as never, status());
+            return { harness, promotion: (opened as { promotion: ReleasePromotion }).promotion };
+        }
+
+        it('leaves a non-promotion Task alone', async () => {
+            const { service } = build();
+            await expect(
+                service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: ['chore'],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toEqual({ promotion: false });
+        });
+
+        it('allows a promotion whose gate said success for exactly this commit', async () => {
+            const { harness, promotion } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toEqual({
+                promotion: true,
+                allowed: true,
+                promotionId: promotion.id,
+                // The promotion's OWN branches travel with the allowance —
+                // the merge path's default base is the Work's
+                // `taskIsolationBaseBranch`, which is right for every Task
+                // pull request and wrong for every promotion.
+                headBranch: 'develop',
+                baseBranch: 'stage',
+                prNumber: 42,
+            });
+        });
+
+        it('is NOT disarmed by stripping the Task’s labels — the ROW is the identity', async () => {
+            // `PATCH /api/tasks/:id {"labels":[]}` is available to any
+            // owner (`TasksService.update` applies `input.labels`
+            // verbatim). The guard used to short-circuit on the labels one
+            // line ABOVE the row lookup, so one request turned a live
+            // release pull request into an ordinary agent merge with the
+            // promotion gate never consulted.
+            const { harness } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'failure',
+                headSha: HEAD,
+            });
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toMatchObject({
+                promotion: true,
+                allowed: false,
+                code: 'promotion-gate-not-success',
+            });
+        });
+
+        it('refuses a pull request that is not the one the promotion opened', async () => {
+            // An agent run on the promotion Task overwrites
+            // `tasks.prNumber` with its own pull request. A verdict
+            // recorded for one pull request must never authorise the merge
+            // of another.
+            const { harness } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 77,
+                    headSha: HEAD,
+                }),
+            ).resolves.toMatchObject({
+                promotion: true,
+                allowed: false,
+                code: 'promotion-pull-request-mismatch',
+            });
+        });
+
+        it.each([
+            ['pending', { id: 1, status: 'in_progress', conclusion: null, headSha: HEAD }],
+            ['failure', { id: 1, status: 'completed', conclusion: 'failure', headSha: HEAD }],
+            ['cancelled', { id: 1, status: 'completed', conclusion: 'cancelled', headSha: HEAD }],
+            ['skipped', { id: 1, status: 'completed', conclusion: 'skipped', headSha: HEAD }],
+            [
+                'neutral (skipped)',
+                { id: 1, status: 'completed', conclusion: 'neutral', headSha: HEAD },
+            ],
+            ['absent', null],
+        ])('refuses a %s gate', async (_label, run) => {
+            const { harness } = await openAndObserve(run as Record<string, unknown> | null);
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toMatchObject({
+                promotion: true,
+                allowed: false,
+                code: 'promotion-gate-not-success',
+            });
+        });
+
+        it('refuses a SUCCESS recorded for a different commit', async () => {
+            // The verdict is about a commit. It is never inherited.
+            const { harness } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: NEXT_HEAD,
+                }),
+            ).resolves.toMatchObject({ allowed: false, code: 'promotion-gate-stale' });
+        });
+
+        it('refuses an unusable head SHA', async () => {
+            const { harness } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: 'refs/heads/develop',
+                }),
+            ).resolves.toMatchObject({ allowed: false, code: 'promotion-gate-stale' });
+        });
+
+        it('refuses a promotion Task with no promotion row behind it', async () => {
+            const { service } = build();
+            await expect(
+                service.assessPromotionForMerge({
+                    taskId: 'task-orphan',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toMatchObject({ allowed: false, code: 'promotion-row-missing' });
+        });
+
+        it('refuses once the promotion is no longer open', async () => {
+            const { harness, promotion } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            await promotions.closeLane(promotion.id, 'merged');
+            await expect(
+                harness.service.assessPromotionForMerge({
+                    taskId: 'task-1',
+                    labels: [PROMOTION_TASK_LABEL],
+                    prNumber: 42,
+                    headSha: HEAD,
+                }),
+            ).resolves.toMatchObject({ allowed: false, code: 'promotion-not-open' });
+        });
+
+        it('has no verdict that permits a merge the ordinary path would refuse', async () => {
+            // The guard can only ever say NO. `{ promotion: false }` leaves
+            // the ordinary path alone; `allowed: true` only ever restores
+            // it. Nothing here bypasses the slice-AE approval.
+            const { harness } = await openAndObserve({
+                id: 1,
+                status: 'completed',
+                conclusion: 'success',
+                headSha: HEAD,
+            });
+            const verdict = await harness.service.assessPromotionForMerge({
+                taskId: 'task-1',
+                labels: [PROMOTION_TASK_LABEL],
+                prNumber: 42,
+                headSha: HEAD,
+            });
+            expect(Object.keys(verdict)).not.toContain('approved');
+            expect(Object.keys(verdict)).not.toContain('merge');
+        });
+    });
+
+    describe('ReleasePromotionRepository.findByTaskId', () => {
+        it('prefers the OPEN row over a terminal one for the same Task', async () => {
+            // The merge guard runs this lookup. Ordering the two together
+            // by `laneKey` would lose the live promotion to a terminal one,
+            // because `'closed:…'` and `'merged:…'` both sort before
+            // `'open'` — and the guard would then refuse a perfectly good
+            // promotion with `promotion-not-open`.
+            await rows.save(
+                rows.create({
+                    userId: USER,
+                    workId: WORK,
+                    taskId: 'task-shared',
+                    rung: 'develop-to-stage',
+                    headBranch: 'develop',
+                    baseBranch: 'stage',
+                    gateWorkflow: 'promotion-gate.yml',
+                    state: 'closed',
+                    laneKey: 'closed:legacy',
+                }),
+            );
+            const live = await rows.save(
+                rows.create({
+                    userId: USER,
+                    workId: WORK,
+                    taskId: 'task-shared',
+                    rung: 'develop-to-stage',
+                    headBranch: 'develop',
+                    baseBranch: 'stage',
+                    gateWorkflow: 'promotion-gate.yml',
+                    state: 'open',
+                    laneKey: 'open',
+                }),
+            );
+
+            await expect(promotions.findByTaskId('task-shared')).resolves.toMatchObject({
+                id: live.id,
+                state: 'open',
+            });
+        });
+
+        it('falls back to the newest terminal row when nothing is open', async () => {
+            await rows.save(
+                rows.create({
+                    userId: USER,
+                    workId: WORK,
+                    taskId: 'task-done',
+                    rung: 'stage-to-main',
+                    headBranch: 'stage',
+                    baseBranch: 'main',
+                    gateWorkflow: 'promotion-gate.yml',
+                    state: 'merged',
+                    laneKey: 'merged:done',
+                }),
+            );
+            await expect(promotions.findByTaskId('task-done')).resolves.toMatchObject({
+                state: 'merged',
+            });
+        });
+
+        it('returns null for a Task that has no promotion', async () => {
+            await expect(promotions.findByTaskId('task-ordinary')).resolves.toBeNull();
+        });
+    });
+
+    describe('ReleasePromotionRepository.recordGateVerdict — who gets to narrate', () => {
+        async function seed() {
+            return rows.save(
+                rows.create({
+                    userId: USER,
+                    workId: WORK,
+                    taskId: 'task-cas',
+                    rung: 'develop-to-stage',
+                    headBranch: 'develop',
+                    baseBranch: 'stage',
+                    gateWorkflow: 'promotion-gate.yml',
+                    state: 'open',
+                    laneKey: 'open',
+                }),
+            );
+        }
+
+        it('reports `changed` from the DATABASE, so two replicas cannot both narrate one transition', async () => {
+            // `observe()` used to decide this with a read-then-write on its
+            // own in-memory row. The two-minute cron sweep and an on-demand
+            // `?refresh=true` run in DIFFERENT processes: both would hold
+            // the same stale row, both would compute "this is new", and the
+            // Task thread — this promotion's audit trail — would show the
+            // same line twice, and again for every later transition.
+            const row = await seed();
+            const patch = {
+                gateVerdict: 'success' as const,
+                gateVerdictSha: HEAD,
+                gateCheckedAt: new Date(),
+                gateRunUrl: null,
+                gateOverridden: false,
+            };
+
+            await expect(promotions.recordGateVerdict(row.id, patch)).resolves.toEqual({
+                changed: true,
+            });
+            // The SECOND caller holding the same stale row loses.
+            await expect(
+                promotions.recordGateVerdict(row.id, { ...patch, gateCheckedAt: new Date() }),
+            ).resolves.toEqual({ changed: false });
+        });
+
+        it('treats an override appearing on the SAME verdict and commit as a change', async () => {
+            // A maintainer applying `override-e2e-gate` re-runs the gate and
+            // flips a red run to `success`. If the waiver were not part of
+            // the compare-and-set, a `success → success (waived)` transition
+            // would be silent — and "waived" is the whole difference the
+            // person deciding a release needs to see.
+            const row = await seed();
+            const base = {
+                gateVerdict: 'success' as const,
+                gateVerdictSha: HEAD,
+                gateRunUrl: null,
+            };
+            await promotions.recordGateVerdict(row.id, {
+                ...base,
+                gateCheckedAt: new Date(),
+                gateOverridden: false,
+            });
+            await expect(
+                promotions.recordGateVerdict(row.id, {
+                    ...base,
+                    gateCheckedAt: new Date(),
+                    gateOverridden: true,
+                }),
+            ).resolves.toEqual({ changed: true });
+            expect((await rows.findOne({ where: { id: row.id } }))?.gateOverridden).toBe(true);
+        });
+
+        it('still stamps "last looked at" when nothing changed', async () => {
+            const row = await seed();
+            const patch = {
+                gateVerdict: 'pending' as const,
+                gateVerdictSha: HEAD,
+                gateRunUrl: null,
+                gateOverridden: false,
+            };
+            await promotions.recordGateVerdict(row.id, { ...patch, gateCheckedAt: new Date(1) });
+            const later = new Date(2_000_000);
+            await promotions.recordGateVerdict(row.id, { ...patch, gateCheckedAt: later });
+            const stored = await rows.findOne({ where: { id: row.id } });
+            expect(new Date(stored!.gateCheckedAt!).getTime()).toBe(later.getTime());
+        });
+    });
+
+    it('contains no merge call, and no successor-rung call, at all', () => {
+        // The strongest statement available here: a promotion cannot merge
+        // itself and cannot chain, because the service has nothing to do
+        // either WITH. Read from source rather than asserted behaviourally
+        // so that ADDING one fails, not just exercising one.
+        const source = readFileSync(join(__dirname, '..', 'release-promotion.service.ts'), 'utf8');
+        // Call sites, not mentions: the class docblock names
+        // `GitFacadeService.mergePullRequest` when explaining that the
+        // slice-AE path is where a promotion is landed, and that sentence
+        // is worth keeping.
+        expect(source).not.toMatch(/\.mergePullRequest\(/);
+        expect(source).not.toMatch(/attemptMergeForOpenPullRequest\(/);
+        expect(source).not.toMatch(/attemptAgentMerge\(/);
+        // No self-call to openPromotion anywhere but the public entry point.
+        expect(source.match(/openPromotion\(/g)).toHaveLength(1);
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-merge-gate.promotion.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-merge-gate.promotion.spec.ts
@@ -1,0 +1,409 @@
+import type { MergePolicy } from '@ever-works/contracts';
+import { PROMOTION_TASK_LABEL } from '@ever-works/contracts';
+import { TaskMergeGateService } from '../task-merge-gate.service';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) × merge approval
+ * (slice AE) — the ONE integration point, from the merge gate's side.
+ *
+ * The property this file exists for: a promotion pull request goes
+ * through the SAME approval path as every other agent merge, and the
+ * promotion guard can only ever make that path NARROWER.
+ *
+ * So the assertions come in pairs. For a non-promotion Task, nothing
+ * changes. For a promotion Task, every non-`success` gate reading stops
+ * the gate BEFORE `requestMergeApproval` — because raising an approval on
+ * a gate that skipped itself would show a human an Approve button next to
+ * a green badge the platform manufactured.
+ */
+describe('TaskMergeGateService — promotion Tasks', () => {
+    const HEAD = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+    const NEEDS_APPROVAL: MergePolicy = {
+        allowAgentMerge: true,
+        requireGreenGate: true,
+        requireHumanApproval: true,
+        allowedMergeMethods: ['squash'],
+        protectedBranches: ['main'],
+    };
+
+    const NO_APPROVAL_NEEDED: MergePolicy = { ...NEEDS_APPROVAL, requireHumanApproval: false };
+
+    /**
+     * What the guard says about a promotion that MAY proceed.
+     *
+     * It carries the promotion's own branches and pull request, because
+     * the merge path's default answer to "what is this pull request's
+     * base?" is the Work's `taskIsolationBaseBranch` — right for every
+     * Task pull request and wrong for every promotion.
+     */
+    const ALLOWED = {
+        promotion: true,
+        allowed: true,
+        promotionId: 'rp-1',
+        headBranch: 'stage',
+        baseBranch: 'main',
+        prNumber: 7,
+    } as const;
+
+    const task = (over: Record<string, unknown> = {}) =>
+        ({
+            id: 'task-1',
+            userId: 'owner-1',
+            slug: 'T-42',
+            workId: 'work-1',
+            agentId: 'agent-1',
+            prNumber: 7,
+            prUrl: 'https://github.com/ever-works/ever-works/pull/7',
+            labels: [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main'],
+            ...over,
+        }) as never;
+
+    const status = (over: Record<string, unknown> = {}) =>
+        ({
+            number: 7,
+            state: 'open',
+            merged: false,
+            ciState: 'passing',
+            checksComplete: true,
+            headSha: HEAD,
+            checks: [],
+            ...over,
+        }) as never;
+
+    function build(
+        over: {
+            policy?: MergePolicy;
+            approved?: boolean;
+            guard?: { assessPromotionForMerge: jest.Mock } | null;
+            work?: Record<string, unknown>;
+        } = {},
+    ) {
+        const works = {
+            findById: jest.fn().mockResolvedValue({
+                id: 'work-1',
+                organizationId: null,
+                tenantId: null,
+                taskIsolationBaseBranch: 'main',
+                getRepoOwner: () => 'ever-works',
+                getDataRepo: () => 'ever-works',
+                ...over.work,
+            }),
+        };
+        const mergePolicy = {
+            resolve: jest.fn().mockResolvedValue({
+                policy: over.policy ?? NEEDS_APPROVAL,
+                source: 'work',
+                chain: [],
+            }),
+        };
+        const taskWorkspace = {
+            attemptMergeForOpenPullRequest: jest
+                .fn()
+                .mockResolvedValue({ attempted: true, merged: true }),
+        };
+        const mergeApprovals = {
+            verifyMergeApproval: jest
+                .fn()
+                .mockResolvedValue(
+                    over.approved
+                        ? { approved: true, approvalId: 'p-1', approvedById: 'human-1' }
+                        : { approved: false, code: 'approval-missing' },
+                ),
+            requestMergeApproval: jest
+                .fn()
+                .mockResolvedValue({ raised: true, proposal: { id: 'p-new' } }),
+        };
+        const guard =
+            over.guard === null
+                ? undefined
+                : (over.guard ?? {
+                      assessPromotionForMerge: jest.fn().mockResolvedValue(ALLOWED),
+                  });
+        const service = new TaskMergeGateService(
+            works as never,
+            mergePolicy as never,
+            taskWorkspace as never,
+            mergeApprovals as never,
+            guard as never,
+        );
+        return { service, works, mergePolicy, taskWorkspace, mergeApprovals, guard };
+    }
+
+    // ── The promotion still needs a human ─────────────────────────────
+
+    it('raises the SAME merge_pull_request approval for a green promotion — it does not merge it', async () => {
+        const { service, mergeApprovals, taskWorkspace } = build();
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ taskId: 'task-1', prNumber: 7, headSha: HEAD }),
+        );
+        // A passing promotion gate is permission to ASK, never to merge.
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('merges a promotion only once a human approval verifies for THIS head', async () => {
+        const { service, taskWorkspace, mergeApprovals } = build({ approved: true });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toMatchObject({ action: 'merge-attempted' });
+        expect(mergeApprovals.verifyMergeApproval).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            prNumber: 7,
+            headSha: HEAD,
+        });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ agentId: 'agent-1', gateStatus: 'green', headSha: HEAD }),
+        );
+    });
+
+    // ── The promotion's OWN base branch, everywhere it is used ────────
+
+    it('shows the human the branch the promotion actually merges INTO, not the Work default', async () => {
+        // The Work's `taskIsolationBaseBranch` is `develop` in the only
+        // configuration this lane can run in (operators remove `develop`
+        // from `protectedBranches` so Task pull requests can land there).
+        // A `stage -> main` promotion described as "into develop" is
+        // approved as one thing and merged as another.
+        const { service, mergeApprovals } = build({
+            work: { taskIsolationBaseBranch: 'develop' },
+        });
+
+        await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ targetBranch: 'main' }),
+        );
+    });
+
+    it('hands the merge path the promotion’s base, so the protected-branch rule sees `main`', async () => {
+        // `git.facade` uses `agentActor.targetBranch` verbatim and only
+        // reads the pull request's real base when it is ABSENT — so a
+        // wrong value here means `canAgentMerge` evaluates a branch that
+        // is not being merged into, and the `protected-branch` refusal
+        // never fires for a promotion into production.
+        const { service, taskWorkspace } = build({
+            approved: true,
+            work: { taskIsolationBaseBranch: 'develop' },
+        });
+
+        await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ baseRef: 'main', requireHumanApproval: true }),
+        );
+    });
+
+    it('leaves an ordinary Task’s base branch exactly as it was', async () => {
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({ promotion: false }),
+        };
+        const { service, mergeApprovals, taskWorkspace } = build({
+            guard,
+            approved: true,
+            work: { taskIsolationBaseBranch: 'develop' },
+        });
+
+        await service.onPullRequestStatusRefreshed(task({ labels: ['chore'] }), status());
+
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ baseRef: null, requireHumanApproval: false }),
+        );
+        expect(mergeApprovals.verifyMergeApproval).toHaveBeenCalled();
+    });
+
+    // ── A promotion ALWAYS needs a human ──────────────────────────────
+
+    it('never merges a promotion under a policy that needs no approval — it asks anyway', async () => {
+        // THE property this slice exists for, on the ALLOWING side.
+        // `requireHumanApproval: false` is a legitimate operator choice
+        // for ordinary agent work; it is not a choice about releases. A
+        // promotion that landed here with no Inbox proposal and no human
+        // identity would be exactly the automatic cascade the brief
+        // forbids.
+        const { service, taskWorkspace, mergeApprovals } = build({
+            policy: NO_APPROVAL_NEEDED,
+        });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalled();
+    });
+
+    it('merges a promotion under that policy only after a human approval verifies', async () => {
+        const { service, taskWorkspace, mergeApprovals } = build({
+            policy: NO_APPROVAL_NEEDED,
+            approved: true,
+        });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toMatchObject({ action: 'merge-attempted' });
+        expect(mergeApprovals.verifyMergeApproval).toHaveBeenCalled();
+        // And the facade is told to keep the requirement, so the property
+        // does not rest on this service alone.
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ requireHumanApproval: true }),
+        );
+    });
+
+    it('still lets an ORDINARY Task merge without an approval under that policy', async () => {
+        // The narrowing is for promotions only; the operator's choice for
+        // everything else is untouched.
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({ promotion: false }),
+        };
+        const { service, taskWorkspace, mergeApprovals } = build({
+            policy: NO_APPROVAL_NEEDED,
+            guard,
+        });
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            task({ labels: ['chore'] }),
+            status(),
+        );
+
+        expect(outcome).toMatchObject({ action: 'merge-attempted' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    // ── The narrowing ─────────────────────────────────────────────────
+
+    it.each([
+        ['promotion-gate-not-success', 'promotion-gate.yml for … : skipped'],
+        ['promotion-gate-stale', 'no verdict for this commit'],
+        ['promotion-not-open', 'the promotion is merged'],
+        ['promotion-row-missing', 'no promotion record resolves'],
+    ])('stops BEFORE the approval when the guard refuses with %s', async (code, reason) => {
+        const guard = {
+            assessPromotionForMerge: jest
+                .fn()
+                .mockResolvedValue({ promotion: true, allowed: false, code, reason }),
+        };
+        const { service, mergeApprovals, taskWorkspace } = build({ guard });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'skipped', reason: code });
+        // Neither half of the merge path is reached: no Inbox ask, no merge.
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(mergeApprovals.verifyMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses a refused promotion even under a policy that needs no approval', async () => {
+        // The most dangerous combination: an operator who turned approvals
+        // off for the scope. The promotion gate still holds.
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({
+                promotion: true,
+                allowed: false,
+                code: 'promotion-gate-not-success',
+                reason: 'absent',
+            }),
+        };
+        const { service, taskWorkspace } = build({ policy: NO_APPROVAL_NEEDED, guard });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'promotion-gate-not-success' });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('asks the guard about the LIVE head and the pull request it is about to merge', async () => {
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue(ALLOWED),
+        };
+        const { service } = build({ guard });
+
+        await service.onPullRequestStatusRefreshed(task(), status({ headSha: HEAD.toUpperCase() }));
+
+        expect(guard.assessPromotionForMerge).toHaveBeenCalledWith({
+            taskId: 'task-1',
+            labels: [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main'],
+            // Named so a verdict recorded for the promotion's pull request
+            // cannot authorise the merge of one that later took over
+            // `tasks.prNumber`.
+            prNumber: 7,
+            headSha: HEAD,
+        });
+    });
+
+    // ── Fail closed ───────────────────────────────────────────────────
+
+    it('refuses a promotion Task when NO guard is bound, without needing one', async () => {
+        // A deployment that cannot evaluate promotions must not merge them
+        // through the ordinary agent path. The refusal is read off the
+        // Task's own labels precisely so it does not depend on the service
+        // that is missing.
+        const { service, mergeApprovals, taskWorkspace } = build({ guard: null });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'promotion-guard-unbound' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('treats a THROWING guard as a refusal, not as a pass', async () => {
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockRejectedValue(new Error('db down')),
+        };
+        const { service, mergeApprovals } = build({ guard });
+
+        const outcome = await service.onPullRequestStatusRefreshed(task(), status());
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'promotion-guard-failed' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    // ── No effect on anything else ────────────────────────────────────
+
+    it('leaves an ordinary Task completely unchanged when the guard says "not a promotion"', async () => {
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({ promotion: false }),
+        };
+        const { service, mergeApprovals } = build({ guard });
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            task({ labels: ['chore'] }),
+            status(),
+        );
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalled();
+    });
+
+    it('leaves an ordinary Task unchanged when NO guard is bound', async () => {
+        const { service, mergeApprovals } = build({ guard: null });
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            task({ labels: null }),
+            status(),
+        );
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalled();
+    });
+
+    it('never consults the guard for a promotion the ordinary gate already refused', async () => {
+        // Ordering matters only for cost, not for safety — but a red
+        // promotion must not cause a provider read either.
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({ promotion: false }),
+        };
+        const { service } = build({ guard });
+
+        await service.onPullRequestStatusRefreshed(task(), status({ ciState: 'failing' }));
+        await service.onPullRequestStatusRefreshed(task(), status({ checksComplete: false }));
+        await service.onPullRequestStatusRefreshed(task(), status({ state: 'draft' }));
+
+        expect(guard.assessPromotionForMerge).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-merge-gate.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-merge-gate.service.spec.ts
@@ -219,6 +219,14 @@ describe('TaskMergeGateService', () => {
             // than on every two-minute sweep. Never an input to the
             // decision — the facade re-reads and pins the head itself.
             headSha: HEAD,
+            // Release promotion lane (slice AI): both are the ORDINARY
+            // Task answers, asserted rather than omitted so the promotion
+            // narrowing can never leak into an ordinary merge. `null` base
+            // means "use the Work's `taskIsolationBaseBranch`", exactly as
+            // before; `false` leaves the resolved policy's approval
+            // requirement untouched.
+            baseRef: null,
+            requireHumanApproval: false,
         });
         expect(outcome).toEqual({
             action: 'merge-attempted',

--- a/packages/agent/src/tasks-domain/__tests__/task-pr-status.promotion.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-pr-status.promotion.spec.ts
@@ -60,6 +60,12 @@ describe('TaskPrStatusService — promotion lane seam', () => {
             findDuePrStatusSync: jest.fn().mockResolvedValue([]),
             updatePrStatusCache: jest.fn().mockResolvedValue(undefined),
             updateById: jest.fn().mockResolvedValue(undefined),
+            // Slice AC (EW-806) merged while this branch was in review and made
+            // the refresh path record the provider's head. Without this stub the
+            // call throws, the surrounding catch swallows it, and BOTH the
+            // promotion watcher and the merge gate below are skipped — which is
+            // how this suite went red on a rebase without either hook changing.
+            recordCiHead: jest.fn().mockResolvedValue(false),
         };
         const works = {
             findById: jest.fn().mockResolvedValue({
@@ -93,6 +99,12 @@ describe('TaskPrStatusService — promotion lane seam', () => {
             git as never,
             transitions as never,
             mergeGate as never,
+            // Slice AC (EW-806) merged while this branch was in review and its
+            // auto-resume evaluator took the slot before this one. Passing
+            // `undefined` keeps the promotion watcher in the argument the
+            // constructor actually declares for it — shifting it would make this
+            // suite construct an auto-resume service and silently test nothing.
+            undefined,
             promotionLane as never,
         );
         return { service, tasks, git, mergeGate, promotionLane, calls };

--- a/packages/agent/src/tasks-domain/__tests__/task-pr-status.promotion.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-pr-status.promotion.spec.ts
@@ -1,0 +1,174 @@
+import type { Task } from '@src/entities/task.entity';
+import { PROMOTION_TASK_LABEL } from '@ever-works/contracts';
+import { TaskPrStatusService } from '../task-pr-status.service';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the seam
+ * `TaskPrStatusService` gives the lane, and the two properties that seam
+ * has to have.
+ *
+ *   1. **Ordering.** The promotion watcher runs BEFORE the merge gate, on
+ *      the same live status, because the gate's promotion guard is a pure
+ *      read of what the watcher just recorded. Reversed, the guard would
+ *      always be judging the PREVIOUS sweep's head.
+ *   2. **Unconditional.** The watcher runs whatever CI says. A promotion
+ *      has to be legible even when it can never merge — an operator
+ *      watching a red promotion should see the gate's verdict, not
+ *      silence.
+ *
+ * Plus the standing rule for everything on this seam: it is best-effort,
+ * and it can never fail a status refresh for the Tasks behind it.
+ */
+describe('TaskPrStatusService — promotion lane seam', () => {
+    const USER = 'user-1';
+    const WORK = 'work-1';
+
+    const task = (over: Record<string, unknown> = {}) =>
+        ({
+            id: 'task-1',
+            userId: USER,
+            workId: WORK,
+            slug: 'T-9',
+            prNumber: 41,
+            prUrl: 'https://example.invalid/pr/41',
+            prState: 'open',
+            ciState: 'pending',
+            ciCheckedAt: null,
+            prChecks: null,
+            labels: [PROMOTION_TASK_LABEL],
+            ...over,
+        }) as unknown as Task;
+
+    const status = (over: Record<string, unknown> = {}) => ({
+        number: 41,
+        state: 'open' as const,
+        merged: false,
+        mergeable: true,
+        headSha: 'abc1234',
+        reviewDecision: null,
+        ciState: 'passing' as const,
+        checksComplete: true,
+        checks: [],
+        url: 'https://example.invalid/pr/41',
+        ...over,
+    });
+
+    function build(over: { promotionLane?: unknown } = {}) {
+        const calls: string[] = [];
+        const tasks = {
+            findByIdAndUser: jest.fn(),
+            findDuePrStatusSync: jest.fn().mockResolvedValue([]),
+            updatePrStatusCache: jest.fn().mockResolvedValue(undefined),
+            updateById: jest.fn().mockResolvedValue(undefined),
+        };
+        const works = {
+            findById: jest.fn().mockResolvedValue({
+                id: WORK,
+                gitProvider: 'github',
+                taskIsolationBaseBranch: 'develop',
+                getRepoOwner: () => 'ever-works',
+                getDataRepo: () => 'ever-works',
+            }),
+        };
+        const git = { getPullRequestStatus: jest.fn().mockResolvedValue(status()) };
+        const transitions = { transition: jest.fn().mockResolvedValue(undefined) };
+        const mergeGate = {
+            onPullRequestStatusRefreshed: jest.fn().mockImplementation(async () => {
+                calls.push('merge-gate');
+                return { action: 'skipped', reason: 'no-agent' };
+            }),
+        };
+        const promotionLane =
+            over.promotionLane === null
+                ? undefined
+                : (over.promotionLane ?? {
+                      onPullRequestStatusRefreshed: jest.fn().mockImplementation(async () => {
+                          calls.push('promotion');
+                          return { action: 'observed' };
+                      }),
+                  });
+        const service = new TaskPrStatusService(
+            tasks as never,
+            works as never,
+            git as never,
+            transitions as never,
+            mergeGate as never,
+            promotionLane as never,
+        );
+        return { service, tasks, git, mergeGate, promotionLane, calls };
+    }
+
+    it('drives the promotion watcher BEFORE the merge gate, on the same live status', async () => {
+        const harness = build();
+        harness.tasks.findByIdAndUser.mockResolvedValue(task());
+
+        await harness.service.getForTask(USER, 'task-1', { refresh: true });
+
+        expect(harness.calls).toEqual(['promotion', 'merge-gate']);
+        const live = harness.git.getPullRequestStatus.mock.results[0].value;
+        await expect(live).resolves.toBeDefined();
+        expect(
+            (harness.promotionLane as { onPullRequestStatusRefreshed: jest.Mock })
+                .onPullRequestStatusRefreshed,
+        ).toHaveBeenCalledWith(expect.objectContaining({ id: 'task-1' }), await live);
+    });
+
+    it.each([
+        ['failing CI', { ciState: 'failing' }],
+        ['an incomplete check read', { checksComplete: false }],
+        ['a draft pull request', { state: 'draft' }],
+    ])('still runs the watcher for %s, where the merge gate stands down', async (_label, over) => {
+        const harness = build();
+        harness.tasks.findByIdAndUser.mockResolvedValue(task());
+        harness.git.getPullRequestStatus.mockResolvedValue(status(over));
+
+        await harness.service.getForTask(USER, 'task-1', { refresh: true });
+
+        expect(
+            (harness.promotionLane as { onPullRequestStatusRefreshed: jest.Mock })
+                .onPullRequestStatusRefreshed,
+        ).toHaveBeenCalledTimes(1);
+    });
+
+    it('never lets a throwing watcher fail the status refresh', async () => {
+        const harness = build({
+            promotionLane: {
+                onPullRequestStatusRefreshed: jest.fn().mockRejectedValue(new Error('db down')),
+            },
+        });
+        harness.tasks.findByIdAndUser.mockResolvedValue(task());
+
+        const view = await harness.service.getForTask(USER, 'task-1', { refresh: true });
+
+        expect(view.ciState).toBe('passing');
+        expect(harness.tasks.updatePrStatusCache).toHaveBeenCalled();
+        // And the merge gate still ran, so one Task's promotion problem
+        // cannot stall every other Task's merge evaluation.
+        expect(harness.mergeGate.onPullRequestStatusRefreshed).toHaveBeenCalled();
+    });
+
+    it('behaves exactly as before when no watcher is bound', async () => {
+        const harness = build({ promotionLane: null });
+        harness.tasks.findByIdAndUser.mockResolvedValue(task());
+
+        const view = await harness.service.getForTask(USER, 'task-1', { refresh: true });
+
+        expect(view.ciState).toBe('passing');
+        expect(harness.calls).toEqual(['merge-gate']);
+    });
+
+    it('runs the watcher for a Task the provider no longer has a status for — never', async () => {
+        // A deleted pull request records the read and stops; there is no
+        // live status to judge a promotion against.
+        const harness = build();
+        harness.tasks.findByIdAndUser.mockResolvedValue(task());
+        harness.git.getPullRequestStatus.mockResolvedValue(null);
+
+        await harness.service.getForTask(USER, 'task-1', { refresh: true });
+
+        expect(
+            (harness.promotionLane as { onPullRequestStatusRefreshed: jest.Mock })
+                .onPullRequestStatusRefreshed,
+        ).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-workspace.merge.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-workspace.merge.spec.ts
@@ -231,7 +231,18 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
             taskId: '123e4567-e89b-12d3-a456-426614174000',
             // The Work's configured base branch, not the repo default —
             // the protected-branch rule is worthless against the wrong one.
+            // (Release promotion lane, slice AI: a PROMOTION overrides this
+            // with its own base, because a promotion is the first pull
+            // request on this platform whose base is not the Work's
+            // isolation base. An ordinary Task is unaffected.)
             targetBranch: 'release',
+            // Release promotion lane (slice AI) — a caller-side RAISE of
+            // the approval requirement, asserted as `false` for an ordinary
+            // merge rather than omitted. The facade ORs it with the
+            // resolved policy, so it can only ever add a requirement; a
+            // `true` reaching here from a non-promotion path would be a
+            // caller quietly re-imposing a gate the operator turned off.
+            requireHumanApproval: false,
         });
     });
 
@@ -574,6 +585,43 @@ describe('TaskWorkspaceService — agent merge path (Wave 3 D4)', () => {
                 targetBranch: 'release',
             }),
         );
+    });
+
+    it('attemptMergeForOpenPullRequest merges into the base the CALLER names, when it names one', async () => {
+        // Release promotion lane (slice AI). A promotion's pull request is
+        // the first on this platform whose base is not the Work's
+        // `taskIsolationBaseBranch`, and `git.facade` uses
+        // `agentActor.targetBranch` VERBATIM — it only reads the pull
+        // request's real base when the value is absent. So a promotion
+        // reported with the Work default would have the protected-branch
+        // rule evaluated against a branch it is not merging into, and the
+        // post-merge audit line would name the wrong one too.
+        const task = { ...makeTask(), prNumber: 7, prUrl: 'https://x/pull/7' };
+        await build().attemptMergeForOpenPullRequest({
+            task: task as never,
+            agentId: 'agent-1',
+            gateStatus: 'green',
+            baseRef: 'main',
+            requireHumanApproval: true,
+        });
+
+        const [, , , , , actor] = gitFacade.mergePullRequest.mock.calls[0];
+        expect(actor).toEqual(
+            expect.objectContaining({ targetBranch: 'main', requireHumanApproval: true }),
+        );
+    });
+
+    it('attemptMergeForOpenPullRequest ignores a blank caller base and keeps the Work default', async () => {
+        const task = { ...makeTask(), prNumber: 7, prUrl: 'https://x/pull/7' };
+        await build().attemptMergeForOpenPullRequest({
+            task: task as never,
+            agentId: 'agent-1',
+            gateStatus: 'green',
+            baseRef: '   ',
+        });
+
+        const [, , , , , actor] = gitFacade.mergePullRequest.mock.calls[0];
+        expect(actor).toEqual(expect.objectContaining({ targetBranch: 'release' }));
     });
 
     it('attemptMergeForOpenPullRequest does nothing for a Task with no pull request', async () => {

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -77,6 +77,17 @@ export {
     TaskCiAutoResumeAttemptRepository,
     type ClaimAutoResumeAttemptInput,
 } from '../database/repositories/task-ci-auto-resume-attempt.repository';
+// Release promotion lane (self-build slice AI, EW-808) — develop -> stage
+// -> main. Opens a promotion pull request and reports the gate; merging it
+// stays on the slice-AE human-approval path.
+export * from './release-promotion.service';
+export * from './release-promotion.module';
+export { ReleasePromotion } from '../entities/release-promotion.entity';
+export {
+    ReleasePromotionRepository,
+    type ClaimPromotionLaneInput,
+    type PromotionLaneClaim,
+} from '../database/repositories/release-promotion.repository';
 // Git activity ingestion (audit item j) — branch/PR → Task resolver.
 export * from './task-git-link.service';
 export {

--- a/packages/agent/src/tasks-domain/release-promotion.module.ts
+++ b/packages/agent/src/tasks-domain/release-promotion.module.ts
@@ -1,0 +1,75 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReleasePromotion } from '../entities/release-promotion.entity';
+import { ReleasePromotionRepository } from '../database/repositories/release-promotion.repository';
+import {
+    PROMOTION_LANE_WATCHER,
+    PROMOTION_MERGE_GUARD,
+} from '../policy/promotion-merge-guard.port';
+import { FacadesModule } from '../facades/facades.module';
+import { ReleasePromotionService } from './release-promotion.service';
+import { TasksDomainModule } from './tasks.module';
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — the module that
+ * binds `PROMOTION_MERGE_GUARD` and `PROMOTION_LANE_WATCHER`.
+ *
+ * ## Why it is @Global(), and why it is not inside TasksDomainModule
+ *
+ * `ReleasePromotionService` FILES A TASK, so it needs `TasksService`, and
+ * it opens a pull request, so it needs `GitFacadeService`. That makes it a
+ * consumer of `TasksDomainModule`. But two services INSIDE
+ * `TasksDomainModule` need it back — `TaskPrStatusService` drives the
+ * refresh and `TaskMergeGateService` consults the guard — and a module
+ * cycle is a boot failure, not a lint warning.
+ *
+ * The way out is the one `INBOX_PRODUCER` already uses in this codebase:
+ * the consumers inject a TOKEN, `@Optional()`, and a `@Global()` module at
+ * the app root binds it. `TasksDomainModule` stays a leaf with respect to
+ * this feature, and a deployment that never imports this module simply has
+ * no promotion lane — which is the safe direction, because the merge gate
+ * refuses a promotion Task outright when the guard is unbound.
+ *
+ * ## `ReleasePromotionRepository` is provided HERE
+ *
+ * It is deliberately NOT in `_repository-inventory.ts` — that file is the
+ * DatabaseModule-owned set, and adding a feature repository to it exports
+ * it to the whole platform for the benefit of one module. Same call
+ * `MergeApprovalModule` makes for `TaskRepository`. Injecting it without
+ * this provider line is an unresolvable dependency and the API does not
+ * boot; `release-promotion.module.spec.ts` compiles the provider list
+ * against a real container so that cannot ship again.
+ *
+ * `ReleasePromotion` must ALSO stay registered in
+ * `database/_entities-inventory.ts` — this repo has no `autoLoadEntities`,
+ * so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query.
+ */
+@Global()
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ReleasePromotion]),
+        // Exports TasksService (files the promotion Task), TaskRepository,
+        // WorkRepository and TaskChatMessageRepository.
+        TasksDomainModule,
+        // Exports GitFacadeService (opens the pull request, reads the
+        // branch tips and the gate run).
+        FacadesModule,
+    ],
+    providers: [
+        ReleasePromotionRepository,
+        ReleasePromotionService,
+        // Bound with `useExisting` so consumers depend on the CONTRACT and
+        // never on the concrete class — and so both tokens resolve to ONE
+        // instance, which matters: the guard reads state the watcher wrote.
+        { provide: PROMOTION_MERGE_GUARD, useExisting: ReleasePromotionService },
+        { provide: PROMOTION_LANE_WATCHER, useExisting: ReleasePromotionService },
+    ],
+    exports: [
+        ReleasePromotionRepository,
+        ReleasePromotionService,
+        PROMOTION_MERGE_GUARD,
+        PROMOTION_LANE_WATCHER,
+    ],
+})
+export class ReleasePromotionModule {}

--- a/packages/agent/src/tasks-domain/release-promotion.service.ts
+++ b/packages/agent/src/tasks-domain/release-promotion.service.ts
@@ -1,0 +1,1207 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import type { GitPullRequest, GitPullRequestStatus } from '@ever-works/plugin';
+import {
+    PROMOTION_GATE_OVERRIDE_LABEL,
+    PROMOTION_GATE_WORKFLOW_FILE,
+    isPromotionGateDecided,
+    isPromotionGateDecisionOverdue,
+    isPromotionGateOverridden,
+    isPromotionGatePass,
+    isPromotionTask,
+    normalizeCommitSha,
+    promotionGateVerdictFromRun,
+    promotionTaskLabels,
+    resolvePromotionBranches,
+    sanitizeReleaseLadder,
+    type PromotionGateVerdict,
+    type PromotionRung,
+} from '@ever-works/contracts';
+import { Task, TaskPriority, TaskStatus } from '../entities/task.entity';
+import type { Work } from '../entities/work.entity';
+import type { ReleasePromotion } from '../entities/release-promotion.entity';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { ReleasePromotionRepository } from '../database/repositories/release-promotion.repository';
+import { TaskChatMessageRepository } from '../database/repositories/task-side.repositories';
+import { GitFacadeService, type GitFacadeOptions } from '../facades/git.facade';
+import { INBOX_PRODUCER, type InboxProducer } from '../inbox/inbox-producer.port';
+import type {
+    PromotionMergeGuard,
+    PromotionMergeSubject,
+    PromotionMergeVerdict,
+} from '../policy/promotion-merge-guard.port';
+import { TasksService } from './tasks.service';
+
+/** Why a promotion could not be opened. All of them leave nothing behind. */
+export type PromotionOpenRefusal =
+    | 'no-git-provider'
+    | 'work-not-found'
+    | 'ladder-not-configured'
+    | 'head-branch-missing'
+    | 'base-branch-missing'
+    | 'head-sha-unknown'
+    | 'branches-not-as-claimed'
+    | 'pull-request-failed'
+    /**
+     * The pull request is OPEN on the provider but the platform could not
+     * record it (database write failed mid-open). The lane is freed and
+     * the existing pull request is ADOPTED by the next attempt rather than
+     * duplicated.
+     */
+    | 'promotion-not-recorded';
+
+export type PromotionOpenResult =
+    | { outcome: 'opened'; promotion: ReleasePromotion; task: Task }
+    /** A promotion for this lane is already live. NOT an error. */
+    | { outcome: 'already-open'; promotion: ReleasePromotion }
+    | { outcome: 'refused'; code: PromotionOpenRefusal; reason: string };
+
+export interface OpenPromotionInput {
+    /** Owner. Everything else is resolved from platform state. */
+    userId: string;
+    workId: string;
+    /** WHICH rung — the only thing the caller chooses. */
+    rung: PromotionRung;
+    /**
+     * Agent the promotion Task is attributed to. Validated as owned by
+     * `userId` by `TasksService.create`, which is the same ownership rule
+     * `AgentApprovalsService.createProposal` enforces — so the Inbox
+     * approval this Task will later raise is decidable by its owner.
+     */
+    agentId: string;
+}
+
+/** What one refresh did, for the sweep summary and for tests. */
+export type PromotionRefreshOutcome =
+    | { action: 'not-a-promotion' }
+    | { action: 'closed'; state: 'merged' | 'closed' }
+    | { action: 'refused'; code: string }
+    | { action: 'observed'; verdict: PromotionGateVerdict; headSha: string };
+
+/**
+ * What the ONE Inbox notice per (commit, reading) is keyed by.
+ *
+ * Every undecided reading collapses to `'stuck'` so a `pending →
+ * unreadable → pending` flap is one notice rather than three, while every
+ * decided verdict keeps its own identity and therefore gets its own
+ * notice. Keyed on the commit alone — as it was — the first post-grace
+ * `pending` consumed the slot and the FAILURE that followed was never
+ * filed.
+ */
+function noticeToken(verdict: PromotionGateVerdict, overridden: boolean): string {
+    if (!isPromotionGateDecided(verdict)) return 'stuck';
+    // A pass that was WAIVED is a different thing to tell a human than a
+    // pass that was green, so it gets its own slot: a red gate that is
+    // then overridden into `success` must file a second notice, not be
+    // swallowed as "we already told them about `success` for this commit".
+    // Fits `varchar(16)`.
+    return overridden ? `${verdict}-waived` : verdict;
+}
+
+/**
+ * Is this reading worth telling the human about?
+ *
+ * A decided verdict always is. `pending` / `absent` / `unreadable` are
+ * only worth reporting once they have STAYED that way past the grace
+ * window: a workflow run does not exist the instant a pull request opens,
+ * and filing "the gate never ran" ten seconds in would be both noisy and
+ * wrong. The window itself is `isPromotionGateDecisionOverdue`, in
+ * contracts beside the constant, so the value has one meaning and one
+ * test — including its fail-closed behaviour on an unusable clock.
+ */
+function shouldFileNotice(
+    promotion: ReleasePromotion,
+    verdict: PromotionGateVerdict,
+    now: Date,
+): boolean {
+    if (isPromotionGateDecided(verdict)) return true;
+    return isPromotionGateDecisionOverdue(promotion.headRecordedAt ?? null, now);
+}
+
+/**
+ * What a green gate on THIS rung actually gated on.
+ *
+ * `promotion-gate.yml` has two jobs and only one of them runs on both
+ * rungs: `e2e-result` carries `if: …head.ref == 'stage'`, so on a
+ * `develop -> stage` promotion it never runs and the workflow concludes
+ * `success` off `node-contract` alone. That is by design — `e2e.yml` runs
+ * on push to `develop`, so there is no end-to-end result for a
+ * `develop -> stage` head to consult — but "PASSED" then means something
+ * materially narrower than it does on the second rung, and the person
+ * deciding sees the Inbox item, not the runbook.
+ */
+function gateScopeNote(rung: PromotionRung): string {
+    return rung === 'stage-to-main'
+        ? 'Legs evaluated on this rung: the node wire contract AND stage’s own end-to-end result.'
+        : 'Legs evaluated on this rung: the node wire contract ONLY. The end-to-end leg does not run on a ' +
+              'pull request into `stage` (e2e.yml runs on push to `develop`), so NO end-to-end result was ' +
+              'consulted here. The first one for this batch appears on `stage` and is what the next rung gates on.';
+}
+
+/** The sentence an overridden E2E leg has to put in front of a human. */
+function overrideNote(): string {
+    return (
+        `WAIVED, NOT GREEN: the \`${PROMOTION_GATE_OVERRIDE_LABEL}\` label is on this pull request, so ` +
+        'the gate’s end-to-end leg exited 0 despite being red, unreadable or unfinished. Somebody with ' +
+        'repository write decided the failing specs were unrelated. The run conclusion cannot tell you ' +
+        'that on its own — this line is the only place it is said.'
+    );
+}
+
+/**
+ * Release promotion lane (self-build slice AI, EW-808) — `develop → stage
+ * → main`, made POSSIBLE and LEGIBLE, and deliberately not automatic.
+ *
+ * ## What a promotion Task does
+ *
+ *   1. Opens ONE pull request, from the branch the Work's ladder says to
+ *      the branch the Work's ladder says. Nothing about which branches is
+ *      taken from the caller.
+ *   2. Waits on `promotion-gate.yml` for the pull request's head commit
+ *      and records what it said, stamped with the commit it was about.
+ *   3. Reports each of those into the Task, and files ONE Inbox item so a
+ *      human can see the gate result.
+ *
+ * ## What it will NEVER do on its own
+ *
+ *   - **Merge.** This service contains no merge call. A promotion pull
+ *     request is landed by the SAME machinery as every other agent merge:
+ *     `TaskMergeGateService` raises a `merge_pull_request` Inbox approval
+ *     (slice AE), a human with a real platform identity decides it, and
+ *     `GitFacadeService.mergePullRequest` re-verifies the approval against
+ *     the live head before the provider is touched. This service's only
+ *     contribution to that path is {@link assessPromotionForMerge}, which
+ *     can only say NO.
+ *   - **Cascade.** Nothing here opens `stage → main` when `develop →
+ *     stage` merges. {@link onPullRequestStatusRefreshed} frees the lane
+ *     and stops. The second promotion is a separate, separately-approved
+ *     human act — because the stage e2e gate has been unreliable for weeks
+ *     and a bad promotion is a multi-hour outage on a build lane measured
+ *     at 215–243 minutes. `PROMOTION_RUNGS` has no successor function for
+ *     the same reason.
+ *
+ * ## Why the gate is read here and not by the merge gate
+ *
+ * Because a promotion has to be legible even when it can never merge. The
+ * refresh runs on EVERY PR-status sweep, whatever CI says, so an operator
+ * watching a red promotion sees the gate's actual verdict instead of
+ * silence. {@link assessPromotionForMerge} is then a pure read of what
+ * this recorded moments earlier, on the same live head.
+ *
+ * BEST-EFFORT BY CONTRACT, like the merge gate beside it: the caller is a
+ * status refresh whose job is to keep a cache honest, and a promotion
+ * refresh that threw would turn a provider hiccup into a failed sweep for
+ * every Task behind it.
+ */
+@Injectable()
+export class ReleasePromotionService implements PromotionMergeGuard {
+    private readonly logger = new Logger(ReleasePromotionService.name);
+
+    constructor(
+        private readonly works: WorkRepository,
+        private readonly tasks: TaskRepository,
+        private readonly promotions: ReleasePromotionRepository,
+        private readonly tasksService: TasksService,
+        private readonly chat: TaskChatMessageRepository,
+        // Everything below is @Optional() and APPENDED LAST per the
+        // positional-spec arity rule. Any future dependency goes after
+        // these, also @Optional(), and the spec helpers get the same
+        // treatment — this convention has bitten five times.
+        @Optional() private readonly gitFacade?: GitFacadeService,
+        @Optional() @Inject(INBOX_PRODUCER) private readonly inbox?: InboxProducer,
+    ) {}
+
+    // ── Opening a promotion ───────────────────────────────────────────
+
+    /**
+     * Open one rung's pull request and file the Task that reports it.
+     *
+     * Ordering is load-bearing: the lane is CLAIMED before anything is
+     * created, so a race loses in the database rather than on the
+     * provider. A caller that loses gets `already-open` and the winner's
+     * row — never a second pull request.
+     */
+    async openPromotion(input: OpenPromotionInput): Promise<PromotionOpenResult> {
+        if (!this.gitFacade) {
+            return {
+                outcome: 'refused',
+                code: 'no-git-provider',
+                reason: 'No git provider is wired in this deployment.',
+            };
+        }
+
+        const work = await this.works.findById(input.workId);
+        if (!work || work.userId !== input.userId) {
+            // Same wording for "does not exist" and "is not yours": the
+            // difference would tell a caller which Works exist.
+            return {
+                outcome: 'refused',
+                code: 'work-not-found',
+                reason: `Work ${input.workId} not found.`,
+            };
+        }
+
+        // THE branch resolution. Platform state only — a caller that could
+        // name its own branches could open `their-branch -> main` and call
+        // it a release.
+        const ladder = sanitizeReleaseLadder(work.releaseLadder);
+        const branches = resolvePromotionBranches(ladder, input.rung);
+        if (!branches) {
+            return {
+                outcome: 'refused',
+                code: 'ladder-not-configured',
+                reason:
+                    `Work ${work.slug ?? work.id} has no usable release ladder. ` +
+                    'Set integration / staging / production branches on the Work before promoting.',
+            };
+        }
+
+        const target = this.resolveRepo(work, input.userId);
+
+        // Read the tip of the branch being promoted BEFORE anything is
+        // created, so the promotion has a commit to name from the start
+        // and so a missing branch refuses before a Task exists.
+        let branchHeads: Map<string, string>;
+        try {
+            const listed = await this.gitFacade.listBranches(
+                target.owner,
+                target.repo,
+                target.gitOptions,
+            );
+            branchHeads = new Map(listed.map((branch) => [branch.name, branch.commit]));
+        } catch (error) {
+            return {
+                outcome: 'refused',
+                code: 'head-sha-unknown',
+                reason: `Could not read branches for ${target.owner}/${target.repo}: ${describe(error)}`,
+            };
+        }
+
+        if (!branchHeads.has(branches.head)) {
+            return {
+                outcome: 'refused',
+                code: 'head-branch-missing',
+                reason: `Branch ${branches.head} does not exist in ${target.owner}/${target.repo}.`,
+            };
+        }
+        if (!branchHeads.has(branches.base)) {
+            return {
+                outcome: 'refused',
+                code: 'base-branch-missing',
+                reason: `Branch ${branches.base} does not exist in ${target.owner}/${target.repo}.`,
+            };
+        }
+
+        const headSha = normalizeCommitSha(branchHeads.get(branches.head));
+        if (!headSha) {
+            return {
+                outcome: 'refused',
+                code: 'head-sha-unknown',
+                reason: `Could not resolve the head commit of ${branches.head}.`,
+            };
+        }
+
+        // Claim the lane. From here on exactly one caller proceeds.
+        const claim = await this.promotions.claimLane({
+            userId: input.userId,
+            workId: work.id,
+            rung: input.rung,
+            headBranch: branches.head,
+            baseBranch: branches.base,
+            gateWorkflow: PROMOTION_GATE_WORKFLOW_FILE,
+            tenantId: work.tenantId ?? null,
+            organizationId: work.organizationId ?? null,
+        });
+        if (!claim.claimed) {
+            return { outcome: 'already-open', promotion: claim.promotion };
+        }
+        const promotion = claim.promotion;
+
+        // Filed IN_REVIEW, not TODO. A promotion Task has an open pull
+        // request from the moment it exists, so `in_review` is where it
+        // belongs on the board — and it keeps the Task out of
+        // `TaskGraphFanoutService`, which starts unblocked TODO Tasks and
+        // would otherwise dispatch an agent run against a Task whose whole
+        // job is to sit and wait for a human.
+        let task: Task;
+        try {
+            task = await this.tasksService.create(input.userId, {
+                title: `Release: promote ${branches.head} → ${branches.base}`,
+                description: promotionTaskDescription(work, branches.head, branches.base),
+                status: TaskStatus.IN_REVIEW,
+                priority: TaskPriority.P1,
+                labels: promotionTaskLabels(input.rung),
+                workId: work.id,
+                agentId: input.agentId,
+                createdByType: 'user',
+                createdById: input.userId,
+            });
+            await this.promotions.attachTask(promotion.id, task.id);
+        } catch (error) {
+            // Either write failing leaves the lane HELD by a row nothing
+            // can ever free — no pull request means the PR-status sweep
+            // never looks at it — so the lane is released here rather than
+            // left to the abandon window.
+            await this.promotions.closeLane(promotion.id, 'refused', 'task-create-failed');
+            return {
+                outcome: 'refused',
+                code: 'pull-request-failed',
+                reason: `Could not file the promotion Task: ${describe(error)}`,
+            };
+        }
+        promotion.taskId = task.id;
+
+        // ADOPT before opening. The founder performs this promotion by hand
+        // today, so an open `head -> base` pull request is the NORMAL state
+        // of the world on the day this lane is first used — and the provider
+        // answers a second request for the same pair with a 422, which used
+        // to leave the Task filed above stranded in `in_review` with the
+        // promotion labels and no pull request at all, once per retry. Same
+        // call `openPullRequestForBranch` already makes for Task branches.
+        let pr: GitPullRequest | null = await this.findOpenPullRequest(
+            target,
+            branches.head,
+            branches.base,
+        );
+        const adopted = pr !== null;
+        if (!pr) {
+            try {
+                pr = await this.gitFacade.createPullRequest(
+                    {
+                        owner: target.owner,
+                        repo: target.repo,
+                        title: `release: ${branches.head} -> ${branches.base}`,
+                        head: branches.head,
+                        base: branches.base,
+                        body: promotionPullRequestBody(task, branches.head, branches.base),
+                    },
+                    target.gitOptions,
+                );
+            } catch (error) {
+                await this.abandon(
+                    promotion.id,
+                    task,
+                    input.agentId,
+                    'pull-request-failed',
+                    `Promotion refused — could not open the pull request: ${describe(error)}`,
+                );
+                return {
+                    outcome: 'refused',
+                    code: 'pull-request-failed',
+                    reason: `Could not open ${branches.head} → ${branches.base}: ${describe(error)}`,
+                };
+            }
+        }
+
+        // PROMOTING THE WRONG THING. The provider is the authority on what
+        // it just created — or on what it already had open; if the pull
+        // request is not between the branches we asked for, the promotion
+        // is abandoned rather than adopted. Nothing merges it, because a
+        // refused promotion's guard says no.
+        if (!refMatches(pr.head, branches.head) || !refMatches(pr.base, branches.base)) {
+            await this.abandon(
+                promotion.id,
+                task,
+                input.agentId,
+                'branches-not-as-claimed',
+                `Promotion refused — the provider opened ${pr.head} → ${pr.base}, not ` +
+                    `${branches.head} → ${branches.base}. Pull request ${pr.url} is NOT managed by this promotion; ` +
+                    'close it by hand.',
+            );
+            return {
+                outcome: 'refused',
+                code: 'branches-not-as-claimed',
+                reason: `Provider opened ${pr.head} → ${pr.base}, expected ${branches.head} → ${branches.base}.`,
+            };
+        }
+
+        // THE head this promotion reports, read back from the PULL REQUEST
+        // rather than taken from the branch listing above.
+        //
+        // That listing is a branch's tip at the instant it was read, and
+        // `createPullRequest` is a whole round trip later; two merges to
+        // `develop` seconds apart — the exact interleaving this lane exists
+        // to survive — put a newer commit on the branch in between.
+        // Publishing the older one would name a commit that is not what
+        // gets promoted, and would then spend a spurious "head moved"
+        // report plus a fresh 20-minute grace window on the next sweep.
+        // `GitPullRequest` carries no head SHA and the status read does,
+        // which is the only reason this is a second call.
+        const confirmed = await this.readPullRequestHead(target, pr.number);
+        const reportedHead = confirmed ?? headSha;
+
+        const now = new Date();
+        try {
+            await this.promotions.recordPullRequest(promotion.id, {
+                prNumber: pr.number,
+                prUrl: pr.url ?? null,
+                headSha: reportedHead,
+                headRecordedAt: now,
+            });
+            Object.assign(promotion, {
+                prNumber: pr.number,
+                prUrl: pr.url ?? null,
+                headSha: reportedHead,
+                headRecordedAt: now,
+            });
+
+            // Bind the pull request to the Task. This is what puts the
+            // promotion into `findDuePrStatusSync`, and therefore into the
+            // slice-AE merge path — the ONLY way it can ever be merged.
+            //
+            // `branchRef` is deliberately NOT written, and that is a safety
+            // property rather than an omission. It is the slot the platform
+            // treats as a DISPOSABLE task branch: `discardBranch`
+            // (`DELETE /api/tasks/:id/branch`) and the nightly
+            // `findBranchCleanupCandidates` sweep both call
+            // `gitFacade.deleteBranch(owner, repo, task.branchRef)`, and
+            // `runWorkspace` provisions an agent run onto it. Writing
+            // `develop` or `stage` there would aim the branch reaper at the
+            // integration branch and let an agent run push to it with no
+            // pull request at all. A promotion owns no branch of its own —
+            // it moves two that already exist — so the slot stays NULL,
+            // which keeps the Task out of the cleanup query
+            // (`branchRef IS NOT NULL`) while `findDuePrStatusSync`, which
+            // selects on `prNumber`, still picks it up.
+            await this.tasks.updateById(task.id, {
+                prNumber: pr.number,
+                prUrl: pr.url ?? null,
+            });
+            Object.assign(task, { prNumber: pr.number, prUrl: pr.url ?? null });
+        } catch (error) {
+            // A real pull request is open and the platform cannot watch it.
+            // Free the lane so a human can retry — the retry ADOPTS this
+            // pull request rather than opening a second one — and say so on
+            // the Task before it is cancelled.
+            await this.abandon(
+                promotion.id,
+                task,
+                input.agentId,
+                'promotion-not-recorded',
+                `Promotion refused — pull request ${pr.url ?? `#${pr.number}`} is open but could not be ` +
+                    `recorded: ${describe(error)}. Re-running the promotion adopts it rather than opening another.`,
+            );
+            return {
+                outcome: 'refused',
+                code: 'promotion-not-recorded',
+                reason: `Opened ${branches.head} → ${branches.base} but could not record it: ${describe(error)}`,
+            };
+        }
+
+        await this.report(
+            task,
+            input.agentId,
+            (adopted
+                ? `Promotion adopted the pull request already open for ${branches.head} → ${branches.base}`
+                : `Promotion opened — ${branches.head} → ${branches.base}`) +
+                ` at ${reportedHead.slice(0, 12)} (${pr.url ?? `#${pr.number}`}).\n` +
+                (confirmed
+                    ? ''
+                    : 'The pull request head could not be read back, so that is the branch tip as it was ' +
+                      'when the promotion started; the next status refresh corrects it.\n') +
+                `Waiting on ${PROMOTION_GATE_WORKFLOW_FILE}. This Task will NOT merge the pull request: ` +
+                'landing it needs a human approval in the Inbox, the same as any other agent merge.',
+        );
+
+        return { outcome: 'opened', promotion, task };
+    }
+
+    /**
+     * The pull request already open for `head -> base`, if there is one.
+     *
+     * A READ, never a create. The founder opens this promotion by hand
+     * today, so an open `develop -> stage` is the normal state of the world
+     * the first time this lane runs; asking the provider for a second one
+     * answers 422 (`A pull request already exists for …`), and the lane
+     * would otherwise leave a promotion-labelled Task with no pull request
+     * behind it once per retry. Same move `openPullRequestForBranch`
+     * already makes for Task branches.
+     *
+     * A failed listing answers `null`: "we could not tell" is not "there is
+     * none", but the create path that follows fails loudly and is itself
+     * handled, so this degrades to the pre-adoption behaviour rather than
+     * to a wrong adoption.
+     */
+    private async findOpenPullRequest(
+        target: { owner: string; repo: string; gitOptions: GitFacadeOptions },
+        head: string,
+        base: string,
+    ): Promise<GitPullRequest | null> {
+        if (!this.gitFacade) return null;
+        try {
+            const open = await this.gitFacade.listPullRequests(
+                target.owner,
+                target.repo,
+                { state: 'open', perPage: 100 },
+                target.gitOptions,
+            );
+            return (
+                open.find(
+                    (candidate) =>
+                        refMatches(candidate.head, head) && refMatches(candidate.base, base),
+                ) ?? null
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Promotion: could not list open pull requests for ${target.owner}/${target.repo}: ${describe(error)}`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * The pull request's OWN head commit, straight from the provider.
+     *
+     * `null` on any failure — the caller falls back to the branch tip and
+     * says in the Task that it did, rather than publishing a commit it
+     * could not confirm without saying so.
+     */
+    private async readPullRequestHead(
+        target: { owner: string; repo: string; gitOptions: GitFacadeOptions },
+        prNumber: number,
+    ): Promise<string | null> {
+        if (!this.gitFacade) return null;
+        try {
+            const live = await this.gitFacade.getPullRequestStatus(
+                target.owner,
+                target.repo,
+                prNumber,
+                target.gitOptions,
+            );
+            return normalizeCommitSha(live?.headSha) ?? null;
+        } catch (error) {
+            this.logger.warn(
+                `Promotion: could not read the head of ${target.owner}/${target.repo}#${prNumber}: ${describe(error)}`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Give the lane back and leave nothing usable behind.
+     *
+     * Every failure after the Task exists goes through here, because two
+     * things have to happen together and either alone is a mess. The lane
+     * must be FREED, or the UNIQUE `(workId, rung, laneKey)` index refuses
+     * every later promotion for that rung — there is no abandon endpoint
+     * and the PR-status sweep never looks at a Task with no pull request,
+     * so nothing else would ever free it. And the Task must not be left
+     * sitting in `in_review` wearing the promotion labels with no pull
+     * request behind it: the merge guard refuses such a Task, but a human
+     * reading the board cannot tell it from a real promotion, and each
+     * retry would add another.
+     */
+    private async abandon(
+        promotionId: string,
+        task: Task,
+        agentId: string | null,
+        code: string,
+        narrative: string,
+    ): Promise<void> {
+        await this.promotions.closeLane(promotionId, 'refused', code);
+        await this.report(task, agentId, narrative);
+        try {
+            await this.tasks.updateById(task.id, { status: TaskStatus.CANCELLED });
+            Object.assign(task, { status: TaskStatus.CANCELLED });
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotionId}: could not cancel the orphaned Task ${task.id}: ${describe(error)}`,
+            );
+        }
+    }
+
+    // ── Watching a promotion ──────────────────────────────────────────
+
+    /**
+     * Called by `TaskPrStatusService` after every successful provider
+     * read, BEFORE the merge gate, with the live status.
+     *
+     * Never throws: the caller's job is to keep a PR-status cache honest.
+     */
+    async onPullRequestStatusRefreshed(
+        task: Task,
+        status: GitPullRequestStatus,
+    ): Promise<PromotionRefreshOutcome> {
+        try {
+            return await this.refresh(task, status);
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: promotion refresh failed (PR status still recorded): ${describe(error)}`,
+            );
+            return { action: 'not-a-promotion' };
+        }
+    }
+
+    private async refresh(
+        task: Task,
+        status: GitPullRequestStatus,
+    ): Promise<PromotionRefreshOutcome> {
+        // THE identity, and it is the ROW — not the Task's labels.
+        //
+        // This used to bail on `!isPromotionTask(task.labels)` before the
+        // row was ever looked up, which made a free-form field the gate's
+        // on/off switch: `UpdateTaskDto.labels` is applied verbatim by
+        // `TasksService.update`, so `PATCH /api/tasks/<promotion>` with
+        // `{"labels":[]}` froze a live `develop -> stage` lane — it stopped
+        // being refreshed, and the merge guard (which bailed on the same
+        // check) stopped consulting the gate at all. `release_promotions`
+        // is the authority and it is keyed by `taskId`, so it is asked
+        // FIRST. Labels survive only where there is no row to ask: as the
+        // fail-closed hint in {@link assessPromotionForMerge}.
+        const promotion = await this.promotions.findOpenByTaskId(task.id);
+        if (!promotion) return { action: 'not-a-promotion' };
+
+        // PROMOTING THE WRONG THING, third time: is this status even about
+        // the promotion's pull request?
+        //
+        // `status` is the provider read `TaskPrStatusService` did for
+        // `task.prNumber`, and that is a MUTABLE binding — an agent run on
+        // this Task opens its own pull request and overwrites it
+        // (`task-workspace.service.ts` `recordRemotePush`). Everything
+        // below stamps a head, a gate verdict and a merged/closed decision
+        // from this object, so a rebound Task would have the promotion
+        // recording `promotion-gate.yml`'s answer about somebody else's
+        // pull request. The lane refuses instead: nothing merges through a
+        // refused promotion, the lane is freed, and a human can open a new
+        // one. A provider that does not echo the number is not punished for
+        // it — the guard still compares numbers at merge time.
+        if (
+            typeof status.number === 'number' &&
+            typeof promotion.prNumber === 'number' &&
+            status.number !== promotion.prNumber
+        ) {
+            await this.promotions.closeLane(promotion.id, 'refused', 'pull-request-rebound');
+            await this.report(
+                task,
+                task.agentId ?? null,
+                `Promotion refused — this Task now reports pull request #${status.number}, not the ` +
+                    `#${promotion.prNumber} the ${promotion.headBranch} → ${promotion.baseBranch} promotion ` +
+                    'opened. Nothing will merge through this lane; open a new promotion if the release is ' +
+                    'still wanted.',
+            );
+            return { action: 'refused', code: 'pull-request-rebound' };
+        }
+
+        // A landed or abandoned promotion frees its lane and STOPS. There
+        // is deliberately nothing here that opens the next rung: `stage →
+        // main` is a separate, separately-approved human act.
+        if (status.state === 'merged' || status.state === 'closed') {
+            await this.promotions.closeLane(
+                promotion.id,
+                status.state === 'merged' ? 'merged' : 'closed',
+            );
+            await this.report(
+                task,
+                task.agentId ?? null,
+                status.state === 'merged'
+                    ? `Promotion merged — ${promotion.headBranch} → ${promotion.baseBranch} has landed. ` +
+                          'The next rung is a separate promotion and is not opened automatically.'
+                    : `Promotion closed without merging — ${promotion.headBranch} → ${promotion.baseBranch}.`,
+            );
+            return { action: 'closed', state: status.state === 'merged' ? 'merged' : 'closed' };
+        }
+
+        const work = await this.works.findById(promotion.workId);
+        if (!work) {
+            return { action: 'observed', verdict: 'unreadable', headSha: promotion.headSha ?? '' };
+        }
+        const target = this.resolveRepo(work, promotion.userId);
+
+        // PROMOTING THE WRONG THING, from the other side: re-assert on
+        // every refresh that the pull request is still between the branches
+        // this promotion claims. The rolled-up status does not carry the
+        // refs, so the pull request itself is read — the PROMOTION's, never
+        // the Task's current one, so the branches that get checked and the
+        // head that gets recorded are the same pull request's.
+        const prNumber = promotion.prNumber ?? null;
+        if (!prNumber) {
+            return { action: 'observed', verdict: 'unreadable', headSha: promotion.headSha ?? '' };
+        }
+        let live;
+        try {
+            live = this.gitFacade
+                ? await this.gitFacade.getPullRequest(
+                      target.owner,
+                      target.repo,
+                      prNumber,
+                      target.gitOptions,
+                  )
+                : null;
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: pull-request read failed: ${describe(error)}`,
+            );
+            live = null;
+        }
+        if (!live) {
+            // Cannot confirm the branches. Fail closed: record the gate as
+            // unreadable for the live head so the guard refuses, and say so.
+            const unknownHead = normalizeCommitSha(status.headSha) ?? promotion.headSha ?? '';
+            await this.observe(task, promotion, unknownHead, 'unreadable', null, false);
+            return { action: 'observed', verdict: 'unreadable', headSha: unknownHead };
+        }
+        if (
+            !refMatches(live.head, promotion.headBranch) ||
+            !refMatches(live.base, promotion.baseBranch)
+        ) {
+            await this.promotions.closeLane(promotion.id, 'refused', 'branches-moved');
+            await this.report(
+                task,
+                task.agentId ?? null,
+                `Promotion refused — pull request #${prNumber} is now ${live.head} → ${live.base}, ` +
+                    `not the ${promotion.headBranch} → ${promotion.baseBranch} it was opened as. ` +
+                    'Nothing will merge it through this lane.',
+            );
+            return { action: 'refused', code: 'branches-moved' };
+        }
+
+        const headSha = normalizeCommitSha(status.headSha);
+        if (!headSha) {
+            await this.observe(task, promotion, promotion.headSha ?? '', 'unreadable', null, false);
+            return { action: 'observed', verdict: 'unreadable', headSha: promotion.headSha ?? '' };
+        }
+
+        if (promotion.headSha !== headSha) {
+            // The branch advanced under the promotion. Adopt the new head
+            // and DROP the old verdict — a verdict is about a commit. Any
+            // human approval dies with it for free: the slice-AE subject
+            // key contains the head SHA.
+            const movedAt = new Date();
+            await this.promotions.recordHeadMoved(promotion.id, headSha, movedAt);
+            Object.assign(promotion, {
+                headSha,
+                headRecordedAt: movedAt,
+                gateVerdict: null,
+                gateVerdictSha: null,
+                gateRunUrl: null,
+                // The waiver went with the verdict: a label applied to the
+                // old commit's run says nothing about this one. Mirrors
+                // what `recordHeadMoved` wrote.
+                gateOverridden: false,
+            });
+            await this.report(
+                task,
+                task.agentId ?? null,
+                `Promotion head moved to ${headSha.slice(0, 12)} — the previous gate verdict and any ` +
+                    'approval for the old commit no longer apply.',
+            );
+        }
+
+        const reading = await this.readGate(promotion, target, headSha, prNumber);
+
+        // Was the gate's E2E leg WAIVED rather than green? Read off the
+        // pull request we just re-verified, because the run cannot say:
+        // `promotion-gate.yml` exits 0 on the `override-e2e-gate` label in
+        // all four of its failure branches, and GitHub folds that back into
+        // a plain `success` conclusion. Without this the person deciding a
+        // production release is told "the gate passed" when what happened
+        // is that somebody with repository write applied a label.
+        //
+        // It does NOT change the verdict — the override is a deliberate,
+        // documented escape hatch and refusing it would only get the lane
+        // routed around — it changes what the human is told.
+        const overridden = isPromotionGateOverridden(live.labels);
+
+        await this.observe(task, promotion, headSha, reading.verdict, reading.url, overridden);
+        return { action: 'observed', verdict: reading.verdict, headSha };
+    }
+
+    /**
+     * Read the gate for one commit.
+     *
+     * A THROW is `unreadable`, not `absent`: a token without `actions:read`
+     * and a workflow that never ran are different problems and send the
+     * operator to different places. A missing capability is `unreadable`
+     * for the same reason.
+     *
+     * A run that names pull requests NOT including this promotion's is
+     * `absent`. A workflow run is keyed by COMMIT, and one commit can head
+     * more than one pull request — `stage` can be the head of both a
+     * `stage -> main` promotion and somebody's comparison branch — so a run
+     * adopted off the commit alone need not be this promotion's, and the
+     * two differ in exactly the way that matters: the override label is
+     * per pull request. A provider that does not report the association
+     * (`undefined`) is taken at its word, because inventing a mismatch
+     * would make every gate unreadable on such a provider.
+     */
+    private async readGate(
+        promotion: ReleasePromotion,
+        target: { owner: string; repo: string; gitOptions: GitFacadeOptions },
+        headSha: string,
+        prNumber: number,
+    ): Promise<{ verdict: PromotionGateVerdict; url: string | null }> {
+        if (!this.gitFacade) return { verdict: 'unreadable', url: null };
+        try {
+            const run = await this.gitFacade.getWorkflowRunForCommit(
+                target.owner,
+                target.repo,
+                promotion.gateWorkflow || PROMOTION_GATE_WORKFLOW_FILE,
+                headSha,
+                target.gitOptions,
+            );
+            if (run && Array.isArray(run.pullRequestNumbers) && run.pullRequestNumbers.length > 0) {
+                if (!run.pullRequestNumbers.includes(prNumber)) {
+                    this.logger.log(
+                        `Promotion ${promotion.id}: ${promotion.gateWorkflow} run ${run.id} for ${headSha} ` +
+                            `is for pull request(s) ${run.pullRequestNumbers.join(', ')}, not #${prNumber}.`,
+                    );
+                    return { verdict: 'absent', url: null };
+                }
+            }
+            return { verdict: promotionGateVerdictFromRun(run), url: run?.url ?? null };
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: ${promotion.gateWorkflow} lookup failed for ${headSha}: ${describe(error)}`,
+            );
+            return { verdict: 'unreadable', url: null };
+        }
+    }
+
+    /** Record a verdict, report a CHANGE into the Task, file the one Inbox item. */
+    private async observe(
+        task: Task,
+        promotion: ReleasePromotion,
+        headSha: string,
+        verdict: PromotionGateVerdict,
+        url: string | null,
+        overridden: boolean,
+    ): Promise<void> {
+        const checkedAt = new Date();
+        // `changed` comes from the DATABASE's own answer, not from a
+        // read-then-write on the in-memory row. The two-minute cron sweep
+        // and an on-demand `?refresh=true` run in different processes; two
+        // callers holding the same stale row would both compute "this is
+        // new" and both narrate it, and the Task thread is this promotion's
+        // audit trail.
+        const { changed } = await this.promotions.recordGateVerdict(promotion.id, {
+            gateVerdict: verdict,
+            gateVerdictSha: headSha,
+            gateCheckedAt: checkedAt,
+            gateRunUrl: url,
+            gateOverridden: overridden,
+        });
+        Object.assign(promotion, {
+            gateVerdict: verdict,
+            gateVerdictSha: headSha,
+            gateCheckedAt: checkedAt,
+            gateRunUrl: url,
+            gateOverridden: overridden,
+        });
+
+        if (changed) {
+            // Only on a change: the sweep runs every two minutes, and a
+            // `pending` gate re-reported 300 times is not a report.
+            await this.report(
+                task,
+                task.agentId ?? null,
+                gateNarrative(promotion, verdict, headSha, url, overridden),
+            );
+        }
+
+        if (!shouldFileNotice(promotion, verdict, checkedAt)) return;
+        // Exactly once per (head commit, reading), claimed with a
+        // compare-and-set so the cron worker and an on-demand refresh
+        // cannot both file it.
+        const token = noticeToken(verdict, overridden);
+        if (!(await this.promotions.claimInboxNotice(promotion.id, headSha, token))) return;
+        Object.assign(promotion, { inboxFiledForSha: headSha, inboxFiledVerdict: token });
+        await this.fileNotice(task, promotion, verdict, headSha, url, overridden);
+    }
+
+    private async fileNotice(
+        task: Task,
+        promotion: ReleasePromotion,
+        verdict: PromotionGateVerdict,
+        headSha: string,
+        url: string | null,
+        overridden: boolean,
+    ): Promise<void> {
+        if (!this.inbox) return;
+        const lane = `${promotion.headBranch} → ${promotion.baseBranch}`;
+        const at = `(@ ${headSha.slice(0, 12)})`;
+        // A pass that was WAIVED is not reported as a plain pass. This is
+        // the one artefact the founder reads before deciding, and the run
+        // conclusion cannot carry the difference.
+        const title = !isPromotionGatePass(verdict)
+            ? `Promotion gate ${verdict.toUpperCase()} for ${lane} ${at}`
+            : overridden
+              ? `Promotion gate PASSED — E2E WAIVED, not green — for ${lane} ${at}`
+              : `Promotion gate PASSED for ${lane} ${at}`;
+        const next = isPromotionGatePass(verdict)
+            ? 'A separate "Merge pull request" approval will appear in this Inbox on the next status refresh. ' +
+              'Nothing merges until you approve it.'
+            : 'This promotion will NOT be offered for merge while the gate says anything other than success. ' +
+              'Read the run, fix or re-run it, or close the promotion.';
+        try {
+            await this.inbox.notice(promotion.userId, {
+                title: title.slice(0, 300),
+                body: [
+                    `${lane} — pull request ${promotion.prUrl ?? `#${promotion.prNumber ?? '?'}`}.`,
+                    `${promotion.gateWorkflow} for ${headSha}: ${verdict}.`,
+                    // WHAT was actually evaluated on this rung, and whether
+                    // any of it was waived. Both belong in front of the
+                    // person deciding, because "PASSED" alone means
+                    // different things on the two rungs and can mean a
+                    // label rather than a green run.
+                    gateScopeNote(promotion.rung),
+                    ...(overridden ? [overrideNote()] : []),
+                    url ? `Gate run: ${url}` : 'No gate run to link.',
+                    next,
+                ]
+                    .join('\n')
+                    .slice(0, 8000),
+                taskId: task.id,
+                workId: promotion.workId,
+                agentId: task.agentId ?? null,
+                organizationId: promotion.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(`Promotion ${promotion.id}: inbox notice failed: ${describe(error)}`);
+        }
+    }
+
+    // ── The extra refusal (PromotionMergeGuard) ───────────────────────
+
+    /**
+     * The ONLY thing this service contributes to the merge path, and it
+     * can only ever say NO.
+     *
+     * A pure read of what {@link onPullRequestStatusRefreshed} recorded
+     * moments earlier in the same sweep, on the same live head. It does
+     * not re-read the provider: the read that matters already happened,
+     * and doing it twice would let the two answers disagree.
+     */
+    async assessPromotionForMerge(subject: PromotionMergeSubject): Promise<PromotionMergeVerdict> {
+        // THE ROW FIRST, and the labels only where there is no row.
+        //
+        // This used to short-circuit on `isPromotionTask(subject.labels)`
+        // one line ABOVE the lookup, which made a free-form, owner-writable
+        // field (`PATCH /api/tasks/:id` → `TasksService.update` applies
+        // `input.labels` verbatim) the gate's on/off switch: clearing the
+        // labels on a live `develop -> stage` pull request returned
+        // `{ promotion: false }`, and the release then dropped into the
+        // ordinary agent-merge path with the promotion gate never consulted
+        // — under a policy with `requireHumanApproval: false`, an entirely
+        // ungated merge into `stage` or `main`. The authority is
+        // `release_promotions`, keyed by `taskId`, and it is asked first.
+        const promotion = await this.promotions.findByTaskId(subject.taskId);
+        if (!promotion) {
+            // No row. The labels are the FAIL-CLOSED half and nothing more:
+            // a Task that claims to be a promotion with nothing backing it
+            // is refused, and a Task that claims nothing is left to the
+            // ordinary path exactly as before this slice existed.
+            return isPromotionTask(subject.labels)
+                ? {
+                      promotion: true,
+                      allowed: false,
+                      code: 'promotion-row-missing',
+                      reason: 'This Task is labelled a promotion but no promotion record resolves for it.',
+                  }
+                : { promotion: false };
+        }
+        if (promotion.state !== 'open') {
+            return {
+                promotion: true,
+                allowed: false,
+                promotionId: promotion.id,
+                code: 'promotion-not-open',
+                reason: `The promotion is ${promotion.state}.`,
+            };
+        }
+
+        // Is the pull request about to be merged the one this promotion
+        // opened? `tasks.prNumber` is mutable — an agent run on the
+        // promotion Task overwrites it with its own pull request — and a
+        // verdict recorded for one pull request must never authorise the
+        // merge of another.
+        if (typeof promotion.prNumber !== 'number' || promotion.prNumber !== subject.prNumber) {
+            return {
+                promotion: true,
+                allowed: false,
+                promotionId: promotion.id,
+                code: 'promotion-pull-request-mismatch',
+                reason:
+                    `This promotion is for pull request ` +
+                    `${promotion.prNumber === null || promotion.prNumber === undefined ? '(none recorded)' : `#${promotion.prNumber}`}` +
+                    `, not #${subject.prNumber}.`,
+            };
+        }
+
+        const headSha = normalizeCommitSha(subject.headSha);
+        if (!headSha || promotion.gateVerdictSha !== headSha) {
+            return {
+                promotion: true,
+                allowed: false,
+                promotionId: promotion.id,
+                code: 'promotion-gate-stale',
+                reason:
+                    `${promotion.gateWorkflow} has no verdict for ${subject.headSha}` +
+                    (promotion.gateVerdictSha
+                        ? ` (the recorded one is for ${promotion.gateVerdictSha})`
+                        : '') +
+                    '.',
+            };
+        }
+        if (!isPromotionGatePass(promotion.gateVerdict)) {
+            return {
+                promotion: true,
+                allowed: false,
+                promotionId: promotion.id,
+                code: 'promotion-gate-not-success',
+                reason: `${promotion.gateWorkflow} for ${headSha}: ${promotion.gateVerdict ?? 'not read'}.`,
+            };
+        }
+        // The promotion's OWN coordinates travel with the allowance. The
+        // merge path's default answer to "what is this pull request's
+        // base?" is the Work's `taskIsolationBaseBranch` — right for every
+        // Task pull request, wrong for every promotion — and it is what
+        // both the protected-branch rule and the human's Inbox line are
+        // computed from.
+        return {
+            promotion: true,
+            allowed: true,
+            promotionId: promotion.id,
+            headBranch: promotion.headBranch,
+            baseBranch: promotion.baseBranch,
+            prNumber: promotion.prNumber,
+        };
+    }
+
+    // ── Reads for the operator surface ────────────────────────────────
+
+    async listForWork(workId: string, userId: string, limit?: number): Promise<ReleasePromotion[]> {
+        return this.promotions.listForWork(workId, userId, limit);
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────
+
+    /**
+     * Owner, repository and credentials — ALL from the Work, never from a
+     * caller. Same resolution `TaskPrStatusService` uses, so a promotion
+     * pull request and a Task pull request cannot end up on different
+     * repositories for the same Work.
+     */
+    private resolveRepo(
+        work: Work,
+        userId: string,
+    ): { owner: string; repo: string; gitOptions: GitFacadeOptions } {
+        return {
+            owner: work.getRepoOwner(),
+            repo: work.getDataRepo(),
+            gitOptions: { userId, providerId: work.gitProvider, workId: work.id },
+        };
+    }
+
+    /** One line of narrative on the Task's own thread. Best-effort. */
+    private async report(task: Task, agentId: string | null, body: string): Promise<void> {
+        if (!agentId) return;
+        try {
+            await this.chat.create({
+                taskId: task.id,
+                authorType: 'agent',
+                authorId: agentId,
+                body,
+                tenantId: task.tenantId ?? null,
+                organizationId: task.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(`Task ${task.id}: promotion report failed: ${describe(error)}`);
+        }
+    }
+}
+
+/** Do two refs name the same branch? Providers echo `owner:branch` heads. */
+function refMatches(actual: string | null | undefined, expected: string): boolean {
+    if (typeof actual !== 'string') return false;
+    const trimmed = actual.trim();
+    if (trimmed === expected) return true;
+    // GitHub reports a cross-fork head as `owner:branch`. A promotion is
+    // same-repository by construction, so a qualified head only matches
+    // when the branch half does — and a fork head can never match, which
+    // is the correct refusal.
+    const colon = trimmed.indexOf(':');
+    return colon > 0 && trimmed.slice(colon + 1) === expected;
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function gateNarrative(
+    promotion: ReleasePromotion,
+    verdict: PromotionGateVerdict,
+    headSha: string,
+    url: string | null,
+    overridden: boolean,
+): string {
+    const where = url ? ` (${url})` : '';
+    const head = headSha ? headSha.slice(0, 12) : 'an unknown commit';
+    switch (verdict) {
+        case 'success':
+            return (
+                `${promotion.gateWorkflow} ${overridden ? 'PASSED WITH THE E2E LEG WAIVED' : 'PASSED'} ` +
+                `for ${head}${where}.\n` +
+                `${gateScopeNote(promotion.rung)}\n` +
+                (overridden ? `${overrideNote()}\n` : '') +
+                'A merge approval will be raised in the Inbox; nothing merges until a human approves it.'
+            );
+        case 'failure':
+            return `${promotion.gateWorkflow} FAILED for ${head}${where}. This promotion will not be offered for merge.`;
+        case 'pending':
+            return `${promotion.gateWorkflow} is still running for ${head}${where}.`;
+        case 'cancelled':
+            return (
+                `${promotion.gateWorkflow} was CANCELLED for ${head}${where}. ` +
+                'A cancelled gate is the absence of a verdict, not a pass.'
+            );
+        case 'skipped':
+            return (
+                `${promotion.gateWorkflow} did not evaluate for ${head}${where} (skipped / neutral / stale). ` +
+                'Branch protection renders this green; this lane does not.'
+            );
+        case 'absent':
+            return (
+                `${promotion.gateWorkflow} has no run for ${head}. ` +
+                'A gate that never ran is not a pass.'
+            );
+        case 'unreadable':
+        default:
+            return (
+                `${promotion.gateWorkflow} could not be read for ${head}. ` +
+                'That is a broken gate, not a verdict, and it is not a pass.'
+            );
+    }
+}
+
+function promotionTaskDescription(work: Work, head: string, base: string): string {
+    // Deliberately names NO commit. The description is written before the
+    // pull request exists, and the branch tip read a round trip earlier is
+    // not necessarily what the pull request ends up heading — two merges to
+    // `develop` seconds apart is the case this lane is built for. The
+    // confirmed head is reported into the Task thread instead, where it can
+    // be re-stated when it moves.
+    return [
+        `Promote \`${head}\` → \`${base}\` in ${work.getRepoOwner()}/${work.getDataRepo()}.`,
+        '',
+        'This Task opens the pull request and reports what ' +
+            `\`${PROMOTION_GATE_WORKFLOW_FILE}\` says about it. It does not merge it.`,
+        'The commit being promoted is whatever the pull request heads; the Task thread records it,',
+        'and a gate verdict is only ever valid for the commit it was read for.',
+        '',
+        'Landing the pull request needs a human approval in the Inbox, verified against the head commit',
+        'at merge time — the same path as every other agent merge.',
+        '',
+        'The next rung is NOT opened automatically when this one lands.',
+    ].join('\n');
+}
+
+function promotionPullRequestBody(task: Task, head: string, base: string): string {
+    return [
+        `Release promotion \`${head}\` → \`${base}\`.`,
+        '',
+        `Opened by Ever Works for Task ${task.slug ?? task.id}.`,
+        '',
+        `Gated on \`${PROMOTION_GATE_WORKFLOW_FILE}\`. The platform will not merge this pull request`,
+        'without a recorded human approval for its exact head commit.',
+    ].join('\n');
+}

--- a/packages/agent/src/tasks-domain/task-merge-gate.service.ts
+++ b/packages/agent/src/tasks-domain/task-merge-gate.service.ts
@@ -1,10 +1,15 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type { GitPullRequestStatus } from '@ever-works/plugin';
-import { normalizeCommitSha } from '@ever-works/contracts';
+import { isPromotionTask, normalizeCommitSha } from '@ever-works/contracts';
 import { Task } from '../entities/task.entity';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { MergePolicyService } from '../policy/merge-policy.service';
 import { MergeApprovalService } from '../agent-approvals/merge-approval.service';
+import {
+    PROMOTION_MERGE_GUARD,
+    type PromotionMergeGuard,
+    type PromotionMergeVerdict,
+} from '../policy/promotion-merge-guard.port';
 import { TaskWorkspaceService, type TaskAgentMergeOutcome } from './task-workspace.service';
 
 /** What one post-CI evaluation did, for logs and for the sweep summary. */
@@ -68,6 +73,19 @@ export class TaskMergeGateService {
         // per the positional-spec arity rule; absent, the gate degrades to
         // "never raise, never merge", which is the safe direction.
         @Optional() private readonly mergeApprovals?: MergeApprovalService,
+        // Release promotion lane (self-build slice AI, EW-808) — the
+        // NARROWING for a promotion pull request. Appended LAST +
+        // @Optional() per the positional-spec arity rule, and injected by
+        // TOKEN so `TasksDomainModule` does not have to import the module
+        // that imports it.
+        //
+        // Unbound does NOT mean "degrade gracefully" here: the check below
+        // recognises a promotion Task off its own labels and stands down,
+        // so a deployment that cannot evaluate promotions never merges one
+        // through the ordinary agent path.
+        @Optional()
+        @Inject(PROMOTION_MERGE_GUARD)
+        private readonly promotionGuard?: PromotionMergeGuard,
     ) {}
 
     /**
@@ -119,6 +137,29 @@ export class TaskMergeGateService {
             return { action: 'skipped', reason: 'head-sha-unknown' };
         }
 
+        // Release promotion lane (slice AI) — the extra refusal, applied
+        // BEFORE any approval is raised and before any merge is attempted.
+        //
+        // It exists because the `ciState === 'passing'` check above cannot
+        // answer a release question: the roll-up treats `skipped`,
+        // `cancelled`, `neutral` and `stale` as non-blocking, and
+        // `promotion-gate.yml` SKIPS its e2e job by design on any head that
+        // is not `stage`. Without this, a promotion whose gate never
+        // evaluated would reach a human as an Approve button next to a
+        // green badge the platform manufactured.
+        //
+        // It can only ever say NO. A Task that is not a promotion returns
+        // `{ promotion: false }` and the path below is unchanged.
+        const assessed = await this.assessPromotion(task, headSha);
+        if (assessed.blocked) return assessed.blocked;
+        // A live promotion this merge may proceed with. It carries the
+        // promotion's OWN branches and pull request, which is what the
+        // protected-branch rule and the human's Inbox line are computed
+        // from below — the Work's `taskIsolationBaseBranch` is the right
+        // answer for every Task pull request and the wrong answer for
+        // every promotion.
+        const promotion = assessed.promotion;
+
         const work = await this.works.findById(task.workId);
         if (!work) return { action: 'skipped', reason: 'no-work' };
 
@@ -142,7 +183,23 @@ export class TaskMergeGateService {
             return { action: 'skipped', reason: 'agent-merge-disabled' };
         }
 
-        if (!resolved.policy.requireHumanApproval) {
+        // Release promotion lane (slice AI) — THE property the slice
+        // exists for: a promotion is never merged without a recorded human
+        // approval, whatever the scope's policy says.
+        //
+        // `requireHumanApproval: false` is a legitimate operator choice for
+        // ordinary agent work ("agents land their own green work"). It is
+        // not a choice about releases: a promotion moves a whole batch onto
+        // `stage` or into production, the stage e2e gate has been
+        // unreliable for weeks, and a bad promotion is a multi-hour outage
+        // on a build lane measured at 215-243 minutes. So a promotion
+        // ignores the shortcut below and always takes the approval path,
+        // and `attemptMergeForOpenPullRequest` additionally RAISES the
+        // requirement inside the facade so the property does not rest on
+        // this branch alone.
+        const needsApproval = resolved.policy.requireHumanApproval || promotion !== null;
+
+        if (!needsApproval) {
             // The operator opted out of approvals for this scope. Green
             // provider CI is the trigger; the facade still pins the head
             // and still applies the branch / method / gate rules.
@@ -170,6 +227,10 @@ export class TaskMergeGateService {
                 agentId,
                 gateStatus: 'green',
                 headSha,
+                // The promotion's own base, not the Work's default — see
+                // `attemptMergeForOpenPullRequest`.
+                baseRef: promotion?.baseBranch ?? null,
+                requireHumanApproval: promotion !== null,
             });
             return { action: 'merge-attempted', merge };
         }
@@ -185,8 +246,13 @@ export class TaskMergeGateService {
             prNumber: task.prNumber,
             prUrl: task.prUrl ?? null,
             headSha,
+            // The branch this pull request MERGES INTO, as the human will
+            // read it in the Inbox ("Merge PR #7 into <branch> in <repo>").
+            // A promotion carries its own base; only an ordinary Task pull
+            // request targets the Work's isolation base.
             targetBranch:
-                (work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || null,
+                promotion?.baseBranch ??
+                ((work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || null),
             repository: `${work.getRepoOwner()}/${work.getDataRepo()}`,
             ciState: status.ciState,
             // Provider-side human review, surfaced to the approver as
@@ -206,5 +272,77 @@ export class TaskMergeGateService {
         return request.reason === 'already-open' || request.reason === 'already-decided'
             ? { action: 'approval-pending' }
             : { action: 'skipped', reason: request.reason ?? 'not-raised' };
+    }
+
+    /**
+     * Release promotion lane (slice AI) — decides whether this Task's pull
+     * request may go on to the approval path, and hands back the
+     * promotion's own coordinates when it may.
+     *
+     * `blocked` is a SKIP outcome the caller returns verbatim.
+     * `promotion` is the allowing verdict for a live promotion, or `null`
+     * when this is an ordinary Task — the ordinary path is then exactly
+     * what it was before this slice existed.
+     *
+     * Three fail-closed properties, all load-bearing:
+     *
+     *   1. **Unbound guard.** A Task whose labels say it is a promotion is
+     *      refused when no guard is bound, without consulting the guard —
+     *      so the refusal does not depend on the service that is missing.
+     *   2. **A throwing guard.** Treated as a refusal, not as a pass. The
+     *      port says implementations must not throw for "no"; if one does,
+     *      the answer we did not get is not assumed to be yes.
+     *   3. **The pull request is named.** The guard is told WHICH pull
+     *      request is about to be merged, so a verdict recorded for the
+     *      promotion's pull request can never authorise a merge of some
+     *      other one that later took over `tasks.prNumber`.
+     */
+    private async assessPromotion(
+        task: Task,
+        headSha: string,
+    ): Promise<{
+        blocked?: TaskMergeGateOutcome;
+        promotion: Extract<PromotionMergeVerdict, { allowed: true }> | null;
+    }> {
+        if (!this.promotionGuard) {
+            return isPromotionTask(task.labels)
+                ? {
+                      blocked: { action: 'skipped', reason: 'promotion-guard-unbound' },
+                      promotion: null,
+                  }
+                : { promotion: null };
+        }
+        let verdict: PromotionMergeVerdict;
+        try {
+            verdict = await this.promotionGuard.assessPromotionForMerge({
+                taskId: task.id,
+                labels: task.labels,
+                // Non-null by the `!task.prNumber` guard at the top of
+                // `evaluate`; the guard refuses when it is not the pull
+                // request the promotion opened.
+                prNumber: task.prNumber as number,
+                headSha,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Task ${task.id}: promotion guard threw; treating as a refusal: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return {
+                blocked: { action: 'skipped', reason: 'promotion-guard-failed' },
+                promotion: null,
+            };
+        }
+        if (!verdict.promotion) return { promotion: null };
+        // `=== true`, not a truthiness check: this package compiles with
+        // `strictNullChecks: false`, under which truthiness narrowing on a
+        // boolean-literal discriminant does not exclude the `true` member
+        // and `verdict.code` below stops type-checking.
+        if (verdict.allowed === true) return { promotion: verdict };
+        this.logger.log(
+            `Task ${task.id}: promotion not mergeable — ${verdict.code}: ${verdict.reason}`,
+        );
+        return { blocked: { action: 'skipped', reason: verdict.code }, promotion: null };
     }
 }

--- a/packages/agent/src/tasks-domain/task-pr-status.service.ts
+++ b/packages/agent/src/tasks-domain/task-pr-status.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import type { GitDiffResult, GitPullRequestStatus } from '@ever-works/plugin';
 import { DEFAULT_DIFF_MAX_BYTES, DEFAULT_DIFF_MAX_FILES, capChecks } from '@ever-works/plugin';
 import { normalizeCommitSha } from '@ever-works/contracts';
@@ -10,6 +10,10 @@ import { TaskTransitionService } from './task-transition.service';
 import { TaskMergeGateService } from './task-merge-gate.service';
 import { TaskCiAutoResumeService } from './task-ci-auto-resume.service';
 import { classifyCheckResult, computeCiFailureKey } from './task-ci-auto-resume';
+import {
+    PROMOTION_LANE_WATCHER,
+    type PromotionLaneWatcher,
+} from '../policy/promotion-merge-guard.port';
 
 /**
  * PR insights (kanban run cockpit, plan 04 M5 + M6 + the merged half of
@@ -118,6 +122,15 @@ export class TaskPrStatusService {
         // meaning, and an install without the fix loop polls exactly as
         // it did before.
         @Optional() private readonly autoResume?: TaskCiAutoResumeService,
+        // Release promotion lane (self-build slice AI, EW-808) — the
+        // watcher that records what `promotion-gate.yml` said about this
+        // Task's pull request. Appended LAST + @Optional() per the
+        // positional-spec arity rule, and injected by TOKEN so
+        // `TasksDomainModule` does not have to import the module that
+        // imports it. Absent, promotions simply are not watched.
+        @Optional()
+        @Inject(PROMOTION_LANE_WATCHER)
+        private readonly promotionLane?: PromotionLaneWatcher,
     ) {}
 
     // ── Read paths ────────────────────────────────────────────────────
@@ -415,6 +428,25 @@ export class TaskPrStatusService {
                 Object.assign(task, { branchState: 'merged' });
             }
             Object.assign(task, patch);
+
+            // Release promotion lane (slice AI) — runs BEFORE the merge
+            // gate, and deliberately runs whatever CI says: a promotion
+            // has to be legible even when it can never merge, so an
+            // operator watching a red promotion sees the gate's actual
+            // verdict instead of silence. The merge gate below then reads
+            // what this just recorded, for the same live head.
+            if (this.promotionLane) {
+                await this.promotionLane
+                    .onPullRequestStatusRefreshed(task, status)
+                    .catch((error: unknown) => {
+                        this.logger.warn(
+                            `Task ${task.id}: promotion lane threw after a PR status refresh: ${
+                                error instanceof Error ? error.message : String(error)
+                            }`,
+                        );
+                        return undefined;
+                    });
+            }
 
             // Merge approval (self-build slice AE) — THIS is the moment
             // the merge question can finally be answered: the provider has

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -1603,6 +1603,30 @@ export class TaskWorkspaceService {
          * and never trusts this value.
          */
         headSha?: string | null;
+        /**
+         * The branch this pull request actually merges INTO.
+         *
+         * Release promotion lane (self-build slice AI, EW-808). Every
+         * other caller's pull request targets the Work's
+         * `taskIsolationBaseBranch`, which is why that used to be assumed
+         * here unconditionally — and a promotion is the first pull request
+         * on this platform for which it is WRONG. It matters twice: the
+         * protected-branch rule is evaluated against this value, and it is
+         * the branch named in the string the approving human reads. A
+         * `stage -> main` promotion reported as `develop` would be
+         * approved as one thing and merged as another, and the
+         * `protected-branch` refusal would never fire.
+         *
+         * Omitted (the ordinary Task case) it falls back to the Work's
+         * base branch exactly as before.
+         */
+        baseRef?: string | null;
+        /**
+         * RAISE the approval requirement for this merge, whatever the
+         * resolved policy says. Never lowers it — see
+         * {@link AgentMergeActor.requireHumanApproval}.
+         */
+        requireHumanApproval?: boolean;
     }): Promise<TaskAgentMergeOutcome | undefined> {
         const { task } = input;
         if (!this.gitFacade || !this.mergePolicy) return undefined;
@@ -1619,7 +1643,9 @@ export class TaskWorkspaceService {
             workId: work.id,
         };
         const baseRef =
-            (work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || 'main';
+            (input.baseRef && input.baseRef.trim()) ||
+            (work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) ||
+            'main';
 
         return this.attemptAgentMerge({
             task,
@@ -1633,6 +1659,7 @@ export class TaskWorkspaceService {
             baseRef,
             gateStatus: input.gateStatus ?? null,
             headSha: input.headSha ?? task.prHeadSha ?? null,
+            requireHumanApproval: input.requireHumanApproval === true,
         });
     }
 
@@ -1685,6 +1712,8 @@ export class TaskWorkspaceService {
         gateStatus: GateStatus | null;
         /** Head commit the refusal record is keyed by. Never an input to the decision. */
         headSha?: string | null;
+        /** Raises the approval requirement; can never clear it (slice AI). */
+        requireHumanApproval?: boolean;
     }): Promise<TaskAgentMergeOutcome | undefined> {
         const { task, work, userId, agentId, owner, repo, prNumber, baseRef } = args;
         if (!this.mergePolicy || !this.gitFacade) return undefined;
@@ -1749,6 +1778,12 @@ export class TaskWorkspaceService {
                     // approval would not be a gate.
                     taskId: task.id,
                     targetBranch: baseRef,
+                    // Release promotion lane (slice AI): a caller-side
+                    // RAISE only. The facade ORs it with the resolved
+                    // policy, so this can never clear an approval
+                    // requirement — only insist on one the policy did not
+                    // ask for.
+                    requireHumanApproval: args.requireHumanApproval === true,
                 },
             );
 

--- a/packages/contracts/src/__tests__/index.barrel.spec.ts
+++ b/packages/contracts/src/__tests__/index.barrel.spec.ts
@@ -15,6 +15,7 @@ import * as ingest from '../ingest/index.js';
 import * as item from '../item/index.js';
 import * as kb from '../kb/index.js';
 import * as policy from '../policy/index.js';
+import * as release from '../release/index.js';
 import * as skills from '../skills/index.js';
 import * as tasks from '../tasks/index.js';
 import * as terminal from '../terminal/index.js';
@@ -51,6 +52,7 @@ const AREAS: Array<[string, Record<string, unknown>]> = [
 	['item', item],
 	['kb', kb],
 	['policy', policy],
+	['release', release],
 	['skills', skills],
 	['tasks', tasks],
 	['terminal', terminal],
@@ -62,7 +64,7 @@ describe('src/index.ts — the package root barrel', () => {
 		// Guard against an area being added to src/index.ts without being added
 		// here, which would leave the collision check below blind to it.
 		const exportLines = AREAS.length;
-		expect(exportLines).toBe(17);
+		expect(exportLines).toBe(18);
 	});
 
 	it('has no name exported by two different areas', () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,3 +20,7 @@ export * from './delegation/index.js';
 // Inbox (operator message center) — one surface for questions /
 // approvals / escalations / notices addressed to the human.
 export * from './inbox/index.js';
+// Release promotion lane (self-build slice AI, EW-808) — develop -> stage
+// -> main as platform state, plus the ONE rule that reads the promotion
+// gate's verdict. Deliberately carries no cascade.
+export * from './release/index.js';

--- a/packages/contracts/src/release/__tests__/index.spec.ts
+++ b/packages/contracts/src/release/__tests__/index.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import * as release from '../index.js';
+
+/**
+ * The barrel declares nothing of its own (two `export *` lines), but it IS the
+ * public surface every consumer reaches through `@ever-works/contracts`. A
+ * dropped re-export line compiles fine here and only breaks at the call site in
+ * another package, so it is pinned explicitly — same shape as the `policy`
+ * barrel guard.
+ *
+ * Type-only exports are deliberately NOT asserted: they do not exist at runtime,
+ * and any such check would be a no-op that always passes.
+ */
+
+const FUNCTION_EXPORTS = [
+	'isPromotionRung',
+	'sanitizeReleaseLadder',
+	'resolvePromotionBranches',
+	'promotionRungLabel',
+	'promotionTaskLabels',
+	'isPromotionTask',
+	'promotionRungFromLabels',
+	'promotionLaneKey',
+	'isPromotionGatePass',
+	'isPromotionGateDecided',
+	'isPromotionGateDecisionOverdue',
+	'isPromotionGateOverridden',
+	'promotionGateVerdictFromRun'
+] as const;
+
+const VALUE_EXPORTS = [
+	'PROMOTION_RUNGS',
+	'RELEASE_BRANCH_MAX_LENGTH',
+	'PROMOTION_TASK_LABEL',
+	'PROMOTION_STATES',
+	'PROMOTION_LANE_OPEN',
+	'PROMOTION_GATE_WORKFLOW_FILE',
+	'PROMOTION_GATE_VERDICTS',
+	'PROMOTION_GATE_DECISION_GRACE_MS',
+	'PROMOTION_GATE_OVERRIDE_LABEL'
+] as const;
+
+describe('release barrel', () => {
+	it.each(FUNCTION_EXPORTS.map((name) => [name]))('re-exports %s as a function', (name) => {
+		expect(typeof (release as Record<string, unknown>)[name]).toBe('function');
+	});
+
+	it.each(VALUE_EXPORTS.map((name) => [name]))('re-exports %s as a defined value', (name) => {
+		expect((release as Record<string, unknown>)[name]).toBeDefined();
+	});
+
+	it('exposes exactly these 22 runtime symbols', () => {
+		// Regression guard in BOTH directions: a re-export accidentally deleted
+		// from index.ts fails here, and a NEW runtime export added without a spec
+		// also fails here — forcing the author back to cover it.
+		expect(Object.keys(release).sort()).toEqual([...FUNCTION_EXPORTS, ...VALUE_EXPORTS].sort());
+		expect(Object.keys(release)).toHaveLength(22);
+	});
+
+	it('names each of the two source modules in the barrel', () => {
+		// One symbol per `export *` line, so a whole missing line is unmissable.
+		expect(release.PROMOTION_RUNGS).toBeDefined(); // promotion.types.js
+		expect(release.PROMOTION_GATE_VERDICTS).toBeDefined(); // promotion-gate.types.js
+	});
+});

--- a/packages/contracts/src/release/__tests__/promotion-gate.types.spec.ts
+++ b/packages/contracts/src/release/__tests__/promotion-gate.types.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	PROMOTION_GATE_DECISION_GRACE_MS,
+	PROMOTION_GATE_OVERRIDE_LABEL,
+	PROMOTION_GATE_VERDICTS,
+	PROMOTION_GATE_WORKFLOW_FILE,
+	isPromotionGateDecided,
+	isPromotionGateDecisionOverdue,
+	isPromotionGateOverridden,
+	isPromotionGatePass,
+	promotionGateVerdictFromRun,
+	type PromotionGateVerdict
+} from '../promotion-gate.types.js';
+
+describe('isPromotionGatePass — only an explicit success is a pass', () => {
+	it('passes an explicit success', () => {
+		expect(isPromotionGatePass('success')).toBe(true);
+	});
+
+	it.each(PROMOTION_GATE_VERDICTS.filter((verdict) => verdict !== 'success').map((verdict) => [verdict]))(
+		'refuses %s',
+		(verdict: PromotionGateVerdict) => {
+			expect(isPromotionGatePass(verdict)).toBe(false);
+		}
+	);
+
+	it.each([
+		['null', null],
+		['undefined', undefined]
+	])('refuses %s — "cannot tell" is not a pass', (_label, verdict) => {
+		expect(isPromotionGatePass(verdict as PromotionGateVerdict | null | undefined)).toBe(false);
+	});
+
+	it('refuses a value that is not a verdict at all', () => {
+		// Written as an equality against the literal so anything new is a
+		// refusal by default rather than falling into the pass set.
+		expect(isPromotionGatePass('SUCCESS' as PromotionGateVerdict)).toBe(false);
+		expect(isPromotionGatePass('passed' as PromotionGateVerdict)).toBe(false);
+		expect(isPromotionGatePass('passing' as PromotionGateVerdict)).toBe(false);
+	});
+
+	it('exposes exactly one pass across the whole vocabulary', () => {
+		expect(PROMOTION_GATE_VERDICTS.filter(isPromotionGatePass)).toEqual(['success']);
+	});
+});
+
+describe('promotionGateVerdictFromRun', () => {
+	it('reads a completed success as the pass', () => {
+		expect(promotionGateVerdictFromRun({ status: 'completed', conclusion: 'success' })).toBe('success');
+	});
+
+	it.each([
+		['no run at all', null, 'absent'],
+		['an undefined run', undefined, 'absent']
+	])('reads %s as %s', (_label, run, expected) => {
+		expect(promotionGateVerdictFromRun(run as null | undefined)).toBe(expected);
+	});
+
+	it.each([
+		['queued', 'queued'],
+		['in_progress', 'in_progress'],
+		['waiting', 'waiting'],
+		['requested', 'requested'],
+		['pending', 'pending']
+	])('reads a run still in %s as pending, ignoring any attached conclusion', (_label, status) => {
+		expect(promotionGateVerdictFromRun({ status, conclusion: 'success' })).toBe('pending');
+	});
+
+	it.each([
+		['failure', 'failure'],
+		['timed_out', 'failure'],
+		['action_required', 'failure']
+	])('reads a %s conclusion as %s', (conclusion, expected) => {
+		expect(promotionGateVerdictFromRun({ status: 'completed', conclusion })).toBe(expected);
+	});
+
+	it('reads a cancelled run as cancelled, never as a pass', () => {
+		// The platform's CI roll-up (`deriveCiState`) treats `cancelled` as
+		// non-blocking, so a cancelled gate rolls up GREEN there. Here it is
+		// the absence of a verdict.
+		expect(promotionGateVerdictFromRun({ status: 'completed', conclusion: 'cancelled' })).toBe('cancelled');
+		expect(isPromotionGatePass(promotionGateVerdictFromRun({ status: 'completed', conclusion: 'cancelled' }))).toBe(
+			false
+		);
+	});
+
+	it.each([['skipped'], ['neutral'], ['stale']])(
+		'reads a %s conclusion as skipped — the reading branch protection renders green',
+		(conclusion) => {
+			const verdict = promotionGateVerdictFromRun({ status: 'completed', conclusion });
+			expect(verdict).toBe('skipped');
+			expect(isPromotionGatePass(verdict)).toBe(false);
+		}
+	);
+
+	it.each([
+		['a completed run with no conclusion', { status: 'completed', conclusion: null }],
+		['a completed run with an empty conclusion', { status: 'completed', conclusion: '   ' }],
+		['a run with neither field', {}],
+		['a conclusion this platform does not know', { status: 'completed', conclusion: 'quantum' }]
+	])('reads %s as unreadable rather than guessing', (_label, run) => {
+		expect(promotionGateVerdictFromRun(run)).toBe('unreadable');
+	});
+
+	it('normalises provider casing and whitespace', () => {
+		expect(promotionGateVerdictFromRun({ status: ' COMPLETED ', conclusion: ' Success ' })).toBe('success');
+	});
+});
+
+describe('isPromotionGateDecided', () => {
+	it.each([['success'], ['failure'], ['cancelled'], ['skipped']])('treats %s as decided', (verdict) => {
+		expect(isPromotionGateDecided(verdict as PromotionGateVerdict)).toBe(true);
+	});
+
+	it.each([['pending'], ['absent'], ['unreadable']])('treats %s as not yet decided', (verdict) => {
+		// These three are what the grace window exists for: "no run yet" ten
+		// seconds after opening and "no run, ever" twenty minutes later are
+		// the same reading with different meanings.
+		expect(isPromotionGateDecided(verdict as PromotionGateVerdict)).toBe(false);
+	});
+});
+
+describe('constants', () => {
+	it('names the workflow by a bare file name, which is its stable identity', () => {
+		// The INVARIANT the doc states, not a restatement of the literal: a
+		// file name, never a display name, never a path. `workflowFileName()`
+		// in the GitHub provider compares last path segments, so a value
+		// carrying a directory would silently never match. That the file name
+		// is also the name of a workflow file that really exists is pinned
+		// separately, against the repository, by
+		// `apps/api/src/release/promotion-gate-workflow.contract.spec.ts`.
+		expect(PROMOTION_GATE_WORKFLOW_FILE).toMatch(/^[a-z0-9][a-z0-9._-]*\.ya?ml$/);
+		expect(PROMOTION_GATE_WORKFLOW_FILE).not.toMatch(/[/\\]/);
+	});
+
+	it('names the override label the workflow itself reads', () => {
+		// A plain label name: `contains(...labels.*.name, …)` in the workflow
+		// matches it verbatim, so whitespace or casing drift is a silent
+		// no-match on one side and a working override on the other.
+		expect(PROMOTION_GATE_OVERRIDE_LABEL).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+	});
+});
+
+describe('isPromotionGateDecisionOverdue — the behaviour the grace window names', () => {
+	const now = new Date('2026-09-06T12:00:00.000Z');
+	const at = (msAgo: number) => new Date(now.getTime() - msAgo);
+
+	it('is not overdue the instant the head is recorded', () => {
+		expect(isPromotionGateDecisionOverdue(at(0), now)).toBe(false);
+	});
+
+	it('is not overdue one millisecond short of the window', () => {
+		expect(isPromotionGateDecisionOverdue(at(PROMOTION_GATE_DECISION_GRACE_MS - 1), now)).toBe(false);
+	});
+
+	it('is overdue exactly at the window, which is where the 20-minute budget lands', () => {
+		// `node-contract` has a 20-minute job budget; anything still
+		// undecided at that point is stuck rather than slow.
+		expect(isPromotionGateDecisionOverdue(at(PROMOTION_GATE_DECISION_GRACE_MS), now)).toBe(true);
+		expect(isPromotionGateDecisionOverdue(at(20 * 60 * 1000), now)).toBe(true);
+	});
+
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an unparseable string', 'whenever'],
+		['an invalid Date', new Date('nope')]
+	])('fails closed on %s — no clock is not an elapsed interval', (_label, value) => {
+		expect(isPromotionGateDecisionOverdue(value as Date | string | null | undefined, now)).toBe(false);
+	});
+
+	it('accepts an ISO string, which is what a portable date column reads back as', () => {
+		expect(isPromotionGateDecisionOverdue(at(PROMOTION_GATE_DECISION_GRACE_MS + 1).toISOString(), now)).toBe(true);
+	});
+});
+
+describe('isPromotionGateOverridden', () => {
+	it('recognises the override label', () => {
+		expect(isPromotionGateOverridden(['chore', PROMOTION_GATE_OVERRIDE_LABEL])).toBe(true);
+	});
+
+	it.each([
+		['no labels', []],
+		['other labels', ['release']],
+		['labels the provider did not report', undefined],
+		['null', null]
+	])('answers false for %s — this only ever ADDS a warning', (_label, labels) => {
+		expect(isPromotionGateOverridden(labels as readonly string[] | null | undefined)).toBe(false);
+	});
+});

--- a/packages/contracts/src/release/__tests__/promotion.types.spec.ts
+++ b/packages/contracts/src/release/__tests__/promotion.types.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	PROMOTION_LANE_OPEN,
+	PROMOTION_RUNGS,
+	PROMOTION_STATES,
+	PROMOTION_TASK_LABEL,
+	RELEASE_BRANCH_MAX_LENGTH,
+	isPromotionRung,
+	isPromotionTask,
+	promotionLaneKey,
+	promotionRungFromLabels,
+	promotionRungLabel,
+	promotionTaskLabels,
+	resolvePromotionBranches,
+	sanitizeReleaseLadder,
+	type PromotionState
+} from '../promotion.types.js';
+
+const LADDER = { integration: 'develop', staging: 'stage', production: 'main' };
+
+describe('the ladder is not a cascade', () => {
+	it('lists the rungs in reading order without offering a successor', async () => {
+		expect(PROMOTION_RUNGS).toEqual(['develop-to-stage', 'stage-to-main']);
+		// THE load-bearing absence. Nothing in the release surface maps a
+		// finished rung onto the next one — no `nextRung`, no `advance`, no
+		// `cascade`. If a future edit adds one, this fails and the author
+		// has to argue for automating a promotion the founder performs
+		// deliberately, per batch, after reading the end-to-end verdict.
+		const surface = Object.keys(await import('../index.js'));
+		expect(surface.filter((name) => /next|advance|cascade|chain|succeed/i.test(name))).toEqual([]);
+	});
+
+	it('has no develop-to-main rung', () => {
+		expect(isPromotionRung('develop-to-main')).toBe(false);
+	});
+});
+
+describe('isPromotionRung', () => {
+	it('accepts the two real rungs', () => {
+		expect(isPromotionRung('develop-to-stage')).toBe(true);
+		expect(isPromotionRung('stage-to-main')).toBe(true);
+	});
+
+	it.each([['', null, undefined, 42, {}, 'DEVELOP-TO-STAGE', ' stage-to-main ']].flat())('refuses %p', (value) => {
+		expect(isPromotionRung(value)).toBe(false);
+	});
+});
+
+describe('sanitizeReleaseLadder', () => {
+	it('accepts a well-formed ladder and trims it', () => {
+		expect(sanitizeReleaseLadder({ integration: ' develop ', staging: 'stage', production: 'main' })).toEqual(
+			LADDER
+		);
+	});
+
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an array', ['develop', 'stage', 'main']],
+		['a string', 'develop,stage,main'],
+		['a partial ladder', { integration: 'develop', staging: 'stage' }],
+		['an empty branch', { integration: 'develop', staging: '', production: 'main' }],
+		['a non-string branch', { integration: 'develop', staging: 7, production: 'main' }]
+	])('refuses %s', (_label, value) => {
+		expect(sanitizeReleaseLadder(value)).toBeNull();
+	});
+
+	it('refuses a ladder whose rungs are not three distinct branches', () => {
+		// `develop -> develop` is not a promotion, and `stage === main`
+		// would ask a human to approve a production merge that does nothing.
+		expect(sanitizeReleaseLadder({ integration: 'develop', staging: 'develop', production: 'main' })).toBeNull();
+		expect(sanitizeReleaseLadder({ integration: 'develop', staging: 'main', production: 'main' })).toBeNull();
+	});
+
+	it.each([
+		['a path escape', '../main'],
+		['a leading dash so it cannot be read as an option', '--force'],
+		['a leading slash', '/main'],
+		['whitespace', 'release main'],
+		['a refspec character', 'main:main'],
+		['a glob', 'rele*se'],
+		['a caret', 'main^'],
+		['a tilde', 'main~1'],
+		['a trailing slash', 'release/'],
+		['a lock name', 'main.lock'],
+		['a doubled slash', 'release//main']
+	])('refuses %s in a branch name', (_label, branch) => {
+		expect(sanitizeReleaseLadder({ ...LADDER, staging: branch })).toBeNull();
+	});
+
+	it('refuses a branch longer than the column can hold', () => {
+		const tooLong = 'b'.repeat(RELEASE_BRANCH_MAX_LENGTH + 1);
+		expect(sanitizeReleaseLadder({ ...LADDER, staging: tooLong })).toBeNull();
+		expect(sanitizeReleaseLadder({ ...LADDER, staging: 'b'.repeat(RELEASE_BRANCH_MAX_LENGTH) })).not.toBeNull();
+	});
+});
+
+describe('resolvePromotionBranches', () => {
+	it('resolves each rung off the ladder, never off the caller', () => {
+		expect(resolvePromotionBranches(LADDER, 'develop-to-stage')).toEqual({ head: 'develop', base: 'stage' });
+		expect(resolvePromotionBranches(LADDER, 'stage-to-main')).toEqual({ head: 'stage', base: 'main' });
+	});
+
+	it('honours a non-default ladder', () => {
+		const custom = { integration: 'trunk', staging: 'preprod', production: 'release' };
+		expect(resolvePromotionBranches(custom, 'develop-to-stage')).toEqual({ head: 'trunk', base: 'preprod' });
+		expect(resolvePromotionBranches(custom, 'stage-to-main')).toEqual({ head: 'preprod', base: 'release' });
+	});
+
+	it('returns null rather than a half-resolved pair when the ladder is unusable', () => {
+		expect(resolvePromotionBranches(null, 'stage-to-main')).toBeNull();
+		expect(resolvePromotionBranches(undefined, 'develop-to-stage')).toBeNull();
+		expect(
+			resolvePromotionBranches({ integration: 'develop', staging: '', production: 'main' }, 'develop-to-stage')
+		).toBeNull();
+	});
+
+	it('returns null for a rung that is not one', () => {
+		expect(resolvePromotionBranches(LADDER, 'develop-to-main' as never)).toBeNull();
+	});
+});
+
+describe('promotion Task labels', () => {
+	it('files both the generic and the per-rung label', () => {
+		expect(promotionTaskLabels('stage-to-main')).toEqual([PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main']);
+	});
+
+	it('recognises a promotion Task off the generic label alone', () => {
+		// The merge gate reads this to fail CLOSED when the promotion
+		// service is not bound, so it must not need the per-rung label.
+		expect(isPromotionTask([PROMOTION_TASK_LABEL])).toBe(true);
+		expect(isPromotionTask(['chore', PROMOTION_TASK_LABEL])).toBe(true);
+	});
+
+	it.each([
+		['no labels', null],
+		['undefined labels', undefined],
+		['an empty list', []],
+		['an unrelated label', ['chore']],
+		['a near miss', ['release:promotions']],
+		['only the per-rung label', [promotionRungLabel('stage-to-main')]]
+	])('does not treat %s as a promotion', (_label, labels) => {
+		expect(isPromotionTask(labels as string[] | null | undefined)).toBe(false);
+	});
+
+	it('reads the rung back off the labels', () => {
+		expect(promotionRungFromLabels(promotionTaskLabels('develop-to-stage'))).toBe('develop-to-stage');
+		expect(promotionRungFromLabels(promotionTaskLabels('stage-to-main'))).toBe('stage-to-main');
+	});
+
+	it('returns null when the rung label is missing or the Task is not a promotion', () => {
+		expect(promotionRungFromLabels([PROMOTION_TASK_LABEL])).toBeNull();
+		expect(promotionRungFromLabels(['chore'])).toBeNull();
+	});
+});
+
+describe('promotionLaneKey — the portable partial-unique index', () => {
+	it('gives every OPEN promotion the same colliding value', () => {
+		expect(promotionLaneKey('open', 'p-1')).toBe(PROMOTION_LANE_OPEN);
+		expect(promotionLaneKey('open', 'p-2')).toBe(PROMOTION_LANE_OPEN);
+	});
+
+	it('gives every TERMINAL promotion a value unique to itself', () => {
+		const terminal = PROMOTION_STATES.filter((state) => state !== 'open');
+		const keys = terminal.flatMap((state: PromotionState) => [
+			promotionLaneKey(state, 'p-1'),
+			promotionLaneKey(state, 'p-2')
+		]);
+		expect(new Set(keys).size).toBe(keys.length);
+		expect(keys).not.toContain(PROMOTION_LANE_OPEN);
+	});
+
+	it('refuses to free the lane without a row id', () => {
+		// Writing `'open'` would hold the lane forever; writing a constant
+		// would collide with the next terminal row. Neither is silent.
+		expect(() => promotionLaneKey('merged', '')).toThrow(/row id/i);
+		expect(() => promotionLaneKey('closed', '   ')).toThrow(/row id/i);
+	});
+});

--- a/packages/contracts/src/release/index.ts
+++ b/packages/contracts/src/release/index.ts
@@ -1,0 +1,2 @@
+export * from './promotion.types.js';
+export * from './promotion-gate.types.js';

--- a/packages/contracts/src/release/promotion-gate.types.ts
+++ b/packages/contracts/src/release/promotion-gate.types.ts
@@ -1,0 +1,231 @@
+/**
+ * The promotion gate verdict (self-build slice AI, EW-808).
+ *
+ * `.github/workflows/promotion-gate.yml` is the workflow a promotion
+ * waits on. This file is how its answer is read, and it exists because
+ * the platform's EXISTING CI roll-up cannot answer this question.
+ *
+ * ## Why not `GitCiState` / `deriveCiState`
+ *
+ * `deriveCiState` (packages/plugin) answers "should the board's dot be
+ * green?" over the whole check set for a commit, and it deliberately
+ * treats `neutral`, `skipped`, `stale` and `cancelled` as NON-BLOCKING —
+ * a human stopped it, so it neither reds nor holds the roll-up. That is
+ * the right rule for a dot and the wrong rule for a promotion:
+ *
+ *   - `promotion-gate.yml`'s `e2e-result` job SKIPS itself whenever the
+ *     head branch is not `stage`, and a skipped job reports as SUCCESS in
+ *     branch protection. The workflow file says so itself.
+ *   - A gate that never ran at all contributes NOTHING to the roll-up, so
+ *     a commit with other green checks rolls up `passing` while the gate
+ *     is absent.
+ *   - `cancelled` means somebody stopped the gate. That is an absence of
+ *     a verdict, not a verdict.
+ *
+ * So the promotion lane reads ONE named workflow run and applies ONE
+ * rule: {@link isPromotionGatePass} is true for `'success'` and for
+ * nothing else. Every other reading — including "we could not tell" — is
+ * not a pass. This is strictly NARROWER than the CI roll-up the merge
+ * gate already applies; it never widens it.
+ */
+
+/**
+ * The workflow whose verdict a promotion waits on, by FILE NAME.
+ *
+ * A file name rather than the workflow's display name (`Promotion Gate`)
+ * or one of its job names: the display name is editable prose, the job
+ * names are two separate strings that would each have to be tracked, and
+ * a check-run name is what a caller would have to match against the
+ * capped, unordered `checks[]` sample the PR-status read returns — which
+ * cannot prove a named check is ABSENT. The file path is the workflow's
+ * stable identity on every provider that has workflows at all.
+ */
+export const PROMOTION_GATE_WORKFLOW_FILE = 'promotion-gate.yml';
+
+/**
+ * What the promotion gate said about one commit.
+ *
+ * Seven values rather than a boolean because the operator's next action
+ * differs for each, and because a broken lookup and a real answer must
+ * never render identically (the workflow file makes the same point about
+ * its own E2E lookup).
+ */
+export type PromotionGateVerdict =
+	/** The workflow run completed and concluded `success`. THE ONLY PASS. */
+	| 'success'
+	/** It ran and failed (`failure`, `timed_out`, `action_required`). */
+	| 'failure'
+	/** A run exists for the commit and has not finished. Ask again later. */
+	| 'pending'
+	/** Somebody stopped the run. There is no verdict, and none is coming. */
+	| 'cancelled'
+	/**
+	 * The run finished without evaluating (`skipped`, `neutral`, `stale`).
+	 * The most dangerous reading, because branch protection renders it
+	 * green — here it is explicitly not a pass.
+	 */
+	| 'skipped'
+	/** No run of that workflow exists for that commit at all. */
+	| 'absent'
+	/**
+	 * The lookup itself failed, or the provider cannot answer this
+	 * question. A BROKEN GATE, not a verdict.
+	 */
+	| 'unreadable';
+
+export const PROMOTION_GATE_VERDICTS = [
+	'success',
+	'failure',
+	'pending',
+	'cancelled',
+	'skipped',
+	'absent',
+	'unreadable'
+] as const satisfies readonly PromotionGateVerdict[];
+
+/**
+ * THE rule. `true` for an explicit success and for nothing else.
+ *
+ * Written as an equality against the literal rather than as a set of
+ * refusals so that a verdict added later is a not-a-pass by default —
+ * a new value must be argued INTO the pass set, never fall into it.
+ */
+export function isPromotionGatePass(verdict: PromotionGateVerdict | null | undefined): boolean {
+	return verdict === 'success';
+}
+
+/**
+ * Has the gate said something final about this commit?
+ *
+ * `pending` is the only reading worth waiting on. `absent` and
+ * `unreadable` are NOT decided — they may resolve as a run appears or a
+ * token is fixed — but they are handled by the caller's grace window
+ * rather than here, because "no run yet" ten seconds after opening a pull
+ * request and "no run, ever" twenty minutes later are the same reading
+ * with very different meanings.
+ */
+export function isPromotionGateDecided(verdict: PromotionGateVerdict | null | undefined): boolean {
+	return verdict === 'success' || verdict === 'failure' || verdict === 'cancelled' || verdict === 'skipped';
+}
+
+/**
+ * How long a promotion waits on a `pending` / `absent` / `unreadable`
+ * gate before it tells the human anyway.
+ *
+ * A run does not exist the instant a pull request opens, so filing "the
+ * gate never ran" immediately would be both noisy and wrong. Twenty
+ * minutes is past the promotion gate's own longest job budget
+ * (`node-contract`, 20 minutes) plus queue time, so anything still
+ * unresolved by then is genuinely stuck rather than slow.
+ */
+export const PROMOTION_GATE_DECISION_GRACE_MS = 20 * 60 * 1000;
+
+/**
+ * Has an UNDECIDED gate stayed undecided long enough to be worth telling
+ * a human about?
+ *
+ * The behavioural half of {@link PROMOTION_GATE_DECISION_GRACE_MS}, here
+ * rather than private to the lane so the constant has one meaning and one
+ * test. Fails CLOSED on an unusable clock: without a recorded time there
+ * is no elapsed interval to measure, and inventing one would file "the
+ * gate never ran" on a pull request opened seconds ago.
+ */
+export function isPromotionGateDecisionOverdue(
+	headRecordedAt: Date | string | number | null | undefined,
+	now: Date = new Date()
+): boolean {
+	if (headRecordedAt === null || headRecordedAt === undefined) return false;
+	const since = headRecordedAt instanceof Date ? headRecordedAt.getTime() : new Date(headRecordedAt).getTime();
+	if (Number.isNaN(since)) return false;
+	const at = now.getTime();
+	if (Number.isNaN(at)) return false;
+	return at - since >= PROMOTION_GATE_DECISION_GRACE_MS;
+}
+
+/**
+ * The label `promotion-gate.yml` accepts as a deliberate, attributable
+ * override of its E2E leg.
+ *
+ * Shared with the workflow file BY VALUE because the two must agree
+ * byte-for-byte: the workflow reads it off the pull request to decide
+ * whether to exit 0 despite a red or unreadable E2E, and the lane reads
+ * it off the SAME pull request to tell the approving human that the leg
+ * may have been waived rather than green. GitHub folds an overridden run
+ * back into a plain `success` conclusion, so without this the two are
+ * indistinguishable downstream — see `isPromotionGateOverridden`.
+ */
+export const PROMOTION_GATE_OVERRIDE_LABEL = 'override-e2e-gate';
+
+/**
+ * Is the gate's E2E leg overridden on this pull request?
+ *
+ * `undefined` labels mean the provider read did not report labels at all,
+ * which answers `false` — the caller uses this to ADD a warning, never to
+ * grant anything, so an unknown label set must not manufacture one.
+ */
+export function isPromotionGateOverridden(labels: readonly string[] | null | undefined): boolean {
+	return Array.isArray(labels) && labels.includes(PROMOTION_GATE_OVERRIDE_LABEL);
+}
+
+/**
+ * The shape this reads from a provider's workflow run. Structural on
+ * purpose: `@ever-works/contracts` has no dependencies, and the provider
+ * types live in `@ever-works/plugin`.
+ *
+ * The two vocabularies are the same strings (`GitCheckStatus` /
+ * `GitCheckConclusion`). That agreement is asserted where BOTH types are
+ * importable — `packages/agent/src/facades/__tests__/git.facade.workflow-run.spec.ts`
+ * assigns a `GitWorkflowRun` to this interface and feeds every
+ * `GitCheckStatus` / `GitCheckConclusion` member through
+ * {@link promotionGateVerdictFromRun}. It is NOT asserted by the
+ * plugin-side conformance suite, which covers the pull-request insight
+ * reads only; an earlier version of this comment said otherwise and sent
+ * readers looking for a guard that was not there.
+ */
+export interface PromotionGateRunReading {
+	readonly status?: string | null;
+	readonly conclusion?: string | null;
+}
+
+/**
+ * Map one workflow run onto a verdict.
+ *
+ * `null` / `undefined` (no run for this commit) is `'absent'`, NOT
+ * `'pending'`: the difference is whether waiting can help.
+ *
+ * A run that reports `completed` with no conclusion is `'unreadable'`
+ * rather than being guessed at — an unrecognised answer must never be
+ * laundered into a pass, and it must not be laundered into a clean
+ * failure either, because those two send an operator to different places.
+ */
+export function promotionGateVerdictFromRun(run: PromotionGateRunReading | null | undefined): PromotionGateVerdict {
+	if (!run) return 'absent';
+
+	const status = typeof run.status === 'string' ? run.status.trim().toLowerCase() : '';
+	const conclusion = typeof run.conclusion === 'string' ? run.conclusion.trim().toLowerCase() : '';
+
+	// Not finished yet — whatever conclusion is attached is stale or empty.
+	if (status && status !== 'completed') return 'pending';
+
+	switch (conclusion) {
+		case 'success':
+			return 'success';
+		case 'failure':
+		case 'timed_out':
+		case 'action_required':
+			return 'failure';
+		case 'cancelled':
+			return 'cancelled';
+		case 'skipped':
+		case 'neutral':
+		case 'stale':
+			return 'skipped';
+		case '':
+			// Completed with nothing to say, or a status we could not read
+			// at all. Either way the gate did not answer.
+			return 'unreadable';
+		default:
+			// A conclusion this platform does not know. Refuse to interpret.
+			return 'unreadable';
+	}
+}

--- a/packages/contracts/src/release/promotion.types.ts
+++ b/packages/contracts/src/release/promotion.types.ts
@@ -1,0 +1,236 @@
+/**
+ * The release promotion lane — `develop → stage → main` (self-build
+ * slice AI, EW-808).
+ *
+ * ## What this file is
+ *
+ * The house release flow moves a batch forward one rung at a time by
+ * opening a pull request from one long-lived branch to the next. Nothing
+ * in the platform modelled that: a Task's pull request goes from a Task
+ * branch to ONE base branch (`Work.taskIsolationBaseBranch`), which
+ * cannot express a ladder, and the deploy surface refuses a Repository
+ * Work outright.
+ *
+ * These are the zero-dependency pieces both halves of the lane must
+ * agree on byte-for-byte — the API that opens a promotion, and the
+ * merge-gate guard that decides whether one may be merged. Two
+ * implementations of `resolvePromotionBranches` is how a promotion opens
+ * against the wrong branch.
+ *
+ * ## What this file deliberately is NOT
+ *
+ * It is not a cascade. There is no "next rung" function here, no
+ * `advance()`, and nothing that maps a completed promotion onto the one
+ * after it. That absence is the point: the founder performs each rung
+ * deliberately, per batch, after reading the end-to-end verdict, because
+ * the stage e2e gate has been unreliable for weeks and a bad promotion
+ * is a multi-hour outage on a build lane measured at 215–243 minutes.
+ * `PROMOTION_RUNGS` is ORDERED so a human reading a list sees the ladder;
+ * it is not an iteration the platform walks.
+ */
+
+/**
+ * One rung of the ladder. The value names both ends, so a row, a log
+ * line and a Task label all say which promotion this is without a
+ * lookup.
+ *
+ * There is no `develop-to-main`: skipping `stage` is the exact mistake
+ * the lane exists to make hard.
+ */
+export type PromotionRung = 'develop-to-stage' | 'stage-to-main';
+
+/**
+ * The ladder, in order, for display and for validation.
+ *
+ * ORDERED FOR READING, NOT FOR WALKING. Nothing in the platform consumes
+ * `PROMOTION_RUNGS[i + 1]`; a second promotion is a separate,
+ * separately-approved act. See the file header.
+ */
+export const PROMOTION_RUNGS = ['develop-to-stage', 'stage-to-main'] as const satisfies readonly PromotionRung[];
+
+/** Narrowing guard for a rung arriving from a request body or a column. */
+export function isPromotionRung(value: unknown): value is PromotionRung {
+	return typeof value === 'string' && (PROMOTION_RUNGS as readonly string[]).includes(value);
+}
+
+/**
+ * The three long-lived branches, as PLATFORM STATE.
+ *
+ * Stored on the Work (`works.releaseLadder`) and never accepted from the
+ * caller who asks for a promotion: a request that could name its own
+ * branches could open `attacker-branch → main` and call it a release.
+ * The caller picks a RUNG; the branches come from here.
+ */
+export interface ReleaseLadder {
+	/** Where merged work lands first. `develop` in this repository. */
+	readonly integration: string;
+	/** The rehearsal branch. `stage`. */
+	readonly staging: string;
+	/** Production. `main`. */
+	readonly production: string;
+}
+
+/**
+ * Longest branch name accepted into a ladder. Matches the physical width
+ * of `works.taskIsolationBaseBranch`, so the two branch-shaped columns on
+ * a Work cannot disagree about what fits.
+ */
+export const RELEASE_BRANCH_MAX_LENGTH = 128;
+
+/**
+ * Branch names a ladder may contain. Deliberately narrower than git's
+ * own rules: a release branch in this platform is a plain, boring,
+ * long-lived name. Refusing `..`, a leading `-`, whitespace, `~^:?*[\`
+ * and a trailing `.lock` keeps a ladder value from ever being read as a
+ * refspec, an option, or a path escape by anything downstream.
+ */
+const RELEASE_BRANCH_PATTERN = /^(?!-)(?!\/)[A-Za-z0-9._\-/]+$/;
+
+function normalizeBranch(raw: unknown): string | null {
+	if (typeof raw !== 'string') return null;
+	const trimmed = raw.trim();
+	if (!trimmed || trimmed.length > RELEASE_BRANCH_MAX_LENGTH) return null;
+	if (!RELEASE_BRANCH_PATTERN.test(trimmed)) return null;
+	if (trimmed.includes('..') || trimmed.includes('//')) return null;
+	if (trimmed.endsWith('/') || trimmed.endsWith('.lock')) return null;
+	return trimmed;
+}
+
+/**
+ * Read a stored / submitted ladder, or `null` when it is not one.
+ *
+ * FAILS CLOSED in every direction. A Work with no ladder, a partial
+ * ladder, a ladder with a branch name this platform will not vouch for,
+ * or a ladder whose rungs are not three DISTINCT branches, has no
+ * promotion lane at all — the service refuses rather than guessing
+ * `main`. Guessing is how a promotion opens against production.
+ */
+export function sanitizeReleaseLadder(raw: unknown): ReleaseLadder | null {
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+	const candidate = raw as Record<string, unknown>;
+	const integration = normalizeBranch(candidate.integration);
+	const staging = normalizeBranch(candidate.staging);
+	const production = normalizeBranch(candidate.production);
+	if (!integration || !staging || !production) return null;
+	// Three distinct branches. `develop → develop` is not a promotion, and
+	// `stage === main` would make the second rung a no-op that still asked
+	// a human to approve a production merge.
+	if (new Set([integration, staging, production]).size !== 3) return null;
+	return { integration, staging, production };
+}
+
+/** The head/base pair one rung promotes. */
+export interface PromotionBranches {
+	/** Branch being promoted FROM — the pull request's head. */
+	readonly head: string;
+	/** Branch being promoted INTO — the pull request's base. */
+	readonly base: string;
+}
+
+/**
+ * THE branch resolution. One function, so the opener and every later
+ * verification agree about what a promotion is for.
+ *
+ * `null` when the ladder is unusable — never a partially-resolved pair.
+ */
+export function resolvePromotionBranches(
+	ladder: ReleaseLadder | null | undefined,
+	rung: PromotionRung
+): PromotionBranches | null {
+	const safe = sanitizeReleaseLadder(ladder);
+	if (!safe) return null;
+	switch (rung) {
+		case 'develop-to-stage':
+			return { head: safe.integration, base: safe.staging };
+		case 'stage-to-main':
+			return { head: safe.staging, base: safe.production };
+		default:
+			return null;
+	}
+}
+
+// ── Task labelling ───────────────────────────────────────────────────
+//
+// A promotion Task is an ordinary Task carrying two labels. Labels rather
+// than a new `kind` column because the Task entity has no discriminator
+// today and adding one would touch every Task read in the product for a
+// feature two rows a week use — and because the merge gate needs a
+// FAIL-CLOSED answer to "is this a promotion?" even when the promotion
+// service itself is not wired, which a label on the row it already loaded
+// gives it for free.
+
+/** Present on every promotion Task. */
+export const PROMOTION_TASK_LABEL = 'release:promotion';
+
+/** Per-rung label, e.g. `release:promotion:stage-to-main`. */
+export function promotionRungLabel(rung: PromotionRung): string {
+	return `${PROMOTION_TASK_LABEL}:${rung}`;
+}
+
+/** The labels a promotion Task is filed with. */
+export function promotionTaskLabels(rung: PromotionRung): string[] {
+	return [PROMOTION_TASK_LABEL, promotionRungLabel(rung)];
+}
+
+/**
+ * Is this Task a promotion?
+ *
+ * Used by the merge gate to fail CLOSED when the promotion service is not
+ * bound: a Task that says it is a promotion, in a deployment that cannot
+ * evaluate promotions, must not be merged by the ordinary agent path.
+ */
+export function isPromotionTask(labels: readonly string[] | null | undefined): boolean {
+	return Array.isArray(labels) && labels.includes(PROMOTION_TASK_LABEL);
+}
+
+/** Which rung a promotion Task is, or `null` if it is not one. */
+export function promotionRungFromLabels(labels: readonly string[] | null | undefined): PromotionRung | null {
+	if (!isPromotionTask(labels)) return null;
+	for (const rung of PROMOTION_RUNGS) {
+		if (labels!.includes(promotionRungLabel(rung))) return rung;
+	}
+	return null;
+}
+
+// ── Lane occupancy ───────────────────────────────────────────────────
+
+/** Lifecycle of one promotion row. */
+export type PromotionState = 'open' | 'merged' | 'closed' | 'refused';
+
+export const PROMOTION_STATES = ['open', 'merged', 'closed', 'refused'] as const satisfies readonly PromotionState[];
+
+/**
+ * The value `ReleasePromotion.laneKey` carries while the promotion is
+ * live. See {@link promotionLaneKey}.
+ */
+export const PROMOTION_LANE_OPEN = 'open';
+
+/**
+ * The third column of the UNIQUE `(workId, rung, laneKey)` index — a
+ * portable stand-in for a partial unique index.
+ *
+ * Postgres can express "at most one OPEN promotion per (Work, rung)" as
+ * `CREATE UNIQUE INDEX … WHERE state = 'open'`. better-sqlite3 — which CI
+ * and the e2e stack run — cannot, and a migration that behaves
+ * differently on the two databases is a race that only reproduces in
+ * production. So the constraint is carried in a VALUE instead: every live
+ * promotion writes the same literal `'open'` and therefore collides, and
+ * every terminal one writes something unique to itself and therefore does
+ * not.
+ *
+ * This is the whole anti-duplicate guarantee. Two merges to `develop`
+ * seconds apart both try to claim `(work, 'develop-to-stage', 'open')`;
+ * exactly one INSERT survives, and the loser is told an open promotion
+ * already exists instead of opening a competing pull request.
+ */
+export function promotionLaneKey(state: PromotionState, promotionId: string): string {
+	if (state === 'open') return PROMOTION_LANE_OPEN;
+	const id = (promotionId ?? '').trim();
+	if (!id) {
+		// A terminal row with no id cannot free the lane safely: writing
+		// `'open'` would keep it occupied forever, and writing a constant
+		// would collide with the next terminal row. Refuse loudly.
+		throw new Error('A terminal promotion needs its row id to release the lane.');
+	}
+	return `${state}:${id}`;
+}

--- a/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
@@ -221,6 +221,19 @@ export interface GitPullRequest {
 	readonly updatedAt: string;
 	readonly body?: string;
 	readonly author?: GitPullRequestAuthor;
+	/**
+	 * Provider-side labels on the pull request, when the read that
+	 * produced this object carried them.
+	 *
+	 * OPTIONAL and ABSENCE-AMBIGUOUS by construction: `undefined` means
+	 * "this read did not report labels", never "there are none". A caller
+	 * that treats a label as permission must therefore never infer safety
+	 * from its absence — the release promotion lane reads
+	 * `override-e2e-gate` off this to tell a human that a gate leg may
+	 * have been WAIVED rather than green, which is a warning it adds, not
+	 * a permission it grants.
+	 */
+	readonly labels?: readonly string[];
 }
 
 export interface GitRepositoryPermissions {
@@ -334,6 +347,66 @@ export interface GitPullRequestStatus {
 	readonly checksComplete?: boolean;
 	readonly url?: string;
 	readonly title?: string;
+}
+
+// ── Workflow runs (release promotion lane, self-build slice AI) ─────
+//
+// One OPTIONAL read capability, deliberately narrow: the verdict of ONE
+// named workflow file for ONE commit.
+//
+// This is not the same question as `getPullRequestStatus`. That answers
+// "should the board's dot be green?" by rolling up every check on the
+// head commit, and that roll-up treats `skipped`, `neutral`, `stale` and
+// `cancelled` as non-blocking — correct for a dot, and unusable as a
+// release gate, where a gate that skipped itself is precisely the case
+// that must not read as a pass. It also cannot prove ABSENCE: the
+// `checks[]` it returns is a capped sample, so a named check missing from
+// it may simply have sorted past the cap.
+//
+// A provider without workflows simply omits this, and the caller treats
+// the absence as "the gate is unreadable", which is not a pass.
+
+/**
+ * One run of one workflow file against one commit.
+ *
+ * `status` / `conclusion` reuse the check vocabulary above on purpose:
+ * providers already map their own words onto it, and a second vocabulary
+ * for the same idea is a second place for a mapping to go wrong.
+ */
+export interface GitWorkflowRun {
+	/** Provider-side run id — for the operator, not for logic. */
+	readonly id: number;
+	/**
+	 * Workflow file this run belongs to, as the provider reports it
+	 * (e.g. `.github/workflows/promotion-gate.yml`). Echoed back so a
+	 * caller can assert it got the workflow it asked for.
+	 */
+	readonly workflowPath: string;
+	/** The commit the run was for. */
+	readonly headSha: string;
+	readonly status: GitCheckStatus;
+	/** `null` while the run has not completed. */
+	readonly conclusion?: GitCheckConclusion | null;
+	/** Deep link for the human who has to read the log. */
+	readonly url?: string;
+	/** Re-runs bump this; the newest attempt is the one reported. */
+	readonly runAttempt?: number;
+	/**
+	 * Pull requests this run was triggered for, by number, when the
+	 * provider reports them.
+	 *
+	 * A workflow run is keyed by COMMIT, and one commit can head more
+	 * than one pull request — `stage` can be the head of both a
+	 * `stage -> main` promotion and somebody's hotfix comparison. A run
+	 * adopted off the commit alone therefore need not be the run for the
+	 * pull request being judged, and the two can differ in exactly the
+	 * way that matters (a per-pull-request override label).
+	 *
+	 * `undefined` means the provider did not say, which is NOT a licence
+	 * to assume a match: the release promotion lane treats a run that
+	 * names pull requests NOT including its own as no run at all.
+	 */
+	readonly pullRequestNumbers?: readonly number[];
 }
 
 /** Hard caps a diff request may ask for. */
@@ -510,6 +583,29 @@ export interface IGitProviderPlugin extends IPlugin, IGitOperations {
 		opts: GitDiffOptions | undefined,
 		token: string
 	): Promise<GitDiffResult>;
+
+	/**
+	 * Release promotion lane (slice AI) — the MOST RECENT run of one
+	 * named workflow file for one commit, or `null` when that workflow has
+	 * no run for that commit.
+	 *
+	 * `null` and a throw mean different things and both matter: `null` is
+	 * a real answer ("the gate never ran on this commit"), a throw is a
+	 * broken lookup. Implementations MUST NOT collapse a failed read into
+	 * `null` — the caller renders them differently and refuses on both,
+	 * but sends the operator to different places.
+	 *
+	 * `workflowPath` may be given as a bare file name (`promotion-gate.yml`)
+	 * or a repository path (`.github/workflows/promotion-gate.yml`);
+	 * implementations match on the file name.
+	 */
+	getWorkflowRunForCommit?(
+		owner: string,
+		repo: string,
+		workflowPath: string,
+		headSha: string,
+		token: string
+	): Promise<GitWorkflowRun | null>;
 
 	/**
 	 * Same shape for a branch that has no PR yet (`base...head`). Cheap

--- a/packages/plugin/src/git/index.ts
+++ b/packages/plugin/src/git/index.ts
@@ -39,7 +39,10 @@ export type {
 	GitPullRequestStatus,
 	GitDiffOptions,
 	GitDiffFile,
-	GitDiffResult
+	GitDiffResult,
+	// Release promotion lane (self-build slice AI) — one named workflow's
+	// verdict for one commit.
+	GitWorkflowRun
 } from '../contracts/capabilities/git-provider.interface.js';
 
 export { isGitProviderPlugin } from '../contracts/capabilities/git-provider.interface.js';

--- a/packages/plugins/github/src/__tests__/github-api.service.workflow-run.spec.ts
+++ b/packages/plugins/github/src/__tests__/github-api.service.workflow-run.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * Release promotion lane (self-build slice AI, EW-808) —
+ * `GitHubApiService.getWorkflowRunForCommit`.
+ *
+ * The read that answers "what did `promotion-gate.yml` say about THIS
+ * commit?", which the rolled-up `getPullRequestStatus` cannot: that roll-up
+ * folds `skipped` and `cancelled` into `passing`, and it cannot see a
+ * workflow that never ran at all.
+ *
+ * The distinction this file mostly asserts is `null` versus a THROW.
+ * `null` means "the gate has no run for this commit" — a real answer. A
+ * throw means the lookup is broken. The promotion lane refuses on both and
+ * sends the operator to different places, so collapsing one into the other
+ * would be a silent downgrade.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('libsodium-wrappers', () => ({
+	default: {
+		ready: Promise.resolve(),
+		from_base64: vi.fn(),
+		crypto_box_seal: vi.fn(),
+		to_base64: vi.fn()
+	}
+}));
+
+const listWorkflowRunsForRepoMock = vi.fn();
+
+vi.mock('octokit', () => {
+	class FakeOctokit {
+		rest = {
+			actions: {
+				listWorkflowRunsForRepo: listWorkflowRunsForRepoMock
+			},
+			orgs: { checkMembershipForUser: vi.fn() }
+		};
+		constructor(public opts: unknown) {}
+	}
+	class FakeRequestError extends Error {
+		readonly status: number;
+		constructor(message: string, status: number) {
+			super(message);
+			this.status = status;
+		}
+	}
+	return { Octokit: FakeOctokit, RequestError: FakeRequestError };
+});
+
+const { GitHubApiService } = await import('../github-api.service.js');
+const { RequestError } = await import('octokit');
+
+const OWNER = 'ever-works';
+const REPO = 'ever-works';
+const TOKEN = 'gh-token';
+const SHA = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+function run(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 1001,
+		path: '.github/workflows/promotion-gate.yml',
+		head_sha: SHA,
+		status: 'completed',
+		conclusion: 'success',
+		html_url: 'https://github.com/ever-works/ever-works/actions/runs/1001',
+		run_attempt: 1,
+		...overrides
+	};
+}
+
+function service() {
+	return new GitHubApiService();
+}
+
+beforeEach(() => {
+	listWorkflowRunsForRepoMock.mockReset();
+});
+
+describe('getWorkflowRunForCommit', () => {
+	it('asks for exactly the commit, in one request', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: { workflow_runs: [run()] } });
+
+		await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+
+		expect(listWorkflowRunsForRepoMock).toHaveBeenCalledTimes(1);
+		expect(listWorkflowRunsForRepoMock).toHaveBeenCalledWith(
+			expect.objectContaining({ owner: OWNER, repo: REPO, head_sha: SHA })
+		);
+	});
+
+	it('maps the run onto the provider-neutral shape', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: { workflow_runs: [run()] } });
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+
+		expect(result).toEqual({
+			id: 1001,
+			workflowPath: '.github/workflows/promotion-gate.yml',
+			headSha: SHA,
+			status: 'completed',
+			conclusion: 'success',
+			url: 'https://github.com/ever-works/ever-works/actions/runs/1001',
+			runAttempt: 1
+		});
+	});
+
+	it('matches on the FILE NAME, so a bare name and a full path both work', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: { workflow_runs: [run()] } });
+		const api = service();
+
+		await expect(
+			api.getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)
+		).resolves.not.toBeNull();
+		await expect(
+			api.getWorkflowRunForCommit(OWNER, REPO, '.github/workflows/promotion-gate.yml', SHA, TOKEN)
+		).resolves.not.toBeNull();
+		await expect(
+			api.getWorkflowRunForCommit(OWNER, REPO, 'PROMOTION-GATE.YML', SHA, TOKEN)
+		).resolves.not.toBeNull();
+	});
+
+	it('ignores every OTHER workflow that ran on the same commit', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: {
+				workflow_runs: [
+					run({ id: 900, path: '.github/workflows/ci.yml', conclusion: 'success' }),
+					run({ id: 901, path: '.github/workflows/e2e.yml', conclusion: 'success' })
+				]
+			}
+		});
+
+		// A commit whose OTHER checks are green but whose gate never ran is
+		// exactly the case the rolled-up CI state gets wrong.
+		await expect(
+			service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)
+		).resolves.toBeNull();
+	});
+
+	it('returns null when the commit has no runs at all', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: { workflow_runs: [] } });
+		await expect(
+			service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)
+		).resolves.toBeNull();
+	});
+
+	it('returns null when the payload has no runs array', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: {} });
+		await expect(
+			service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)
+		).resolves.toBeNull();
+	});
+
+	it('returns null for a missing repository (404), which is a real answer', async () => {
+		listWorkflowRunsForRepoMock.mockRejectedValue(new RequestError('Not Found', 404));
+		await expect(
+			service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)
+		).resolves.toBeNull();
+	});
+
+	it('THROWS on a 403 — a token without actions:read is a broken gate, not a missing run', async () => {
+		listWorkflowRunsForRepoMock.mockRejectedValue(new RequestError('Forbidden', 403));
+		await expect(service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)).rejects.toThrow(
+			'Forbidden'
+		);
+	});
+
+	it('THROWS on a 5xx rather than reporting the gate absent', async () => {
+		listWorkflowRunsForRepoMock.mockRejectedValue(new RequestError('Bad gateway', 502));
+		await expect(service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN)).rejects.toThrow(
+			'Bad gateway'
+		);
+	});
+
+	it('reports the NEWEST run when the workflow ran more than once for the commit', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: {
+				workflow_runs: [
+					run({ id: 1000, conclusion: 'failure' }),
+					run({ id: 1002, conclusion: 'success' }),
+					run({ id: 1001, conclusion: 'failure' })
+				]
+			}
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.id).toBe(1002);
+		expect(result?.conclusion).toBe('success');
+	});
+
+	it('prefers the latest ATTEMPT when a run was re-run in place', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: {
+				workflow_runs: [
+					run({ id: 1001, run_attempt: 1, conclusion: 'failure' }),
+					run({ id: 1001, run_attempt: 3, conclusion: 'success' })
+				]
+			}
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.runAttempt).toBe(3);
+		expect(result?.conclusion).toBe('success');
+	});
+
+	it('carries a run that has not finished through as pending, with a null conclusion', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: { workflow_runs: [run({ status: 'in_progress', conclusion: null })] }
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.status).toBe('in_progress');
+		expect(result?.conclusion).toBeNull();
+	});
+
+	it.each([
+		['cancelled', 'cancelled'],
+		['skipped', 'skipped'],
+		['neutral', 'neutral'],
+		['stale', 'stale'],
+		['timed_out', 'timed_out'],
+		['action_required', 'action_required']
+	])('passes a %s conclusion through verbatim rather than laundering it', async (raw, expected) => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: { workflow_runs: [run({ conclusion: raw })] }
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.conclusion).toBe(expected);
+	});
+
+	it('reports an UNKNOWN conclusion as null rather than guessing', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: { workflow_runs: [run({ conclusion: 'quantum' })] }
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		// Unrecognised must never be laundered into a pass; the lane maps
+		// "completed with no readable conclusion" to `unreadable`.
+		expect(result?.conclusion).toBeNull();
+	});
+
+	it('reports an UNKNOWN status as unknown rather than as completed', async () => {
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: { workflow_runs: [run({ status: 'teleporting', conclusion: 'success' })] }
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.status).toBe('unknown');
+	});
+
+	// Each row isolates ONE guard: the workflow name and the commit are
+	// varied INDEPENDENTLY, so deleting either half of
+	// `if (!wanted || !headSha) return null` reds a row. The previous
+	// version blanked both on the "empty workflow name" row, which left
+	// `!wanted` with no coverage at all — a caller passing an empty
+	// workflow name would then have matched the first run of ANY workflow
+	// on the commit, silently.
+	it.each([
+		['an empty workflow name, with a real commit', '', SHA],
+		['a workflow name that is only whitespace, with a real commit', '   ', SHA],
+		['an empty commit, with a real workflow name', 'promotion-gate.yml', ''],
+		['a workflow name and a commit that are both empty', '', '']
+	])('short-circuits on %s without calling the API', async (_label, workflow, commit) => {
+		await expect(service().getWorkflowRunForCommit(OWNER, REPO, workflow, commit, TOKEN)).resolves.toBeNull();
+		expect(listWorkflowRunsForRepoMock).not.toHaveBeenCalled();
+	});
+
+	it('reports which pull requests the run was for, so a caller can refuse a run that is not its own', async () => {
+		// A workflow run is keyed by COMMIT, and one commit can head more
+		// than one pull request — `stage` can be the head of both a
+		// `stage -> main` promotion and somebody's comparison branch. The
+		// override label is per pull request, so a run adopted off the
+		// commit alone can differ in exactly the way that matters.
+		listWorkflowRunsForRepoMock.mockResolvedValue({
+			data: {
+				workflow_runs: [run({ pull_requests: [{ number: 42 }, null, { number: 43 }, {}] })]
+			}
+		});
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result?.pullRequestNumbers).toEqual([42, 43]);
+	});
+
+	it('omits the association entirely when the provider did not report one', async () => {
+		// `undefined` is "the provider did not say", which is NOT the same
+		// as "this run belongs to no pull request" — the caller must not
+		// manufacture a mismatch out of it.
+		listWorkflowRunsForRepoMock.mockResolvedValue({ data: { workflow_runs: [run()] } });
+
+		const result = await service().getWorkflowRunForCommit(OWNER, REPO, 'promotion-gate.yml', SHA, TOKEN);
+		expect(result).not.toHaveProperty('pullRequestNumbers');
+	});
+});

--- a/packages/plugins/github/src/github-api.service.ts
+++ b/packages/plugins/github/src/github-api.service.ts
@@ -26,7 +26,8 @@ import type {
 	GitDiffResult,
 	GitPullRequestCheck,
 	GitPullRequestStatus,
-	GitReviewDecision
+	GitReviewDecision,
+	GitWorkflowRun
 } from '@ever-works/plugin/git';
 import { capChecks, capDiffFiles, deriveCiState, resolveDiffCaps } from '@ever-works/plugin/git';
 import { GitHubVerifiedOrgService, parseVerifiedOrgs } from './github-verified-org.service.js';
@@ -64,6 +65,63 @@ const REVIEW_DECISION_MAP: Record<string, GitReviewDecision> = {
 	CHANGES_REQUESTED: 'changes_requested',
 	REVIEW_REQUIRED: 'review_required'
 };
+
+/**
+ * How many of a commit's workflow runs to read when looking for one named
+ * workflow (release promotion lane, slice AI). A single commit in this
+ * monorepo triggers well under a dozen workflows; 100 is one page and
+ * covers every realistic repository without a second round trip.
+ */
+const WORKFLOW_RUNS_PER_PAGE = 100;
+
+/** The subset of GitHub's workflow-run payload this reads. */
+interface WorkflowRunPayload {
+	id?: number;
+	path?: string;
+	head_sha?: string;
+	status?: string | null;
+	conclusion?: string | null;
+	html_url?: string;
+	run_attempt?: number;
+	/** `pull_requests[]` on a workflow run — present for `pull_request` events. */
+	pull_requests?: Array<{ number?: number } | null> | null;
+}
+
+/** GitHub's label shape, as it appears on a pull-request payload. */
+interface LabelPayload {
+	name?: string | null;
+}
+
+/**
+ * Label NAMES off a pull-request payload.
+ *
+ * Returns `undefined` — not `[]` — when the payload carried no `labels`
+ * key at all, because `GitPullRequest.labels` is absence-ambiguous by
+ * contract: "this read did not report labels" and "this pull request has
+ * none" are different facts and must not render identically.
+ */
+function labelNames(raw: unknown): readonly string[] | undefined {
+	if (!Array.isArray(raw)) return undefined;
+	return raw
+		.map((label) => (typeof label === 'string' ? label : ((label as LabelPayload)?.name ?? null)))
+		.filter((name): name is string => typeof name === 'string' && name.length > 0);
+}
+
+/**
+ * Last path segment of a workflow reference, lowercased.
+ *
+ * Callers name the gate as `promotion-gate.yml` while GitHub reports
+ * `.github/workflows/promotion-gate.yml`; comparing file names makes both
+ * forms work and keeps a repository that moves its workflows directory
+ * from silently reading as "gate absent".
+ */
+function workflowFileName(reference: string | null | undefined): string {
+	if (typeof reference !== 'string') return '';
+	const trimmed = reference.trim().toLowerCase();
+	if (!trimmed) return '';
+	const segments = trimmed.split('/');
+	return segments[segments.length - 1] ?? '';
+}
 
 /** Pages of check-runs/statuses to read before giving up (rate budget). */
 const CHECKS_PER_PAGE = 100;
@@ -614,6 +672,7 @@ export class GitHubApiService {
 			});
 
 			const author = await this.buildPrAuthor(data.user, token, baseUrl);
+			const labels = labelNames(data.labels);
 			return {
 				number: data.number,
 				title: data.title,
@@ -624,7 +683,8 @@ export class GitHubApiService {
 				createdAt: data.created_at,
 				updatedAt: data.updated_at,
 				body: data.body ?? undefined,
-				...(author ? { author } : {})
+				...(author ? { author } : {}),
+				...(labels ? { labels } : {})
 			};
 		} catch (err) {
 			if (err instanceof RequestError && err.status === 404) {
@@ -694,6 +754,7 @@ export class GitHubApiService {
 		const result: GitPullRequest[] = [];
 		for (const pr of data) {
 			const author = await this.buildPrAuthor(pr.user, token, baseUrl);
+			const labels = labelNames(pr.labels);
 			result.push({
 				number: pr.number,
 				title: pr.title,
@@ -704,7 +765,8 @@ export class GitHubApiService {
 				createdAt: pr.created_at,
 				updatedAt: pr.updated_at,
 				body: pr.body ?? undefined,
-				...(author ? { author } : {})
+				...(author ? { author } : {}),
+				...(labels ? { labels } : {})
 			});
 		}
 		return result;
@@ -806,6 +868,89 @@ export class GitHubApiService {
 			checksComplete: read.complete,
 			url: pr.html_url,
 			title: pr.title
+		};
+	}
+
+	/**
+	 * Release promotion lane (slice AI) — the most recent
+	 * `promotion-gate.yml`-style workflow run for one commit.
+	 *
+	 * ONE request: `GET /repos/{owner}/{repo}/actions/runs?head_sha=…`,
+	 * then filter by workflow file. The alternative — asking
+	 * `/actions/workflows/{file}/runs` directly — 404s whenever the
+	 * workflow file is not on the repository's default branch, which is
+	 * exactly the situation a release lane is in the day the workflow is
+	 * introduced, and a 404 there is indistinguishable from "no runs".
+	 * Filtering client-side keeps "the workflow has no run for this
+	 * commit" (`null`) separate from "the lookup failed" (a throw), which
+	 * the caller renders differently.
+	 *
+	 * A 404 on the repository itself resolves to `null`; every other error
+	 * propagates, because a token without `actions:read` must surface as a
+	 * BROKEN GATE and not as a missing run.
+	 */
+	async getWorkflowRunForCommit(
+		owner: string,
+		repo: string,
+		workflowPath: string,
+		headSha: string,
+		token: string,
+		baseUrl?: string
+	): Promise<GitWorkflowRun | null> {
+		const wanted = workflowFileName(workflowPath);
+		if (!wanted || !headSha) return null;
+
+		const octokit = this.createOctokit(token, baseUrl);
+		let runs: WorkflowRunPayload[];
+		try {
+			const response = await octokit.rest.actions.listWorkflowRunsForRepo({
+				owner,
+				repo,
+				head_sha: headSha,
+				per_page: WORKFLOW_RUNS_PER_PAGE
+			});
+			runs = (response.data?.workflow_runs ?? []) as WorkflowRunPayload[];
+		} catch (err) {
+			// Only a missing REPOSITORY is an answer. A 403 (no
+			// `actions:read`) or a 5xx is a broken lookup and must throw.
+			if (err instanceof RequestError && err.status === 404) return null;
+			throw err;
+		}
+
+		const matches = runs.filter((run) => workflowFileName(run.path) === wanted);
+		if (matches.length === 0) return null;
+
+		// Newest wins: a re-run of a red gate is the verdict that counts.
+		// Ordered explicitly rather than trusting the API's default sort —
+		// run id first (a later trigger is a later run), then `run_attempt`
+		// as the tie-break, because a re-run keeps the run id and only bumps
+		// the attempt.
+		const newest = matches.reduce((best, run) => {
+			const bestId = best.id ?? 0;
+			const runId = run.id ?? 0;
+			if (runId !== bestId) return runId > bestId ? run : best;
+			return (run.run_attempt ?? 1) > (best.run_attempt ?? 1) ? run : best;
+		});
+
+		return {
+			id: newest.id ?? 0,
+			workflowPath: newest.path ?? workflowPath,
+			headSha: newest.head_sha ?? headSha,
+			status: CHECK_STATUS_MAP[newest.status ?? ''] ?? 'unknown',
+			conclusion: newest.conclusion ? (CHECK_CONCLUSION_MAP[newest.conclusion] ?? null) : null,
+			...(newest.html_url ? { url: newest.html_url } : {}),
+			...(typeof newest.run_attempt === 'number' ? { runAttempt: newest.run_attempt } : {}),
+			// Which pull request(s) this run was for. A run is keyed by
+			// COMMIT, and one commit can head two pull requests; the caller
+			// needs to be able to tell "this run is not about my pull
+			// request" from "there is no run".
+			...(Array.isArray(newest.pull_requests)
+				? {
+						pullRequestNumbers: newest.pull_requests
+							.map((pr) => pr?.number)
+							.filter((n): n is number => typeof n === 'number')
+					}
+				: {})
 		};
 	}
 

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -37,7 +37,8 @@ import type {
 	// PR insights (kanban run cockpit M5/M6).
 	GitDiffOptions,
 	GitDiffResult,
-	GitPullRequestStatus
+	GitPullRequestStatus,
+	GitWorkflowRun
 } from '@ever-works/plugin';
 import { GITHUB_SCOPES } from '@ever-works/plugin';
 // Security (SSRF): lexical guard to keep the admin-configurable `apiBaseUrl`
@@ -341,6 +342,22 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 	): Promise<GitPullRequestStatus | null> {
 		const settings = await this.getSettings();
 		return this.apiService.getPullRequestStatus(owner, repo, prNumber, token, settings.apiBaseUrl);
+	}
+
+	// Release promotion lane (self-build slice AI) — the verdict of ONE
+	// named workflow for ONE commit, which the rolled-up CI state above
+	// cannot answer (it folds a skipped or cancelled gate into `passing`,
+	// and cannot see a gate that never ran).
+
+	async getWorkflowRunForCommit(
+		owner: string,
+		repo: string,
+		workflowPath: string,
+		headSha: string,
+		token: string
+	): Promise<GitWorkflowRun | null> {
+		const settings = await this.getSettings();
+		return this.apiService.getWorkflowRunForCommit(owner, repo, workflowPath, headSha, token, settings.apiBaseUrl);
 	}
 
 	async getPullRequestDiff(


### PR DESCRIPTION
Second promotion of the day. Carries slice **AI** ([#2391](https://github.com/ever-works/ever-works/pull/2391), EW-808) — the release promotion lane.

It opens the two promotion pull requests the house flow requires and reports the gate verdict, and it **cannot promote by itself**: `openPromotion` has one production call site (the operator controller), the promotion service contains no merge call at all, and merging a promotion PR goes through slice AE's human approval, re-verified against the head commit.

The gate workflow now also triggers on pull requests into `stage`, which is what gives the develop→stage rung a verdict to read.

Verified on the branch before merge: contracts 41 files / 1967 tests, agent 164 suites / 2645 tests, api release + migrations 54 suites / 271 tests, node-contract gate 82, typecheck and prettier clean.

Note: the GitHub account is billing-locked for GitHub-hosted runners, so some checks may not start. That is unrelated to this change and is recorded in `CI_RELEASE_GATES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)