### PR TITLE
feat(release): verify a promotion after it lands, and offer a revert (EW-809)

### DIFF
--- a/apps/api/src/migrations/1790100000000-AddReleaseVerification.ts
+++ b/apps/api/src/migrations/1790100000000-AddReleaseVerification.ts
@@ -1,0 +1,212 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809) — the
+ * `verify*` / `revert*` columns on `release_promotions`, plus the one
+ * column on `works` that says WHERE a deployed environment can be observed.
+ *
+ * Entities:
+ *   `packages/agent/src/entities/release-promotion.entity.ts`
+ *   `packages/agent/src/entities/work.entity.ts` (`releaseVerification`)
+ *
+ * ## `works.releaseVerification`
+ *
+ * The per-environment `{ versionUrl, appUrl, appExpectText }` map, as
+ * platform state, beside the `releaseLadder` slice AI added. NULL on every
+ * existing row, which is both the correct history and the correct default:
+ * a merged promotion for a Work with no target is recorded `unsupported`
+ * and reported to its owner as NOT VERIFIED. It is never read as a pass —
+ * "nobody configured a URL" and "the deployment is healthy" must not be
+ * the same reading.
+ *
+ * `text` here and `simple-json` on the entity, matching exactly how
+ * `releaseLadder` shipped in `1790000000000`, and read back only through
+ * `sanitizeReleaseVerificationTargets` — these URLs are loaded by a real
+ * browser on somebody's PC.
+ *
+ * ## Why the verification lives on the promotion row
+ *
+ * One promotion has exactly one deployment to verify, for ever. A separate
+ * table would buy nothing and cost a join on every operator read, and "the
+ * verdict is visible ON the promotion" is the requirement.
+ *
+ * ## The two columns that make the lane bounded
+ *
+ * `verifyAttempts` and `verifyDeadlineAt`. Whichever is reached first ends
+ * the verification as `inconclusive`. Two independent stops rather than
+ * one, because a cap counted in attempts survives a clock that jumps and a
+ * deadline survives a sweep that runs far more often than intended.
+ *
+ * ## `verifyJobId` is the mutual exclusion
+ *
+ * The sweep claims an attempt with `WHERE verifyJobId IS NULL`, so at most
+ * one browser is ever pointed at one environment for one promotion however
+ * many API replicas are running. Deliberately NOT indexed on its own: the
+ * completion listener's lookup by job id is a single-row hit on a table
+ * with two rows a week, and the sweep's index below already covers the one
+ * query that runs on a schedule.
+ *
+ * ## `revertTaskId` records an OFFER, not an act
+ *
+ * There is deliberately no `revertedAt`, no `revertPrNumber` and no
+ * `revertMergedAt` on this table, and there never should be. The platform
+ * does not revert production: it files a Task holding the coordinates and
+ * stops, and landing whatever pull request that Task eventually produces
+ * goes through the same `merge_pull_request` Inbox approval as every other
+ * merge. A column that could record "we reverted" would be the first sign
+ * somebody had built the thing this slice refuses to build.
+ *
+ * FK: `revertTaskId` → `tasks.id` SET NULL, the same choice
+ * `1790000000000` made for `taskId` and for the same reason — deleting the
+ * Task must not erase the record that a revert was offered, and CASCADE
+ * would delete the promotion's whole history with it.
+ *
+ * Forward-only + idempotent (`findColumnByName` guards), and portable
+ * `TableColumn` DDL rather than raw SQL, because production runs Postgres
+ * while CI runs better-sqlite3.
+ */
+export class AddReleaseVerification1790100000000 implements MigrationInterface {
+    name = 'AddReleaseVerification1790100000000';
+
+    private static readonly PROMOTION_COLUMNS = [
+        // `awaiting-rollout` | `checking-app` | `confirming-failure` |
+        // `passed` | `failed` | `inconclusive` | `unsupported`.
+        // NULL = never started, which is NOT a pass.
+        new TableColumn({ name: 'verifyState', type: 'varchar', length: '24', isNullable: true }),
+        // THE artefact identity: the base branch's tip read immediately
+        // after the merge, which is what the environment must be SERVING
+        // before this lane says anything. Not `headSha` — the merge makes a
+        // new commit and the pull-request status carries no merge sha.
+        new TableColumn({
+            name: 'verifyExpectedSha',
+            type: 'varchar',
+            length: '64',
+            isNullable: true,
+        }),
+        new TableColumn({
+            name: 'verifyTargetUrl',
+            type: 'varchar',
+            length: '512',
+            isNullable: true,
+        }),
+        new TableColumn({ name: 'verifyStartedAt', type: 'timestamp', isNullable: true }),
+        new TableColumn({ name: 'verifyDeadlineAt', type: 'timestamp', isNullable: true }),
+        // Bound #1. Not nullable, defaulted, so an existing row backfills
+        // to 0 and an unstarted verification cannot look part-way through.
+        new TableColumn({ name: 'verifyAttempts', type: 'int', default: 0 }),
+        // Consecutive same-direction results in the current state.
+        new TableColumn({ name: 'verifyStreak', type: 'int', default: 0 }),
+        new TableColumn({ name: 'verifyJobId', type: 'varchar', length: '64', isNullable: true }),
+        new TableColumn({ name: 'verifyRetryAt', type: 'timestamp', isNullable: true }),
+        new TableColumn({ name: 'verifyCheckedAt', type: 'timestamp', isNullable: true }),
+        new TableColumn({ name: 'verifyDetail', type: 'varchar', length: '512', isNullable: true }),
+        // The Task that OFFERS a revert. Never a Task that performed one.
+        new TableColumn({ name: 'revertTaskId', type: 'uuid', isNullable: true }),
+        new TableColumn({ name: 'revertOfferedAt', type: 'timestamp', isNullable: true }),
+    ];
+
+    private static readonly WORK_COLUMN = new TableColumn({
+        name: 'releaseVerification',
+        type: 'text',
+        isNullable: true,
+    });
+
+    /**
+     * The verification sweep's ONLY query: live rows whose next probe is
+     * due. Without it a cron running every few minutes table-scans
+     * `release_promotions` for ever.
+     */
+    private static readonly SWEEP_INDEX = new TableIndex({
+        name: 'idx_release_promotions_verify',
+        columnNames: ['verifyState', 'verifyRetryAt'],
+    });
+
+    private static readonly REVERT_TASK_FK = new TableForeignKey({
+        name: 'fk_release_promotions_revert_task',
+        columnNames: ['revertTaskId'],
+        referencedTableName: 'tasks',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+    });
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const works = await queryRunner.getTable('works');
+        if (works && !works.findColumnByName('releaseVerification')) {
+            await queryRunner.addColumn('works', AddReleaseVerification1790100000000.WORK_COLUMN);
+        }
+
+        const promotions = await queryRunner.getTable('release_promotions');
+        if (!promotions) {
+            // `1790000000000-CreateReleasePromotions` has not run. TypeORM
+            // runs migrations in timestamp order, so this cannot happen in
+            // a normal boot; returning beats throwing on a hand-rolled
+            // database that is missing the table entirely.
+            return;
+        }
+
+        for (const column of AddReleaseVerification1790100000000.PROMOTION_COLUMNS) {
+            if (!promotions.findColumnByName(column.name)) {
+                await queryRunner.addColumn('release_promotions', column);
+            }
+        }
+
+        const withColumns = await queryRunner.getTable('release_promotions');
+        if (
+            withColumns &&
+            !withColumns.indices.some((index) => index.name === 'idx_release_promotions_verify')
+        ) {
+            await queryRunner.createIndex(
+                'release_promotions',
+                AddReleaseVerification1790100000000.SWEEP_INDEX,
+            );
+        }
+        if (
+            withColumns &&
+            !withColumns.foreignKeys.some((fk) => fk.name === 'fk_release_promotions_revert_task')
+        ) {
+            await queryRunner.createForeignKey(
+                'release_promotions',
+                AddReleaseVerification1790100000000.REVERT_TASK_FK,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const promotions = await queryRunner.getTable('release_promotions');
+        if (promotions) {
+            const fk = promotions.foreignKeys.find(
+                (candidate) => candidate.name === 'fk_release_promotions_revert_task',
+            );
+            if (fk) {
+                await queryRunner.dropForeignKey('release_promotions', fk);
+            }
+            const index = promotions.indices.find(
+                (candidate) => candidate.name === 'idx_release_promotions_verify',
+            );
+            if (index) {
+                await queryRunner.dropIndex('release_promotions', index);
+            }
+            // `dropColumn` rather than a raw `ALTER TABLE … DROP COLUMN`:
+            // the query runner rebuilds the table on drivers that cannot
+            // drop a column in place, which is exactly the driver CI uses.
+            // Re-read the table between drops for the same reason — each
+            // rebuild produces a NEW Table object and the stale one's
+            // columns no longer describe what exists.
+            for (const column of AddReleaseVerification1790100000000.PROMOTION_COLUMNS) {
+                const table = await queryRunner.getTable('release_promotions');
+                const existing = table?.findColumnByName(column.name);
+                if (existing) {
+                    await queryRunner.dropColumn('release_promotions', existing);
+                }
+            }
+        }
+
+        const works = await queryRunner.getTable('works');
+        if (works) {
+            const column = works.findColumnByName('releaseVerification');
+            if (column) {
+                await queryRunner.dropColumn('works', column);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddReleaseVerification.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddReleaseVerification.spec.ts
@@ -1,0 +1,296 @@
+import { DataSource } from 'typeorm';
+import { CreateReleasePromotions1790000000000 } from '../1790000000000-CreateReleasePromotions';
+import { AddReleaseVerification1790100000000 } from '../1790100000000-AddReleaseVerification';
+
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809) —
+ * migration test for the `verify*` / `revert*` columns on
+ * `release_promotions` and `works.releaseVerification`, against an
+ * in-memory better-sqlite3 DataSource (the same harness
+ * `CreateReleasePromotions.spec.ts` uses).
+ *
+ * Slice AI's migration is run FIRST, because this one is an ALTER and
+ * asserting it in isolation would prove nothing about the table it has to
+ * land on.
+ *
+ * Schema shape is asserted against the PHYSICAL table (`PRAGMA
+ * table_info`), never by watching an INSERT fail: a column that silently
+ * does not exist makes an INSERT fail for the wrong reason, and this
+ * migration's whole job is thirteen columns existing.
+ *
+ * The inserts pass `createdAt`/`updatedAt` explicitly: the table's `now()`
+ * / `uuid_generate_v4()` defaults are Postgres functions (the shape every
+ * migration in this folder ships), and sqlite is used here only as a cheap
+ * DDL harness.
+ */
+describe('AddReleaseVerification1790100000000', () => {
+    let dataSource: DataSource;
+    const base = new CreateReleasePromotions1790000000000();
+    const migration = new AddReleaseVerification1790100000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`CREATE TABLE "users" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "users" ("id") VALUES ('u-a')`);
+        await dataSource.query(
+            `CREATE TABLE "works" ("id" varchar PRIMARY KEY NOT NULL, "slug" varchar)`,
+        );
+        await dataSource.query(`INSERT INTO "works" ("id", "slug") VALUES ('w-1', 'one')`);
+        await dataSource.query(`CREATE TABLE "tasks" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "tasks" ("id") VALUES ('t-1'), ('t-2')`);
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function runBase(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await base.up(runner);
+        await runner.release();
+    }
+
+    async function up(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function down(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+    }
+
+    async function columnNames(table: string): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("${table}")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    async function columnInfo(
+        table: string,
+        column: string,
+    ): Promise<{ name: string; notnull: number; dflt_value: string | null } | undefined> {
+        const rows: Array<{ name: string; notnull: number; dflt_value: string | null }> =
+            await dataSource.query(`PRAGMA table_info("${table}")`);
+        return rows.find((r) => r.name === column);
+    }
+
+    async function indexNames(table: string): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA index_list("${table}")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    const COLUMNS =
+        '"id", "userId", "workId", "taskId", "rung", "headBranch", "baseBranch", "state", "laneKey", "gateWorkflow", "createdAt", "updatedAt"';
+    const STAMPS = `'2026-09-06 00:00:00', '2026-09-06 00:00:00'`;
+
+    function insert(id: string, laneKey = 'open'): Promise<unknown> {
+        return dataSource.query(
+            `INSERT INTO "release_promotions" (${COLUMNS}) VALUES ('${id}', 'u-a', 'w-1', 't-1', 'stage-to-main', 'stage', 'main', 'open', '${laneKey}', 'promotion-gate.yml', ${STAMPS})`,
+        );
+    }
+
+    const VERIFY_COLUMNS = [
+        'verifyState',
+        'verifyExpectedSha',
+        'verifyTargetUrl',
+        'verifyStartedAt',
+        'verifyDeadlineAt',
+        'verifyAttempts',
+        'verifyStreak',
+        'verifyJobId',
+        'verifyRetryAt',
+        'verifyCheckedAt',
+        'verifyDetail',
+        'revertTaskId',
+        'revertOfferedAt',
+    ];
+
+    describe('up', () => {
+        it('adds every verification and revert column to release_promotions', async () => {
+            await runBase();
+            await up();
+            expect(await columnNames('release_promotions')).toEqual(
+                expect.arrayContaining(VERIFY_COLUMNS),
+            );
+        });
+
+        it('adds releaseVerification to works', async () => {
+            await runBase();
+            await up();
+            expect(await columnNames('works')).toContain('releaseVerification');
+        });
+
+        it('leaves the slice AI columns alone', async () => {
+            // An ALTER that rebuilds a table on sqlite is exactly where a
+            // column quietly disappears.
+            await runBase();
+            await up();
+            expect(await columnNames('release_promotions')).toEqual(
+                expect.arrayContaining([
+                    'id',
+                    'userId',
+                    'workId',
+                    'taskId',
+                    'rung',
+                    'headBranch',
+                    'baseBranch',
+                    'headSha',
+                    'state',
+                    'laneKey',
+                    'gateWorkflow',
+                    'gateVerdict',
+                    'gateVerdictSha',
+                    'gateOverridden',
+                    'inboxFiledForSha',
+                    'inboxFiledVerdict',
+                ]),
+            );
+        });
+
+        it('keeps the UNIQUE lane index working after the rebuild', async () => {
+            // THE anti-duplicate guarantee from slice AI. A table rebuild
+            // that dropped it would leave two competing promotion pull
+            // requests possible, and nothing else in this suite would notice.
+            await runBase();
+            await up();
+            expect(await indexNames('release_promotions')).toContain('uq_release_promotions_lane');
+            await insert('p-1');
+            await expect(insert('p-2')).rejects.toThrow();
+        });
+
+        it('creates the sweep index the verification cron reads', async () => {
+            await runBase();
+            await up();
+            expect(await indexNames('release_promotions')).toContain(
+                'idx_release_promotions_verify',
+            );
+        });
+
+        it('defaults the two bound counters to 0 rather than NULL', async () => {
+            // `verifyAttempts` is one of the two independent stops that keep
+            // the lane bounded. A NULL there would make
+            // `isReleaseVerifyExhausted` count from zero on every pass on a
+            // row that had already used its budget.
+            await runBase();
+            await up();
+            await insert('p-1');
+            const rows: Array<{ verifyAttempts: number; verifyStreak: number; verifyState: null }> =
+                await dataSource.query(
+                    `SELECT "verifyAttempts", "verifyStreak", "verifyState" FROM "release_promotions" WHERE "id" = 'p-1'`,
+                );
+            expect(rows[0].verifyAttempts).toBe(0);
+            expect(rows[0].verifyStreak).toBe(0);
+            // NULL, not a state: an existing promotion has not been verified
+            // and must not read as one that has.
+            expect(rows[0].verifyState).toBeNull();
+        });
+
+        it('leaves every verification column nullable, so history backfills honestly', async () => {
+            await runBase();
+            await up();
+            for (const name of VERIFY_COLUMNS.filter(
+                (c) => c !== 'verifyAttempts' && c !== 'verifyStreak',
+            )) {
+                const info = await columnInfo('release_promotions', name);
+                expect(info).toBeDefined();
+                expect(info!.notnull).toBe(0);
+            }
+        });
+
+        it('is idempotent — running it twice adds nothing and throws nothing', async () => {
+            await runBase();
+            await up();
+            const first = await columnNames('release_promotions');
+            await up();
+            expect(await columnNames('release_promotions')).toEqual(first);
+        });
+
+        it('does nothing rather than throwing when the promotions table is absent', async () => {
+            // TypeORM runs migrations in timestamp order so this cannot
+            // happen on a normal boot, but a hand-rolled database must not
+            // crash-loop the API.
+            await expect(up()).resolves.toBeUndefined();
+            expect(await columnNames('works')).toContain('releaseVerification');
+        });
+    });
+
+    describe('down', () => {
+        it('removes every column it added, from both tables', async () => {
+            await runBase();
+            await up();
+            await down();
+            const promotionColumns = await columnNames('release_promotions');
+            for (const name of VERIFY_COLUMNS) {
+                expect(promotionColumns).not.toContain(name);
+            }
+            expect(await columnNames('works')).not.toContain('releaseVerification');
+        });
+
+        it('leaves the slice AI table intact and still constrained', async () => {
+            await runBase();
+            await up();
+            await down();
+            expect(await columnNames('release_promotions')).toEqual(
+                expect.arrayContaining([
+                    'id',
+                    'userId',
+                    'workId',
+                    'rung',
+                    'laneKey',
+                    'gateVerdict',
+                ]),
+            );
+            expect(await indexNames('release_promotions')).toContain('uq_release_promotions_lane');
+            await insert('p-1');
+            await expect(insert('p-2')).rejects.toThrow();
+        });
+
+        it('survives being run without a preceding up', async () => {
+            await runBase();
+            await expect(down()).resolves.toBeUndefined();
+        });
+
+        it('round-trips — up, down, up again', async () => {
+            await runBase();
+            await up();
+            await down();
+            await up();
+            expect(await columnNames('release_promotions')).toEqual(
+                expect.arrayContaining(VERIFY_COLUMNS),
+            );
+            expect(await indexNames('release_promotions')).toContain(
+                'idx_release_promotions_verify',
+            );
+        });
+    });
+
+    describe('what the schema deliberately does NOT have', () => {
+        it('has no column that could record production having been reverted', async () => {
+            // THE load-bearing absence. This platform does not revert
+            // production: it files a Task offering one and stops. A
+            // `revertedAt` / `revertPrNumber` / `revertMergedAt` column
+            // would be the first sign somebody had built the thing this
+            // slice refuses to build, so adding one fails here and the
+            // author has to argue for it.
+            await runBase();
+            await up();
+            const columns = await columnNames('release_promotions');
+            expect(columns.filter((name) => /^revert/i.test(name)).sort()).toEqual([
+                'revertOfferedAt',
+                'revertTaskId',
+            ]);
+        });
+    });
+});

--- a/apps/api/src/release/release-promotions.controller.spec.ts
+++ b/apps/api/src/release/release-promotions.controller.spec.ts
@@ -33,7 +33,32 @@ describe('ReleasePromotionsController', () => {
         gateRunUrl: null,
         refusalCode: null,
         laneKey: 'open',
+        // Post-deploy verification (slice AJ). Present on the fixture
+        // because they are present on the entity: a fixture that omitted
+        // them let the whole `verification` projection be deleted from the
+        // controller with the suite still green.
+        verifyState: 'failed',
+        verifyExpectedSha: 'b'.repeat(40),
+        verifyTargetUrl: 'https://app.ever.works/api/health',
+        verifyAttempts: 7,
+        verifyCheckedAt: new Date('2026-09-06T04:00:00Z'),
+        verifyDetail: 'The app failed 3 consecutive checks.',
+        revertTaskId: 'task-99',
+        revertOfferedAt: new Date('2026-09-06T04:01:00Z'),
         createdAt: new Date('2026-09-06T00:00:00Z'),
+    };
+
+    /** A promotion nobody has verified — the shape the field must not hide. */
+    const unverified = {
+        ...promotion,
+        verifyState: null,
+        verifyExpectedSha: null,
+        verifyTargetUrl: null,
+        verifyAttempts: 0,
+        verifyCheckedAt: null,
+        verifyDetail: null,
+        revertTaskId: null,
+        revertOfferedAt: null,
     };
 
     function build(over: { work?: Record<string, unknown> | null; open?: unknown } = {}) {
@@ -210,14 +235,201 @@ describe('ReleasePromotionsController', () => {
 
     // ── What the surface deliberately lacks ───────────────────────────
 
-    it('exposes no merge and no cascade route', () => {
+    it('exposes no merge, no cascade and no revert route', () => {
         // Landing a promotion is an Inbox approval (slice AE), and the next
         // rung is a separate deliberate act. Neither is reachable here.
+        //
+        // `getVerificationTargets` / `setVerificationTargets` were added by
+        // slice AJ (EW-809) and are the same KIND of route as the ladder
+        // pair: they declare PLATFORM STATE — which URLs a deployment may
+        // be checked against — deliberately and separately from asking for
+        // a promotion, so that no promotion or verification request can
+        // ever name its own URL. They start nothing, retry nothing and
+        // force nothing.
+        //
+        // What is still absent, and must stay absent: anything that reverts.
+        // A failed verification files an inert Task offering one; there is
+        // no endpoint a caller can hit to undo a deployment.
         const routes = Object.getOwnPropertyNames(ReleasePromotionsController.prototype).filter(
             (name) => name !== 'constructor',
         );
-        expect(routes.sort()).toEqual(['getLadder', 'list', 'open', 'setLadder']);
+        expect(routes.sort()).toEqual([
+            'getLadder',
+            'getVerificationTargets',
+            'list',
+            'open',
+            'setLadder',
+            'setVerificationTargets',
+        ]);
         expect(routes.some((name) => /merge|approve|cascade|promoteAll/i.test(name))).toBe(false);
+        expect(routes.some((name) => /revert|rollback|undo|redeploy/i.test(name))).toBe(false);
+        // Nor may a caller drive the verification lane by hand: starting,
+        // retrying or forcing a check is how a human would talk a green
+        // verdict out of a lane whose whole job is to withhold one.
+        expect(routes.some((name) => /verify|recheck|forceCheck/i.test(name))).toBe(false);
+    });
+
+    it('takes the verification target from the Work, and echoes back the SANITISED value', async () => {
+        // Slice AJ. A caller that could name the URL a verification loads
+        // could point a green verdict at a page it controls.
+        const { controller, works } = build();
+
+        const result = await controller.setVerificationTargets(USER, WORK, {
+            production: {
+                versionUrl: 'https://api.ever.works/api/version',
+                appUrl: 'https://app.ever.works/api/health',
+                appExpectText: '"status":"OK"',
+            },
+        } as never);
+
+        expect(works.update).toHaveBeenCalledWith(WORK, {
+            releaseVerification: {
+                production: {
+                    versionUrl: 'https://api.ever.works/api/version',
+                    appUrl: 'https://app.ever.works/api/health',
+                    appExpectText: '"status":"OK"',
+                },
+            },
+        });
+        expect(result.releaseVerification).toEqual({
+            production: expect.objectContaining({
+                versionUrl: 'https://api.ever.works/api/version',
+            }),
+        });
+    });
+
+    it.each([
+        ['plain http', 'http://api.ever.works/api/version'],
+        ['an IP literal', 'https://169.254.169.254/api/version'],
+        ['localhost', 'https://localhost/api/version'],
+    ])('refuses a verification target on %s', async (_label, versionUrl) => {
+        const { controller, works } = build();
+
+        await expect(
+            controller.setVerificationTargets(USER, WORK, {
+                production: {
+                    versionUrl,
+                    appUrl: 'https://app.ever.works/api/health',
+                    appExpectText: '"status":"OK"',
+                },
+            } as never),
+        ).rejects.toThrow(BadRequestException);
+        expect(works.update).not.toHaveBeenCalled();
+    });
+
+    it('answers 404 identically for a Work that is not yours', async () => {
+        const { controller, works } = build();
+
+        await expect(
+            controller.setVerificationTargets(OTHER, WORK, {
+                production: {
+                    versionUrl: 'https://api.ever.works/api/version',
+                    appUrl: 'https://app.ever.works/api/health',
+                    appExpectText: '"status":"OK"',
+                },
+            } as never),
+        ).rejects.toThrow(NotFoundException);
+        expect(works.update).not.toHaveBeenCalled();
+    });
+
+    it('reads a stored verification target back through the sanitiser, not raw', async () => {
+        // The column is `simple-json` and therefore holds whatever was last
+        // written to it — including by a migration, a console, or an older
+        // build. A read that trusted it would hand a caller a URL the lane
+        // would refuse to use.
+        const { controller } = build({
+            work: {
+                releaseVerification: {
+                    production: {
+                        versionUrl: 'http://api.ever.works/api/version',
+                        appUrl: 'https://app.ever.works/api/health',
+                        appExpectText: '"status":"OK"',
+                    },
+                },
+            },
+        });
+
+        const result = await controller.getVerificationTargets(USER, WORK);
+
+        expect(result.releaseVerification).toBeNull();
+    });
+
+    // ── The verdict, on the promotion ────────────────────────────────
+
+    it('reports the post-deploy verification on every promotion it returns', async () => {
+        // Requirement 2 of slice AJ — "make the verdict visible on the
+        // promotion". The whole block had no test: deleting it left the
+        // entire apps/api release suite green, so renaming `state`,
+        // omitting it when null, or dropping `revertOffer` entirely all
+        // shipped silently.
+        const { controller } = build();
+
+        const result = (await controller.open(USER, WORK, {
+            rung: 'develop-to-stage',
+            agentId: 'agent-1',
+        })) as unknown as { promotion: Record<string, Record<string, unknown>> };
+
+        expect(result.promotion.verification).toEqual({
+            state: 'failed',
+            // NOT `headSha`: the merge produced a new commit, and this is
+            // the base branch's tip read straight afterwards.
+            expectedSha: 'b'.repeat(40),
+            lastUrl: 'https://app.ever.works/api/health',
+            attempts: 7,
+            checkedAt: new Date('2026-09-06T04:00:00Z'),
+            detail: 'The app failed 3 consecutive checks.',
+        });
+        expect(result.promotion.verification.expectedSha).not.toBe(promotion.headSha);
+    });
+
+    it('always carries `verification.state`, so "never checked" cannot read as fine', async () => {
+        // The safety property the controller comment states: `state: null`
+        // means the deployment was never checked, which a reader must not
+        // round up to "fine" — so the field is present rather than omitted.
+        const { controller, promotions } = build();
+        promotions.openPromotion.mockResolvedValue({
+            outcome: 'opened',
+            promotion: unverified,
+            task: { id: 'task-1', slug: 'T-9' },
+        });
+
+        const result = (await controller.open(USER, WORK, {
+            rung: 'develop-to-stage',
+            agentId: 'agent-1',
+        })) as unknown as { promotion: Record<string, Record<string, unknown>> };
+
+        expect(result.promotion).toHaveProperty('verification');
+        expect(result.promotion.verification).toHaveProperty('state');
+        expect(result.promotion.verification.state).toBeNull();
+        expect(result.promotion.verification.attempts).toBe(0);
+    });
+
+    it('exposes a revert that was OFFERED, and never one that was taken', async () => {
+        // There is deliberately no field saying a revert HAPPENED, because
+        // nothing in this platform reverts. What a caller gets is a Task id
+        // a human may act on.
+        const { controller } = build();
+
+        const rows = (await controller.list(USER, WORK, undefined)) as {
+            promotions: Array<Record<string, unknown>>;
+        };
+
+        expect(rows.promotions[0].revertOffer).toEqual({
+            taskId: 'task-99',
+            offeredAt: new Date('2026-09-06T04:01:00Z'),
+        });
+        expect(JSON.stringify(rows.promotions[0])).not.toMatch(/reverted/i);
+    });
+
+    it('answers `revertOffer: null` — not an empty object — when none was filed', async () => {
+        const { controller, promotions } = build();
+        promotions.listForWork.mockResolvedValue([unverified]);
+
+        const rows = (await controller.list(USER, WORK, undefined)) as {
+            promotions: Array<Record<string, unknown>>;
+        };
+
+        expect(rows.promotions[0].revertOffer).toBeNull();
     });
 
     it('is mounted by a module that binds the promotion tokens app-wide', () => {

--- a/apps/api/src/release/release-promotions.controller.ts
+++ b/apps/api/src/release/release-promotions.controller.ts
@@ -13,12 +13,16 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { sanitizeReleaseLadder } from '@ever-works/contracts';
+import { sanitizeReleaseLadder, sanitizeReleaseVerificationTargets } from '@ever-works/contracts';
 import { ReleasePromotionService } from '@ever-works/agent/tasks-domain';
 import { WorkRepository } from '@ever-works/agent/database';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
-import { OpenPromotionDto, SetReleaseLadderDto } from './release-promotions.dto';
+import {
+    OpenPromotionDto,
+    SetReleaseLadderDto,
+    SetReleaseVerificationDto,
+} from './release-promotions.dto';
 
 /**
  * Release promotion lane (self-build slice AI, EW-808) — the operator's
@@ -39,6 +43,19 @@ import { OpenPromotionDto, SetReleaseLadderDto } from './release-promotions.dto'
  * lane measured at 215–243 minutes. Six a minute is already far more than
  * a human performs; the lane's UNIQUE index is the real duplicate guard,
  * and this is the cheap one in front of it.
+ *
+ * ## Post-deploy verification (slice AJ, EW-809)
+ *
+ * `PUT/GET verification-targets` declares WHERE each environment can be
+ * observed, as platform state, exactly as `release-ladder` declares which
+ * branches a promotion may touch. `GET promotions` then reports what the
+ * verification found.
+ *
+ * There is still no endpoint here that reverts anything, and there is no
+ * endpoint that starts, retries or forces a verification. A verification
+ * begins when a promotion is observed merged and advances on a cron; a
+ * failed one files an inert Task offering a revert for a human to decide
+ * on. Nothing a caller can say to this controller reverts a deployment.
  */
 @ApiTags('release')
 @Controller('api/works/:workId')
@@ -86,6 +103,54 @@ export class ReleasePromotionsController {
             throw new NotFoundException(`Work ${workId} not found.`);
         }
         return { workId, releaseLadder: sanitizeReleaseLadder(work.releaseLadder) };
+    }
+
+    @Put('verification-targets')
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Declare where this Work’s deployed environments can be observed',
+        description:
+            'PLATFORM STATE. Set by the owner; every post-deploy verification reads it. A promotion request can never name the URL its deployment is checked against.',
+    })
+    async setVerificationTargets(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+        @Body() body: SetReleaseVerificationDto,
+    ) {
+        const work = await this.works.findById(workId);
+        if (!work || work.userId !== user.userId) {
+            // Same answer for "no such Work" and "not yours".
+            throw new NotFoundException(`Work ${workId} not found.`);
+        }
+        const targets = sanitizeReleaseVerificationTargets(body);
+        if (!targets) {
+            throw new BadRequestException(
+                'A verification target needs an https versionUrl, an https appUrl and a non-trivial ' +
+                    'appExpectText, on a public DNS hostname, for at least one environment.',
+            );
+        }
+        await this.works.update(workId, { releaseVerification: targets });
+        // Echo the SANITIZED value, never the request body: what comes back
+        // is what a verification will actually load.
+        return { workId, releaseVerification: targets };
+    }
+
+    @Get('verification-targets')
+    @ApiOperation({
+        summary: 'Read this Work’s verification targets (null when none are configured)',
+    })
+    async getVerificationTargets(
+        @CurrentUser() user: AuthenticatedUser,
+        @Param('workId', ParseUUIDPipe) workId: string,
+    ) {
+        const work = await this.works.findById(workId);
+        if (!work || work.userId !== user.userId) {
+            throw new NotFoundException(`Work ${workId} not found.`);
+        }
+        return {
+            workId,
+            releaseVerification: sanitizeReleaseVerificationTargets(work.releaseVerification),
+        };
     }
 
     @Post('promotions')
@@ -170,6 +235,14 @@ function view(promotion: {
     gateRunUrl?: string | null;
     gateOverridden?: boolean | null;
     refusalCode?: string | null;
+    verifyState?: string | null;
+    verifyExpectedSha?: string | null;
+    verifyTargetUrl?: string | null;
+    verifyAttempts?: number | null;
+    verifyCheckedAt?: Date | null;
+    verifyDetail?: string | null;
+    revertTaskId?: string | null;
+    revertOfferedAt?: Date | null;
     createdAt: Date;
 }) {
     return {
@@ -196,6 +269,27 @@ function view(promotion: {
             // promoting.
             overridden: promotion.gateOverridden === true,
         },
+        // Post-deploy verification (slice AJ). `state: null` means the
+        // deployment was never checked — which a reader must not round up
+        // to "fine", so the field is always present rather than omitted.
+        verification: {
+            state: promotion.verifyState ?? null,
+            // The commit the deployment was held to. Not `headSha`: the
+            // merge produced a new commit, and this is the base branch's
+            // tip read straight afterwards.
+            expectedSha: promotion.verifyExpectedSha ?? null,
+            lastUrl: promotion.verifyTargetUrl ?? null,
+            attempts: promotion.verifyAttempts ?? 0,
+            checkedAt: promotion.verifyCheckedAt ?? null,
+            detail: promotion.verifyDetail ?? null,
+        },
+        // A revert that was OFFERED. There is deliberately no field here
+        // saying a revert happened, because nothing in this platform
+        // reverts: this is a Task id a human may act on, and landing what
+        // it produces still needs a merge approval.
+        revertOffer: promotion.revertTaskId
+            ? { taskId: promotion.revertTaskId, offeredAt: promotion.revertOfferedAt ?? null }
+            : null,
         refusalCode: promotion.refusalCode ?? null,
         createdAt: promotion.createdAt,
     };

--- a/apps/api/src/release/release-promotions.dto.ts
+++ b/apps/api/src/release/release-promotions.dto.ts
@@ -1,8 +1,19 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsString, IsUUID, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+    IsIn,
+    IsObject,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    ValidateNested,
+} from 'class-validator';
 import {
     PROMOTION_RUNGS,
     RELEASE_BRANCH_MAX_LENGTH,
+    RELEASE_VERIFY_EXPECT_MAX_LENGTH,
+    RELEASE_VERIFY_URL_MAX_LENGTH,
     type PromotionRung,
 } from '@ever-works/contracts';
 
@@ -64,4 +75,75 @@ export class SetReleaseLadderDto {
     @IsString()
     @MaxLength(RELEASE_BRANCH_MAX_LENGTH)
     production: string;
+}
+
+/**
+ * Where ONE deployed environment can be observed from outside.
+ *
+ * PLATFORM STATE, set deliberately by the Work's owner and read by every
+ * later verification. It is not accepted anywhere on the promotion or
+ * verification path: a request that could name the URL a check loads could
+ * point a green verdict at a page it controls, and that verdict is the
+ * only thing standing between a bad release and a human being told
+ * everything is fine.
+ *
+ * Re-validated server-side with `sanitizeReleaseVerificationTargets`,
+ * which is much stricter than these decorators — https only, no
+ * credentials, no fragment, and a public DNS hostname, because these URLs
+ * are loaded by a real browser on an enrolled fleet node.
+ */
+export class ReleaseVerificationTargetDto {
+    @ApiProperty({
+        maxLength: RELEASE_VERIFY_URL_MAX_LENGTH,
+        example: 'https://api.ever.works/api/version',
+        description:
+            'A URL whose rendered DOM contains the deployed commit sha. THE artefact-identity probe: it is what lets a verification claim to have checked the build that was just promoted rather than the one that happened to be running. A plain health endpoint with no version in it will not do.',
+    })
+    @IsString()
+    @MaxLength(RELEASE_VERIFY_URL_MAX_LENGTH)
+    versionUrl: string;
+
+    @ApiProperty({
+        maxLength: RELEASE_VERIFY_URL_MAX_LENGTH,
+        example: 'https://app.ever.works/api/health',
+        description: 'The page that must actually render once the rollout has landed.',
+    })
+    @IsString()
+    @MaxLength(RELEASE_VERIFY_URL_MAX_LENGTH)
+    appUrl: string;
+
+    @ApiProperty({
+        maxLength: RELEASE_VERIFY_EXPECT_MAX_LENGTH,
+        example: '"status":"OK"',
+        description:
+            'Text that must appear in the app page. Required: a browser check with no expectation passes on any document the browser managed to render, including a CDN error page.',
+    })
+    @IsString()
+    @MaxLength(RELEASE_VERIFY_EXPECT_MAX_LENGTH)
+    appExpectText: string;
+}
+
+/**
+ * The per-environment verification targets, keyed by the environment a
+ * rung DEPLOYS — `develop → stage` is verified against staging, and
+ * `stage → main` against production.
+ *
+ * Both are optional and independent. An environment with no target makes a
+ * promotion into it `unsupported`, reported to the owner as NOT VERIFIED,
+ * which is never read as a pass.
+ */
+export class SetReleaseVerificationDto {
+    @ApiPropertyOptional({ type: ReleaseVerificationTargetDto })
+    @IsOptional()
+    @IsObject()
+    @ValidateNested()
+    @Type(() => ReleaseVerificationTargetDto)
+    staging?: ReleaseVerificationTargetDto;
+
+    @ApiPropertyOptional({ type: ReleaseVerificationTargetDto })
+    @IsOptional()
+    @IsObject()
+    @ValidateNested()
+    @Type(() => ReleaseVerificationTargetDto)
+    production?: ReleaseVerificationTargetDto;
 }

--- a/apps/api/src/release/release-verification-cron.service.spec.ts
+++ b/apps/api/src/release/release-verification-cron.service.spec.ts
@@ -1,0 +1,99 @@
+import { ReleaseVerificationCronService } from './release-verification-cron.service';
+
+/**
+ * Post-deploy verification (self-build slice AJ, EW-809) — the clock.
+ *
+ * Small on purpose: the state machine is tested in
+ * `packages/agent/src/tasks-domain/__tests__/release-verification.service.spec.ts`
+ * against a real database. What has to be true HERE is that the sweep runs
+ * exclusively, that it cannot take the process down, and that it does not
+ * quietly do the work twice when two API replicas tick at the same second.
+ */
+describe('ReleaseVerificationCronService', () => {
+    function build(opts: { locked?: boolean; sweepError?: Error } = {}) {
+        const verification = {
+            enqueueDueChecks: opts.sweepError
+                ? jest.fn().mockRejectedValue(opts.sweepError)
+                : jest.fn().mockResolvedValue({ considered: 2, enqueued: 1, settled: 1 }),
+        };
+        const taskLockService = {
+            runExclusive: jest
+                .fn()
+                .mockImplementation(
+                    async (
+                        _key: string,
+                        work: () => Promise<void>,
+                        options: { onLocked?: () => void },
+                    ) => {
+                        if (opts.locked) {
+                            options.onLocked?.();
+                            return;
+                        }
+                        await work();
+                    },
+                ),
+        };
+        return {
+            cron: new ReleaseVerificationCronService(
+                verification as never,
+                taskLockService as never,
+            ),
+            verification,
+            taskLockService,
+        };
+    }
+
+    it('runs the sweep under a distributed lock', async () => {
+        // Every API replica has this cron. Without the lock they would all
+        // claim attempts for the same rows on the same tick — and while the
+        // per-row compare-and-set would still keep exactly one browser per
+        // promotion, the wasted enqueues would burn the attempt budget that
+        // bounds the whole lane.
+        const { cron, verification, taskLockService } = build();
+
+        await cron.sweep();
+
+        expect(taskLockService.runExclusive).toHaveBeenCalledTimes(1);
+        expect(taskLockService.runExclusive.mock.calls[0][0]).toBe(
+            'release:post-deploy-verification',
+        );
+        expect(verification.enqueueDueChecks).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing at all when another instance holds the lock', async () => {
+        const { cron, verification } = build({ locked: true });
+
+        await cron.sweep();
+
+        expect(verification.enqueueDueChecks).not.toHaveBeenCalled();
+    });
+
+    it('never throws — an unhandled rejection in a @Cron handler takes the pod down', async () => {
+        const { cron } = build({ sweepError: new Error('database down') });
+
+        await expect(cron.sweep()).resolves.toBeUndefined();
+    });
+
+    it('holds the lock for at least as long as its own interval', async () => {
+        // A TTL shorter than the cron period lets the next tick start while
+        // the previous one is still enqueueing.
+        const { cron, taskLockService } = build();
+
+        await cron.sweep();
+
+        expect(taskLockService.runExclusive.mock.calls[0][2].ttlMs).toBeGreaterThanOrEqual(
+            5 * 60_000,
+        );
+    });
+
+    it('exposes no way to start, retry or force a verification', () => {
+        // The lane's whole value is that it withholds a verdict until it
+        // has one. A "run it now" entry point is how somebody talks a green
+        // reading out of it — and it is also how a bounded lane stops being
+        // bounded, because the attempt budget assumes one enqueuer.
+        const methods = Object.getOwnPropertyNames(ReleaseVerificationCronService.prototype).filter(
+            (name) => name !== 'constructor',
+        );
+        expect(methods).toEqual(['sweep']);
+    });
+});

--- a/apps/api/src/release/release-verification-cron.service.ts
+++ b/apps/api/src/release/release-verification-cron.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DistributedTaskLockService } from '@ever-works/agent/cache';
+import { ReleaseVerificationService } from '@ever-works/agent/tasks-domain';
+
+const VERIFICATION_SWEEP_LOCK_KEY = 'release:post-deploy-verification';
+
+/**
+ * Post-deploy verification (self-build slice AJ, EW-809) — the clock.
+ *
+ * ## Why a sweep exists at all
+ *
+ * The fleet job queue has NO delay primitive. `FleetJobRepository.create`
+ * writes a row that is lease-able the instant it exists; there is no
+ * `runAfter`, no `notBefore`, and no scheduled-at column anywhere on the
+ * path. The production build lane is measured at 215–243 minutes and
+ * ArgoCD's rollout follows it, so a check enqueued at merge time answers
+ * "the old build is still serving" for hours. Something has to space the
+ * probes out, and this is it.
+ *
+ * A sweep is also the only thing that CAN end a verification whose browser
+ * check never came back. The completion listener advances a row when a job
+ * settles; if a job never settles, only a clock can notice.
+ *
+ * ## Why the promotion lane could not do this itself
+ *
+ * `ReleasePromotionService`'s refresh is driven by the two-minute
+ * PR-status sweep, and it stops dead at the merge: `closeLane` rewrites
+ * `laneKey` to `merged:<id>`, `findOpenByTaskId` stops matching, and no
+ * existing sweep in the platform ever visits the row again. Verification
+ * begins exactly where the promotion lane ends, so it needs its own clock.
+ *
+ * ## Five minutes, not one
+ *
+ * The probe spacing is `RELEASE_VERIFY_ATTEMPT_INTERVAL_MS` (ten minutes)
+ * and lives in contracts beside the bounds it has to agree with; this cron
+ * only decides how promptly a due row is noticed. Five minutes keeps the
+ * worst-case latency on a state transition to half an interval while
+ * running twelve times an hour against an indexed query over a table that
+ * gains two rows a week.
+ *
+ * Distributed-locked, like every other multi-replica sweep in this
+ * codebase: without it every API replica would claim attempts for the same
+ * rows. The per-row compare-and-set (`WHERE verifyJobId IS NULL`) is the
+ * real guarantee and this is the cheap one in front of it.
+ */
+@Injectable()
+export class ReleaseVerificationCronService {
+    private readonly logger = new Logger(ReleaseVerificationCronService.name);
+
+    constructor(
+        private readonly verification: ReleaseVerificationService,
+        private readonly taskLockService: DistributedTaskLockService,
+    ) {}
+
+    @Cron(CronExpression.EVERY_5_MINUTES)
+    async sweep(): Promise<void> {
+        await this.taskLockService.runExclusive(
+            VERIFICATION_SWEEP_LOCK_KEY,
+            async () => {
+                try {
+                    const summary = await this.verification.enqueueDueChecks();
+                    if (summary.enqueued > 0 || summary.settled > 0 || summary.recovered > 0) {
+                        this.logger.log(
+                            `Post-deploy verification sweep: ${summary.enqueued} check(s) enqueued, ` +
+                                `${summary.settled} verification(s) settled, ${summary.recovered} ` +
+                                `result(s) recovered, ${summary.considered} considered.`,
+                        );
+                    }
+                    if (summary.recovered > 0) {
+                        // A non-zero recovery count means a browser check
+                        // reached a terminal fleet state without its result
+                        // reaching the state machine — a dropped
+                        // `fleet.job.completed`, or a replica that restarted
+                        // mid-handler. The sweep repaired it, but it is a
+                        // fact about this deployment worth seeing.
+                        this.logger.warn(
+                            `Post-deploy verification recovered ${summary.recovered} check result(s) ` +
+                                'that the completion listener never recorded.',
+                        );
+                    }
+                } catch (error) {
+                    // The service already swallows per-row failures; this is
+                    // the belt for a failure of the sweep itself. A throw out
+                    // of a @Cron handler is an unhandled rejection.
+                    this.logger.error(
+                        'Post-deploy verification sweep failed',
+                        error instanceof Error ? error.stack : String(error),
+                    );
+                }
+            },
+            {
+                ttlMs: 5 * 60_000,
+                onLocked: () =>
+                    this.logger.debug(
+                        'Skipping post-deploy verification sweep — another instance holds the lock',
+                    ),
+            },
+        );
+    }
+}

--- a/apps/api/src/release/release-verification.listener.spec.ts
+++ b/apps/api/src/release/release-verification.listener.spec.ts
@@ -1,0 +1,198 @@
+import { FleetJobCompletedEvent } from '@ever-works/agent/events';
+import type { FleetJobView } from '@ever-works/contracts';
+import { ReleaseVerificationListener } from './release-verification.listener';
+
+/**
+ * Post-deploy verification (self-build slice AJ, EW-809) — the TRUST
+ * BOUNDARY.
+ *
+ * `FleetJobCompletedEvent.result` is whatever a node PUT on
+ * `POST /api/fleet/jobs/:id/complete` — untrusted data from somebody's PC
+ * — and this listener is the single place it becomes the boolean the
+ * verification state machine acts on. Get it wrong in the permissive
+ * direction and a human is told a broken production deployment is healthy,
+ * or a failure is "confirmed" that never happened.
+ *
+ * So the shape of this file is a long list of things that are NOT a pass.
+ */
+describe('ReleaseVerificationListener', () => {
+    function build() {
+        const verification = { onBrowserCheckCompleted: jest.fn().mockResolvedValue(undefined) };
+        return {
+            listener: new ReleaseVerificationListener(verification as never),
+            verification,
+        };
+    }
+
+    function job(overrides: Partial<FleetJobView> = {}): FleetJobView {
+        return {
+            id: 'job-1',
+            kind: 'browser-check',
+            status: 'done',
+            nodeId: 'node-1',
+            requiredCapabilities: ['browser'],
+            payload: { url: 'https://api.ever.works/api/version' },
+            leaseExpiresAt: null,
+            attempts: 1,
+            maxAttempts: 1,
+            createdAt: null,
+            startedAt: null,
+            completedAt: null,
+            leaseGeneration: 1,
+            ...overrides,
+        } as FleetJobView;
+    }
+
+    function event(
+        overrides: {
+            job?: Partial<FleetJobView>;
+            result?: Record<string, unknown> | null;
+            error?: string | null;
+            source?: 'node-report' | 'lease-exhausted' | 'cancelled' | 'queue-expired';
+        } = {},
+    ): FleetJobCompletedEvent {
+        return new FleetJobCompletedEvent(
+            job(overrides.job),
+            'user-1',
+            overrides.source ?? 'node-report',
+            'node-1',
+            overrides.result ?? null,
+            overrides.error ?? null,
+        );
+    }
+
+    /** What `ok` the listener derived, for one event. */
+    async function verdictFor(e: FleetJobCompletedEvent): Promise<boolean | 'not-called'> {
+        const { listener, verification } = build();
+        await listener.onCompleted(e);
+        if (verification.onBrowserCheckCompleted.mock.calls.length === 0) return 'not-called';
+        return verification.onBrowserCheckCompleted.mock.calls[0][1] as boolean;
+    }
+
+    describe('what it looks at', () => {
+        it('ignores every job kind but browser-check', async () => {
+            for (const kind of ['agent-task', 'acceptance-checks'] as const) {
+                expect(await verdictFor(event({ job: { kind } }))).toBe('not-called');
+            }
+        });
+
+        it('routes a browser-check by its JOB ID, not by anything in the payload', async () => {
+            // The promotion row is what points at the job; the payload is an
+            // echo of what we sent and proves nothing about whose check it is.
+            const { listener, verification } = build();
+
+            await listener.onCompleted(event({ job: { id: 'job-77' }, result: { ok: true } }));
+
+            expect(verification.onBrowserCheckCompleted).toHaveBeenCalledTimes(1);
+            expect(verification.onBrowserCheckCompleted.mock.calls[0][0]).toBe('job-77');
+        });
+    });
+
+    describe('what counts as a pass', () => {
+        it('passes on a done job whose executor said ok', async () => {
+            expect(
+                await verdictFor(
+                    event({ result: { ok: true, domBytes: 4096, title: 'Ever Works' } }),
+                ),
+            ).toBe(true);
+        });
+
+        it.each([
+            ['ok is false', { ok: false }],
+            ['ok is absent', { domBytes: 4096 }],
+            ['ok is the STRING "true"', { ok: 'true' }],
+            ['ok is the number 1', { ok: 1 }],
+            ['ok is an object', { ok: {} }],
+            ['ok is null', { ok: null }],
+            ['the result is empty', {}],
+        ])('is NOT a pass when %s', async (_label, result) => {
+            // Strict `=== true`. Every coercion here would be a node
+            // talking a green verdict out of the platform.
+            expect(await verdictFor(event({ result: result as never }))).toBe(false);
+        });
+
+        it('is NOT a pass when the job settled with no result at all', async () => {
+            expect(await verdictFor(event({ result: null }))).toBe(false);
+        });
+
+        it('is NOT a pass when the job FAILED, whatever the result says', async () => {
+            // A node can report `ok: true` on a failed job. The job status
+            // is the platform's own record and wins.
+            expect(
+                await verdictFor(
+                    event({ job: { status: 'failed' }, result: { ok: true }, error: 'boom' }),
+                ),
+            ).toBe(false);
+        });
+
+        it.each([
+            ['the lease was exhausted', 'lease-exhausted' as const],
+            ['an operator cancelled it', 'cancelled' as const],
+            ['the queue SLA expired it — no browser node ever took it', 'queue-expired' as const],
+        ])('is NOT a pass when %s', async (_label, source) => {
+            // Three ways a check can fail to HAPPEN. Each has to reach the
+            // state machine, or a verification hangs until its deadline for
+            // a reason nobody recorded — and none of them is evidence that
+            // the deployment is fine.
+            expect(
+                await verdictFor(
+                    event({ job: { status: 'failed' }, source, error: 'queued-max-age-exceeded' }),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('the reading it passes on', () => {
+        it('quotes the node error when there is one', async () => {
+            const { listener, verification } = build();
+
+            await listener.onCompleted(
+                event({ job: { status: 'failed' }, error: 'No executor registered' }),
+            );
+
+            expect(verification.onBrowserCheckCompleted.mock.calls[0][2]).toContain(
+                'No executor registered',
+            );
+        });
+
+        it('describes a failed check with the executor’s own reason', async () => {
+            const { listener, verification } = build();
+
+            await listener.onCompleted(
+                event({ result: { ok: false, error: 'expected text not found in DOM' } }),
+            );
+
+            expect(verification.onBrowserCheckCompleted.mock.calls[0][2]).toContain(
+                'expected text not found in DOM',
+            );
+        });
+
+        it('says so plainly when a job settled with nothing to read', async () => {
+            const { listener, verification } = build();
+
+            await listener.onCompleted(event({ result: null, source: 'lease-exhausted' }));
+
+            expect(verification.onBrowserCheckCompleted.mock.calls[0][2]).toMatch(/no result/i);
+        });
+    });
+
+    it('never throws out of the event handler', async () => {
+        // An emitter has no caller to report to, and an unhandled rejection
+        // in a Nest event handler takes the process down.
+        const { listener, verification } = build();
+        verification.onBrowserCheckCompleted.mockRejectedValue(new Error('database down'));
+
+        await expect(
+            listener.onCompleted(event({ result: { ok: true } })),
+        ).resolves.toBeUndefined();
+    });
+
+    it('survives a malformed event with no job', async () => {
+        const { listener, verification } = build();
+
+        await expect(
+            listener.onCompleted({ job: null } as unknown as FleetJobCompletedEvent),
+        ).resolves.toBeUndefined();
+        expect(verification.onBrowserCheckCompleted).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/release/release-verification.listener.ts
+++ b/apps/api/src/release/release-verification.listener.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { FleetJobCompletedEvent } from '@ever-works/agent/events';
+import { ReleaseVerificationService } from '@ever-works/agent/tasks-domain';
+import { isReleaseVerifyCheckPass, type FleetBrowserCheckResult } from '@ever-works/contracts';
+
+/**
+ * Post-deploy verification (self-build slice AJ, EW-809) — the API-side
+ * half that turns "a node reported on a browser check" into a verdict on
+ * the promotion it belonged to.
+ *
+ * ## Why a listener
+ *
+ * Every terminal path a fleet job can take converges on ONE event:
+ * `FleetJobCompletedEvent`, emitted for a node's own report, for an
+ * operator cancel, for a lease the reclaim sweep exhausted, and for a job
+ * the queue SLA failed after nobody took it. Subscribing here covers all
+ * four with one subscription — which matters more than usual for this
+ * slice, because three of the four are ways a check can fail to happen at
+ * all, and every one of them has to reach the state machine or a
+ * verification would hang until its deadline for a reason nobody recorded.
+ *
+ * ## Where `ok` is decided, and why it is decided HERE
+ *
+ * This is the trust boundary. `result` is whatever a node PUT on the
+ * completion endpoint — untrusted data from somebody's PC — so it is
+ * narrowed to a strict `=== true` on a `done` job and nothing else is
+ * allowed to mean "pass":
+ *
+ *   - a `failed` job is not a pass;
+ *   - a job with no result is not a pass;
+ *   - `ok: "true"`, `ok: 1`, `ok: {}` are not passes;
+ *   - a lease exhausted, a cancel and a queue-SLA expiry are not passes.
+ *
+ * The direction matters. A false negative delays a verdict and, at worst,
+ * settles it `inconclusive` — which offers nothing and reverts nothing. A
+ * false positive would tell a human a broken production deployment is
+ * healthy, or, one state later, would confirm a failure that never
+ * happened. So every ambiguity resolves to "not a pass".
+ *
+ * The rule itself lives in `@ever-works/contracts` as
+ * `isReleaseVerifyCheckPass`, because this is no longer the only caller:
+ * the sweep reconciles a check that reached a terminal fleet state without
+ * its result reaching the state machine (a transient database error here,
+ * or a replica restarting between the fleet write and this handler), and a
+ * lane where the two paths disagreed could call one job green on one and
+ * red on the other.
+ */
+@Injectable()
+export class ReleaseVerificationListener {
+    private readonly logger = new Logger(ReleaseVerificationListener.name);
+
+    constructor(private readonly verification: ReleaseVerificationService) {}
+
+    @OnEvent(FleetJobCompletedEvent.EVENT_NAME, { async: true })
+    async onCompleted(event: FleetJobCompletedEvent): Promise<void> {
+        // Cheap guard, not an authorization: the authorization is that the
+        // promotion row itself has to be pointing at this job id.
+        if (event.job?.kind !== 'browser-check') return;
+
+        const ok = isCheckPass(event);
+        try {
+            await this.verification.onBrowserCheckCompleted(
+                event.job.id,
+                ok,
+                describeReading(event),
+            );
+        } catch (error) {
+            // Never throw out of an event handler: the emitter has no
+            // caller to report to, and the verification's own deadline
+            // still ends the row if this keeps failing.
+            this.logger.warn(
+                `Browser check ${event.job.id}: could not record the verification result: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+}
+
+/**
+ * Did this check PASS?
+ *
+ * `succeeded` is the job reaching `done`; `result.ok === true` is the
+ * executor's own verdict, which it sets only when the browser rendered the
+ * page AND every expectation held (`apps/node/src/core/executors/browser-check.ts`).
+ * Both, strictly, or it is not a pass.
+ */
+function isCheckPass(event: FleetJobCompletedEvent): boolean {
+    // `event.succeeded` is `job.status === 'done'`; passing the status
+    // itself keeps this and the sweep's recovery path on ONE rule.
+    return isReleaseVerifyCheckPass(event.job?.status, event.result);
+}
+
+/**
+ * A short, human-readable note about what the node saw.
+ *
+ * Everything here is node-reported and therefore untrusted; the service
+ * flattens control characters and caps the length before it reaches a row,
+ * an Inbox body or a Task thread.
+ */
+function describeReading(event: FleetJobCompletedEvent): string {
+    if (event.error) return `Node reported: ${event.error}`;
+    const result = event.result as Partial<FleetBrowserCheckResult> | null;
+    if (!result) {
+        return `The check settled ${event.job.status} with no result (${event.source}).`;
+    }
+    if (result.ok === true) {
+        const title = typeof result.title === 'string' && result.title ? ` "${result.title}"` : '';
+        return `Page loaded${title} (${result.domBytes ?? 0} bytes of DOM).`;
+    }
+    return typeof result.error === 'string' && result.error
+        ? `Check failed: ${result.error}`
+        : 'Check failed with no reason given.';
+}

--- a/apps/api/src/release/release.module.spec.ts
+++ b/apps/api/src/release/release.module.spec.ts
@@ -10,10 +10,16 @@ import {
 import { PluginUsageService } from '@ever-works/agent/usage';
 import { BudgetGuardService } from '@ever-works/agent/budgets';
 import { EverWorksK8sDeployProvider } from '@ever-works/agent/ever-works-providers';
-import { ReleasePromotionService } from '@ever-works/agent/tasks-domain';
+import {
+    ReleasePromotionService,
+    ReleaseVerificationService,
+} from '@ever-works/agent/tasks-domain';
+import { DistributedTaskLockService } from '@ever-works/agent/cache';
 import { PROMOTION_LANE_WATCHER, PROMOTION_MERGE_GUARD } from '@ever-works/agent/policy';
 import { ReleaseModule } from './release.module';
 import { ReleasePromotionsController } from './release-promotions.controller';
+import { ReleaseVerificationCronService } from './release-verification-cron.service';
+import { ReleaseVerificationListener } from './release-verification.listener';
 
 /**
  * `ReleaseModule` against a REAL Nest container.
@@ -26,11 +32,30 @@ import { ReleasePromotionsController } from './release-promotions.controller';
  * `Reflect.getMetadata('imports', …)` does not catch it either; that only
  * proves a name is in a list, never that the graph resolves.
  *
- * MUTATION CHECK, executed rather than assumed: removing `DatabaseModule`
- * from `ReleaseModule`'s imports makes `WorkRepository` — which
- * `ReleasePromotionsController` injects to read and write the Work's
- * release ladder — unresolvable, and this file fails. Before it existed,
- * that change left `apps/api` entirely green.
+ * MUTATION CHECKS, executed rather than assumed:
+ *
+ *   - removing `DatabaseModule` from `ReleaseModule`'s imports makes
+ *     `WorkRepository` — which `ReleasePromotionsController` injects to
+ *     read and write the Work's release ladder — unresolvable, and this
+ *     file fails. Before it existed, that change left `apps/api` entirely
+ *     green;
+ *   - removing `DistributedTaskLockService` from `providers` makes
+ *     `ReleaseVerificationCronService` unresolvable — it is not a global
+ *     provider — and this file fails;
+ *   - removing `ReleaseVerificationListener` or
+ *     `ReleaseVerificationCronService` from `providers` fails the two
+ *     slice-AJ tests below — and would otherwise mean a platform that
+ *     enqueues nothing and reads nothing back, silently.
+ *
+ * NOT a mutation check, corrected during the slice-AJ review: this file
+ * used to claim that removing `TypeOrmModule.forFeature([CacheEntry])`
+ * makes `DistributedTaskLockService` unresolvable. It does not — I removed
+ * it and all three tests still passed. `DatabaseModule` already registers
+ * every entity and re-exports `TypeOrmModule`, which is why
+ * `NotificationsModule` provides the same lock service with no `forFeature`
+ * of its own. The line stays for self-containedness; the claim does not,
+ * because a false provenance note is worse than none — it tells the next
+ * author a guard exists where there is nothing.
  *
  * The `@Global()` stub below stands in for the providers the running API
  * supplies from its ROOT module, which `FacadesModule`'s graph reaches
@@ -82,6 +107,34 @@ describe('ReleaseModule — dependency injection', () => {
             ReleasePromotionService,
         );
         expect(moduleRef.get(WorkRepository, { strict: false })).toBeInstanceOf(WorkRepository);
+
+        await moduleRef.close();
+    });
+
+    it('resolves the post-deploy verification clock — both halves of it', async () => {
+        // Slice AJ (EW-809). Without BOTH of these the lane is inert in a
+        // way nothing else would notice: the cron is the only thing that
+        // ever produces a `browser-check`, and the listener is the only
+        // thing that ever reads one back. A promotion would merge, a
+        // verification would start, and the row would sit in
+        // `awaiting-rollout` until its deadline.
+        const moduleRef = await compile();
+
+        expect(moduleRef.get(ReleaseVerificationCronService)).toBeInstanceOf(
+            ReleaseVerificationCronService,
+        );
+        expect(moduleRef.get(ReleaseVerificationListener)).toBeInstanceOf(
+            ReleaseVerificationListener,
+        );
+        // The lock service the sweep needs, and the entity that backs it.
+        expect(moduleRef.get(DistributedTaskLockService)).toBeInstanceOf(
+            DistributedTaskLockService,
+        );
+        // Both halves drive the SAME verification service the promotion
+        // lane hands merged promotions to.
+        expect(moduleRef.get(ReleaseVerificationService, { strict: false })).toBeInstanceOf(
+            ReleaseVerificationService,
+        );
 
         await moduleRef.close();
     });

--- a/apps/api/src/release/release.module.ts
+++ b/apps/api/src/release/release.module.ts
@@ -1,30 +1,71 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CacheEntry } from '@ever-works/agent/entities';
+import { DistributedTaskLockService } from '@ever-works/agent/cache';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { ReleasePromotionModule } from '@ever-works/agent/tasks-domain';
 import { ReleasePromotionsController } from './release-promotions.controller';
+import { ReleaseVerificationCronService } from './release-verification-cron.service';
+import { ReleaseVerificationListener } from './release-verification.listener';
 
 /**
- * Release promotion lane (self-build slice AI, EW-808) — the api-side
- * mount for `develop → stage → main`.
+ * Release lane (self-build slices AI + AJ, EW-808 / EW-809) — the api-side
+ * mount for `develop → stage → main` and for the post-deploy verification
+ * that follows a merged rung.
  *
  * Importing `ReleasePromotionModule` here is what BINDS
  * `PROMOTION_MERGE_GUARD` and `PROMOTION_LANE_WATCHER` for the whole app:
  * that module is `@Global()`, so `TaskPrStatusService` and
  * `TaskMergeGateService` — which inject both tokens `@Optional()` — pick
  * them up without `TasksDomainModule` having to import the module that
- * imports it.
+ * imports it. It also exports `ReleaseVerificationService`, which the two
+ * providers below drive.
  *
  * The consequence, stated because it is a safety property rather than an
  * accident: DROP this import and the platform does not silently start
  * merging promotions through the ordinary agent path. `TaskMergeGateService`
  * recognises a promotion Task off its own labels and stands down when the
- * guard is unbound, so the lane fails closed rather than open.
+ * guard is unbound, so the lane fails closed rather than open. The same
+ * direction holds for the verification half: without this module nothing
+ * checks a deployment, and — because a verdict only ever exists as a row
+ * somebody wrote — nothing claims one was checked either.
+ *
+ * ## The two halves of the verification clock
+ *
+ * `ReleaseVerificationListener` reacts to `fleet.job.completed` and turns a
+ * node's browser-check report into a verdict.
+ * `ReleaseVerificationCronService` spaces the probes out and expires the
+ * verifications that ran out of road — the fleet queue has no delay
+ * primitive, and nothing else in the platform ever revisits a merged
+ * promotion.
+ *
+ * `DistributedTaskLockService` is the documented wiring for a multi-replica
+ * sweep (`docs/agent-services/distributed-task-lock.md#module-wiring`), and
+ * providing it HERE is load-bearing: it is not global, so removing it from
+ * `providers` below makes `ReleaseVerificationCronService` unresolvable and
+ * the API does not boot.
+ *
+ * `TypeOrmModule.forFeature([CacheEntry])` is NOT load-bearing, and this is
+ * stated because an earlier version of the spec beside this file claimed it
+ * was. `DatabaseModule` already does `TypeOrmModule.forFeature(ENTITIES)`
+ * with `CacheEntry` among them and re-exports `TypeOrmModule`, so the
+ * repository token is in scope through the import above; the sibling
+ * `NotificationsModule` provides the same lock service with `DatabaseModule`
+ * alone. This line is kept so the module states its own storage dependency
+ * rather than inheriting it silently — removing it is undetectable, so no
+ * mutation check claims otherwise.
  *
  * `DatabaseModule` is imported for `WorkRepository`, which the controller
- * uses to read and write the Work's release ladder.
+ * uses to read and write the Work's release ladder and verification
+ * targets.
  */
 @Module({
-    imports: [DatabaseModule, ReleasePromotionModule],
+    imports: [TypeOrmModule.forFeature([CacheEntry]), DatabaseModule, ReleasePromotionModule],
     controllers: [ReleasePromotionsController],
+    providers: [
+        ReleaseVerificationListener,
+        ReleaseVerificationCronService,
+        DistributedTaskLockService,
+    ],
 })
 export class ReleaseModule {}

--- a/docs/runbooks/RELEASE_PROMOTION.md
+++ b/docs/runbooks/RELEASE_PROMOTION.md
@@ -7,6 +7,10 @@ reuses wholesale for landing, and to
 [`FLEET_BREAK_GLASS.md`](./FLEET_BREAK_GLASS.md), whose manual `gh pr create`
 cascade this replaces for the platform's own repository.
 
+**What happens after a promotion merges** — the post-deploy check, the
+verdict you read, and the revert offer — is
+[`RELEASE_VERIFICATION.md`](./RELEASE_VERIFICATION.md) (slice AJ, EW-809).
+
 ---
 
 ## 1. What this fixes

--- a/docs/runbooks/RELEASE_VERIFICATION.md
+++ b/docs/runbooks/RELEASE_VERIFICATION.md
@@ -1,0 +1,425 @@
+# Post-deploy verification and revert
+
+Self-build slice AJ (EW-809), epic EW-762. Closes finding R21.
+
+The second half of [`RELEASE_PROMOTION.md`](./RELEASE_PROMOTION.md). Slice
+AI opens the promotion pull request and reads the promotion gate; this
+lane finds out whether the release that followed **actually worked**, and
+offers you the undo when it did not.
+
+Landing anything — a promotion or a revert — still goes through
+[`MERGE_APPROVAL.md`](./MERGE_APPROVAL.md). Nothing here merges.
+
+---
+
+## 1. What this fixes
+
+Nothing verified a deployment. The `browser-check` fleet job kind had
+existed since the node shipped, with a working executor
+(`apps/node/src/core/executors/browser-check.ts`), a capability tag and a
+queue SLA — and **no producer anywhere on the platform**. Searching
+`apps/api/src` and `packages/agent/src` for the string found type
+declarations and two negative-control test fixtures.
+
+So on 2026-09-06 a whole batch was cascaded `develop → stage → main` and
+nothing on the platform confirmed the result. The production build lane is
+measured at 215–243 minutes, which makes an unverified bad deploy a
+multi-hour outage the fleet could neither detect nor reverse.
+
+---
+
+## 2. The one thing to understand first
+
+**A revert is an OFFER, not an action.**
+
+A promotion is merged only by a recorded human approval, and undoing one is
+the same class of act. Nothing in this lane reverts production. When a
+deployment is confirmed broken the platform files an inert Task holding the
+coordinates and tells you about it. You decide.
+
+There is no endpoint that reverts, no column that could record having
+reverted, and no code path in `release-verification.service.ts` that
+merges, pushes, deploys or rolls back. Those absences are asserted by
+tests, so adding one fails CI rather than shipping.
+
+---
+
+## 3. What runs after a promotion merges
+
+```
+promotion pull request merges
+        │
+        │  ReleasePromotionService.refresh() observes state === 'merged'
+        │  (the ONE moment the platform learns a promotion landed — the lane
+        │   is freed in the same pass and no sweep ever visits the row again)
+        ▼
+  read the BASE branch's tip  ──────────────►  verifyExpectedSha
+        │                                       THE artefact identity
+        ▼
+  verifyState = 'awaiting-rollout'
+        │
+        │  ReleaseVerificationCronService, every 5 minutes, distributed-locked
+        │  enqueues ONE browser-check per promotion at a time, ≥10 min apart
+        ▼
+┌───────────────────────────────────────────────────────────────────────┐
+│ awaiting-rollout   probe: <versionUrl>, expect <sha12>                │
+│   3 consecutive hits ──────────────────────────────► checking-app     │
+│   a miss           → streak resets, wait, try again (NOT a failure)   │
+├───────────────────────────────────────────────────────────────────────┤
+│ checking-app       probe: <appUrl>, expect <appExpectText>            │
+│   a hit            ─────────────────────────────────► passed          │
+│   3 consecutive misses ─────────────────────► confirming-failure      │
+├───────────────────────────────────────────────────────────────────────┤
+│ confirming-failure probe: <versionUrl> again, expect <sha12>          │
+│   a hit  (environment reachable, still serving us) ──► failed  →offer │
+│   a miss (cannot reach it at all) ──────────────────► inconclusive    │
+└───────────────────────────────────────────────────────────────────────┘
+        │
+        │  at ANY point: 48 attempts used, or 8 hours elapsed
+        ▼
+   inconclusive     (never `failed`, therefore never a revert offer)
+```
+
+Everything above runs on **your own fleet**: the browser check is executed
+by an enrolled node advertising the `browser` capability, against the
+public URL, from outside the cluster. If no such node exists the job sits
+until the kind's two-hour queue SLA fails it, and the verification settles
+`inconclusive` — never `passed`.
+
+---
+
+## 4. What proves the deployed build is the one you promoted
+
+This is the question the whole lane turns on, and the honest answer has a
+limit in it.
+
+**What is proven.** Before this lane says a single word about a
+deployment, the environment's version endpoint must have served the
+expected commit, in a real browser, on **three consecutive probes ten
+minutes apart**. `verifyExpectedSha` is the tip of the promotion's **base**
+branch, read from the git provider immediately after the pull request was
+observed merged.
+
+It is the base branch's tip and **not** `headSha`, because the merge
+produces a new commit: the platform merges with the provider default
+`merge` method, `GitPullRequestStatus` carries no merge-commit sha, and a
+verification that compared the deployed `gitSha` against `headSha` would
+report "not rolled out" for ever. `k8s-build` builds the branch tip and
+stamps it into the image as `GIT_SHA`, which `/api/version` serves — that
+is the chain the check closes.
+
+The three-consecutive rule is the same discipline
+`.github/workflows/smoke-deployed.yml` already encodes for the CI smoke
+lane: ArgoCD replaces pods gradually, so immediately after a deploy the
+version endpoint alternates between the old and the new commit depending on
+which pod answers. Sampling once is a coin flip.
+
+**What is NOT proven, stated plainly.**
+
+1. **The commit may not be exclusively yours.** If another pull request
+   lands on the base branch between your merge and our read, we record
+   _that_ commit. Your promotion is still an ancestor of it — a pass never
+   means your change is absent — but the artefact verified is then a later
+   one. Fixing this properly needs a `mergeCommitSha` on
+   `GitPullRequestStatus`, which does not exist and would touch every git
+   provider.
+2. **Three samples are not every pod.** Three consecutive hits mean three
+   samples in a row reached updated pods. It is strong evidence the rollout
+   settled; it is not a proof that no old pod survives. `smoke-deployed.yml`
+   has the same limitation with five samples.
+3. **The web bundle is only checked if you ask it to be.** The app probe
+   asserts `appExpectText`, whatever you configured. Point it at a page
+   that carries the build sha and the check becomes sha-aware for the web
+   half too; point it at `/api/health` and it only proves the app answers.
+
+    **The verdict says which one you got.** A pass whose app expectation
+    does not contain the promoted commit reads
+
+    > The app answered as expected at `app.ever.works`, and
+    > `api.ever.works` served the promoted commit. The app expectation is a
+    > fixed string that does not carry the commit, so this does NOT prove
+    > the app deployment itself rolled out — a build that never rolled out
+    > answers it identically.
+
+    and the Task thread says "Confirm the app deployment itself by hand"
+    instead of "Nothing further is required". Only a sha-carrying app
+    expectation gets the stronger sentence. This was added after the
+    slice-AJ review: the verdict used to say "The app rendered as expected.
+    Nothing further is required" for both, which is a claim the lane had not
+    measured — the API image can publish and roll out while the web
+    deployment fails its rollout entirely.
+
+4. **The failure confirmation is a different origin from the failure.**
+   `confirming-failure` re-probes `versionUrl`, and `versionUrl` is
+   normally a different host from `appUrl`. The two must share a
+   registrable domain — a target whose hosts are unrelated is refused
+   outright, which is why an unrelated `status.example.com` cannot
+   "confirm" anything about `app.ever.works` — but a bot interstitial, an
+   HTTP Basic wall or a proxy rule scoped to the app host **alone** would
+   fail three app probes and still be confirmed by a healthy version host.
+   The `failed` verdict therefore names both hosts and says so:
+
+    > The failures were at `app.ever.works` and the confirmation at
+    > `api.ever.works`; a network condition specific to `app.ever.works`
+    > would look the same from this node.
+
+    Read that sentence before acting on a revert offer.
+
+None of these can make a `failed` verdict fire on nothing — that path also
+requires a re-confirmed, reachable environment — and none of them is
+hidden: `GET /api/works/:workId/promotions` returns `verification.expectedSha`
+and `verification.lastUrl` so you can check the reasoning yourself.
+
+---
+
+## 5. Set it up
+
+Two configuration acts, both platform state on the Work, both separate from
+asking for a promotion.
+
+```bash
+# 1. The branch ladder (slice AI).
+curl -X PUT https://api.ever.works/api/works/$WORK_ID/release-ladder \
+  -H 'content-type: application/json' \
+  -d '{"integration":"develop","staging":"stage","production":"main"}'
+
+# 2. Where each environment can be observed (slice AJ).
+curl -X PUT https://api.ever.works/api/works/$WORK_ID/verification-targets \
+  -H 'content-type: application/json' \
+  -d '{
+    "staging": {
+      "versionUrl": "https://apistage.ever.works/api/version",
+      "appUrl": "https://appstage.ever.works/api/health",
+      "appExpectText": "\"status\":\"OK\""
+    },
+    "production": {
+      "versionUrl": "https://api.ever.works/api/version",
+      "appUrl": "https://app.ever.works/api/health",
+      "appExpectText": "\"status\":\"OK\""
+    }
+  }'
+```
+
+The host is `app.ever.works`, singular. (`apps.ever.works` appears only in
+two stale specs.)
+
+`versionUrl` **must** serve the commit sha in its rendered body.
+`/api/version` does; `apps/web`'s `/api/health` does **not** — it answers a
+fixed `{"status":"OK"}` with no version in it, so it returns 200 for the
+old build throughout a rollout and for a rollout that never started. That
+is why it is the _app_ probe and never the _version_ probe.
+
+`appUrl` is `/api/health` above because it is what this platform actually
+serves today. If your app renders the build commit anywhere — a
+`/build-info` page, a `<meta name="build-sha">`, a footer — point `appUrl`
+there and set `appExpectText` to the **twelve-character** commit prefix
+instead. That is the only configuration in which a pass proves the app
+deployment itself rolled out; see §4 limit 3.
+
+`appExpectText` is required, minimum **eight** characters, and it may not
+be a slice of a bare HTML skeleton — `div`, `<html><head`, `<!doctype`,
+`</body></html>` and the like are refused. A check with no real expectation
+passes on any document the browser managed to render, including Chrome's
+own network-error page and a CDN 502 interstitial: both exit 0 under
+`--dump-dom` and produce a non-empty document, so the executor's
+empty-document guard does not catch them either. (The minimum was three
+until the slice-AJ review pointed out that three characters has exactly the
+property the guard was documented as preventing.)
+
+`versionUrl` and `appUrl` must share a registrable domain —
+`api.ever.works` + `app.ever.works` is fine, `api.ever.works` +
+`status.example.com` is refused. The failure confirmation re-probes
+`versionUrl` to tell "the app is broken" apart from "this node lost the
+internet", and that argument only holds while the two URLs are about the
+same deployment.
+
+Refused on write and again on read: plain `http`, embedded credentials, a
+fragment, an IP literal, a bracketed IPv6 address, a single-label host like
+`localhost` or a bare Kubernetes service name. These URLs are loaded by a
+real browser on somebody's actual PC inside their actual network, so a
+target that could name a link-local address would be an SSRF primitive
+pointed at the node operator.
+
+**An environment with no target is `unsupported`, reported to you as NOT
+VERIFIED.** It is never read as a pass.
+
+---
+
+## 6. What you see, and what you must decide
+
+One Inbox item per verdict, exactly once, claimed with a compare-and-set so
+two API replicas cannot both narrate.
+
+| Verdict            | Inbox title                                                            | What happened                                                                                                           | What you must decide                                                                                                 |
+| ------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `passed`           | `Deployment VERIFIED for <lane> (@ sha)`                               | The promoted commit served on three consecutive probes, then the app rendered.                                          | Nothing. The next rung is a separate promotion and is not opened automatically.                                      |
+| `failed`           | `DEPLOYMENT FAILED after <lane> (@ sha) — revert prepared`             | The environment is reachable and serving your commit, and the app failed three consecutive checks, re-confirmed.        | **Do nothing** (the release stands), **roll forward**, or **start the revert Task**. See §7.                         |
+| `failed`, no offer | `DEPLOYMENT FAILED after <lane> (@ sha) — NO revert could be prepared` | The same, except the offer Task could not be written. The verdict is terminal, so nothing retries it.                   | Decide by hand — there is no Task waiting in review, and the notice says so rather than sending you looking for one. |
+| `inconclusive`     | `Deployment NOT VERIFIED for <lane>`                                   | The rollout never arrived inside the budget, the node could not reach the environment, or the target became unreadable. | Read the environment yourself. Nothing was measured, so nothing was offered.                                         |
+| `unsupported`      | `Deployment NOT VERIFIED for <lane>`                                   | No verification target is configured for the environment this rung deploys.                                             | Configure one (§5) if you want future releases checked.                                                              |
+
+The promotion Task's own chat thread carries the same story in order:
+verification started, rollout confirmed, verdict.
+
+`GET /api/works/:workId/promotions` returns the machine-readable version:
+
+```jsonc
+{
+	"verification": {
+		"state": "failed",
+		"expectedSha": "bbbbbbbbbbbb…",
+		"lastUrl": "https://app.ever.works/api/health",
+		"attempts": 11,
+		"checkedAt": "2026-09-06T18:40:00.000Z",
+		"detail": "The environment is serving bbbbbbbbbbbb but the app failed 3 consecutive checks."
+	},
+	"revertOffer": { "taskId": "…", "offeredAt": "2026-09-06T18:40:00.000Z" }
+}
+```
+
+`state: null` means the deployment was never checked. The field is always
+present rather than omitted, precisely so a reader cannot round an absence
+up to "fine".
+
+---
+
+## 7. The revert offer
+
+When — and only when — a verification reaches `failed`, the platform files
+one Task:
+
+- **Title** `Revert release: <head> → <base>`
+- **Status** `in_review`, deliberately. `TaskGraphFanoutService` starts
+  unblocked `todo` Tasks; a revert Task filed `todo` would be a platform
+  that reverts production by itself the moment a check goes red.
+- **Labels** `release:revert` and `release:revert:<rung>`. Note what is
+  **absent**: `release:promotion`. A revert Task is an ordinary Task, so
+  the promotion refresh answers `not-a-promotion` for it and the promotion
+  merge guard leaves it to the ordinary path — which is what stops "a
+  revert triggers a promotion that triggers another check" from being a
+  cycle.
+- **Body** the promotion pull request, the base branch, the commit the
+  failing deployment was serving, the URL that failed and the reading.
+
+Your three options, in the order you should consider them:
+
+1.  **Do nothing.** The release stands. The Task sits in review and changes
+    nothing, for ever, until you touch it.
+2.  **Roll forward.** Usually cheaper here: the production build lane is
+    215–243 minutes, so a revert is not a fast undo — it is another full
+    release with its own promotion and its own approval. Roll forward when
+    the fix is obvious.
+3.  **Start the revert Task.** Move it to `todo` yourself. It becomes an
+    ordinary agent Task that opens an ordinary pull request, and landing
+    that pull request needs the same `merge_pull_request` approval in your
+    Inbox, verified against the head commit at merge time, as every other
+    merge in this platform.
+
+        Moving a Task out of review is a **start this work** act, not a merge
+        approval, and `TaskMergeGateService` treats it as such: it recognises
+        the `release:revert` label, forces the approval path **whatever your
+        scope's `requireHumanApproval` says**, and resolves the pull request's
+        base branch from your release ladder rather than from the Work's
+        `taskIsolationBaseBranch`. That base is both the branch the
+        protected-branch rule is evaluated against and the branch named in the
+        Inbox line you read ("Merge PR #12 into `main`"). Until the slice-AJ
+        review neither was true: on the exact configuration this lane requires
+        (`allowAgentMerge: true`, `main` unprotected, `requireHumanApproval:
+
+    false`) a revert pull request merged into production unattended, and the
+    protected-branch rule was evaluated against a branch nobody was merging
+    into.
+
+        A revert Task whose rung label is missing, or whose Work has no usable
+        ladder, is refused outright with `revert-base-unresolved` rather than
+        merged against a guess.
+
+Offered at most once per promotion, ever, enforced by
+`WHERE revertTaskId IS NULL AND verifyState = 'failed'`.
+
+---
+
+## 8. Every path that could reach a revert, and how each is gated
+
+| #   | Path                                              | Gate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | A verification concludes the deployment is broken | Requires `verifyState = 'failed'`, which requires a confirmed rollout **and** a full failure streak **and** a re-confirmation that the environment is reachable and still serving the promoted commit.                                                                                                                                                                                                                                                                                         |
+| 2   | An inconclusive or unsupported verification       | `isReleaseVerifyRevertOffered()` is `state === 'failed'` and nothing else; `claimRevertOffer` writes only `WHERE verifyState = 'failed'`. Three layers, two of them in the database.                                                                                                                                                                                                                                                                                                           |
+| 3   | A flapping app check                              | A single failure never counts; the streak must be consecutive; a green reading resolves the verification to `passed` (and says it was not clean).                                                                                                                                                                                                                                                                                                                                              |
+| 4   | A fleet node that lost its network                | The failure confirmation re-probes the **version** endpoint. If the node cannot reach it either, the verdict is `inconclusive` and no offer is made. The two URLs must share a registrable domain, and the verdict names both hosts — see §4 limit 4 for what this still cannot rule out.                                                                                                                                                                                                      |
+| 5   | A node reporting a forged result                  | `ok` must be strictly `=== true` on a `done` job (`isReleaseVerifyCheckPass`, one rule shared by the completion listener and the sweep's recovery path). A failed job, a missing result, `"true"`, `1`, `{}` are all not-a-pass, and a not-a-pass in `confirming-failure` produces `inconclusive`, not a revert.                                                                                                                                                                               |
+| 5b  | A job substituted under the idempotency key       | `FleetJobService.enqueue` returns an existing row for a matching key with no status, owner or kind filter. The lane checks what it was handed: a `browser-check`, still live, owned by the promotion's owner, carrying the exact probe payload. Anything else burns the attempt instead of being recorded.                                                                                                                                                                                     |
+| 6   | The offer Task itself                             | Filed `in_review`, so no agent is dispatched. It does nothing until a human moves it.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| 7   | The Task, once a human starts it                  | An ordinary Task with one narrowing: `TaskMergeGateService` recognises `release:revert`, so the human approval is required **regardless of `requireHumanApproval`**, and the base branch is resolved from the release ladder. Its pull request lands only through `TaskMergeGateService` → `MergeApprovalService` → a human approval verified against the live head at merge time (slice AE). One `gitFacade.mergePullRequest(...)` call exists in the whole platform and it sits behind that. |
+| 8   | An API caller asking for a revert                 | There is no such endpoint. Asserted by a route-inventory test.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 9   | The verification service reverting directly       | It contains no `mergePullRequest(`, `createPullRequest(`, `createBranch(`, `push(`, `deploy(` or `rollback(` call site. Asserted by reading its source in a test.                                                                                                                                                                                                                                                                                                                              |
+| 10  | A revert causing another release                  | The revert Task carries no promotion label and cannot open a promotion — only `POST /works/:id/promotions` does, which is a deliberate human act.                                                                                                                                                                                                                                                                                                                                              |
+
+---
+
+## 9. Why it cannot loop
+
+Four independent stops, any one of which ends the lane:
+
+1. **A failed check never re-enqueues itself.** It writes a result and a
+   `verifyRetryAt`; only the cron sweep enqueues, and only for a live row
+   with no check in flight.
+2. **`RELEASE_VERIFY_MAX_ATTEMPTS` = 48 probes**, whatever the clock says.
+3. **`RELEASE_VERIFY_BUDGET_MS` = 8 hours** from the merge, whatever the
+   attempt count says — and this is checked **even while a check is in
+   flight**, so a browser job that never comes back cannot hold a promotion
+   open.
+4. **Every terminal state clears `verifyRetryAt`**, so a settled promotion
+   is invisible to the sweep for ever.
+
+And one stop in the other direction, added by the slice-AJ review: a check
+that reaches a terminal fleet state **without its result reaching the state
+machine** — a dropped `fleet.job.completed`, an API replica that restarted
+mid-handler, a transient database error inside the listener — used to wedge
+the promotion until its deadline, because the sweep declines to enqueue
+while a job is bound. The sweep now re-reads the bound job: a terminal one
+is recorded off the job row (through the same pass rule the listener uses),
+and a live one has its `verifyRetryAt` pushed forward so it cannot sit at
+the head of the platform-wide sweep queue and starve other owners. The cron
+logs a warning whenever it has to do this.
+
+An unreadable deadline counts as **reached** (`isReleaseVerifyExhausted`
+fails closed toward stopping), so a corrupt timestamp settles the row
+rather than probing indefinitely. Note this is the opposite direction to
+`isPromotionGateDecisionOverdue`, which fails closed by _not_ filing a
+notice — there, an unreadable clock must not raise a false alarm; here, it
+must not create an unbounded loop.
+
+The fleet job itself is enqueued with `maxAttempts: 1`, so the fleet's own
+reclaim does not multiply the attempt ladder in this file by three.
+
+---
+
+## 10. When it goes wrong
+
+| Symptom                                                      | What it means                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Verdict `unsupported` immediately after a merge              | No verification target for that environment. §5.                                                                                                                                                                                                  |
+| Verdict `inconclusive`, detail mentions the budget           | The build never reached the cluster inside 8 hours. Check `k8s-build` and ArgoCD; the lane is telling you it does not know, which is correct.                                                                                                     |
+| Verdict `inconclusive`, detail mentions the version endpoint | The fleet node could not reach the environment. Check the node's network before you suspect the release.                                                                                                                                          |
+| Nothing happens at all after a merge                         | Is a node enrolled with the `browser` capability? Without one the job sits until the two-hour queue SLA fails it. `EVER_WORKS_NODE_BROWSER` pins a browser path; a pinned path that does not exist resolves to _no browser_, with no fallthrough. |
+| `awaiting-rollout` for hours on a production promotion       | Expected. The build lane is 215–243 minutes and the rollout follows it.                                                                                                                                                                           |
+| A revert Task appeared                                       | Read §7 before doing anything. Rolling forward is usually cheaper.                                                                                                                                                                                |
+| Two Inbox items for one verdict                              | Should be impossible — every terminal transition is a compare-and-set and only the winner narrates. If you see it, the two items will be for different `expectedSha` values or different verdicts.                                                |
+
+---
+
+## 11. Files
+
+| Concern                                                                   | File                                                                                                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Environment mapping, target validation, verdicts, bounds, probe selection | `packages/contracts/src/release/deployment-verification.types.ts`                                                               |
+| The state machine, the browser-check producer, the revert offer           | `packages/agent/src/tasks-domain/release-verification.service.ts`                                                               |
+| The compare-and-set writes                                                | `packages/agent/src/database/repositories/release-promotion.repository.ts`                                                      |
+| Storage                                                                   | `packages/agent/src/entities/release-promotion.entity.ts`, `packages/agent/src/entities/work.entity.ts` (`releaseVerification`) |
+| Migration                                                                 | `apps/api/src/migrations/1790100000000-AddReleaseVerification.ts`                                                               |
+| The trust boundary (node result → verdict)                                | `apps/api/src/release/release-verification.listener.ts`                                                                         |
+| The clock                                                                 | `apps/api/src/release/release-verification-cron.service.ts`                                                                     |
+| Operator surface                                                          | `apps/api/src/release/release-promotions.controller.ts`                                                                         |
+| The executor that runs on the node                                        | `apps/node/src/core/executors/browser-check.ts`                                                                                 |
+| The CI lane this mirrors                                                  | `.github/workflows/smoke-deployed.yml`                                                                                          |

--- a/packages/agent/src/database/repositories/release-promotion.repository.ts
+++ b/packages/agent/src/database/repositories/release-promotion.repository.ts
@@ -1,12 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, LessThanOrEqual, Repository } from 'typeorm';
 import {
     PROMOTION_LANE_OPEN,
+    RELEASE_VERIFY_STATES,
+    isReleaseVerifyTerminal,
     promotionLaneKey,
     type PromotionGateVerdict,
     type PromotionRung,
     type PromotionState,
+    type ReleaseVerifyState,
 } from '@ever-works/contracts';
 import { ReleasePromotion } from '../../entities/release-promotion.entity';
 
@@ -346,7 +349,361 @@ export class ReleasePromotionRepository {
             .execute();
         return (result.affected ?? 0) > 0;
     }
+
+    // ── Post-deploy verification (slice AJ, EW-809) ───────────────────
+    //
+    // Every write below is a CONDITIONAL update whose WHERE clause
+    // restates the precondition, the same posture `FleetJobService` uses
+    // for the lease protocol and `recordGateVerdict` uses for the gate.
+    // Two API replicas run this sweep and this listener, and the row is
+    // the only thing that can arbitrate between them.
+
+    /**
+     * Start a verification, but only for a promotion that has never had
+     * one.
+     *
+     * `WHERE verifyState IS NULL` is what makes "exactly once per
+     * promotion" a database fact rather than an argument about call sites.
+     * The merge-detection block that calls this frees the lane in the same
+     * pass, so in practice it runs once anyway — but "in practice" is how
+     * two Inbox notices for one event get shipped.
+     */
+    async beginVerification(
+        id: string,
+        patch: {
+            verifyState: ReleaseVerifyState;
+            verifyExpectedSha: string | null;
+            verifyTargetUrl: string | null;
+            verifyStartedAt: Date;
+            verifyDeadlineAt: Date | null;
+            verifyRetryAt: Date | null;
+            verifyDetail: string | null;
+        },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyState: patch.verifyState,
+                verifyExpectedSha: patch.verifyExpectedSha,
+                verifyTargetUrl: patch.verifyTargetUrl,
+                verifyStartedAt: patch.verifyStartedAt,
+                verifyDeadlineAt: patch.verifyDeadlineAt,
+                verifyRetryAt: patch.verifyRetryAt,
+                verifyDetail: patch.verifyDetail,
+                verifyAttempts: 0,
+                verifyStreak: 0,
+                verifyJobId: null,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyState IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Rows the verification sweep should look at: still being verified,
+     * and due.
+     *
+     * Deliberately NOT filtered on `verifyJobId IS NULL`. A row whose
+     * browser check never comes back must still be able to reach its
+     * deadline and settle, or one wedged fleet job would hold a promotion
+     * in `awaiting-rollout` for ever — exactly the unbounded state this
+     * lane is not allowed to have. The sweep decides per row whether it is
+     * claiming an attempt or expiring the row.
+     */
+    async findVerificationsDue(now: Date, limit = 25): Promise<ReleasePromotion[]> {
+        return this.repository.find({
+            where: {
+                // DERIVED, not restated. A verification state added later is
+                // live unless `isReleaseVerifyTerminal` says otherwise, so a
+                // new state cannot be introduced into a lane the sweep
+                // silently never visits — which would be a promotion stuck
+                // for ever with nothing to notice it.
+                verifyState: In(LIVE_VERIFY_STATES),
+                verifyRetryAt: LessThanOrEqual(now),
+            },
+            order: { verifyRetryAt: 'ASC' },
+            take: Math.max(1, Math.min(limit, 100)),
+        });
+    }
+
+    /** The promotion a browser check belongs to, so a completion can be routed back. */
+    async findByVerifyJobId(jobId: string): Promise<ReleasePromotion | null> {
+        return this.repository.findOne({ where: { verifyJobId: jobId } });
+    }
+
+    /**
+     * Take ownership of the next probe.
+     *
+     * The caller enqueues FIRST (with a key deterministic in
+     * `(promotion, attempt)`) and claims second. Both orderings leak
+     * something; this one leaks the harmless thing. A crash between the
+     * two leaves an enqueued job nobody recorded, and the next sweep
+     * computes the SAME attempt number, re-enqueues the SAME key, is
+     * handed the SAME job row back by `FleetJobService`, and records it.
+     * Claiming first and enqueuing second would instead leave a row
+     * pointing at a job that does not exist, which nothing can complete.
+     *
+     * `WHERE verifyJobId IS NULL AND verifyState = :state` is the mutual
+     * exclusion: at most one browser is ever pointed at one environment
+     * for one promotion.
+     *
+     * `reconsiderAt` is when the sweep should LOOK at this row again — not
+     * when it may enqueue again, which is gated on the job coming back. See
+     * the note on `verifyRetryAt` below.
+     */
+    async claimVerifyAttempt(
+        id: string,
+        state: ReleaseVerifyState,
+        patch: { jobId: string; attempts: number; targetUrl: string; reconsiderAt: Date },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyJobId: patch.jobId,
+                verifyAttempts: patch.attempts,
+                verifyTargetUrl: patch.targetUrl,
+                // NOT null, and this is load-bearing. `verifyRetryAt` is the
+                // sweep's WHERE clause, so a row that nulled it while a
+                // check was out would become invisible to the only thing
+                // that can enforce the deadline — and a browser job that
+                // never came back would hold the promotion open for ever,
+                // which is precisely the unbounded state this lane is not
+                // allowed to have. Instead the row stays sweepable: the
+                // sweep re-reads it, sees `verifyJobId` set, and declines to
+                // enqueue a second check while still being able to expire
+                // the row. (The fleet settles a stuck job on its own — a
+                // lease it exhausts or a queue SLA it expires both emit a
+                // completion — but "the other subsystem will notice" is not
+                // a bound, it is a hope.)
+                verifyRetryAt: patch.reconsiderAt,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyState = :state', { state })
+            .andWhere('verifyJobId IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Burn an attempt WITHOUT binding a job to it.
+     *
+     * Added during the slice-AJ review, for the one case
+     * {@link claimVerifyAttempt}'s recovery argument does not cover:
+     * `FleetJobService.enqueue` short-circuits on the idempotency key with
+     * a bare `findOne({ where: { idempotencyKey } })` that has no status
+     * filter and no owner scope, so re-deriving the same key can hand back
+     * a job that has ALREADY SETTLED (its completion fired while nothing
+     * was bound to it, and no second one will ever arrive) or a job
+     * somebody else created under that key. Binding either would wedge the
+     * verification until its deadline for a reason nobody recorded.
+     *
+     * Advancing `verifyAttempts` is what breaks the loop: the next sweep
+     * derives attempt N+1, therefore a DIFFERENT idempotency key,
+     * therefore a genuinely new job. The attempt cap still bounds it.
+     *
+     * `WHERE verifyJobId IS NULL AND verifyState = :state` for the same
+     * reason the claim has it: this must never overwrite a live claim.
+     */
+    async burnVerifyAttempt(
+        id: string,
+        state: ReleaseVerifyState,
+        patch: { attempts: number; reconsiderAt: Date; detail: string | null },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyAttempts: patch.attempts,
+                verifyRetryAt: patch.reconsiderAt,
+                verifyDetail: patch.detail,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyState = :state', { state })
+            .andWhere('verifyJobId IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Push a row with a check STILL IN FLIGHT further down the sweep queue.
+     *
+     * Added during the slice-AJ review. {@link findVerificationsDue} pages
+     * a platform-wide 25 rows ordered `verifyRetryAt ASC` and deliberately
+     * keeps in-flight rows in the result set so their deadline can still be
+     * enforced — but the sweep used to skip such a row without rescheduling
+     * it, so once a check had been out for longer than one interval the row
+     * was permanently `verifyRetryAt <= now` and drifted further into the
+     * past on every pass. Twenty-five of those — one owner whose fleet has
+     * no browser-capable node is enough — filled the page for ever and no
+     * other tenant's verification was enqueued or expired again.
+     *
+     * Pinned to the job it is waiting on, so this cannot silently reschedule
+     * a row whose check came back in the meantime.
+     */
+    async deferVerification(
+        id: string,
+        state: ReleaseVerifyState,
+        jobId: string,
+        reconsiderAt: Date,
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({ verifyRetryAt: reconsiderAt })
+            .where('id = :id', { id })
+            .andWhere('verifyState = :state', { state })
+            .andWhere('verifyJobId = :jobId', { jobId })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Let go of a job binding without settling the row.
+     *
+     * Added during the slice-AJ review for the wedge case: the row points
+     * at a fleet job that has reached a terminal state but whose result
+     * could not be recorded (the in-process listener's transient failure,
+     * or an API replica that restarted between the fleet write and the
+     * handler). Nothing would ever complete that job again, and the sweep
+     * declines to enqueue while `verifyJobId` is set, so the promotion
+     * burned its whole eight-hour budget having checked nothing.
+     *
+     * Releases the binding and burns the attempt in ONE write, so the next
+     * sweep enqueues a fresh check under a fresh idempotency key.
+     */
+    async releaseVerifyJob(
+        id: string,
+        state: ReleaseVerifyState,
+        jobId: string,
+        patch: { attempts: number; reconsiderAt: Date; detail: string | null },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyJobId: null,
+                verifyAttempts: patch.attempts,
+                verifyRetryAt: patch.reconsiderAt,
+                verifyDetail: patch.detail,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyState = :state', { state })
+            .andWhere('verifyJobId = :jobId', { jobId })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Record one probe result and schedule (or not) the following one.
+     *
+     * Pinned to the job that produced it, so a late completion from a
+     * superseded job cannot advance a row that has already moved on. The
+     * state is pinned too: a result read against `checking-app` cannot
+     * land on a row that has since become `confirming-failure`.
+     */
+    async recordVerifyResult(
+        id: string,
+        from: { jobId: string; state: ReleaseVerifyState },
+        patch: {
+            verifyState: ReleaseVerifyState;
+            verifyStreak: number;
+            verifyCheckedAt: Date;
+            verifyRetryAt: Date | null;
+            verifyDetail: string | null;
+        },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyState: patch.verifyState,
+                verifyStreak: patch.verifyStreak,
+                verifyCheckedAt: patch.verifyCheckedAt,
+                verifyRetryAt: patch.verifyRetryAt,
+                verifyDetail: patch.verifyDetail,
+                verifyJobId: null,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyJobId = :jobId', { jobId: from.jobId })
+            .andWhere('verifyState = :state', { state: from.state })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Settle a verification, from a state it is still in.
+     *
+     * The `from` pin is what makes "exactly one process narrates this
+     * verdict" true, and therefore what makes "exactly one Inbox notice"
+     * true: the caller files the notice only when this returned `true`.
+     * Clears `verifyRetryAt` and `verifyJobId` in the same write, so a
+     * settled row is invisible to the sweep and deaf to a late completion.
+     */
+    async settleVerification(
+        id: string,
+        from: ReleaseVerifyState,
+        patch: {
+            verifyState: ReleaseVerifyState;
+            verifyCheckedAt: Date;
+            verifyDetail: string | null;
+        },
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({
+                verifyState: patch.verifyState,
+                verifyCheckedAt: patch.verifyCheckedAt,
+                verifyDetail: patch.verifyDetail,
+                verifyRetryAt: null,
+                verifyJobId: null,
+                verifyStreak: 0,
+            })
+            .where('id = :id', { id })
+            .andWhere('verifyState = :from', { from })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Claim the right to file the ONE revert offer for this promotion.
+     *
+     * `WHERE revertTaskId IS NULL AND verifyState = 'failed'` carries two
+     * separate guarantees, both load-bearing:
+     *
+     *   - a promotion is offered a revert AT MOST ONCE, ever, however many
+     *     replicas notice the failure;
+     *   - a revert can only be offered for a verification that actually
+     *     reached `failed`. An `inconclusive` or `unsupported` promotion
+     *     cannot be handed a revert offer even by a caller that asks for
+     *     one, because the database refuses the write. That is the last
+     *     line of the "an inconclusive verdict does not trigger a revert"
+     *     rule, underneath the service check and the contracts predicate.
+     */
+    async claimRevertOffer(id: string, taskId: string, at: Date): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(ReleasePromotion)
+            .set({ revertTaskId: taskId, revertOfferedAt: at })
+            .where('id = :id', { id })
+            .andWhere('revertTaskId IS NULL')
+            .andWhere('verifyState = :failed', { failed: 'failed' })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
 }
+
+/**
+ * The verification states the sweep must keep looking at.
+ *
+ * Computed from the contract rather than typed out, so the sweep's query
+ * and `isReleaseVerifyTerminal` cannot disagree about what "finished"
+ * means.
+ */
+const LIVE_VERIFY_STATES = RELEASE_VERIFY_STATES.filter((state) => !isReleaseVerifyTerminal(state));
 
 /**
  * An open lane nobody can ever free: no pull request bound, and older

--- a/packages/agent/src/entities/release-promotion.entity.ts
+++ b/packages/agent/src/entities/release-promotion.entity.ts
@@ -6,7 +6,12 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
-import type { PromotionGateVerdict, PromotionRung, PromotionState } from '@ever-works/contracts';
+import type {
+    PromotionGateVerdict,
+    PromotionRung,
+    PromotionState,
+    ReleaseVerifyState,
+} from '@ever-works/contracts';
 import { PortableDateColumn } from './_types';
 
 /**
@@ -42,9 +47,20 @@ import { PortableDateColumn } from './_types';
  * ever NARROWS that: `gateVerdict` must be an explicit `success` for the
  * exact head being merged, or the merge gate stands down.
  *
+ * ## What slice AJ (EW-809) added, and what it still does not do
+ *
+ * The `verify*` columns below record whether the DEPLOYMENT that followed
+ * the merge actually worked, and `revertTaskId` records that a revert was
+ * OFFERED to a human when it did not. Nothing on this row can revert
+ * anything: the offer is a Task filed for a person to decide on, and
+ * landing whatever pull request that Task eventually produces goes through
+ * the same `merge_pull_request` Inbox approval as everything else. There
+ * is deliberately no `revertedAt`, because the platform never reverts.
+ *
  * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
- * cycle-avoidance rule; FKs live in the migration
- * (`1790000000000-CreateReleasePromotions`).
+ * cycle-avoidance rule; FKs live in the migrations
+ * (`1790000000000-CreateReleasePromotions`,
+ * `1790100000000-AddReleaseVerification`).
  *
  * NOTE: also registered in `database/_entities-inventory.ts` and
  * `_entity-names.ts` — this repo has no `autoLoadEntities`, so a
@@ -55,6 +71,10 @@ import { PortableDateColumn } from './_types';
 @Index('uq_release_promotions_lane', ['workId', 'rung', 'laneKey'], { unique: true })
 @Index('idx_release_promotions_task', ['taskId'])
 @Index('idx_release_promotions_work_state', ['workId', 'state'])
+// The post-deploy verification sweep's only query: rows still being
+// verified whose next probe is due. Without it the sweep table-scans
+// `release_promotions` every five minutes for ever.
+@Index('idx_release_promotions_verify', ['verifyState', 'verifyRetryAt'])
 export class ReleasePromotion {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -227,6 +247,148 @@ export class ReleasePromotion {
      */
     @Column({ type: 'varchar', length: 16, nullable: true })
     inboxFiledVerdict?: string | null;
+
+    // ── Post-deploy verification (self-build slice AJ, EW-809) ───────
+    //
+    // Everything below is written ONLY after the pull request has been
+    // observed merged, and only ever by the verification lane. It answers
+    // the question the gate cannot: did the promoted build reach the
+    // environment this rung deploys, and does that environment work?
+    //
+    // Kept on this row rather than in a table of its own because the
+    // relationship is 1:1 and permanent — a promotion has exactly one
+    // deployment to verify, for ever — and because "make the verdict
+    // visible ON the promotion" is the whole requirement.
+
+    /**
+     * `awaiting-rollout` | `checking-app` | `confirming-failure` |
+     * `passed` | `failed` | `inconclusive` | `unsupported`.
+     *
+     * NULL means the verification never started: the promotion has not
+     * merged, or this deployment predates the lane. NULL is NOT a pass,
+     * and the operator surface says "not verified" for it rather than
+     * leaving a blank a reader fills in optimistically.
+     */
+    @Column({ type: 'varchar', length: 24, nullable: true })
+    verifyState?: ReleaseVerifyState | null;
+
+    /**
+     * THE artefact identity: the commit that must be SERVING before this
+     * lane will say anything about the deployment.
+     *
+     * The tip of {@link baseBranch} read from the git provider immediately
+     * after the pull request was observed merged — NOT {@link headSha}.
+     * The merge produces a NEW commit (the platform merges with the
+     * provider default `merge` method) and `GitPullRequestStatus` carries
+     * no merge-commit sha, so a verification that compared the deployed
+     * `gitSha` against `headSha` would report "not rolled out" for ever.
+     *
+     * KNOWN LIMIT, stated because a green verdict leans on it: if another
+     * pull request lands on the base branch between our merge and this
+     * read, this records THAT commit. The promoted code is still an
+     * ancestor of it — so a pass never means "your change is absent" — but
+     * the artefact verified is then not exclusively this promotion's. The
+     * runbook says so too.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    verifyExpectedSha?: string | null;
+
+    /**
+     * The URL the LAST probe actually loaded.
+     *
+     * Recorded so an operator reading a verdict can see which deployment
+     * it was about without re-deriving it from the Work, and so a target
+     * edited under a running verification is visible rather than silent.
+     */
+    @Column({ type: 'varchar', length: 512, nullable: true })
+    verifyTargetUrl?: string | null;
+
+    @PortableDateColumn({ nullable: true })
+    verifyStartedAt?: Date | null;
+
+    /**
+     * When this verification stops, whatever it has found.
+     *
+     * One of the two independent stops that make the lane bounded (the
+     * other is {@link verifyAttempts}). A row past this settles
+     * `inconclusive` — never `failed`, and therefore never a revert offer.
+     */
+    @PortableDateColumn({ nullable: true })
+    verifyDeadlineAt?: Date | null;
+
+    /** Fleet browser checks enqueued so far. Hard-capped; see the deadline. */
+    @Column({ type: 'int', default: 0 })
+    verifyAttempts: number;
+
+    /**
+     * Consecutive same-direction results in the CURRENT state.
+     *
+     * Reset on every state change and on every result that breaks the run.
+     * Rollout needs `RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS` in a row because
+     * ArgoCD replaces pods gradually and one sample is a coin flip;
+     * failure needs `RELEASE_VERIFY_FAILURE_CONFIRMATIONS` in a row because
+     * one failed page load is a transient and filing a revert offer on a
+     * transient is how a flapping check reverts a good release.
+     */
+    @Column({ type: 'int', default: 0 })
+    verifyStreak: number;
+
+    /**
+     * The fleet job currently in flight, or NULL when none is.
+     *
+     * Also the mutual exclusion: the sweep claims an attempt with a
+     * conditional UPDATE pinning this to NULL, so two API replicas cannot
+     * put two browsers on the same environment, and a promotion can never
+     * have more than one outstanding check.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    verifyJobId?: string | null;
+
+    /**
+     * When the sweep should next LOOK at this row.
+     *
+     * NOT nulled while a check is in flight, and that is load-bearing: it
+     * is the sweep’s WHERE clause, so a row that cleared it would drop out
+     * of the only query that can enforce {@link verifyDeadlineAt}, and a
+     * browser job that never came back would hold the promotion open for
+     * ever. A row with {@link verifyJobId} set is re-read and skipped for
+     * enqueueing, but can still be expired.
+     *
+     * NULL only on a settled verification, which is how a terminal row
+     * becomes invisible to the sweep permanently.
+     */
+    @PortableDateColumn({ nullable: true })
+    verifyRetryAt?: Date | null;
+
+    /** When a probe result was last recorded — "when did we last look". */
+    @PortableDateColumn({ nullable: true })
+    verifyCheckedAt?: Date | null;
+
+    /**
+     * Short plain-text note about the last reading, for the operator and
+     * the Inbox body.
+     *
+     * Length-capped at the write site because half of what lands here is
+     * derived from a NODE-REPORTED result, which is untrusted data.
+     */
+    @Column({ type: 'varchar', length: 512, nullable: true })
+    verifyDetail?: string | null;
+
+    /**
+     * The Task filed to OFFER a revert, when one was offered.
+     *
+     * Written exactly once, by a compare-and-set, and only from
+     * `verifyState = 'failed'`. Its presence means a human was handed a
+     * prepared revert to decide on. It does NOT mean anything was
+     * reverted: nothing in this platform reverts, and landing whatever
+     * pull request this Task eventually produces needs the same
+     * `merge_pull_request` Inbox approval as every other merge.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    revertTaskId?: string | null;
+
+    @PortableDateColumn({ nullable: true })
+    revertOfferedAt?: Date | null;
 
     // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
     // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -27,7 +27,7 @@ import type {
     WorksConfigSnapshot as ContractWorksConfigSnapshot,
 } from '@ever-works/contracts/api';
 // Release promotion lane (self-build slice AI, EW-808).
-import type { ReleaseLadder } from '@ever-works/contracts';
+import type { ReleaseLadder, ReleaseVerificationTargets } from '@ever-works/contracts';
 import type { PRUpdate } from '@src/generators/data-generator';
 import { WorkGenerationHistory } from './work-generation-history.entity';
 import { TimestampColumn } from './_types';
@@ -451,6 +451,36 @@ export class Work {
      */
     @Column('simple-json', { nullable: true })
     releaseLadder?: ReleaseLadder | null;
+
+    /**
+     * Where this Work's deployed environments can be OBSERVED from
+     * outside, per environment (self-build slice AJ, EW-809).
+     *
+     * The other half of the release lane's platform state. The ladder says
+     * which branches a promotion may touch; this says which URLs a
+     * post-deploy verification may load, and it is read for the
+     * environment the promoted rung DEPLOYS (its base branch) — merging
+     * `develop -> stage` is verified against staging, never production.
+     *
+     * NULL — the default, and the value on every existing Work — means a
+     * merged promotion for this Work is recorded `unsupported` and
+     * reported to the owner as NOT VERIFIED. It is never treated as a
+     * pass: "nobody configured a URL" and "the deployment is healthy" must
+     * not be the same reading.
+     *
+     * NEVER accepted on a promotion or verification request. A caller that
+     * could name the URL a verification loads could point a green verdict
+     * at a page it controls, and that verdict is the only thing standing
+     * between a bad release and a human being told everything is fine.
+     *
+     * Read through `sanitizeReleaseVerificationTargets` on every use,
+     * never raw: the column is `simple-json` and therefore holds whatever
+     * was written to it, and these URLs are loaded by a real browser on an
+     * enrolled fleet node — somebody's actual PC, inside their actual
+     * network.
+     */
+    @Column('simple-json', { nullable: true })
+    releaseVerification?: ReleaseVerificationTargets | null;
 
     // ── Memory recall (memory upgrades M3) ───────────────────────────
 

--- a/packages/agent/src/tasks-domain/__tests__/release-promotion.module.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/release-promotion.module.spec.ts
@@ -7,6 +7,8 @@ import {
     PROMOTION_MERGE_GUARD,
 } from '@src/policy/promotion-merge-guard.port';
 import { ENTITIES } from '@src/database/database.config';
+import { FleetJobService } from '@src/fleet/fleet-job.service';
+import { FleetJobRepository } from '@src/fleet/fleet-job.repository';
 import { PluginRegistryService } from '@src/plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '@src/plugins/services/plugin-settings.service';
 import { PluginUsageService } from '@src/usage/plugin-usage.service';
@@ -16,6 +18,7 @@ import { WorkCustomDomainRepository } from '@src/database/repositories/work-cust
 import { EverWorksK8sDeployProvider } from '@src/ever-works-providers/ever-works-k8s-deploy.provider';
 import { ReleasePromotionModule } from '../release-promotion.module';
 import { ReleasePromotionService } from '../release-promotion.service';
+import { ReleaseVerificationService } from '../release-verification.service';
 import { TasksDomainModule } from '../tasks.module';
 
 /**
@@ -125,6 +128,61 @@ describe('ReleasePromotionModule — dependency injection', () => {
         await moduleRef.close();
     });
 
+    it('resolves the post-deploy verification service from the REAL module', async () => {
+        // Slice AJ (EW-809). `ReleaseVerificationService` injects
+        // `FleetJobService`, which lives in a module this one did not use
+        // to import — and a service that injects a provider its module does
+        // not supply passes every unit spec (they construct it
+        // positionally) and then refuses to boot the API.
+        //
+        // MUTATION CHECK, executed rather than assumed:
+        //   - deleting `FleetModule` from the module's `imports` fails this
+        //     test with "Nest can't resolve dependencies of the
+        //     ReleaseVerificationService"; note that `FleetJobService` is
+        //     @Optional() on the constructor, so the failure surfaces on
+        //     the REQUIRED collaborators rather than silently leaving the
+        //     lane unable to enqueue — which is why the assertion below
+        //     checks the fleet dependency landed, not merely that the
+        //     service exists;
+        //   - deleting `ReleaseVerificationService` from `providers` fails
+        //     to compile as well.
+        const moduleRef = await compile();
+
+        const verification = moduleRef.get(ReleaseVerificationService);
+        expect(verification).toBeInstanceOf(ReleaseVerificationService);
+        // The @Optional() fleet dependency actually RESOLVED. Without
+        // `FleetModule` in `imports` this is `undefined` and the lane
+        // silently never produces a browser check — the exact failure an
+        // @Optional() dependency hides from a compile-only assertion.
+        expect(moduleRef.get(FleetJobService)).toBeDefined();
+        expect((verification as unknown as { fleet?: unknown }).fleet).toBe(
+            moduleRef.get(FleetJobService),
+        );
+        // And the READER added by the slice-AJ review, on the same
+        // argument. Without it the sweep cannot tell whether the job
+        // `enqueue` handed back is the check it asked for, and cannot
+        // recover a check that settled without its result being recorded —
+        // both of which degrade silently, so a compile-only assertion would
+        // not notice. `FleetJobRepository` is exported by the same
+        // `FleetModule` already in `imports`.
+        expect((verification as unknown as { fleetJobs?: unknown }).fleetJobs).toBe(
+            moduleRef.get(FleetJobRepository),
+        );
+
+        await moduleRef.close();
+    });
+
+    it('gives the promotion service the verification service it hands merges to', async () => {
+        const moduleRef = await compile();
+
+        const promotion = moduleRef.get(ReleasePromotionService);
+        expect((promotion as unknown as { verification?: unknown }).verification).toBe(
+            moduleRef.get(ReleaseVerificationService),
+        );
+
+        await moduleRef.close();
+    });
+
     it('exposes the lane to the rest of the app without TasksDomainModule importing it back', async () => {
         // The whole point of the @Global() binding: `TaskPrStatusService`
         // and `TaskMergeGateService` live INSIDE `TasksDomainModule` and
@@ -166,6 +224,15 @@ describe('ReleasePromotionModule — module shape', () => {
         expect(names).toContain('FacadesModule');
     });
 
+    it('imports FleetModule, the ONLY source of a browser check producer', () => {
+        // Slice AJ. `FleetModule` imports nothing but
+        // `TypeOrmModule.forFeature`, so it cannot cycle back into this
+        // one — which is why the verification service can inject
+        // `FleetJobService` directly instead of behind another token.
+        const names = imports().map((entry: { name?: string }) => entry?.name);
+        expect(names).toContain('FleetModule');
+    });
+
     it('registers its own entity with forFeature', () => {
         // A dynamic module has no `.name`, so the check above cannot see
         // it. Named explicitly because dropping it is an API that does not
@@ -184,6 +251,7 @@ describe('ReleasePromotionModule — module shape', () => {
         // platform for the benefit of one module.
         expect(providers()).toContain(ReleasePromotionRepository);
         expect(providers()).toContain(ReleasePromotionService);
+        expect(providers()).toContain(ReleaseVerificationService);
     });
 
     it('binds both tokens with useExisting, so consumers depend on the contract', () => {
@@ -211,6 +279,9 @@ describe('ReleasePromotionModule — module shape', () => {
             expect.arrayContaining([
                 ReleasePromotionRepository,
                 ReleasePromotionService,
+                // The api-side cron sweep and the fleet-completion listener
+                // reach the verification lane through this export.
+                ReleaseVerificationService,
                 PROMOTION_MERGE_GUARD,
                 PROMOTION_LANE_WATCHER,
             ]),

--- a/packages/agent/src/tasks-domain/__tests__/release-promotion.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/release-promotion.service.spec.ts
@@ -108,6 +108,12 @@ describe('ReleasePromotionService', () => {
             confirmedHead?: string | null;
             /** Make the writes that BIND the pull request to the Task fail. */
             bindError?: Error;
+            /**
+             * Slice AJ: run the lane with NO post-deploy verification
+             * bound, which is what a deployment that never imports
+             * `ReleaseModule` looks like.
+             */
+            noVerification?: boolean;
         } = {},
     ) {
         const created = makeTask();
@@ -196,6 +202,9 @@ describe('ReleasePromotionService', () => {
                 : jest.fn().mockResolvedValue(opts.workflowRun ?? null),
         };
         const inbox = { notice: jest.fn().mockResolvedValue(undefined) };
+        // Post-deploy verification (slice AJ, EW-809). APPENDED LAST, like
+        // the constructor parameter it stands in for.
+        const verification = { onPromotionMerged: jest.fn().mockResolvedValue(undefined) };
 
         const service = new ReleasePromotionService(
             works as never,
@@ -205,8 +214,19 @@ describe('ReleasePromotionService', () => {
             chat as never,
             opts.noGitFacade ? undefined : (gitFacade as never),
             opts.noInbox ? undefined : (inbox as never),
+            opts.noVerification ? undefined : (verification as never),
         );
-        return { service, works, tasks, tasksService, chat, gitFacade, inbox, created };
+        return {
+            service,
+            works,
+            tasks,
+            tasksService,
+            chat,
+            gitFacade,
+            inbox,
+            verification,
+            created,
+        };
     }
 
     function status(overrides: Partial<GitPullRequestStatus> = {}): GitPullRequestStatus {
@@ -901,6 +921,77 @@ describe('ReleasePromotionService', () => {
             expect(harness.chat.create.mock.calls.at(-1)?.[0].body).toMatch(
                 /not opened automatically/i,
             );
+        });
+
+        // ── Handing off to post-deploy verification (slice AJ) ────────
+
+        it('starts a post-deploy verification when the promotion MERGES', async () => {
+            // The only moment the platform learns a promotion landed.
+            // `closeLane` has already rewritten `laneKey`, so
+            // `findOpenByTaskId` will never match this row again and no
+            // existing sweep in the platform ever visits it — if the
+            // handoff does not happen here it never happens.
+            const harness = build();
+            const promotion = await openOne(harness);
+
+            await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'merged', merged: true }),
+            );
+
+            expect(harness.verification.onPromotionMerged).toHaveBeenCalledTimes(1);
+            expect(harness.verification.onPromotionMerged.mock.calls[0][0].id).toBe(promotion.id);
+        });
+
+        it('starts NOTHING when the promotion is closed without merging', async () => {
+            // Nothing was deployed, so there is nothing to check — and a
+            // verification started here would sit until its deadline and
+            // then report `inconclusive` about a release that never
+            // happened.
+            const harness = build();
+            await openOne(harness);
+
+            await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'closed' }),
+            );
+
+            expect(harness.verification.onPromotionMerged).not.toHaveBeenCalled();
+        });
+
+        it('still merges and closes cleanly with NO verification bound', async () => {
+            // A deployment that does not import `ReleaseModule` has no
+            // verification. The lane must behave byte-for-byte as it did
+            // before slice AJ: the promotion still lands, the lane is still
+            // freed, and nothing pretends a deployment was checked.
+            const harness = build({ noVerification: true });
+            const promotion = await openOne(harness);
+
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'merged', merged: true }),
+            );
+
+            expect(outcome).toEqual({ action: 'closed', state: 'merged' });
+            const stored = await rows.findOne({ where: { id: promotion.id } });
+            expect(stored?.state).toBe('merged');
+            expect(stored?.verifyState).toBeNull();
+        });
+
+        it('records the merge even when the verification handoff throws', async () => {
+            // Best-effort by contract: this method keeps a PR-status cache
+            // honest for every Task behind this one.
+            const harness = build();
+            harness.verification.onPromotionMerged.mockRejectedValue(new Error('fleet is down'));
+            const promotion = await openOne(harness);
+
+            const outcome = await harness.service.onPullRequestStatusRefreshed(
+                makeTask() as never,
+                status({ state: 'merged', merged: true }),
+            );
+
+            expect(outcome).toEqual({ action: 'closed', state: 'merged' });
+            expect((await rows.findOne({ where: { id: promotion.id } }))?.state).toBe('merged');
         });
 
         it('frees the lane when the promotion pull request is closed unmerged', async () => {

--- a/packages/agent/src/tasks-domain/__tests__/release-verification.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/release-verification.service.spec.ts
@@ -1,0 +1,1848 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DataSource, Repository } from 'typeorm';
+import {
+    FLEET_BROWSER_CAPABILITY,
+    PROMOTION_TASK_LABEL,
+    RELEASE_REVERT_TASK_LABEL,
+    RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+    RELEASE_VERIFY_FAILURE_CONFIRMATIONS,
+    RELEASE_VERIFY_MAX_ATTEMPTS,
+    RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS,
+} from '@ever-works/contracts';
+import { ReleasePromotion } from '@src/entities/release-promotion.entity';
+import { ReleasePromotionRepository } from '@src/database/repositories/release-promotion.repository';
+import { TaskStatus } from '@src/entities/task.entity';
+import { ReleaseVerificationService } from '../release-verification.service';
+
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809).
+ *
+ * The REAL `ReleasePromotionRepository` over a real (in-memory sqlite)
+ * `release_promotions` table. Only the process edges are stubbed: the git
+ * provider, the fleet queue, the Task writer and the Inbox.
+ *
+ * Every compare-and-set that makes this lane safe across replicas — the
+ * start claim, the attempt claim, the result pin, the settle pin, the
+ * defer, the burn, the release and the revert-offer claim — is exercised
+ * DIRECTLY, from a state the guard is supposed to refuse, in "the
+ * compare-and-set guards" block near the end. That block exists because
+ * this header used to claim the coverage the behavioural tests give: it
+ * does not. Four of those `.andWhere` clauses could be deleted from the
+ * repository with the whole suite still green, because each had an
+ * in-process guard in front of it that satisfied the assertion on its own.
+ * A test that goes through the service exercises the SERVICE's guard; only
+ * a test that calls the repository exercises the repository's.
+ *
+ * What this file is mostly about is the three ways the lane must refuse:
+ *
+ *   - it must not report green for a build that was never deployed;
+ *   - it must not offer a revert for something it did not measure;
+ *   - it must not keep checking for ever.
+ *
+ * The happy path is two tests. Everything else is a refusal or a bound.
+ */
+describe('ReleaseVerificationService', () => {
+    let dataSource: DataSource;
+    let rows: Repository<ReleasePromotion>;
+    let promotions: ReleasePromotionRepository;
+
+    const USER = 'user-1';
+    const OTHER_USER = 'user-2';
+    const WORK = 'work-1';
+    const AGENT = 'agent-1';
+    const ORG = 'org-1';
+    /** The promotion's head — the branch being merged FROM. Never deployed. */
+    const HEAD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    /** The BASE branch's tip after the merge — what actually gets built. */
+    const MERGED = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    const STAGING = {
+        versionUrl: 'https://apistage.ever.works/api/version',
+        appUrl: 'https://appstage.ever.works/api/health',
+        appExpectText: '"status":"OK"',
+    };
+    const PRODUCTION = {
+        versionUrl: 'https://api.ever.works/api/version',
+        appUrl: 'https://app.ever.works/api/health',
+        appExpectText: '"status":"OK"',
+    };
+    const TARGETS = { staging: STAGING, production: PRODUCTION };
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [ReleasePromotion],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        rows = dataSource.getRepository(ReleasePromotion);
+        promotions = new ReleasePromotionRepository(rows);
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    beforeEach(async () => {
+        await rows.clear();
+    });
+
+    // ── Harness ───────────────────────────────────────────────────────
+
+    function makeWork(overrides: Record<string, unknown> = {}) {
+        return {
+            id: WORK,
+            slug: 'ever-works',
+            userId: USER,
+            gitProvider: 'github',
+            tenantId: null,
+            organizationId: ORG,
+            releaseVerification: TARGETS,
+            getRepoOwner: () => 'ever-works',
+            getDataRepo: () => 'ever-works',
+            ...overrides,
+        };
+    }
+
+    function makeTask(overrides: Record<string, unknown> = {}) {
+        return {
+            id: 'task-1',
+            slug: 'T-7',
+            userId: USER,
+            agentId: AGENT,
+            workId: WORK,
+            labels: [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main'],
+            tenantId: null,
+            organizationId: ORG,
+            ...overrides,
+        };
+    }
+
+    function build(
+        opts: {
+            work?: Record<string, unknown> | null;
+            branches?: Array<{ name: string; commit: string }>;
+            listBranchesError?: Error;
+            noFleet?: boolean;
+            noGitFacade?: boolean;
+            noInbox?: boolean;
+            enqueueError?: Error;
+            createTaskError?: Error;
+            /** Override what `FleetJobService.enqueue` hands back. */
+            enqueueReturns?: (
+                input: Record<string, unknown>,
+                seq: number,
+            ) => Record<string, unknown>;
+            /** Owner recorded on the fleet job row the enqueue created. */
+            enqueueOwner?: string;
+            /** Fleet job rows the sweep reads back, keyed by id. */
+            fleetJobRows?: Map<string, Record<string, unknown>>;
+            noFleetJobs?: boolean;
+            fleetJobsError?: Error;
+        } = {},
+    ) {
+        const revertTask = { id: 'revert-task-1', slug: 'T-99', agentId: AGENT, title: 'Revert' };
+        const works = {
+            findById: jest.fn().mockResolvedValue(opts.work === null ? null : makeWork(opts.work)),
+        };
+        const tasks = {
+            findById: jest.fn().mockResolvedValue(makeTask()),
+            updateById: jest.fn().mockResolvedValue(undefined),
+        };
+        const tasksService = {
+            create: opts.createTaskError
+                ? jest.fn().mockRejectedValue(opts.createTaskError)
+                : jest.fn().mockResolvedValue(revertTask),
+        };
+        const chat = { create: jest.fn().mockResolvedValue(undefined) };
+        let jobSeq = 0;
+        const fleetRows = new Map<string, Record<string, unknown>>();
+        const fleet = {
+            // Models `FleetJobService.enqueue`'s ACTUAL return value — a
+            // whole `FleetJobView`, echoing the kind, status and payload of
+            // the row it created or found. A double that returned a bare
+            // `{ id }` is how the slice shipped with nothing checking that
+            // the job handed back was the job it asked for.
+            enqueue: opts.enqueueError
+                ? jest.fn().mockRejectedValue(opts.enqueueError)
+                : jest.fn().mockImplementation((input: Record<string, unknown>) => {
+                      jobSeq += 1;
+                      const view = opts.enqueueReturns
+                          ? opts.enqueueReturns(input, jobSeq)
+                          : {
+                                id: `job-${jobSeq}`,
+                                kind: input.kind,
+                                status: 'queued',
+                                payload: input.payload,
+                            };
+                      fleetRows.set(view.id as string, {
+                          ...view,
+                          userId: (opts.enqueueOwner ?? USER) as string,
+                      });
+                      return Promise.resolve(view);
+                  }),
+        };
+        const fleetJobs = {
+            findById: jest.fn().mockImplementation((id: string) => {
+                if (opts.fleetJobsError) return Promise.reject(opts.fleetJobsError);
+                return Promise.resolve(opts.fleetJobRows?.get(id) ?? fleetRows.get(id) ?? null);
+            }),
+        };
+        const gitFacade = {
+            listBranches: opts.listBranchesError
+                ? jest.fn().mockRejectedValue(opts.listBranchesError)
+                : jest.fn().mockResolvedValue(
+                      opts.branches ?? [
+                          { name: 'develop', commit: HEAD, isDefault: true },
+                          { name: 'stage', commit: HEAD, isDefault: false },
+                          { name: 'main', commit: MERGED, isDefault: false },
+                      ],
+                  ),
+        };
+        const inbox = { notice: jest.fn().mockResolvedValue(undefined) };
+
+        const service = new ReleaseVerificationService(
+            promotions,
+            works as never,
+            tasks as never,
+            tasksService as never,
+            chat as never,
+            opts.noFleet ? undefined : (fleet as never),
+            opts.noGitFacade ? undefined : (gitFacade as never),
+            opts.noInbox ? undefined : (inbox as never),
+            opts.noFleetJobs ? undefined : (fleetJobs as never),
+        );
+        return {
+            service,
+            works,
+            tasks,
+            tasksService,
+            chat,
+            fleet,
+            fleetJobs,
+            fleetRows,
+            gitFacade,
+            inbox,
+            revertTask,
+        };
+    }
+
+    /**
+     * A merged promotion row, ready for verification.
+     *
+     * Each gets its own `laneKey`: slice AI's UNIQUE `(workId, rung,
+     * laneKey)` index is REAL in this harness, and every terminal
+     * promotion writes `'<state>:<id>'` precisely so two of them do not
+     * collide.
+     */
+    let seedSeq = 0;
+    async function seed(overrides: Partial<ReleasePromotion> = {}): Promise<ReleasePromotion> {
+        seedSeq += 1;
+        return rows.save(
+            rows.create({
+                userId: USER,
+                workId: WORK,
+                taskId: 'task-1',
+                rung: 'stage-to-main',
+                headBranch: 'stage',
+                baseBranch: 'main',
+                headSha: HEAD,
+                prNumber: 42,
+                prUrl: 'https://github.com/ever-works/ever-works/pull/42',
+                state: 'merged',
+                laneKey: `merged:seed-${seedSeq}`,
+                gateWorkflow: 'promotion-gate.yml',
+                organizationId: ORG,
+                verifyAttempts: 0,
+                verifyStreak: 0,
+                ...overrides,
+            }),
+        );
+    }
+
+    async function reload(id: string): Promise<ReleasePromotion> {
+        const row = await rows.findOne({ where: { id } });
+        if (!row) throw new Error(`promotion ${id} vanished`);
+        return row;
+    }
+
+    const past = new Date('2026-09-06T00:00:00.000Z');
+    const now = new Date('2026-09-06T12:00:00.000Z');
+
+    // ── Starting ──────────────────────────────────────────────────────
+
+    describe('onPromotionMerged', () => {
+        it('holds the deployment to the BASE branch tip, not the promotion head', async () => {
+            // THE artefact identity. Merging `stage -> main` produces a new
+            // commit on `main`; `headSha` is the branch that was merged FROM
+            // and will never be what gets built and served. A verification
+            // that expected `headSha` would report "not rolled out" for ever.
+            const { service } = build();
+            const row = await seed();
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('awaiting-rollout');
+            expect(stored.verifyExpectedSha).toBe(MERGED);
+            expect(stored.verifyExpectedSha).not.toBe(HEAD);
+        });
+
+        it('points at the environment the RUNG deployed, not at production by default', async () => {
+            // `develop -> stage` deploys STAGE. Checking production would
+            // pass against a deployment this promotion never touched — the
+            // "wrong URL" hazard in its most plausible form.
+            const { service } = build({
+                branches: [
+                    { name: 'develop', commit: HEAD },
+                    { name: 'stage', commit: MERGED },
+                    { name: 'main', commit: 'cccccccccccccccccccccccccccccccccccccccc' },
+                ],
+            });
+            const row = await seed({
+                rung: 'develop-to-stage',
+                headBranch: 'develop',
+                baseBranch: 'stage',
+            });
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyTargetUrl).toBe(STAGING.versionUrl);
+            expect(stored.verifyTargetUrl).not.toBe(PRODUCTION.versionUrl);
+            expect(stored.verifyExpectedSha).toBe(MERGED);
+        });
+
+        it('sets both bounds, so the verification can never run for ever', async () => {
+            const { service } = build();
+            const row = await seed();
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyDeadlineAt).toBeTruthy();
+            expect(new Date(stored.verifyDeadlineAt!).getTime()).toBeGreaterThan(Date.now());
+            expect(stored.verifyAttempts).toBe(0);
+        });
+
+        it('records `unsupported` — not a pass — when the environment has no target', async () => {
+            const { service, inbox } = build({ work: { releaseVerification: null } });
+            const row = await seed();
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('unsupported');
+            expect(stored.verifyState).not.toBe('passed');
+            // The human is TOLD. "Nobody configured a URL" must not look
+            // like silence, which a reader rounds up to "fine".
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].title).toContain('NOT VERIFIED');
+        });
+
+        it('records `unsupported` when only the OTHER environment is configured', async () => {
+            const { service } = build({ work: { releaseVerification: { staging: STAGING } } });
+            const row = await seed({ rung: 'stage-to-main', baseBranch: 'main' });
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            expect((await reload(row.id)).verifyState).toBe('unsupported');
+        });
+
+        it.each([
+            ['the base branch tip cannot be read', { listBranchesError: new Error('403') }],
+            [
+                'the base branch is missing from the listing',
+                { branches: [{ name: 'develop', commit: HEAD }] },
+            ],
+            ['no git provider is wired', { noGitFacade: true }],
+            ['no fleet job runtime is wired', { noFleet: true }],
+            ['the Work has vanished', { work: null }],
+        ])('records `inconclusive` when %s', async (_label, opts) => {
+            const { service } = build(opts as never);
+            const row = await seed();
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.verifyDetail).toBeTruthy();
+            // An inconclusive start offers nothing.
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('refuses when the Work has changed hands under the promotion', async () => {
+            // Everything downstream — the URL to load, the credentials to
+            // read the branch with, the owner whose fleet runs the browser
+            // — would otherwise be taken from one party for a promotion
+            // belonging to another.
+            const { service, inbox } = build({ work: { userId: OTHER_USER } });
+            const row = await seed({ userId: USER });
+
+            await service.onPromotionMerged(row, makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.verifyTargetUrl).toBeNull();
+            expect(inbox.notice.mock.calls[0][1].title).toContain('NOT VERIFIED');
+        });
+
+        it('starts exactly once, however many times it is called', async () => {
+            // Two API replicas can both observe the merge before either
+            // frees the lane. `WHERE verifyState IS NULL` decides.
+            //
+            // The second caller is a SEPARATE service whose git provider
+            // answers a DIFFERENT commit. That is what makes this test able
+            // to fail: reading the row before the second call and asserting
+            // the sha is still MERGED — as this did — is satisfied just as
+            // well by a duplicate begin() rewriting the identical values, so
+            // deleting `.andWhere('verifyState IS NULL')` from
+            // `beginVerification` left it green.
+            const { service, inbox } = build();
+            const row = await seed();
+            const LATER = 'dddddddddddddddddddddddddddddddddddddddd';
+            const second = build({
+                branches: [
+                    { name: 'develop', commit: HEAD },
+                    { name: 'stage', commit: HEAD },
+                    { name: 'main', commit: LATER },
+                ],
+            });
+
+            await service.onPromotionMerged(row, makeTask() as never);
+            // A second caller holding a STALE row (verifyState still null).
+            await second.service.onPromotionMerged(await seedStale(row), makeTask() as never);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('awaiting-rollout');
+            expect(stored.verifyExpectedSha).toBe(MERGED);
+            expect(stored.verifyExpectedSha).not.toBe(LATER);
+            expect(inbox.notice).not.toHaveBeenCalled();
+            expect(second.inbox.notice).not.toHaveBeenCalled();
+        });
+
+        it('never throws — the caller is a best-effort PR-status refresh', async () => {
+            const { service, works } = build();
+            works.findById.mockRejectedValue(new Error('database is on fire'));
+            const row = await seed();
+
+            await expect(
+                service.onPromotionMerged(row, makeTask() as never),
+            ).resolves.toBeUndefined();
+        });
+
+        /** The same row as the caller would still be holding: state not yet read back. */
+        async function seedStale(row: ReleasePromotion): Promise<ReleasePromotion> {
+            return { ...row, verifyState: null } as ReleasePromotion;
+        }
+    });
+
+    // ── The sweep ─────────────────────────────────────────────────────
+
+    describe('enqueueDueChecks', () => {
+        it('produces a browser-check against the version URL, expecting the promoted commit', async () => {
+            // THE producer. Before this slice nothing on the platform ever
+            // enqueued a `browser-check` at all.
+            const { service, fleet } = build();
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            const summary = await service.enqueueDueChecks(now);
+
+            expect(summary.enqueued).toBe(1);
+            expect(fleet.enqueue).toHaveBeenCalledTimes(1);
+            const input = fleet.enqueue.mock.calls[0][0];
+            expect(input.kind).toBe('browser-check');
+            expect(input.payload.url).toBe(PRODUCTION.versionUrl);
+            expect(input.payload.expectText).toBe(MERGED.slice(0, 12));
+            expect(input.requiredCapabilities).toEqual([FLEET_BROWSER_CAPABILITY]);
+            // ONE attempt: the fleet's own reclaim would otherwise retry
+            // each probe underneath this file's attempt ladder, multiplying
+            // two independent budgets together.
+            expect(input.maxAttempts).toBe(1);
+            expect(input.idempotencyKey).toBe(`release-verify:${row.id}:1`);
+            expect((await reload(row.id)).verifyJobId).toBe('job-1');
+        });
+
+        it('takes the owner and scope from the ROW, never from a request or a payload', async () => {
+            // There is no request anywhere on this path — the sweep is a
+            // cron — and the browser check runs on the OWNER's fleet, so
+            // getting this wrong would run somebody else's job on their PC.
+            const { service, fleet } = build({
+                work: { organizationId: 'a-different-org' },
+            });
+            await seed({
+                userId: USER,
+                organizationId: ORG,
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            const input = fleet.enqueue.mock.calls[0][0];
+            expect(input.userId).toBe(USER);
+            // The promotion's scope, not the Work's current one.
+            expect(input.organizationId).toBe(ORG);
+        });
+
+        it('checks the APP url once the state says the rollout is confirmed', async () => {
+            const { service, fleet } = build();
+            await seed({
+                verifyState: 'checking-app',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            const input = fleet.enqueue.mock.calls[0][0];
+            expect(input.payload.url).toBe(PRODUCTION.appUrl);
+            expect(input.payload.expectText).toBe(PRODUCTION.appExpectText);
+        });
+
+        it('re-checks the VERSION url when confirming a failure', async () => {
+            // Not "is the app still broken" — we know that. "Can this node
+            // reach the environment at all, and is it still serving what we
+            // promoted." A no there is evidence about the node.
+            const { service, fleet } = build();
+            await seed({
+                verifyState: 'confirming-failure',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            expect(fleet.enqueue.mock.calls[0][0].payload.url).toBe(PRODUCTION.versionUrl);
+        });
+
+        it('does not enqueue a second check while one is in flight', async () => {
+            // At most one browser is ever pointed at one environment for one
+            // promotion, however many replicas tick at the same second.
+            const { service, fleet } = build();
+            await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-already-out',
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            expect(fleet.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('leaves a claimed row VISIBLE to the sweep, so its deadline can still be enforced', async () => {
+            // The sweep's WHERE clause is `verifyRetryAt <= now`. A claim
+            // that nulled it would take the row out of the only query that
+            // can expire it, and a browser job that never came back would
+            // hold the promotion open for ever. Asserted against the REAL
+            // claim, because hand-setting the columns is how a test comes to
+            // pass for a reason production does not provide.
+            const { service } = build();
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            const claimed = await reload(row.id);
+            expect(claimed.verifyJobId).toBe('job-1');
+            expect(claimed.verifyRetryAt).not.toBeNull();
+            // And it really is still selectable by the sweep's own query.
+            const laterStill = new Date(now.getTime() + 3 * RELEASE_VERIFY_ATTEMPT_INTERVAL_MS);
+            const due = await promotions.findVerificationsDue(laterStill);
+            expect(due.map((p) => p.id)).toContain(row.id);
+        });
+
+        it('settles a wedged verification on its deadline EVEN with a check in flight', async () => {
+            // THE anti-wedge, driven through the real claim rather than by
+            // hand: enqueue a check, let the deadline pass while the node
+            // never reports, and sweep again.
+            const { service, fleet, inbox } = build();
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                // Enough clock for the first sweep to claim an attempt.
+                verifyDeadlineAt: new Date(now.getTime() + 60_000),
+            });
+
+            await service.enqueueDueChecks(now);
+            expect((await reload(row.id)).verifyJobId).toBe('job-1');
+            fleet.enqueue.mockClear();
+
+            // Later. The job never came back.
+            const afterDeadline = new Date(now.getTime() + 3 * RELEASE_VERIFY_ATTEMPT_INTERVAL_MS);
+            const summary = await service.enqueueDueChecks(afterDeadline);
+
+            expect(summary.settled).toBe(1);
+            // And it did NOT put a second browser on the environment.
+            expect(fleet.enqueue).not.toHaveBeenCalled();
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.verifyRetryAt).toBeNull();
+            expect(stored.verifyJobId).toBeNull();
+            expect(stored.revertTaskId).toBeNull();
+            expect(inbox.notice.mock.calls[0][1].title).toContain('NOT VERIFIED');
+        });
+
+        it('does not enqueue a second check on a re-sweep while the first is still out', async () => {
+            const { service, fleet } = build();
+            await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+            });
+
+            await service.enqueueDueChecks(now);
+            const laterStill = new Date(now.getTime() + 3 * RELEASE_VERIFY_ATTEMPT_INTERVAL_MS);
+            await service.enqueueDueChecks(laterStill);
+
+            expect(fleet.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('settles on the ATTEMPT cap even with time left on the clock', async () => {
+            const { service, fleet } = build();
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyAttempts: RELEASE_VERIFY_MAX_ATTEMPTS,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            expect(fleet.enqueue).not.toHaveBeenCalled();
+            expect((await reload(row.id)).verifyState).toBe('inconclusive');
+        });
+
+        it('stops probing when the Work changes hands mid-verification', async () => {
+            const { service, fleet } = build({ work: { userId: OTHER_USER } });
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            expect(fleet.enqueue).not.toHaveBeenCalled();
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('settles `inconclusive` when the target is removed underneath a running verification', async () => {
+            const { service } = build({ work: { releaseVerification: null } });
+            const row = await seed({
+                verifyState: 'checking-app',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.enqueueDueChecks(now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('never looks at a settled verification again', async () => {
+            const { service, fleet } = build();
+            for (const state of ['passed', 'failed', 'inconclusive', 'unsupported'] as const) {
+                await rows.clear();
+                await seed({
+                    verifyState: state,
+                    verifyExpectedSha: MERGED,
+                    // Even with a due-looking retry stamp, which a settled
+                    // row should never carry.
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+                });
+                const summary = await service.enqueueDueChecks(now);
+                expect(summary.considered).toBe(0);
+            }
+            expect(fleet.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('leaves the row due when the fleet refuses the job', async () => {
+            const { service } = build({ enqueueError: new Error('queue down') });
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            const summary = await service.enqueueDueChecks(now);
+
+            expect(summary.enqueued).toBe(0);
+            const stored = await reload(row.id);
+            // Still due, still no attempt burned, and the deadline still
+            // ends it if the fleet stays broken.
+            expect(stored.verifyAttempts).toBe(0);
+            expect(stored.verifyJobId).toBeNull();
+            expect(stored.verifyState).toBe('awaiting-rollout');
+        });
+
+        it('does not let one bad row stop the sweep for the rest', async () => {
+            const { service, works, fleet } = build();
+            const bad = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: new Date(past.getTime() - 1000),
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+            await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyRetryAt: past,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+            works.findById.mockImplementation((id: string) =>
+                id === WORK && works.findById.mock.calls.length === 1
+                    ? Promise.reject(new Error('transient'))
+                    : Promise.resolve(makeWork()),
+            );
+
+            const summary = await service.enqueueDueChecks(now);
+
+            expect(summary.considered).toBe(2);
+            expect(fleet.enqueue).toHaveBeenCalledTimes(1);
+            // And the row that threw is left exactly as the per-row catch
+            // promises: STILL DUE, no attempt burned, nothing settled. This
+            // used to be `expect(bad).toBeTruthy()` — a tautology on a value
+            // `seed()` had just returned, which could not fail for any
+            // change to the code under test. A catch block that settled the
+            // row, or nulled its `verifyRetryAt` so it dropped out of
+            // `findVerificationsDue` for ever, passed the old assertion.
+            const failed = await reload(bad.id);
+            expect(failed.verifyState).toBe('awaiting-rollout');
+            expect(failed.verifyAttempts).toBe(0);
+            expect(failed.verifyJobId).toBeNull();
+            expect(failed.verifyRetryAt).not.toBeNull();
+            expect((await promotions.findVerificationsDue(now)).map((row) => row.id)).toContain(
+                bad.id,
+            );
+        });
+
+        // ── The job handed back is not always the job we asked for ────
+
+        describe('the job `enqueue` returns is checked before it is recorded', () => {
+            /**
+             * `FleetJobService.enqueue` short-circuits on the idempotency
+             * key with `FleetJobRepository.findByIdempotencyKey`, a bare
+             * `findOne({ where: { idempotencyKey } })` — no status filter,
+             * no owner scope, no kind check. Every case below is a job it
+             * would hand back for a key this lane derived, and none of them
+             * is a check this lane can read a verdict from.
+             *
+             * In every one the attempt is BURNED rather than bound: the next
+             * sweep derives attempt N+1, therefore a different key,
+             * therefore a genuinely new job. Binding instead would wedge the
+             * row for its whole eight-hour budget, because `sweepOne` will
+             * not enqueue while `verifyJobId` is set.
+             */
+            async function dueRow() {
+                return seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+                });
+            }
+
+            it.each([
+                [
+                    'it has ALREADY SETTLED, so no completion will ever arrive',
+                    {
+                        enqueueReturns: (input: Record<string, unknown>) => ({
+                            id: 'job-done',
+                            kind: 'browser-check',
+                            status: 'done',
+                            payload: input.payload,
+                        }),
+                    },
+                ],
+                [
+                    'it settled FAILED before we ever saw it',
+                    {
+                        enqueueReturns: (input: Record<string, unknown>) => ({
+                            id: 'job-failed',
+                            kind: 'browser-check',
+                            status: 'failed',
+                            payload: input.payload,
+                        }),
+                    },
+                ],
+                [
+                    'it is a different KIND of job',
+                    {
+                        enqueueReturns: (input: Record<string, unknown>) => ({
+                            id: 'job-other',
+                            kind: 'agent-task',
+                            status: 'queued',
+                            payload: input.payload,
+                        }),
+                    },
+                ],
+                [
+                    'its payload points somewhere this lane never chose',
+                    {
+                        enqueueReturns: () => ({
+                            id: 'job-evil',
+                            kind: 'browser-check',
+                            status: 'queued',
+                            payload: {
+                                url: 'https://attacker.example.com/page',
+                                expectText: MERGED.slice(0, 12),
+                            },
+                        }),
+                    },
+                ],
+                ['it belongs to somebody else', { enqueueOwner: OTHER_USER }],
+            ])('refuses a job because %s', async (_label, opts) => {
+                const { service } = build(opts as never);
+                const row = await dueRow();
+
+                const summary = await service.enqueueDueChecks(now);
+
+                expect(summary.enqueued).toBe(0);
+                const stored = await reload(row.id);
+                // NOT bound — this is the whole point. A bound row is deaf
+                // to the sweep until its deadline.
+                expect(stored.verifyJobId).toBeNull();
+                // But the attempt IS burned, so the next key differs.
+                expect(stored.verifyAttempts).toBe(1);
+                expect(stored.verifyState).toBe('awaiting-rollout');
+                expect(stored.verifyDetail).toContain('Attempt 1 could not be started');
+            });
+
+            it('re-enqueues under a DIFFERENT key on the next pass, so it cannot loop', async () => {
+                const { service, fleet } = build({
+                    enqueueReturns: (input: Record<string, unknown>, seq: number) => ({
+                        id: `job-${seq}`,
+                        kind: 'browser-check',
+                        // Always settled: the pathological case.
+                        status: 'done',
+                        payload: input.payload,
+                    }),
+                });
+                await dueRow();
+
+                await service.enqueueDueChecks(now);
+                await service.enqueueDueChecks(new Date(now.getTime() + 60_000));
+
+                expect(fleet.enqueue.mock.calls.map((call) => call[0].idempotencyKey)).toEqual([
+                    expect.stringMatching(/:1$/),
+                    expect.stringMatching(/:2$/),
+                ]);
+            });
+
+            it('still bounds itself — a fleet that only returns settled jobs runs out of attempts', async () => {
+                const { service } = build({
+                    enqueueReturns: (input: Record<string, unknown>, seq: number) => ({
+                        id: `job-${seq}`,
+                        kind: 'browser-check',
+                        status: 'done',
+                        payload: input.payload,
+                    }),
+                });
+                const row = await seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyAttempts: RELEASE_VERIFY_MAX_ATTEMPTS - 1,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+                });
+
+                await service.enqueueDueChecks(now);
+                await service.enqueueDueChecks(new Date(now.getTime() + 60_000));
+
+                expect((await reload(row.id)).verifyState).toBe('inconclusive');
+            });
+
+            it('binds a job that IS the check it asked for', async () => {
+                // The negative control for every refusal above.
+                const { service } = build();
+                const row = await dueRow();
+
+                await service.enqueueDueChecks(now);
+
+                const stored = await reload(row.id);
+                expect(stored.verifyJobId).toBe('job-1');
+                expect(stored.verifyAttempts).toBe(1);
+            });
+        });
+
+        // ── A check that settled with nobody listening ────────────────
+
+        describe('an in-flight check is reconciled, not assumed', () => {
+            /**
+             * `onBrowserCheckCompleted` and the api-side listener both
+             * swallow their own failures by contract, so one transient
+             * database error — or an API replica restarting between the
+             * fleet's write and the `@OnEvent` handler — drops a result for
+             * ever. The job is terminal, `verifyJobId` stays set, and the
+             * sweep used to answer `skipped` every five minutes until the
+             * eight-hour deadline settled the row `inconclusive` for a
+             * reason that never happened.
+             */
+            function jobRows(job: Record<string, unknown>) {
+                return new Map<string, Record<string, unknown>>([
+                    ['job-out', { id: 'job-out', kind: 'browser-check', userId: USER, ...job }],
+                ]);
+            }
+
+            async function inFlight(job: Record<string, unknown>) {
+                const built = build({ fleetJobRows: jobRows(job) });
+                const row = await seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyJobId: 'job-out',
+                    verifyAttempts: 1,
+                    verifyStreak: RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+                });
+                return { ...built, row };
+            }
+
+            it('reads a dropped PASS off the job row and advances the verification', async () => {
+                const { service, row } = await inFlight({
+                    status: 'done',
+                    result: { ok: true, title: 'version' },
+                });
+
+                const summary = await service.enqueueDueChecks(now);
+
+                expect(summary.recovered).toBe(1);
+                const stored = await reload(row.id);
+                // The streak completed, so the rollout is confirmed and the
+                // lane moved on — exactly as the listener would have done.
+                expect(stored.verifyState).toBe('checking-app');
+                expect(stored.verifyJobId).toBeNull();
+            });
+
+            it('reads a dropped FAILURE off the job row without calling it a pass', async () => {
+                const { service, row } = await inFlight({
+                    status: 'failed',
+                    error: 'Browser exited with code 1',
+                });
+
+                await service.enqueueDueChecks(now);
+
+                const stored = await reload(row.id);
+                expect(stored.verifyState).toBe('awaiting-rollout');
+                // Not a pass: the streak resets.
+                expect(stored.verifyStreak).toBe(0);
+                expect(stored.verifyJobId).toBeNull();
+                expect(stored.verifyDetail).toContain('Browser exited with code 1');
+            });
+
+            it.each([
+                ['a done job with no result', { status: 'done', result: null }],
+                [
+                    'a done job whose ok is the STRING true',
+                    { status: 'done', result: { ok: 'true' } },
+                ],
+                ['a done job whose ok is 1', { status: 'done', result: { ok: 1 } }],
+            ])('does not treat %s as a pass', async (_label, job) => {
+                const { service, row } = await inFlight(job);
+
+                await service.enqueueDueChecks(now);
+
+                expect((await reload(row.id)).verifyStreak).toBe(0);
+            });
+
+            it('does not touch a check that is still running — it reschedules it', async () => {
+                // The pair: recovery must not steal a job a node is holding.
+                const { service, row } = await inFlight({ status: 'running', result: null });
+
+                const summary = await service.enqueueDueChecks(now);
+
+                expect(summary.recovered).toBe(0);
+                const stored = await reload(row.id);
+                expect(stored.verifyJobId).toBe('job-out');
+                expect(stored.verifyStreak).toBe(RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1);
+            });
+
+            it('pushes a still-running row DOWN the sweep queue, so it cannot starve other owners', async () => {
+                // `findVerificationsDue` pages 25 rows platform-wide ordered
+                // `verifyRetryAt ASC`. A skipped in-flight row that was never
+                // rescheduled stayed permanently `verifyRetryAt <= now` and
+                // drifted further into the past on every pass, so 25 of them
+                // filled the page for ever and no other tenant's promotion
+                // was enqueued or expired again.
+                const { service, row } = await inFlight({ status: 'queued', result: null });
+
+                await service.enqueueDueChecks(now);
+
+                const stored = await reload(row.id);
+                expect(new Date(stored.verifyRetryAt!).getTime()).toBe(
+                    now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+                );
+                // Not due any more at `now`, so it yields its slot.
+                expect((await promotions.findVerificationsDue(now)).map((r) => r.id)).not.toContain(
+                    row.id,
+                );
+            });
+
+            it('still enforces the DEADLINE on a row whose check never comes back', async () => {
+                // Rescheduling must not become a way to postpone the bound.
+                const { service } = build({ fleetJobRows: jobRows({ status: 'running' }) });
+                const row = await seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyJobId: 'job-out',
+                    verifyAttempts: 1,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() - 1),
+                });
+
+                await service.enqueueDueChecks(now);
+
+                expect((await reload(row.id)).verifyState).toBe('inconclusive');
+            });
+
+            it('lets go of a binding to a job that does not exist at all', async () => {
+                const { service } = build({
+                    fleetJobRows: new Map<string, Record<string, unknown>>(),
+                });
+                const row = await seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyJobId: 'job-vanished',
+                    verifyAttempts: 1,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+                });
+
+                await service.enqueueDueChecks(now);
+
+                const stored = await reload(row.id);
+                expect(stored.verifyJobId).toBeNull();
+                expect(stored.verifyAttempts).toBe(2);
+                expect(stored.verifyState).toBe('awaiting-rollout');
+            });
+
+            it('degrades to rescheduling — never to inventing a verdict — with no job reader bound', async () => {
+                const { service } = build({ noFleetJobs: true });
+                const row = await seed({
+                    verifyState: 'awaiting-rollout',
+                    verifyExpectedSha: MERGED,
+                    verifyJobId: 'job-out',
+                    verifyAttempts: 1,
+                    verifyStreak: RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1,
+                    verifyRetryAt: past,
+                    verifyDeadlineAt: new Date(now.getTime() + 86_400_000),
+                });
+
+                await service.enqueueDueChecks(now);
+
+                const stored = await reload(row.id);
+                expect(stored.verifyJobId).toBe('job-out');
+                expect(stored.verifyStreak).toBe(RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1);
+                expect(new Date(stored.verifyRetryAt!).getTime()).toBe(
+                    now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+                );
+            });
+        });
+    });
+
+    // ── Reading a verdict ─────────────────────────────────────────────
+
+    describe('onBrowserCheckCompleted — the rollout phase', () => {
+        async function rollingOut(overrides: Partial<ReleasePromotion> = {}) {
+            return seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-1',
+                verifyAttempts: 1,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+                ...overrides,
+            });
+        }
+
+        it('does not advance on ONE sighting of the promoted commit', async () => {
+            // ArgoCD replaces pods gradually, so one sample is a coin flip.
+            const { service } = build();
+            const row = await rollingOut();
+
+            await service.onBrowserCheckCompleted('job-1', true, 'ok', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('awaiting-rollout');
+            expect(stored.verifyStreak).toBe(1);
+            expect(RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS).toBeGreaterThan(1);
+        });
+
+        it('advances to the app check after consecutive sightings', async () => {
+            const { service } = build();
+            const row = await rollingOut({
+                verifyStreak: RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1,
+            });
+
+            await service.onBrowserCheckCompleted('job-1', true, 'ok', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('checking-app');
+            expect(stored.verifyStreak).toBe(0);
+        });
+
+        it('resets the streak on a miss — the confirmations must be CONSECUTIVE', async () => {
+            const { service } = build();
+            const row = await rollingOut({
+                verifyStreak: RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS - 1,
+            });
+
+            await service.onBrowserCheckCompleted('job-1', false, 'old sha', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('awaiting-rollout');
+            expect(stored.verifyStreak).toBe(0);
+        });
+
+        it('treats a miss as WAITING, not as a failed release', async () => {
+            // For a production release the expected answer for the first
+            // three or four hours is "the old build is still serving".
+            const { service, inbox } = build();
+            const row = await rollingOut();
+
+            await service.onBrowserCheckCompleted('job-1', false, 'old sha', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).not.toBe('failed');
+            expect(stored.revertTaskId).toBeNull();
+            expect(inbox.notice).not.toHaveBeenCalled();
+            expect(new Date(stored.verifyRetryAt!).getTime()).toBe(
+                now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+            );
+        });
+
+        it('a rollout that never arrives is INCONCLUSIVE, never failed, and offers nothing', async () => {
+            // The single most important refusal in the slice: a deploy that
+            // did not happen is not a broken release, and must not put a
+            // revert in front of a human.
+            const { service, tasksService, inbox } = build();
+            const row = await rollingOut({ verifyDeadlineAt: past });
+
+            await service.onBrowserCheckCompleted('job-1', false, 'still the old sha', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.revertTaskId).toBeNull();
+            expect(tasksService.create).not.toHaveBeenCalled();
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].body).toContain('No revert has been offered');
+        });
+    });
+
+    describe('onBrowserCheckCompleted — the app phase', () => {
+        async function checkingApp(overrides: Partial<ReleasePromotion> = {}) {
+            return seed({
+                verifyState: 'checking-app',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-1',
+                verifyAttempts: 4,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+                ...overrides,
+            });
+        }
+
+        it('passes on a rendering app, and offers no revert', async () => {
+            const { service, tasksService, inbox } = build();
+            const row = await checkingApp();
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyRetryAt).toBeNull();
+            expect(stored.revertTaskId).toBeNull();
+            expect(tasksService.create).not.toHaveBeenCalled();
+            expect(inbox.notice.mock.calls[0][1].title).toContain('VERIFIED');
+        });
+
+        it('does NOT claim the app deployment rolled out when the app probe cannot prove it', async () => {
+            // The artefact identity is established at `versionUrl` only.
+            // The app phase then reads a DIFFERENT url with whatever
+            // expectation the operator configured, and the shipped
+            // recommendation is a fixed `"status":"OK"` health string that
+            // an old bundle answers identically. So a `stage -> main`
+            // promotion whose API image rolled out and whose WEB deployment
+            // failed its rollout entirely used to be reported as
+            // "Deployment VERIFIED … The app rendered as expected. Nothing
+            // further is required."
+            const { service, inbox, chat } = build();
+            const row = await checkingApp();
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            const detail = stored.verifyDetail ?? '';
+            expect(detail).toContain('does NOT prove the app deployment itself rolled out');
+            expect(detail).toContain(new URL(PRODUCTION.appUrl).hostname);
+            expect(detail).not.toContain('The app rendered the promoted commit');
+            // And the founder is not told to stop looking.
+            const narrated = chat.create.mock.calls
+                .map((call: Array<{ body: string }>) => call[0].body)
+                .join(' ');
+            expect(narrated).not.toContain('Nothing further is required');
+            expect(narrated).toContain('Confirm the app deployment itself by hand');
+            expect(inbox.notice.mock.calls[0][1].body).toContain(
+                'does NOT prove the app deployment itself rolled out',
+            );
+        });
+
+        it('DOES claim it when the app expectation carries the promoted commit', async () => {
+            // The positive control, and the configuration the runbook now
+            // recommends: point the app probe at a page that renders the
+            // build sha and the app half becomes artefact-aware too.
+            const { service, chat } = build({
+                work: {
+                    releaseVerification: {
+                        production: {
+                            ...PRODUCTION,
+                            appUrl: 'https://app.ever.works/build-info',
+                            appExpectText: MERGED.slice(0, 12),
+                        },
+                    },
+                },
+            });
+            const row = await checkingApp();
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyDetail).toContain('The app rendered the promoted commit');
+            const narrated = chat.create.mock.calls
+                .map((call: Array<{ body: string }>) => call[0].body)
+                .join(' ');
+            expect(narrated).toContain('Nothing further is required');
+        });
+
+        it('claims the WEAKER thing when the target can no longer be read', async () => {
+            // Fails to the conservative answer rather than throwing: a
+            // verdict that cannot check what it measured must not assert the
+            // stronger claim.
+            const { service, works } = build();
+            const row = await checkingApp();
+            works.findById.mockRejectedValue(new Error('gone'));
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyDetail).toContain('does NOT prove the app deployment itself');
+        });
+
+        it('does not conclude anything on ONE failed page load', async () => {
+            const { service } = build();
+            const row = await checkingApp();
+
+            await service.onBrowserCheckCompleted('job-1', false, 'expected text missing', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('checking-app');
+            expect(stored.verifyStreak).toBe(1);
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('goes to CONFIRMING, not to failed, after a full failure streak', async () => {
+            // "The app is broken" and "this node lost the internet" are the
+            // same browser result. The lane goes and asks before it speaks.
+            const { service, tasksService } = build();
+            const row = await checkingApp({
+                verifyStreak: RELEASE_VERIFY_FAILURE_CONFIRMATIONS - 1,
+            });
+
+            await service.onBrowserCheckCompleted('job-1', false, 'still down', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('confirming-failure');
+            expect(stored.verifyState).not.toBe('failed');
+            expect(tasksService.create).not.toHaveBeenCalled();
+        });
+
+        it('passes rather than reverting when a flapping app comes back green', async () => {
+            // THE flap. Reverting a release that is currently serving pages
+            // on the strength of an earlier blip is the failure this
+            // ordering exists to prevent — but the human is told it was not
+            // clean.
+            const { service } = build();
+            const row = await checkingApp({
+                verifyStreak: RELEASE_VERIFY_FAILURE_CONFIRMATIONS - 1,
+                verifyAttempts: 9,
+            });
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyDetail).toContain('not clean');
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('does not call a slow-but-clean production rollout "not clean"', async () => {
+            // Waiting hours for the build lane is the NORMAL case on this
+            // repository, so a warning keyed on total attempts would fire on
+            // every healthy production release and stop meaning anything.
+            const { service } = build();
+            const row = await checkingApp({ verifyStreak: 0, verifyAttempts: 30 });
+
+            await service.onBrowserCheckCompleted('job-1', true, 'Page loaded', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyDetail).not.toContain('not clean');
+        });
+
+        it('is INCONCLUSIVE, not failed, if the budget runs out mid-streak', async () => {
+            const { service, tasksService } = build();
+            const row = await checkingApp({ verifyDeadlineAt: past });
+
+            await service.onBrowserCheckCompleted('job-1', false, 'down', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(tasksService.create).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('onBrowserCheckCompleted — the confirmation', () => {
+        async function confirming(overrides: Partial<ReleasePromotion> = {}) {
+            return seed({
+                verifyState: 'confirming-failure',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-1',
+                verifyAttempts: 8,
+                verifyTargetUrl: PRODUCTION.versionUrl,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+                ...overrides,
+            });
+        }
+
+        it('fails — and offers a revert — only when the environment is confirmed reachable', async () => {
+            const { service, tasksService, inbox } = build();
+            const row = await confirming();
+
+            await service.onBrowserCheckCompleted('job-1', true, 'version ok', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('failed');
+            expect(stored.revertTaskId).toBe('revert-task-1');
+            expect(stored.revertOfferedAt).toBeTruthy();
+            expect(tasksService.create).toHaveBeenCalledTimes(1);
+            // Two notices: the verdict, then the revert offer.
+            expect(inbox.notice).toHaveBeenCalledTimes(2);
+        });
+
+        it('is INCONCLUSIVE with NO offer when the node cannot reach the environment either', async () => {
+            // THE flaky-node refusal. If the version endpoint does not
+            // answer, the failing app checks are evidence about this node's
+            // network, not about the release.
+            const { service, tasksService, inbox } = build();
+            const row = await confirming();
+
+            await service.onBrowserCheckCompleted('job-1', false, 'connection refused', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('inconclusive');
+            expect(stored.revertTaskId).toBeNull();
+            expect(tasksService.create).not.toHaveBeenCalled();
+            expect(inbox.notice).toHaveBeenCalledTimes(1);
+            expect(inbox.notice.mock.calls[0][1].body).toContain('No revert has been offered');
+        });
+    });
+
+    describe('onBrowserCheckCompleted — what it ignores', () => {
+        it('ignores a job no promotion is pointing at', async () => {
+            const { service } = build();
+            const row = await seed({ verifyState: 'awaiting-rollout', verifyJobId: 'job-1' });
+
+            await service.onBrowserCheckCompleted('somebody-elses-job', true, 'ok', now);
+
+            expect((await reload(row.id)).verifyState).toBe('awaiting-rollout');
+        });
+
+        it('ignores a LATE report from a superseded job', async () => {
+            // The row moved on (its deadline expired and the sweep settled
+            // it, say). A stale completion must not resurrect it.
+            const { service } = build();
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-2',
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.onBrowserCheckCompleted('job-1', true, 'ok', now);
+
+            expect((await reload(row.id)).verifyStreak).toBe(0);
+        });
+
+        it('ignores a report for a verification that already settled', async () => {
+            const { service } = build();
+            const row = await seed({ verifyState: 'passed', verifyJobId: null });
+
+            await service.onBrowserCheckCompleted('job-1', false, 'down', now);
+
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.revertTaskId).toBeNull();
+        });
+
+        it('never throws', async () => {
+            const { service } = build();
+            await seed({ verifyState: 'confirming-failure', verifyJobId: 'job-1' });
+
+            await expect(
+                service.onBrowserCheckCompleted('job-1', true, 'ok', new Date(Number.NaN)),
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    // ── The revert OFFER ──────────────────────────────────────────────
+
+    describe('the revert offer', () => {
+        async function failThrough() {
+            const built = build();
+            const row = await seed({
+                verifyState: 'confirming-failure',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-1',
+                verifyTargetUrl: PRODUCTION.appUrl,
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+            await built.service.onBrowserCheckCompleted('job-1', true, 'version ok', now);
+            return { ...built, row };
+        }
+
+        it('files an INERT Task — in review, so nothing dispatches an agent against it', async () => {
+            // `TaskGraphFanoutService` starts unblocked TODO Tasks. A revert
+            // Task filed TODO would be a platform that reverts production by
+            // itself the moment a check goes red.
+            const { tasksService } = await failThrough();
+
+            const input = tasksService.create.mock.calls[0][1];
+            expect(input.status).toBe(TaskStatus.IN_REVIEW);
+            expect(input.status).not.toBe(TaskStatus.TODO);
+        });
+
+        it('files it as an ORDINARY Task, with no promotion label — that is what breaks the cycle', async () => {
+            // A revert Task carrying `release:promotion` would be picked up
+            // by the promotion refresh and the promotion merge guard, and a
+            // revert that opened a promotion would trigger another
+            // verification which could offer another revert.
+            const { tasksService } = await failThrough();
+
+            const input = tasksService.create.mock.calls[0][1];
+            expect(input.labels).toContain(RELEASE_REVERT_TASK_LABEL);
+            expect(input.labels).not.toContain(PROMOTION_TASK_LABEL);
+        });
+
+        it('creates the Task for the promotion’s OWNER, from the row', async () => {
+            const { tasksService } = await failThrough();
+
+            expect(tasksService.create.mock.calls[0][0]).toBe(USER);
+            expect(tasksService.create.mock.calls[0][1].createdById).toBe(USER);
+        });
+
+        it('carries the coordinates a human needs: the promotion PR and the commit', async () => {
+            const { tasksService, row } = await failThrough();
+
+            const description: string = tasksService.create.mock.calls[0][1].description;
+            expect(description).toContain(row.prUrl);
+            expect(description).toContain(MERGED);
+            expect(description).toContain('main');
+        });
+
+        it('says, in the Task and in the Inbox, that nothing has been reverted', async () => {
+            const { tasksService, inbox } = await failThrough();
+
+            expect(tasksService.create.mock.calls[0][1].description).toContain(
+                'Nothing has been reverted',
+            );
+            const revertNotice = inbox.notice.mock.calls[1][1];
+            expect(revertNotice.body).toContain('NOTHING HAS BEEN REVERTED');
+            // And it says what the human must decide.
+            expect(revertNotice.body).toContain('Roll forward');
+            expect(revertNotice.body).toContain('needs the same "Merge pull request" approval');
+        });
+
+        it('is offered at most ONCE, however many times the failure is observed', async () => {
+            const { service, tasksService, row } = await failThrough();
+            expect(tasksService.create).toHaveBeenCalledTimes(1);
+
+            // A second observation against the settled row.
+            await service.onBrowserCheckCompleted('job-1', true, 'version ok', now);
+
+            expect(tasksService.create).toHaveBeenCalledTimes(1);
+            expect((await reload(row.id)).revertTaskId).toBe('revert-task-1');
+        });
+
+        it('survives the Task write failing, without claiming an offer was made', async () => {
+            const { service, tasksService, inbox, chat } = build({
+                createTaskError: new Error('no'),
+            });
+            const row = await seed({
+                verifyState: 'confirming-failure',
+                verifyExpectedSha: MERGED,
+                verifyJobId: 'job-1',
+                verifyDeadlineAt: new Date(now.getTime() + 3_600_000),
+            });
+
+            await service.onBrowserCheckCompleted('job-1', true, 'version ok', now);
+
+            const stored = await reload(row.id);
+            // The verdict still stands; only the offer is missing.
+            expect(stored.verifyState).toBe('failed');
+            expect(stored.revertTaskId).toBeNull();
+            // TWICE, not once: the first attempt carries the node's own
+            // reading, which `TasksService.create` runs through
+            // `assertNoSecrets` and can refuse for a token-shaped substring
+            // in a browser error string; the retry drops the reading rather
+            // than losing the whole offer. Both fail here.
+            expect(tasksService.create).toHaveBeenCalledTimes(2);
+            expect(tasksService.create.mock.calls[0][1].description).toContain(
+                '- Reading: The environment is serving',
+            );
+            expect(tasksService.create.mock.calls[1][1].description).toContain(
+                '- Reading: see the promotion Task thread',
+            );
+
+            // AND — the reason the ordering was changed — the human is not
+            // told a revert is waiting for them. Before the slice-AJ review
+            // the verdict was narrated before the offer was attempted, so
+            // this said "a revert Task has been prepared and is waiting in
+            // review" for a Task that did not exist, on a TERMINAL verdict
+            // the sweep never revisits.
+            const notice = inbox.notice.mock.calls[0][1];
+            expect(notice.title).toContain('NO revert could be prepared');
+            expect(notice.body).toContain('could NOT be filed');
+            expect(notice.body).not.toContain('has been prepared and is waiting in review');
+            const narrated = chat.create.mock.calls
+                .map((call: Array<{ body: string }>) => call[0].body)
+                .join(' ');
+            expect(narrated).toContain('could NOT be prepared');
+            expect(narrated).toContain('NOTHING HAS BEEN REVERTED');
+        });
+
+        it('files the offer BEFORE it narrates the verdict, so the notice can tell the truth', async () => {
+            // The positive control for the test above: when the Task write
+            // succeeds, the notice says so — and it can only say so because
+            // `revertTaskId` is already on the row by the time it is built.
+            const { inbox, row } = await failThrough();
+
+            expect((await reload(row.id)).revertTaskId).toBe('revert-task-1');
+            expect(inbox.notice.mock.calls[0][1].title).toContain('revert prepared');
+            expect(inbox.notice.mock.calls[0][1].body).toContain(
+                'has been prepared and is waiting in review',
+            );
+        });
+
+        it('names BOTH hosts in the failure, because they are not the same origin', async () => {
+            // `confirming-failure` re-probes the VERSION url to tell "the
+            // app is broken" apart from "this node lost the internet" — and
+            // that is a different origin from the one that failed. A bot
+            // interstitial, an HTTP Basic wall or a proxy rule scoped to the
+            // app host alone fails three app probes and is then "confirmed"
+            // by a healthy version host. The person deciding on a revert is
+            // told which origin produced which half of the evidence.
+            const { row } = await failThrough();
+
+            const detail = (await reload(row.id)).verifyDetail ?? '';
+            expect(detail).toContain(new URL(PRODUCTION.appUrl).hostname);
+            expect(detail).toContain(new URL(PRODUCTION.versionUrl).hostname);
+            expect(detail).toContain('would look the same from this node');
+        });
+    });
+
+    describe('the compare-and-set guards, exercised against the real table', () => {
+        /**
+         * Slice-AJ review. This file's header claimed every compare-and-set
+         * that makes the lane safe across replicas was "EXERCISED rather
+         * than mocked". It was not: four of the five `.andWhere` clauses
+         * could be DELETED from `ReleasePromotionRepository` with all sixty
+         * tests still green, because each one had an in-process guard in
+         * front of it that satisfied the assertion on its own — `sweepOne`'s
+         * `if (promotion.verifyJobId) return 'skipped'` stood in for the
+         * attempt claim, `findByVerifyJobId` returning null stood in for the
+         * result pin, and so on.
+         *
+         * These call the repository DIRECTLY, from a state the guard is
+         * supposed to refuse, and assert both the boolean and that the row
+         * did not move. Deleting any one clause fails one of them.
+         */
+        it('beginVerification refuses a row that already has a state', async () => {
+            const row = await seed({ verifyState: 'awaiting-rollout', verifyExpectedSha: MERGED });
+
+            const started = await promotions.beginVerification(row.id, {
+                verifyState: 'awaiting-rollout',
+                verifyExpectedSha: 'cccccccccccccccccccccccccccccccccccccccc',
+                verifyTargetUrl: PRODUCTION.versionUrl,
+                verifyStartedAt: now,
+                verifyDeadlineAt: now,
+                verifyRetryAt: now,
+                verifyDetail: null,
+            });
+
+            expect(started).toBe(false);
+            // Not merely "returned false": the row is untouched, which is
+            // what stops a second replica re-baselining a live verification.
+            expect((await reload(row.id)).verifyExpectedSha).toBe(MERGED);
+        });
+
+        it('claimVerifyAttempt refuses while another job is already claimed', async () => {
+            // THE mutual exclusion: at most one browser is ever pointed at
+            // one environment for one promotion.
+            const row = await seed({ verifyState: 'awaiting-rollout', verifyJobId: 'job-first' });
+
+            const claimed = await promotions.claimVerifyAttempt(row.id, 'awaiting-rollout', {
+                jobId: 'job-second',
+                attempts: 9,
+                targetUrl: PRODUCTION.versionUrl,
+                reconsiderAt: now,
+            });
+
+            expect(claimed).toBe(false);
+            const stored = await reload(row.id);
+            expect(stored.verifyJobId).toBe('job-first');
+            expect(stored.verifyAttempts).toBe(0);
+        });
+
+        it('claimVerifyAttempt refuses from a state the row has left', async () => {
+            const row = await seed({ verifyState: 'checking-app' });
+
+            const claimed = await promotions.claimVerifyAttempt(row.id, 'awaiting-rollout', {
+                jobId: 'job-1',
+                attempts: 1,
+                targetUrl: PRODUCTION.versionUrl,
+                reconsiderAt: now,
+            });
+
+            expect(claimed).toBe(false);
+            expect((await reload(row.id)).verifyJobId).toBeNull();
+        });
+
+        it('recordVerifyResult refuses a result from a SUPERSEDED job', async () => {
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyJobId: 'job-current',
+                verifyStreak: 1,
+            });
+
+            const applied = await promotions.recordVerifyResult(
+                row.id,
+                { jobId: 'job-stale', state: 'awaiting-rollout' },
+                {
+                    verifyState: 'checking-app',
+                    verifyStreak: 99,
+                    verifyCheckedAt: now,
+                    verifyRetryAt: now,
+                    verifyDetail: 'from the wrong job',
+                },
+            );
+
+            expect(applied).toBe(false);
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('awaiting-rollout');
+            expect(stored.verifyStreak).toBe(1);
+            expect(stored.verifyJobId).toBe('job-current');
+        });
+
+        it('recordVerifyResult refuses a result read against a state the row has left', async () => {
+            const row = await seed({ verifyState: 'confirming-failure', verifyJobId: 'job-1' });
+
+            const applied = await promotions.recordVerifyResult(
+                row.id,
+                { jobId: 'job-1', state: 'checking-app' },
+                {
+                    verifyState: 'checking-app',
+                    verifyStreak: 2,
+                    verifyCheckedAt: now,
+                    verifyRetryAt: now,
+                    verifyDetail: 'late',
+                },
+            );
+
+            expect(applied).toBe(false);
+            expect((await reload(row.id)).verifyState).toBe('confirming-failure');
+        });
+
+        it('settleVerification refuses from a state the row has left — one verdict, one notice', async () => {
+            // This pin is what makes "exactly one Inbox item per verdict"
+            // true across replicas: the service narrates only when it
+            // returned true.
+            const row = await seed({ verifyState: 'passed', verifyDetail: 'the real verdict' });
+
+            const applied = await promotions.settleVerification(row.id, 'checking-app', {
+                verifyState: 'failed',
+                verifyCheckedAt: now,
+                verifyDetail: 'a second replica settling the same row',
+            });
+
+            expect(applied).toBe(false);
+            const stored = await reload(row.id);
+            expect(stored.verifyState).toBe('passed');
+            expect(stored.verifyDetail).toBe('the real verdict');
+        });
+
+        it('settleVerification lands exactly once for two racing callers', async () => {
+            const row = await seed({ verifyState: 'checking-app' });
+            const patch = {
+                verifyState: 'passed' as const,
+                verifyCheckedAt: now,
+                verifyDetail: 'ok',
+            };
+
+            expect(await promotions.settleVerification(row.id, 'checking-app', patch)).toBe(true);
+            expect(await promotions.settleVerification(row.id, 'checking-app', patch)).toBe(false);
+        });
+
+        it('burnVerifyAttempt refuses to touch a row with a live claim', async () => {
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyJobId: 'job-live',
+                verifyAttempts: 1,
+            });
+
+            const burned = await promotions.burnVerifyAttempt(row.id, 'awaiting-rollout', {
+                attempts: 7,
+                reconsiderAt: now,
+                detail: 'nope',
+            });
+
+            expect(burned).toBe(false);
+            expect((await reload(row.id)).verifyAttempts).toBe(1);
+        });
+
+        it('deferVerification only reschedules the row it is still waiting on', async () => {
+            const row = await seed({ verifyState: 'awaiting-rollout', verifyJobId: 'job-1' });
+
+            expect(
+                await promotions.deferVerification(row.id, 'awaiting-rollout', 'job-other', now),
+            ).toBe(false);
+            expect(
+                await promotions.deferVerification(row.id, 'awaiting-rollout', 'job-1', now),
+            ).toBe(true);
+            expect(new Date((await reload(row.id)).verifyRetryAt!).getTime()).toBe(now.getTime());
+        });
+
+        it('releaseVerifyJob only lets go of the job the row is actually bound to', async () => {
+            const row = await seed({
+                verifyState: 'awaiting-rollout',
+                verifyJobId: 'job-1',
+                verifyAttempts: 1,
+            });
+
+            expect(
+                await promotions.releaseVerifyJob(row.id, 'awaiting-rollout', 'job-other', {
+                    attempts: 2,
+                    reconsiderAt: now,
+                    detail: null,
+                }),
+            ).toBe(false);
+            expect((await reload(row.id)).verifyJobId).toBe('job-1');
+        });
+    });
+
+    describe('the database refuses a revert offer the state does not justify', () => {
+        it.each(['passed', 'inconclusive', 'unsupported', 'awaiting-rollout'] as const)(
+            'refuses to record one for a %s verification',
+            async (state) => {
+                // The last line of the "an inconclusive verdict does not
+                // trigger a revert" rule, underneath the service check and
+                // the contracts predicate: `claimRevertOffer` writes only
+                // `WHERE verifyState = 'failed'`.
+                const row = await seed({ verifyState: state });
+
+                const claimed = await promotions.claimRevertOffer(row.id, 'task-x', now);
+
+                expect(claimed).toBe(false);
+                expect((await reload(row.id)).revertTaskId).toBeNull();
+            },
+        );
+
+        it('records one exactly once for a failed verification', async () => {
+            const row = await seed({ verifyState: 'failed' });
+
+            expect(await promotions.claimRevertOffer(row.id, 'task-x', now)).toBe(true);
+            expect(await promotions.claimRevertOffer(row.id, 'task-y', now)).toBe(false);
+            expect((await reload(row.id)).revertTaskId).toBe('task-x');
+        });
+    });
+
+    // ── The absences ──────────────────────────────────────────────────
+
+    describe('what this service cannot do', () => {
+        const source = readFileSync(
+            join(__dirname, '..', 'release-verification.service.ts'),
+            'utf8',
+        );
+
+        it('contains no call that could revert, merge, push or deploy anything', () => {
+            // Read from SOURCE rather than asserted behaviourally, so that
+            // ADDING one fails rather than merely exercising one. The class
+            // docblock names the slice-AE merge path in prose when
+            // explaining where a revert would have to go, and that sentence
+            // is worth keeping — so these match CALL SITES.
+            expect(source).not.toMatch(/\.mergePullRequest\(/);
+            expect(source).not.toMatch(/\.createPullRequest\(/);
+            expect(source).not.toMatch(/\.createBranch\(/);
+            expect(source).not.toMatch(/\.push\(/);
+            expect(source).not.toMatch(/attemptMergeForOpenPullRequest\(/);
+            expect(source).not.toMatch(/attemptAgentMerge\(/);
+            expect(source).not.toMatch(/\.deploy\(/);
+            expect(source).not.toMatch(/\.rollback\(/);
+        });
+
+        it('cannot open a promotion, so a revert cannot start another release', () => {
+            expect(source).not.toMatch(/openPromotion\(/);
+        });
+
+        it('enqueues fleet work in exactly one place', () => {
+            // The producer is `enqueueProbe`, reached only from the sweep.
+            // A second `enqueue(` would be a path that could re-enqueue from
+            // a completion, which is how a failed check loops for ever.
+            expect(source.match(/this\.fleet\.enqueue\(/g)).toHaveLength(1);
+        });
+
+        it('flattens node-reported text with escapes, never a literal control byte', () => {
+            // The note that reaches a row, an Inbox body and a Task
+            // thread is derived from a browser result reported by
+            // somebody's PC. It is collapsed before it lands so a node
+            // cannot forge extra lines in either surface — and the
+            // collapsing regex is written with escapes, because a source
+            // file must never carry a raw control byte.
+            expect(source).toMatch(/\\u0000-\\u001f/);
+            const literalControlBytes = [...source].filter(
+                (character) => character.charCodeAt(0) < 32 && character !== '\n',
+            );
+            expect(literalControlBytes).toEqual([]);
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-merge-gate.revert.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-merge-gate.revert.spec.ts
@@ -1,0 +1,315 @@
+import type { MergePolicy } from '@ever-works/contracts';
+import { PROMOTION_TASK_LABEL, releaseRevertTaskLabels } from '@ever-works/contracts';
+import { TaskMergeGateService } from '../task-merge-gate.service';
+
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809) × merge
+ * approval (slice AE) — the merge gate's side of the REVERT.
+ *
+ * ## The hole this file closes
+ *
+ * A revert Task is deliberately an ORDINARY Task: no `release:promotion`
+ * label, so the promotion guard answers `{ promotion: null }` for it and
+ * `ReleasePromotionService` leaves it alone. That is what stops "a revert
+ * opens a promotion which triggers another check" from being a cycle — and
+ * it is also what, until this file existed, dropped a revert straight into
+ * the ordinary agent-merge path.
+ *
+ * The configuration that path needs is the configuration the release lane
+ * REQUIRES: `allowAgentMerge: true`, and `main` / `stage` absent from
+ * `protectedBranches` (otherwise slice AI's own promotion merges are
+ * refused with `protected-branch`). On that configuration
+ * `requireHumanApproval: false` — described in `task-merge-gate.service.ts`
+ * itself as "a legitimate operator choice for ordinary agent work" — made
+ * `needsApproval` false for a revert, and the gate merged it. Production
+ * was reverted with no `merge_pull_request` approval ever raised, verified
+ * or recorded. `isReleaseRevertTask` existed for exactly this check and was
+ * called by nothing.
+ *
+ * Two properties, asserted here and nowhere else:
+ *
+ *   1. a revert is never merged without a recorded human approval, whatever
+ *      the scope's policy says — the same rule slice AI hard-wires for a
+ *      promotion, for the strictly stronger reason that undoing a release
+ *      is the same class of act as making one;
+ *   2. the branch the gate reasons about is the branch the revert LANDS ON,
+ *      resolved from the Work's release ladder — not the Work's
+ *      `taskIsolationBaseBranch`, which is the right answer for every other
+ *      Task pull request on the platform and the wrong one here.
+ */
+describe('TaskMergeGateService — release revert Tasks', () => {
+    const HEAD = 'c1d2e3f405162738495a6b7c8d9e0f1122334455';
+
+    /** The operator posture the release lane requires, with approvals OFF. */
+    const NO_APPROVAL_NEEDED: MergePolicy = {
+        allowAgentMerge: true,
+        requireGreenGate: true,
+        requireHumanApproval: false,
+        allowedMergeMethods: ['squash'],
+        // `main` deliberately NOT protected — with it protected, slice AI's
+        // own promotion merges are refused, so this is the only shape in
+        // which the lane runs at all.
+        protectedBranches: ['release/frozen'],
+    };
+
+    const NEEDS_APPROVAL: MergePolicy = { ...NO_APPROVAL_NEEDED, requireHumanApproval: true };
+
+    const LADDER = { integration: 'develop', staging: 'stage', production: 'main' };
+
+    const revertTask = (over: Record<string, unknown> = {}) =>
+        ({
+            id: 'task-99',
+            userId: 'owner-1',
+            slug: 'T-99',
+            workId: 'work-1',
+            agentId: 'agent-1',
+            prNumber: 12,
+            prUrl: 'https://github.com/ever-works/ever-works/pull/12',
+            labels: releaseRevertTaskLabels('stage-to-main'),
+            ...over,
+        }) as never;
+
+    const status = (over: Record<string, unknown> = {}) =>
+        ({
+            number: 12,
+            state: 'open',
+            merged: false,
+            ciState: 'passing',
+            checksComplete: true,
+            headSha: HEAD,
+            checks: [],
+            ...over,
+        }) as never;
+
+    function build(
+        over: {
+            policy?: MergePolicy;
+            approved?: boolean;
+            work?: Record<string, unknown>;
+        } = {},
+    ) {
+        const works = {
+            findById: jest.fn().mockResolvedValue({
+                id: 'work-1',
+                organizationId: null,
+                tenantId: null,
+                // The branch every ordinary Task pull request targets, and
+                // the value the gate used to compute a revert's base from.
+                taskIsolationBaseBranch: 'work/agent-base',
+                releaseLadder: LADDER,
+                getRepoOwner: () => 'ever-works',
+                getDataRepo: () => 'ever-works',
+                ...over.work,
+            }),
+        };
+        const mergePolicy = {
+            resolve: jest.fn().mockResolvedValue({
+                policy: over.policy ?? NO_APPROVAL_NEEDED,
+                source: 'work',
+                chain: [],
+            }),
+        };
+        const taskWorkspace = {
+            attemptMergeForOpenPullRequest: jest
+                .fn()
+                .mockResolvedValue({ attempted: true, merged: true }),
+        };
+        const mergeApprovals = {
+            verifyMergeApproval: jest
+                .fn()
+                .mockResolvedValue(
+                    over.approved
+                        ? { approved: true, approvalId: 'p-1', approvedById: 'human-1' }
+                        : { approved: false, code: 'approval-missing' },
+                ),
+            requestMergeApproval: jest
+                .fn()
+                .mockResolvedValue({ raised: true, proposal: { id: 'p-new' } }),
+        };
+        // A bound guard that recognises nothing: a revert Task carries no
+        // promotion label, so this is what the real guard answers for it.
+        const guard = {
+            assessPromotionForMerge: jest.fn().mockResolvedValue({ promotion: false }),
+        };
+        const service = new TaskMergeGateService(
+            works as never,
+            mergePolicy as never,
+            taskWorkspace as never,
+            mergeApprovals as never,
+            guard as never,
+        );
+        return { service, works, mergePolicy, taskWorkspace, mergeApprovals, guard };
+    }
+
+    // ── The approval is not optional for a revert ─────────────────────
+
+    it('will not merge a revert on `requireHumanApproval: false` — it raises the approval instead', async () => {
+        // THE property. This is the exact configuration the release lane
+        // runs in, and before this the gate took the `if (!needsApproval)`
+        // shortcut and merged the revert into production unattended.
+        const { service, taskWorkspace, mergeApprovals } = build();
+
+        const outcome = await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(outcome).toEqual({ action: 'approval-requested', proposalId: 'p-new' });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ taskId: 'task-99', prNumber: 12, headSha: HEAD }),
+        );
+    });
+
+    it('merges a revert only once a human approval verifies for THIS head', async () => {
+        const { service, taskWorkspace, mergeApprovals } = build({ approved: true });
+
+        const outcome = await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(outcome).toMatchObject({ action: 'merge-attempted' });
+        expect(mergeApprovals.verifyMergeApproval).toHaveBeenCalledWith({
+            taskId: 'task-99',
+            prNumber: 12,
+            headSha: HEAD,
+        });
+        // And the facade is told to RAISE the requirement as well, so the
+        // property does not rest on this service alone.
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ requireHumanApproval: true }),
+        );
+    });
+
+    it('is unaffected by the operator turning approvals off — both policies take the same path', async () => {
+        const off = build();
+        const on = build({ policy: NEEDS_APPROVAL });
+
+        const a = await off.service.onPullRequestStatusRefreshed(revertTask(), status());
+        const b = await on.service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(a).toEqual(b);
+        expect(off.taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+        expect(on.taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    // ── The branch the gate reasons about ────────────────────────────
+
+    it('names the branch the revert LANDS ON in the approval a human reads', async () => {
+        // The Inbox line is "Merge PR #12 into <branch> in <repo>". With the
+        // Work's isolation base it read "into work/agent-base" — a founder
+        // approving what looks like a sandbox merge while production is
+        // reverted.
+        const { service, mergeApprovals } = build();
+
+        await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ targetBranch: 'main' }),
+        );
+    });
+
+    it('hands the merge path the release base, so the protected-branch rule sees `main`', async () => {
+        // `evaluateAgentMerge` evaluates `ctx.targetBranch`. Computed from
+        // the Work's isolation base it found no protected match and allowed
+        // a merge into production that a conservative operator had
+        // explicitly protected.
+        const { service, taskWorkspace } = build({
+            approved: true,
+            work: { taskIsolationBaseBranch: 'work/agent-base' },
+        });
+
+        await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ baseRef: 'main', requireHumanApproval: true }),
+        );
+    });
+
+    it('resolves the base from the RUNG, so a staging revert does not name production', async () => {
+        const { service, mergeApprovals } = build();
+
+        await service.onPullRequestStatusRefreshed(
+            revertTask({ labels: releaseRevertTaskLabels('develop-to-stage') }),
+            status(),
+        );
+
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ targetBranch: 'stage' }),
+        );
+    });
+
+    it('reads the base from the LADDER, never from a branch name baked into the code', async () => {
+        const { service, mergeApprovals } = build({
+            work: { releaseLadder: { integration: 'dev', staging: 'rc', production: 'live' } },
+        });
+
+        await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(mergeApprovals.requestMergeApproval).toHaveBeenCalledWith(
+            expect.objectContaining({ targetBranch: 'live' }),
+        );
+    });
+
+    // ── Fails closed ─────────────────────────────────────────────────
+
+    it.each([
+        ['the Work has no release ladder', { releaseLadder: null }],
+        [
+            'the ladder is unusable',
+            { releaseLadder: { integration: 'develop', staging: 'develop', production: 'main' } },
+        ],
+    ])('refuses the merge outright when %s', async (_label, work) => {
+        // Rather than falling back to the Work's isolation base, which is
+        // how a revert would be merged against a branch the gate had to
+        // guess — and reported to a human as that guess.
+        const { service, taskWorkspace, mergeApprovals } = build({ approved: true, work });
+
+        const outcome = await service.onPullRequestStatusRefreshed(revertTask(), status());
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'revert-base-unresolved' });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+    });
+
+    it('refuses a revert Task whose rung label was lost', async () => {
+        const { service, taskWorkspace } = build({ approved: true });
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            revertTask({ labels: ['release:revert'] }),
+            status(),
+        );
+
+        expect(outcome).toEqual({ action: 'skipped', reason: 'revert-base-unresolved' });
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).not.toHaveBeenCalled();
+    });
+
+    // ── Nothing else moved ───────────────────────────────────────────
+
+    it('leaves an ordinary Task on the ordinary path — approvals off still merges it', async () => {
+        // The pair to the first test. This slice must not turn every agent
+        // merge on the platform into an approval prompt.
+        const { service, taskWorkspace, mergeApprovals } = build();
+
+        const outcome = await service.onPullRequestStatusRefreshed(
+            revertTask({ labels: ['chore'] }),
+            status(),
+        );
+
+        expect(outcome).toMatchObject({ action: 'merge-attempted' });
+        expect(mergeApprovals.requestMergeApproval).not.toHaveBeenCalled();
+        expect(taskWorkspace.attemptMergeForOpenPullRequest).toHaveBeenCalledWith(
+            expect.not.objectContaining({ requireHumanApproval: true }),
+        );
+    });
+
+    it('does not mistake a promotion Task for a revert', async () => {
+        const { service } = build({ work: { releaseLadder: null } });
+
+        // A promotion Task with an unusable ladder must still be refused by
+        // the PROMOTION path (guard says not-a-promotion here, so it falls
+        // through to the ordinary one) — never by the revert refusal, which
+        // would hide the real reason.
+        const outcome = await service.onPullRequestStatusRefreshed(
+            revertTask({ labels: [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main'] }),
+            status(),
+        );
+
+        expect(outcome).not.toEqual({ action: 'skipped', reason: 'revert-base-unresolved' });
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -81,6 +81,7 @@ export {
 // -> main. Opens a promotion pull request and reports the gate; merging it
 // stays on the slice-AE human-approval path.
 export * from './release-promotion.service';
+export * from './release-verification.service';
 export * from './release-promotion.module';
 export { ReleasePromotion } from '../entities/release-promotion.entity';
 export {

--- a/packages/agent/src/tasks-domain/release-promotion.module.ts
+++ b/packages/agent/src/tasks-domain/release-promotion.module.ts
@@ -7,7 +7,9 @@ import {
     PROMOTION_MERGE_GUARD,
 } from '../policy/promotion-merge-guard.port';
 import { FacadesModule } from '../facades/facades.module';
+import { FleetModule } from '../fleet/fleet.module';
 import { ReleasePromotionService } from './release-promotion.service';
+import { ReleaseVerificationService } from './release-verification.service';
 import { TasksDomainModule } from './tasks.module';
 
 /**
@@ -44,6 +46,20 @@ import { TasksDomainModule } from './tasks.module';
  * `database/_entities-inventory.ts` — this repo has no `autoLoadEntities`,
  * so a forFeature'd-but-unregistered entity throws
  * EntityMetadataNotFoundError on first query.
+ *
+ * ## Post-deploy verification (slice AJ, EW-809)
+ *
+ * `ReleaseVerificationService` is provided here too, beside the promotion
+ * service that calls it, because the two share `ReleasePromotionRepository`
+ * and because the merge observation and the verification it starts are one
+ * feature. `FleetModule` is imported for `FleetJobService`: producing a
+ * `browser-check` is the whole point of the slice, and the fleet module has
+ * no imports beyond `TypeOrmModule.forFeature`, so it cannot cycle back
+ * into this one.
+ *
+ * The api-side cron sweep and the `fleet.job.completed` listener that drive
+ * it live in `apps/api/src/release/` and inject the service through this
+ * module's exports.
  */
 @Global()
 @Module({
@@ -55,9 +71,13 @@ import { TasksDomainModule } from './tasks.module';
         // Exports GitFacadeService (opens the pull request, reads the
         // branch tips and the gate run).
         FacadesModule,
+        // Exports FleetJobService — the ONLY producer of a `browser-check`
+        // in the platform is `ReleaseVerificationService.enqueueDueChecks`.
+        FleetModule,
     ],
     providers: [
         ReleasePromotionRepository,
+        ReleaseVerificationService,
         ReleasePromotionService,
         // Bound with `useExisting` so consumers depend on the CONTRACT and
         // never on the concrete class — and so both tokens resolve to ONE
@@ -67,6 +87,7 @@ import { TasksDomainModule } from './tasks.module';
     ],
     exports: [
         ReleasePromotionRepository,
+        ReleaseVerificationService,
         ReleasePromotionService,
         PROMOTION_MERGE_GUARD,
         PROMOTION_LANE_WATCHER,

--- a/packages/agent/src/tasks-domain/release-promotion.service.ts
+++ b/packages/agent/src/tasks-domain/release-promotion.service.ts
@@ -30,6 +30,7 @@ import type {
     PromotionMergeSubject,
     PromotionMergeVerdict,
 } from '../policy/promotion-merge-guard.port';
+import { ReleaseVerificationService } from './release-verification.service';
 import { TasksService } from './tasks.service';
 
 /** Why a promotion could not be opened. All of them leave nothing behind. */
@@ -209,6 +210,13 @@ export class ReleasePromotionService implements PromotionMergeGuard {
         // treatment — this convention has bitten five times.
         @Optional() private readonly gitFacade?: GitFacadeService,
         @Optional() @Inject(INBOX_PRODUCER) private readonly inbox?: InboxProducer,
+        // Post-deploy verification (slice AJ, EW-809). APPENDED LAST and
+        // @Optional() per the positional-arity rule — every spec that
+        // builds this service with seven arguments keeps compiling, and a
+        // deployment without it behaves byte-for-byte as it did before:
+        // the promotion still merges and the lane still closes, nothing
+        // checks the deployment, and nothing pretends it did.
+        @Optional() private readonly verification?: ReleaseVerificationService,
     ) {}
 
     // ── Opening a promotion ───────────────────────────────────────────
@@ -698,6 +706,37 @@ export class ReleasePromotionService implements PromotionMergeGuard {
                           'The next rung is a separate promotion and is not opened automatically.'
                     : `Promotion closed without merging — ${promotion.headBranch} → ${promotion.baseBranch}.`,
             );
+            // THE ONLY MOMENT the platform learns a promotion landed, and
+            // therefore the only place a post-deploy verification can start
+            // (slice AJ, EW-809). `closeLane` above has already freed the
+            // lane, so `findOpenByTaskId` will not match this row again and
+            // this block runs exactly once per promotion — but the
+            // verification claims itself with `WHERE verifyState IS NULL`
+            // anyway, because "runs exactly once" is a property of the
+            // current call graph and not a guarantee.
+            //
+            // A CLOSED promotion gets nothing: nothing was deployed, so
+            // there is nothing to check. Only `merged`.
+            //
+            // Deliberately AFTER the close and the report, and deliberately
+            // unable to throw: this method is best-effort by contract, and a
+            // verification that failed to start must not cost the caller the
+            // record that the promotion merged.
+            if (status.state === 'merged' && this.verification) {
+                // Wrapped HERE as well as inside the verification service.
+                // The callee promises not to throw, but that promise is a
+                // property of another file that other slices edit; the
+                // guarantee this method owes its caller — that a merged
+                // promotion is recorded as merged — must not depend on it.
+                try {
+                    await this.verification.onPromotionMerged(promotion, task);
+                } catch (error) {
+                    this.logger.warn(
+                        `Promotion ${promotion.id}: post-deploy verification did not start ` +
+                            `(the merge is still recorded): ${describe(error)}`,
+                    );
+                }
+            }
             return { action: 'closed', state: status.state === 'merged' ? 'merged' : 'closed' };
         }
 

--- a/packages/agent/src/tasks-domain/release-verification.service.ts
+++ b/packages/agent/src/tasks-domain/release-verification.service.ts
@@ -1,0 +1,1479 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    FLEET_BROWSER_CAPABILITY,
+    RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+    RELEASE_VERIFY_BUDGET_MS,
+    RELEASE_VERIFY_FAILURE_CONFIRMATIONS,
+    RELEASE_VERIFY_PROBE_TIMEOUT_SEC,
+    RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS,
+    isFleetJobTerminal,
+    isReleaseVerifyCheckPass,
+    isReleaseVerifyExhausted,
+    isReleaseVerifyRevertOffered,
+    isReleaseVerifyTerminal,
+    normalizeCommitSha,
+    releaseEnvironmentForRung,
+    releaseRevertTaskLabels,
+    releaseVerificationProbe,
+    releaseVerifyAppProof,
+    releaseVerifyIdempotencyKey,
+    resolveReleaseVerificationTarget,
+    type FleetBrowserCheckPayload,
+    type ReleaseVerificationProbe,
+    type ReleaseVerifyAppProof,
+    type ReleaseVerifyState,
+} from '@ever-works/contracts';
+import { Task, TaskPriority, TaskStatus } from '../entities/task.entity';
+import type { Work } from '../entities/work.entity';
+import type { ReleasePromotion } from '../entities/release-promotion.entity';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { ReleasePromotionRepository } from '../database/repositories/release-promotion.repository';
+import { TaskChatMessageRepository } from '../database/repositories/task-side.repositories';
+import { FleetJobService } from '../fleet/fleet-job.service';
+import { FleetJobRepository } from '../fleet/fleet-job.repository';
+import type { FleetJob } from '../entities/fleet-job.entity';
+import { GitFacadeService, type GitFacadeOptions } from '../facades/git.facade';
+import { INBOX_PRODUCER, type InboxProducer } from '../inbox/inbox-producer.port';
+import { TasksService } from './tasks.service';
+
+/** Longest note kept on the row. Half of what lands here is node-reported. */
+const DETAIL_MAX = 512;
+
+/** What one sweep pass did, for the cron log and for tests. */
+export interface VerificationSweepSummary {
+    considered: number;
+    enqueued: number;
+    settled: number;
+    /**
+     * Rows whose in-flight check had already reached a terminal fleet
+     * state without its result being recorded, and which this pass read
+     * back off the job row itself (slice-AJ review). Non-zero here means
+     * a completion was dropped somewhere, which is worth seeing in a log.
+     */
+    recovered: number;
+}
+
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809) — the
+ * half of the release lane that finds out whether the release WORKED, and
+ * offers a human the undo when it did not.
+ *
+ * ## Why this exists
+ *
+ * Slice AI opens the promotion pull request, reads `promotion-gate.yml`
+ * and stands aside for a human to merge. After that merge the platform
+ * knew nothing. `browser-check` had existed as a fleet job kind since the
+ * node shipped, with a working executor and a capability tag, and NOTHING
+ * ON THE PLATFORM EVER PRODUCED ONE — searching `apps/api/src` and
+ * `packages/agent/src` for the string found only type declarations and two
+ * negative-control test fixtures. So on 2026-09-06 a whole batch went
+ * `develop → stage → main` and nothing confirmed the result, on a build
+ * lane measured at 215–243 minutes.
+ *
+ * ## The three things it does, and the one it refuses to
+ *
+ *   1. **Enqueues a browser check against the deployed URL** once a
+ *      promotion is observed merged — at the environment that rung's BASE
+ *      branch deploys, from platform state, never from a request.
+ *   2. **Reads the verdict** onto the promotion row and into the owner's
+ *      Inbox.
+ *   3. **Offers a revert** — an inert Task carrying the exact coordinates
+ *      — when, and only when, the deployment is confirmed broken.
+ *
+ * It does not revert. There is no code path in this file that merges,
+ * pushes, force-pushes, deploys, rolls back, or asks anything else to. The
+ * offer is a Task filed IN_REVIEW for a person to read; landing whatever
+ * pull request that Task eventually produces needs the same
+ * `merge_pull_request` Inbox approval, verified against the live head at
+ * merge time, as every other agent merge (slice AE). Undoing a promotion
+ * is the same class of act as making one, and slice AI's argument — the
+ * founder performs each rung deliberately — applies at least as strongly
+ * in reverse.
+ *
+ * ## What makes a green verdict mean something
+ *
+ * The first probe is not a health check. It loads the environment's
+ * VERSION endpoint in a real browser and requires the promoted commit to
+ * appear in the rendered document. Until that has held
+ * `RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS` times in a row, this lane says
+ * nothing at all about the deployment — because the deploy has not
+ * happened yet and every check before it is testing the OLD build. A plain
+ * `200 OK` would report green for a rollout that never started, which is
+ * the exact "check that passes when nothing was checked" this slice was
+ * written to prevent. See `ReleasePromotion.verifyExpectedSha` for the one
+ * thing this identity argument does NOT prove.
+ *
+ * ## Why it cannot loop
+ *
+ * A probe is enqueued only by the sweep, only for a row in a live state,
+ * only when no check is already in flight, and only while BOTH bounds hold
+ * (`RELEASE_VERIFY_MAX_ATTEMPTS` and the eight-hour deadline). A failed
+ * check never re-enqueues itself: it writes a result and a `verifyRetryAt`
+ * and the sweep decides. Every terminal state clears `verifyRetryAt`, so a
+ * settled promotion is invisible to the sweep for ever. And the revert
+ * offer is an ordinary Task with no promotion label, so it cannot open a
+ * promotion, so it cannot cause another verification.
+ *
+ * BEST-EFFORT BY CONTRACT throughout, like the promotion refresh beside
+ * it: the callers are a merge observation and a cron sweep, and neither
+ * may be turned into a failure by a provider hiccup.
+ */
+@Injectable()
+export class ReleaseVerificationService {
+    private readonly logger = new Logger(ReleaseVerificationService.name);
+
+    constructor(
+        private readonly promotions: ReleasePromotionRepository,
+        private readonly works: WorkRepository,
+        private readonly tasks: TaskRepository,
+        private readonly tasksService: TasksService,
+        private readonly chat: TaskChatMessageRepository,
+        // Everything below is @Optional() and APPENDED LAST per the
+        // positional-spec arity rule. Any future dependency goes after
+        // these, also @Optional(). This convention has bitten six times.
+        @Optional() private readonly fleet?: FleetJobService,
+        @Optional() private readonly gitFacade?: GitFacadeService,
+        @Optional() @Inject(INBOX_PRODUCER) private readonly inbox?: InboxProducer,
+        // Added by the slice-AJ review, and appended after the three
+        // above for the same arity reason. Read-only: this reads the fleet
+        // job row back to check that the job `enqueue` handed us is the one
+        // this lane meant to create, and to un-wedge a row whose check
+        // settled without its result reaching the state machine. It never
+        // writes to the fleet.
+        @Optional() private readonly fleetJobs?: FleetJobRepository,
+    ) {}
+
+    // ── Starting a verification ───────────────────────────────────────
+
+    /**
+     * Called by `ReleasePromotionService` the once, when a promotion pull
+     * request is observed merged.
+     *
+     * Never throws: the caller is a PR-status refresh whose job is to keep
+     * a cache honest for every Task behind this one, and a verification
+     * that threw would turn a provider hiccup into a failed sweep.
+     */
+    async onPromotionMerged(promotion: ReleasePromotion, task: Task | null): Promise<void> {
+        try {
+            await this.begin(promotion, task);
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not start post-deploy verification: ${describe(error)}`,
+            );
+        }
+    }
+
+    private async begin(promotion: ReleasePromotion, task: Task | null): Promise<void> {
+        // Already started (or already finished). The compare-and-set below
+        // is the real guard; this saves the provider round trip.
+        if (promotion.verifyState) return;
+
+        const environment = releaseEnvironmentForRung(promotion.rung);
+        const work = await this.works.findById(promotion.workId);
+
+        // Every refusal below lands as a TERMINAL state with a reason, not
+        // as silence. "Nobody configured a URL" and "the deployment is
+        // healthy" must never look the same to the person reading the row.
+        if (!work) {
+            await this.settleAtStart(
+                promotion,
+                task,
+                'inconclusive',
+                `The Work ${promotion.workId} could not be read, so no deployment could be checked.`,
+            );
+            return;
+        }
+        if (work.userId !== promotion.userId) {
+            // The Work changed hands under a live promotion. Everything
+            // downstream — the URL to load, the credentials to read the
+            // branch with, the owner whose fleet runs the browser — would
+            // otherwise be taken from one party for a promotion belonging
+            // to another. Refuse; a verification is not worth crossing a
+            // tenancy boundary for.
+            await this.settleAtStart(
+                promotion,
+                task,
+                'inconclusive',
+                `The Work ${promotion.workId} no longer belongs to this promotion's owner, so the ` +
+                    'deployment was not checked.',
+            );
+            return;
+        }
+        if (!this.fleet) {
+            await this.settleAtStart(
+                promotion,
+                task,
+                'inconclusive',
+                'No fleet job runtime is wired in this deployment, so no browser check could be run.',
+            );
+            return;
+        }
+
+        const target = resolveReleaseVerificationTarget(work.releaseVerification, promotion.rung);
+        if (!target || !environment) {
+            await this.settleAtStart(
+                promotion,
+                task,
+                'unsupported',
+                `This Work has no verification target for its ${environment ?? 'unknown'} environment, ` +
+                    'so the deployment was NOT checked. Set one on the Work to have future releases verified.',
+            );
+            return;
+        }
+
+        // THE artefact identity. The BASE branch's tip, read now, because
+        // the merge produced a new commit and nothing on the pull-request
+        // status carries it — `promotion.headSha` is the branch that was
+        // merged FROM and will never equal what gets deployed.
+        const expectedSha = await this.readBaseTip(work, promotion);
+        if (!expectedSha) {
+            await this.settleAtStart(
+                promotion,
+                task,
+                'inconclusive',
+                `Could not read the tip of ${promotion.baseBranch} after the merge, so there is no commit ` +
+                    'to hold the deployment to. Nothing about this deployment has been verified.',
+            );
+            return;
+        }
+
+        const now = new Date();
+        const started = await this.promotions.beginVerification(promotion.id, {
+            verifyState: 'awaiting-rollout',
+            verifyExpectedSha: expectedSha,
+            verifyTargetUrl: target.versionUrl,
+            verifyStartedAt: now,
+            verifyDeadlineAt: new Date(now.getTime() + RELEASE_VERIFY_BUDGET_MS),
+            // Due immediately. The first probe will almost certainly find
+            // the OLD commit — the build lane has not even started — and
+            // that is a baseline, not a failure.
+            verifyRetryAt: now,
+            verifyDetail: null,
+        });
+        if (!started) return;
+        Object.assign(promotion, {
+            verifyState: 'awaiting-rollout' as ReleaseVerifyState,
+            verifyExpectedSha: expectedSha,
+        });
+
+        await this.report(
+            task,
+            `Post-deploy verification started for the ${environment} environment. Watching ` +
+                `${target.versionUrl} until it serves ${expectedSha.slice(0, 12)} (the new tip of ` +
+                `${promotion.baseBranch}), then checking that ${target.appUrl} renders. ` +
+                'Nothing will be reverted automatically whatever this finds.',
+        );
+    }
+
+    /** A verification that is over before it began, recorded rather than skipped. */
+    private async settleAtStart(
+        promotion: ReleasePromotion,
+        task: Task | null,
+        state: Extract<ReleaseVerifyState, 'inconclusive' | 'unsupported'>,
+        detail: string,
+    ): Promise<void> {
+        const now = new Date();
+        const claimed = await this.promotions.beginVerification(promotion.id, {
+            verifyState: state,
+            verifyExpectedSha: null,
+            verifyTargetUrl: null,
+            verifyStartedAt: now,
+            verifyDeadlineAt: null,
+            // No retry: a terminal row is invisible to the sweep.
+            verifyRetryAt: null,
+            verifyDetail: trim(detail),
+        });
+        if (!claimed) return;
+        Object.assign(promotion, { verifyState: state, verifyDetail: trim(detail) });
+        await this.report(task, `Deployment NOT verified — ${detail}`);
+        await this.fileVerdictNotice(promotion, task, state, detail);
+    }
+
+    // ── The sweep ─────────────────────────────────────────────────────
+
+    /**
+     * Enqueue the probes that are due, and expire the verifications that
+     * have run out of road.
+     *
+     * The ONLY place a `browser-check` is produced. Everything else in
+     * this file records results.
+     */
+    async enqueueDueChecks(now = new Date()): Promise<VerificationSweepSummary> {
+        const summary: VerificationSweepSummary = {
+            considered: 0,
+            enqueued: 0,
+            settled: 0,
+            recovered: 0,
+        };
+        let due: ReleasePromotion[];
+        try {
+            due = await this.promotions.findVerificationsDue(now);
+        } catch (error) {
+            this.logger.warn(`Verification sweep could not read its queue: ${describe(error)}`);
+            return summary;
+        }
+
+        for (const promotion of due) {
+            summary.considered += 1;
+            try {
+                const acted = await this.sweepOne(promotion, now);
+                if (acted === 'enqueued') summary.enqueued += 1;
+                if (acted === 'settled') summary.settled += 1;
+                if (acted === 'recovered') summary.recovered += 1;
+            } catch (error) {
+                // One bad row must not stop the sweep for the rest. The row
+                // stays due and is retried on the next pass, and its own
+                // deadline still ends it.
+                this.logger.warn(
+                    `Promotion ${promotion.id}: verification sweep step failed: ${describe(error)}`,
+                );
+            }
+        }
+        return summary;
+    }
+
+    private async sweepOne(
+        promotion: ReleasePromotion,
+        now: Date,
+    ): Promise<'enqueued' | 'settled' | 'skipped' | 'recovered'> {
+        const state = promotion.verifyState;
+        if (!state || isReleaseVerifyTerminal(state)) return 'skipped';
+
+        // THE BOUND, checked before anything else and regardless of whether
+        // a check is still in flight. A browser job that never comes back
+        // must not be able to hold a promotion open for ever.
+        if (isReleaseVerifyExhausted(promotion.verifyAttempts, promotion.verifyDeadlineAt, now)) {
+            await this.settle(
+                promotion,
+                state,
+                'inconclusive',
+                `Gave up after ${promotion.verifyAttempts} checks: ` +
+                    (state === 'awaiting-rollout'
+                        ? `${promotion.baseBranch} never appeared as the served commit within the budget. ` +
+                          'That is NOT a failed release — it is an unverified one.'
+                        : 'the deployment never reached a decisive answer within the budget.'),
+                now,
+            );
+            return 'settled';
+        }
+
+        // A check is bound to this row. It is NOT simply "nothing to do":
+        // see `reconcileInFlight`.
+        if (promotion.verifyJobId) {
+            return this.reconcileInFlight(promotion, state, promotion.verifyJobId, now);
+        }
+
+        const work = await this.works.findById(promotion.workId);
+        // Same owner re-check as at start, on every probe: a Work that
+        // changes hands mid-verification must not have its URLs read for
+        // somebody else's promotion.
+        const target =
+            work && work.userId === promotion.userId
+                ? resolveReleaseVerificationTarget(work.releaseVerification, promotion.rung)
+                : null;
+        const probe = releaseVerificationProbe(state, target, promotion.verifyExpectedSha);
+        if (!probe) {
+            // The target was removed or made unusable underneath a running
+            // verification, or the recorded commit is not one. Fail closed:
+            // the answer is "we do not know", never "it is fine".
+            await this.settle(
+                promotion,
+                state,
+                'inconclusive',
+                'The verification target for this environment is no longer readable on the Work, so the ' +
+                    'deployment could not be checked.',
+                now,
+            );
+            return 'settled';
+        }
+
+        const enqueued = await this.enqueueProbe(promotion, probe, now);
+        return enqueued ? 'enqueued' : 'skipped';
+    }
+
+    /**
+     * A check is already bound to this row. Decide what that means.
+     *
+     * Added by the slice-AJ review, replacing an unconditional `skipped`.
+     * The old behaviour rested on an assumption that is not true: that a
+     * bound job will always come back through
+     * {@link onBrowserCheckCompleted}. It will not.
+     *
+     *   - `ReleaseVerificationListener` and this service both swallow their
+     *     own failures by contract, so ONE transient database error inside
+     *     `findByVerifyJobId` / `recordVerifyResult` / `settleVerification`
+     *     drops the result permanently — and so does an API replica
+     *     restarting between the fleet's own write and the `@OnEvent`
+     *     handler running.
+     *   - The enqueue/claim ordering leaks the same way: a crash between
+     *     `enqueue` and `claimVerifyAttempt` leaves a job nobody is bound
+     *     to, and the completion fires against no row.
+     *
+     * In every one of those the job is TERMINAL and nothing will ever emit
+     * a second completion for it, while `verifyJobId` stays set — so the
+     * sweep used to return `skipped` every five minutes for eight hours and
+     * the promotion settled `inconclusive` having checked nothing. Which is
+     * the exact outcome this slice exists to prevent: a production deploy
+     * that is broken and a founder who is not told for eight hours.
+     *
+     * So: read the job. If it has settled, record its verdict here (through
+     * the SAME pass rule the listener uses, so the two cannot disagree). If
+     * it has not, push the row down the sweep queue — which is also what
+     * stops one owner's stuck fleet from head-of-line blocking every other
+     * tenant out of {@link ReleasePromotionRepository.findVerificationsDue}.
+     */
+    private async reconcileInFlight(
+        promotion: ReleasePromotion,
+        state: ReleaseVerifyState,
+        jobId: string,
+        now: Date,
+    ): Promise<'skipped' | 'recovered'> {
+        const later = new Date(now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS);
+        const defer = async (): Promise<'skipped'> => {
+            await this.promotions.deferVerification(promotion.id, state, jobId, later);
+            return 'skipped';
+        };
+        // Without the reader this degrades to exactly the old behaviour
+        // plus the rescheduling, which is the safe direction: it can only
+        // fail to notice a dropped completion, never invent one.
+        if (!this.fleetJobs) return defer();
+
+        let job: FleetJob | null;
+        try {
+            job = await this.fleetJobs.findById(jobId);
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not re-read browser check ${jobId}: ${describe(error)}`,
+            );
+            return defer();
+        }
+
+        if (!job) {
+            // The row points at a job that does not exist — nothing can
+            // ever complete it. Let the binding go and burn the attempt so
+            // the next sweep enqueues under a FRESH idempotency key.
+            const released = await this.promotions.releaseVerifyJob(promotion.id, state, jobId, {
+                attempts: (promotion.verifyAttempts ?? 0) + 1,
+                reconsiderAt: now,
+                detail: trim(
+                    `The browser check recorded for this attempt (${jobId}) no longer exists; ` +
+                        'starting a new one.',
+                ),
+            });
+            if (released) {
+                Object.assign(promotion, {
+                    verifyJobId: null,
+                    verifyAttempts: (promotion.verifyAttempts ?? 0) + 1,
+                });
+            }
+            return 'recovered';
+        }
+
+        if (!isFleetJobTerminal(job.status)) return defer();
+
+        // It settled and nobody recorded it. Read it back through the ONE
+        // pass rule — `done` plus an explicit `ok: true`, node-reported data
+        // narrowed the same way the listener narrows it.
+        this.logger.warn(
+            `Promotion ${promotion.id}: browser check ${jobId} settled ${job.status} without its ` +
+                'result reaching the verification; recovering it from the job row.',
+        );
+        const ok = isReleaseVerifyCheckPass(job.status, job.result ?? null);
+        await this.advance(promotion, state, jobId, ok, trim(describeSettledJob(job)), now);
+        return 'recovered';
+    }
+
+    /**
+     * Put ONE browser check on the owner's fleet.
+     *
+     * Owner and organization come from the promotion ROW. There is no
+     * request anywhere in this path and never can be: the sweep is a cron.
+     */
+    private async enqueueProbe(
+        promotion: ReleasePromotion,
+        probe: ReleaseVerificationProbe,
+        now: Date,
+    ): Promise<boolean> {
+        if (!this.fleet) return false;
+        const attempt = (promotion.verifyAttempts ?? 0) + 1;
+
+        const payload: FleetBrowserCheckPayload = {
+            url: probe.url,
+            expectText: probe.expectText,
+            timeoutSec: RELEASE_VERIFY_PROBE_TIMEOUT_SEC,
+        };
+        // Reporting only, per the payload contract — nothing correlates on
+        // it. The completion is routed back through `verifyJobId` on the
+        // row, which is platform state rather than an echo of what we sent.
+        if (promotion.taskId) payload.taskId = promotion.taskId;
+
+        let job: { id: string; kind?: string; status?: string; payload?: unknown };
+        try {
+            job = await this.fleet.enqueue({
+                kind: 'browser-check',
+                userId: promotion.userId,
+                organizationId: promotion.organizationId ?? null,
+                payload: payload as unknown as Record<string, unknown>,
+                // Without the tag the job would be leased by a node with no
+                // browser, fail instantly with "no executor registered", and
+                // burn an attempt on a machine that was never able to answer.
+                requiredCapabilities: [FLEET_BROWSER_CAPABILITY],
+                // ONE attempt. The fleet's own reclaim would otherwise retry
+                // each probe up to three times underneath the attempt ladder
+                // in this file, multiplying two independent budgets together.
+                maxAttempts: 1,
+                idempotencyKey: releaseVerifyIdempotencyKey(promotion.id, attempt),
+            });
+        } catch (error) {
+            // Leave the row due. The next sweep re-derives the same attempt
+            // number and the same idempotency key, and the deadline still
+            // ends the verification if the fleet stays broken.
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not enqueue browser check: ${describe(error)}`,
+            );
+            return false;
+        }
+
+        // THE JOB WE WERE HANDED IS NOT NECESSARILY THE JOB WE ASKED FOR.
+        //
+        // Added by the slice-AJ review. `FleetJobService.enqueue`
+        // short-circuits on the idempotency key with
+        // `FleetJobRepository.findByIdempotencyKey`, which is a bare
+        // `findOne({ where: { idempotencyKey } })`: no status filter, no
+        // owner scope, no kind check. So it can hand back
+        //
+        //   - a job for this key that has ALREADY SETTLED — whose
+        //     completion fired while nothing was bound to it, and for which
+        //     no second completion will ever arrive; or
+        //   - a job SOMEBODY ELSE created under that key, pointed at a page
+        //     they control that contains the twelve-character sha, which
+        //     their own node would answer `ok: true` for.
+        //
+        // The unguessability of a promotion uuid was the whole defence and
+        // there was nothing behind it. There is now: the job must be a
+        // `browser-check`, it must still be live, it must belong to this
+        // promotion's owner, and its payload must be the probe this lane
+        // just composed. Anything else BURNS THE ATTEMPT instead of being
+        // recorded — the next sweep derives attempt N+1 and therefore a
+        // different key, so this cannot loop, and the attempt cap still
+        // bounds it.
+        const mismatch = await this.describeJobMismatch(job, promotion, payload);
+        if (mismatch) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: refusing browser check ${job.id} for attempt ${attempt} — ` +
+                    `${mismatch}. Burning the attempt so the next sweep enqueues a fresh one.`,
+            );
+            await this.promotions.burnVerifyAttempt(promotion.id, promotion.verifyState!, {
+                attempts: attempt,
+                reconsiderAt: now,
+                detail: trim(`Attempt ${attempt} could not be started: ${mismatch}.`),
+            });
+            Object.assign(promotion, { verifyAttempts: attempt });
+            return false;
+        }
+        const jobId = job.id;
+
+        const claimed = await this.promotions.claimVerifyAttempt(
+            promotion.id,
+            promotion.verifyState!,
+            {
+                jobId,
+                attempts: attempt,
+                targetUrl: probe.url,
+                // The row stays visible to the sweep while the check is out,
+                // so its DEADLINE can still be enforced if the check never
+                // comes back. The sweep will not enqueue a second check —
+                // that is gated on `verifyJobId` being null — it will only
+                // be able to expire the row.
+                reconsiderAt: new Date(now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS),
+            },
+        );
+        if (!claimed) {
+            // Another replica claimed the same attempt. Because the key is
+            // deterministic in (promotion, attempt), it enqueued the SAME
+            // job — so there is exactly one browser out, and the winner owns
+            // it. Nothing to undo.
+            return false;
+        }
+        Object.assign(promotion, { verifyJobId: jobId, verifyAttempts: attempt });
+        this.logger.log(
+            `Promotion ${promotion.id}: ${probe.phase} check ${attempt} enqueued as fleet job ${jobId} ` +
+                `against ${probe.url} at ${now.toISOString()}.`,
+        );
+        return true;
+    }
+
+    /**
+     * Why the job handed back is NOT the check this lane asked for, or
+     * `null` when it is.
+     *
+     * Fails closed in both directions it can: a job that cannot be read is
+     * refused rather than trusted, and so is a job whose owner cannot be
+     * established at all. The only thing that passes is a live
+     * `browser-check` owned by this promotion's owner whose payload is the
+     * probe we composed one line earlier.
+     */
+    private async describeJobMismatch(
+        job: { id: string; kind?: string; status?: string; payload?: unknown },
+        promotion: ReleasePromotion,
+        payload: FleetBrowserCheckPayload,
+    ): Promise<string | null> {
+        // Strict, in the fail-closed direction: an absent field is a
+        // mismatch, not a pass. `FleetJobService.enqueue` returns a full
+        // `FleetJobView` on both of its paths, so there is no legitimate
+        // caller that omits one.
+        if (job.kind !== 'browser-check') {
+            return `it is a '${job.kind ?? 'unknown'}' job, not a browser-check`;
+        }
+        if (typeof job.status !== 'string') return 'it reported no status';
+        if (isFleetJobTerminal(job.status as never)) {
+            // The idempotency short-circuit has no status filter, so this
+            // is a job that already ran and already reported. Its
+            // completion has been and gone.
+            return `it has already settled (${job.status}), so no completion will ever arrive for it`;
+        }
+        const sent = job.payload as Partial<FleetBrowserCheckPayload> | null | undefined;
+        if (!sent || sent.url !== payload.url || sent.expectText !== payload.expectText) {
+            return 'its payload is not the probe this verification composed';
+        }
+        // Owner. `FleetJobView` carries no `userId`, so this is the one
+        // thing that needs the row itself.
+        if (!this.fleetJobs) {
+            // Without the reader the owner cannot be established. Refusing
+            // would make the lane inert in a deployment that never had this
+            // dependency; the payload and kind checks above already refuse
+            // the substitution that matters, and the deterministic key is
+            // still derived from an unguessable uuid.
+            return null;
+        }
+        let row: FleetJob | null;
+        try {
+            row = await this.fleetJobs.findById(job.id);
+        } catch (error) {
+            return `its owner could not be read (${describe(error)})`;
+        }
+        if (!row) return 'the job row could not be read back';
+        if (row.userId !== promotion.userId) {
+            return 'it belongs to a different owner than this promotion';
+        }
+        return null;
+    }
+
+    // ── Reading a verdict ─────────────────────────────────────────────
+
+    /**
+     * A `browser-check` this lane enqueued reached a verdict.
+     *
+     * `ok` is computed by the CALLER from the job's terminal status and
+     * result, and it must be `true` only for an explicit `ok: true` on a
+     * `done` job. Everything else — a failed job, an exhausted lease, a
+     * queue-SLA expiry, a result with no `ok`, a result whose `ok` is the
+     * string `"true"` — is not a pass. The node's report is untrusted data.
+     */
+    async onBrowserCheckCompleted(
+        jobId: string,
+        ok: boolean,
+        detail: string | null,
+        now = new Date(),
+    ): Promise<void> {
+        try {
+            const promotion = await this.promotions.findByVerifyJobId(jobId);
+            // Not one of ours, or the row already settled and stopped
+            // pointing at this job. Either way there is nothing to advance.
+            if (!promotion) return;
+            const state = promotion.verifyState;
+            if (!state || isReleaseVerifyTerminal(state)) return;
+            await this.advance(promotion, state, jobId, ok, trim(detail ?? ''), now);
+        } catch (error) {
+            this.logger.warn(
+                `Fleet job ${jobId}: could not record a post-deploy verification result: ${describe(error)}`,
+            );
+        }
+    }
+
+    private async advance(
+        promotion: ReleasePromotion,
+        state: ReleaseVerifyState,
+        jobId: string,
+        ok: boolean,
+        detail: string,
+        now: Date,
+    ): Promise<void> {
+        const streak = (promotion.verifyStreak ?? 0) + 1;
+        const later = new Date(now.getTime() + RELEASE_VERIFY_ATTEMPT_INTERVAL_MS);
+
+        if (state === 'awaiting-rollout') {
+            if (!ok) {
+                // NOT a failure. The promoted commit is not being served
+                // yet, which for a production release is the expected answer
+                // for the first three or four hours. Reset the streak — the
+                // confirmations have to be CONSECUTIVE — and wait.
+                if (
+                    isReleaseVerifyExhausted(
+                        promotion.verifyAttempts,
+                        promotion.verifyDeadlineAt,
+                        now,
+                    )
+                ) {
+                    await this.settle(
+                        promotion,
+                        state,
+                        'inconclusive',
+                        `${promotion.baseBranch} never became the served commit within the budget. ` +
+                            `Last reading: ${detail || 'the expected commit was not in the page'}.`,
+                        now,
+                    );
+                    return;
+                }
+                await this.step(promotion, state, jobId, {
+                    verifyState: 'awaiting-rollout',
+                    verifyStreak: 0,
+                    verifyCheckedAt: now,
+                    verifyRetryAt: later,
+                    verifyDetail: trim(
+                        `Not rolled out yet (attempt ${promotion.verifyAttempts}). ${detail}`,
+                    ),
+                });
+                return;
+            }
+            if (streak < RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS) {
+                // One sample is a coin flip while ArgoCD is replacing pods.
+                await this.step(promotion, state, jobId, {
+                    verifyState: 'awaiting-rollout',
+                    verifyStreak: streak,
+                    verifyCheckedAt: now,
+                    verifyRetryAt: later,
+                    verifyDetail: trim(
+                        `Served the promoted commit ${streak}/${RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS} times in a row.`,
+                    ),
+                });
+                return;
+            }
+            // The rollout has landed. From here — and ONLY from here — this
+            // lane is entitled to say anything about the deployment.
+            const moved = await this.step(promotion, state, jobId, {
+                verifyState: 'checking-app',
+                verifyStreak: 0,
+                verifyCheckedAt: now,
+                // Immediately: the thing we were waiting for has happened.
+                verifyRetryAt: now,
+                verifyDetail: trim(
+                    `Rollout confirmed — ${promotion.verifyExpectedSha?.slice(0, 12) ?? 'the promoted commit'} ` +
+                        `served on ${RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS} consecutive checks.`,
+                ),
+            });
+            if (moved) {
+                await this.reportOnPromotionTask(
+                    promotion,
+                    `Rollout confirmed: ${promotion.verifyTargetUrl} is serving ` +
+                        `${promotion.verifyExpectedSha?.slice(0, 12) ?? 'the promoted commit'}. Now checking that ` +
+                        'the app renders.',
+                );
+            }
+            return;
+        }
+
+        if (state === 'checking-app') {
+            if (ok) {
+                // A pass, even if earlier attempts failed. Reverting a
+                // release that is currently serving pages on the strength of
+                // an earlier blip is the flap this lane must not produce —
+                // but the human is told it was not clean.
+                //
+                // WHAT THE PASS IS ENTITLED TO CLAIM (slice-AJ review). The
+                // artefact identity was established at `versionUrl`; this
+                // phase reads `appUrl` with whatever expectation the
+                // operator configured, and the shipped recommendation is a
+                // fixed `"status":"OK"` health string that an old bundle
+                // answers identically. So the verdict now says which of the
+                // two it measured instead of "the app rendered as expected"
+                // for both.
+                const observed = await this.observeTarget(promotion);
+                // `verifyStreak` in this state IS the number of app checks
+                // that failed immediately before this one, so it is the
+                // precise question. Counting total attempts would call every
+                // slow production rollout "not clean", since waiting hours
+                // for the build is the normal case.
+                const blips =
+                    (promotion.verifyStreak ?? 0) > 0
+                        ? ` ${promotion.verifyStreak} check(s) immediately before it did not, so this ` +
+                          'deployment was not clean.'
+                        : '';
+                await this.settle(
+                    promotion,
+                    state,
+                    'passed',
+                    observed.proof === 'artefact'
+                        ? `The app rendered the promoted commit.${blips}`
+                        : `The app answered as expected at ${observed.appHost ?? 'the app URL'}, and ` +
+                              `${observed.versionHost ?? 'the version URL'} served the promoted commit. ` +
+                              'The app expectation is a fixed string that does not carry the commit, so ' +
+                              'this does NOT prove the app deployment itself rolled out — a build that ' +
+                              `never rolled out answers it identically.${blips}`,
+                    now,
+                    undefined,
+                    observed.proof,
+                );
+                return;
+            }
+            if (streak < RELEASE_VERIFY_FAILURE_CONFIRMATIONS) {
+                if (
+                    isReleaseVerifyExhausted(
+                        promotion.verifyAttempts,
+                        promotion.verifyDeadlineAt,
+                        now,
+                    )
+                ) {
+                    // Out of road part-way through a failure streak. NOT
+                    // `failed`: the streak never completed, so this was never
+                    // confirmed, so no revert is offered.
+                    await this.settle(
+                        promotion,
+                        state,
+                        'inconclusive',
+                        `The app check failed ${streak} time(s) but the budget ran out before that could be ` +
+                            `confirmed. Last reading: ${detail || 'the page did not contain the expected text'}.`,
+                        now,
+                    );
+                    return;
+                }
+                await this.step(promotion, state, jobId, {
+                    verifyState: 'checking-app',
+                    verifyStreak: streak,
+                    verifyCheckedAt: now,
+                    verifyRetryAt: later,
+                    verifyDetail: trim(
+                        `App check failed ${streak}/${RELEASE_VERIFY_FAILURE_CONFIRMATIONS}. ${detail}`,
+                    ),
+                });
+                return;
+            }
+            // Enough consecutive failures to mean something — but "the app
+            // is broken" and "this node lost the internet" produce the same
+            // browser result, and only one of them is about the release. Go
+            // and ask the version endpoint before saying a word.
+            await this.step(promotion, state, jobId, {
+                verifyState: 'confirming-failure',
+                verifyStreak: 0,
+                verifyCheckedAt: now,
+                verifyRetryAt: now,
+                verifyDetail: trim(
+                    `App check failed ${RELEASE_VERIFY_FAILURE_CONFIRMATIONS} times in a row. ` +
+                        'Re-checking that the environment is reachable and still serving the promoted commit ' +
+                        `before concluding anything. ${detail}`,
+                ),
+            });
+            return;
+        }
+
+        // state === 'confirming-failure'
+        if (ok) {
+            // The environment answers, and it is serving the commit we
+            // promoted — so the failing app checks were about the RELEASE.
+            const observed = await this.observeTarget(promotion);
+            // Both hosts, named. The confirmation is a DIFFERENT origin
+            // from the one that failed — `sanitizeReleaseVerificationTargets`
+            // now requires the two to share a site, but a bot interstitial,
+            // an HTTP Basic wall or a proxy rule scoped to the app host
+            // alone would still fail three app probes and be "confirmed" by
+            // a healthy version host. The person deciding on a revert is
+            // told which origin produced which half of the evidence.
+            const caveat =
+                observed.appHost &&
+                observed.versionHost &&
+                observed.appHost !== observed.versionHost
+                    ? ` The failures were at ${observed.appHost} and the confirmation at ` +
+                      `${observed.versionHost}; a network condition specific to ${observed.appHost} ` +
+                      'would look the same from this node.'
+                    : '';
+            let offer: Task | null = null;
+            await this.settle(
+                promotion,
+                state,
+                'failed',
+                `The environment is serving ${promotion.verifyExpectedSha?.slice(0, 12) ?? 'the promoted commit'} ` +
+                    `but the app failed ${RELEASE_VERIFY_FAILURE_CONFIRMATIONS} consecutive checks.${caveat}`,
+                now,
+                // Prepared BEFORE the verdict is narrated, so the sentence
+                // the human reads cannot promise a revert Task that was
+                // never filed (slice-AJ review: the Inbox used to say "a
+                // revert Task has been prepared and is waiting in review"
+                // whether or not the write had succeeded).
+                async () => {
+                    offer = await this.prepareRevertOffer(promotion, now);
+                },
+            );
+            if (offer) await this.announceRevertOffer(promotion, offer);
+            return;
+        }
+        // We cannot reach the version endpoint either. That is evidence
+        // about this node's network, not about the release. Refusing to
+        // conclude here is what stops a flaky fleet node from filing a
+        // revert offer against a healthy production deployment.
+        await this.settle(
+            promotion,
+            state,
+            'inconclusive',
+            'The app checks failed, but the environment could not be re-confirmed as serving the promoted ' +
+                'commit either — so the failures are not evidence about this release. Nothing has been ' +
+                `offered for revert. Last reading: ${detail || 'the version endpoint did not answer as expected'}.`,
+            now,
+        );
+    }
+
+    /** Record a non-terminal step. */
+    private async step(
+        promotion: ReleasePromotion,
+        from: ReleaseVerifyState,
+        jobId: string,
+        patch: {
+            verifyState: ReleaseVerifyState;
+            verifyStreak: number;
+            verifyCheckedAt: Date;
+            verifyRetryAt: Date | null;
+            verifyDetail: string | null;
+        },
+    ): Promise<boolean> {
+        const applied = await this.promotions.recordVerifyResult(
+            promotion.id,
+            { jobId, state: from },
+            patch,
+        );
+        if (applied) Object.assign(promotion, patch, { verifyJobId: null });
+        return applied;
+    }
+
+    /**
+     * Record a terminal verdict and, for the ONE caller whose write landed,
+     * narrate it.
+     *
+     * The compare-and-set is what makes "one Inbox item per verdict" true
+     * across replicas — the same shape slice AI uses for the gate notice.
+     */
+    private async settle(
+        promotion: ReleasePromotion,
+        from: ReleaseVerifyState,
+        to: Extract<ReleaseVerifyState, 'passed' | 'failed' | 'inconclusive'>,
+        detail: string,
+        now: Date,
+        /**
+         * Runs after the compare-and-set lands and BEFORE anything is
+         * narrated — the one caller that uses it prepares the revert offer,
+         * so the narration below can report what actually exists instead of
+         * what was hoped for. Best-effort like everything else here.
+         */
+        beforeNarration?: () => Promise<void>,
+        /** What a `passed` verdict is entitled to claim; see `observeTarget`. */
+        proof?: ReleaseVerifyAppProof,
+    ): Promise<boolean> {
+        const applied = await this.promotions.settleVerification(promotion.id, from, {
+            verifyState: to,
+            verifyCheckedAt: now,
+            verifyDetail: trim(detail),
+        });
+        if (!applied) return false;
+        Object.assign(promotion, {
+            verifyState: to,
+            verifyDetail: trim(detail),
+            verifyJobId: null,
+        });
+        if (beforeNarration) {
+            try {
+                await beforeNarration();
+            } catch (error) {
+                this.logger.warn(
+                    `Promotion ${promotion.id}: post-verdict step failed: ${describe(error)}`,
+                );
+            }
+        }
+        const task = await this.loadTask(promotion);
+        await this.report(task, verdictNarrative(promotion, to, detail, proof));
+        await this.fileVerdictNotice(promotion, task, to, detail);
+        return true;
+    }
+
+    /**
+     * Re-read this promotion's verification target, for NARRATION only.
+     *
+     * Never an authorization input: the probe URLs were resolved when the
+     * attempt was claimed and are already on the row. This exists so a
+     * verdict can name the two hosts it is talking about and say how much
+     * a green app probe proved. Owner-checked like every other read of the
+     * Work in this file, and it fails to the CONSERVATIVE answer —
+     * `liveness`, the claim that asserts less — rather than throwing.
+     */
+    private async observeTarget(promotion: ReleasePromotion): Promise<{
+        proof: ReleaseVerifyAppProof;
+        appHost: string | null;
+        versionHost: string | null;
+    }> {
+        try {
+            const work = await this.works.findById(promotion.workId);
+            const target =
+                work && work.userId === promotion.userId
+                    ? resolveReleaseVerificationTarget(work.releaseVerification, promotion.rung)
+                    : null;
+            return {
+                proof: releaseVerifyAppProof(target, promotion.verifyExpectedSha),
+                appHost: target ? hostOf(target.appUrl) : null,
+                versionHost: target ? hostOf(target.versionUrl) : null,
+            };
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not re-read the verification target: ${describe(error)}`,
+            );
+            return { proof: 'liveness', appHost: null, versionHost: null };
+        }
+    }
+
+    // ── The revert OFFER ──────────────────────────────────────────────
+
+    /**
+     * File the prepared revert. {@link announceRevertOffer} then says so.
+     *
+     * The two are separate because ORDER MATTERS: the offer is written
+     * before the verdict is narrated, so the verdict can only tell a human
+     * a revert is waiting when one actually is. Before the slice-AJ review
+     * the notice was filed first and said "a revert Task has been prepared
+     * and is waiting in review" even when the Task write had failed and
+     * `revertTaskId` was still null — for a terminal verdict the sweep
+     * never revisits.
+     *
+     * THIS IS AN OFFER. It creates a Task and an Inbox item and stops. It
+     * does not create a branch, does not create a commit, does not open a
+     * pull request, does not merge and does not deploy. Three independent
+     * things have to be true before it even gets this far:
+     *
+     *   1. the verification reached `failed`, which requires a confirmed
+     *      rollout, a confirmed failure streak AND a re-confirmation that
+     *      the environment is reachable;
+     *   2. {@link isReleaseVerifyRevertOffered} agrees, checked here as
+     *      well as in the caller;
+     *   3. `claimRevertOffer` writes only `WHERE verifyState = 'failed' AND
+     *      revertTaskId IS NULL`, so the database refuses an offer for any
+     *      other verdict and refuses a second one.
+     *
+     * The Task is filed IN_REVIEW, not TODO, exactly as a promotion Task
+     * is: `TaskGraphFanoutService` starts unblocked TODO Tasks, and a
+     * revert Task that dispatched an agent run the moment it was created
+     * would be a platform reverting production by itself.
+     *
+     * And when a human does move it to TODO, the pull request it opens
+     * still cannot land unattended: `TaskMergeGateService` recognises the
+     * `release:revert` label, forces the `merge_pull_request` approval path
+     * whatever the scope's `requireHumanApproval` says, and resolves the
+     * base branch from the Work's release LADDER so the branch the
+     * protected-branch rule is evaluated against — and the branch named in
+     * the sentence the approver reads — is the one the revert actually
+     * lands on. Moving a Task out of review is a "start this work" act, not
+     * a merge approval, and the gate now treats it as such.
+     */
+    private async prepareRevertOffer(promotion: ReleasePromotion, now: Date): Promise<Task | null> {
+        if (!isReleaseVerifyRevertOffered(promotion.verifyState)) return null;
+        if (promotion.revertTaskId) return null;
+
+        const work = await this.works.findById(promotion.workId);
+        const promotionTask = await this.loadTask(promotion);
+
+        const task = await this.createRevertTask(promotion, work, promotionTask);
+        if (!task) return null;
+
+        const claimed = await this.promotions.claimRevertOffer(promotion.id, task.id, now);
+        if (!claimed) {
+            // Somebody else got there, or the verdict is not `failed` after
+            // all. Retire the Task rather than leaving a second revert offer
+            // lying about for a human to act on twice.
+            this.logger.warn(
+                `Promotion ${promotion.id}: revert offer not claimed; cancelling the duplicate Task ${task.id}.`,
+            );
+            try {
+                await this.tasks.updateById(task.id, { status: TaskStatus.CANCELLED });
+            } catch (error) {
+                this.logger.warn(
+                    `Could not cancel duplicate revert Task ${task.id}: ${describe(error)}`,
+                );
+            }
+            return null;
+        }
+        Object.assign(promotion, { revertTaskId: task.id, revertOfferedAt: now });
+        return task;
+    }
+
+    /**
+     * Write the Task, once with the node's own reading in it and — if that
+     * is refused — once without.
+     *
+     * `TasksService.create` runs `assertNoSecrets(input.description)`, and
+     * the description embeds `promotion.verifyDetail`, which is derived
+     * from NODE-REPORTED browser output. A node whose failure string
+     * happens to contain a token-shaped substring would otherwise take the
+     * whole offer down (slice-AJ review), and `failed` is terminal, so the
+     * sweep never revisits the row and the offer would be lost for ever.
+     * The reading is the least important part of the description — the
+     * coordinates are the point — so it is what gets dropped.
+     */
+    private async createRevertTask(
+        promotion: ReleasePromotion,
+        work: Work | null,
+        promotionTask: Task | null,
+    ): Promise<Task | null> {
+        const file = async (withReading: boolean): Promise<Task> =>
+            this.tasksService.create(promotion.userId, {
+                title: `Revert release: ${promotion.headBranch} → ${promotion.baseBranch}`,
+                description: revertTaskDescription(promotion, work, withReading),
+                // IN_REVIEW keeps it off the fanout dispatcher. A human
+                // moving it to TODO is the deliberate act that starts any
+                // work at all, and even then the merge stays gated: a revert
+                // Task's own labels make `TaskMergeGateService` require a
+                // recorded human approval whatever the scope's policy says.
+                status: TaskStatus.IN_REVIEW,
+                priority: TaskPriority.P0,
+                labels: releaseRevertTaskLabels(promotion.rung),
+                workId: promotion.workId,
+                agentId: promotionTask?.agentId ?? null,
+                createdByType: 'user',
+                createdById: promotion.userId,
+            });
+        try {
+            return await file(true);
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not file the revert offer Task with the node's ` +
+                    `reading (${describe(error)}); retrying without it.`,
+            );
+        }
+        try {
+            return await file(false);
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not file the revert offer Task: ${describe(error)}`,
+            );
+            return null;
+        }
+    }
+
+    /** Say that the offer exists — only ever called when it does. */
+    private async announceRevertOffer(promotion: ReleasePromotion, task: Task): Promise<void> {
+        await this.reportOnPromotionTask(
+            promotion,
+            `A revert has been PREPARED, not performed: Task ${task.slug ?? task.id}. Nothing has been ` +
+                'reverted, and nothing will be until a human decides to act on it.',
+        );
+        await this.fileRevertNotice(promotion, task);
+    }
+
+    // ── Narration ─────────────────────────────────────────────────────
+
+    private async fileVerdictNotice(
+        promotion: ReleasePromotion,
+        task: Task | null,
+        state: ReleaseVerifyState,
+        detail: string,
+    ): Promise<void> {
+        if (!this.inbox) return;
+        const lane = `${promotion.headBranch} → ${promotion.baseBranch}`;
+        const environment = releaseEnvironmentForRung(promotion.rung) ?? 'unknown';
+        const sha = promotion.verifyExpectedSha?.slice(0, 12) ?? null;
+        const title =
+            state === 'passed'
+                ? `Deployment VERIFIED for ${lane}${sha ? ` (@ ${sha})` : ''}`
+                : state === 'failed'
+                  ? `DEPLOYMENT FAILED after ${lane}${sha ? ` (@ ${sha})` : ''}` +
+                    // Only when one exists. `prepareRevertOffer` runs before
+                    // this line precisely so this can be true rather than
+                    // hopeful.
+                    (promotion.revertTaskId
+                        ? ' — revert prepared'
+                        : ' — NO revert could be prepared')
+                  : `Deployment NOT VERIFIED for ${lane}${sha ? ` (@ ${sha})` : ''}`;
+
+        const body = [
+            `${lane} merged, and the ${environment} environment was checked from a fleet node with a real browser.`,
+            `Verdict: ${state}.`,
+            detail,
+            promotion.verifyTargetUrl ? `Last URL checked: ${promotion.verifyTargetUrl}` : null,
+            sha ? `Commit the deployment was held to: ${sha}` : null,
+            whatHappensNext(promotion, state),
+        ]
+            .filter((line): line is string => Boolean(line))
+            .join('\n')
+            .slice(0, 8000);
+
+        try {
+            await this.inbox.notice(promotion.userId, {
+                title: title.slice(0, 300),
+                body,
+                taskId: task?.id ?? promotion.taskId ?? null,
+                workId: promotion.workId,
+                agentId: task?.agentId ?? null,
+                organizationId: promotion.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(`Promotion ${promotion.id}: inbox notice failed: ${describe(error)}`);
+        }
+    }
+
+    private async fileRevertNotice(promotion: ReleasePromotion, revertTask: Task): Promise<void> {
+        if (!this.inbox) return;
+        const lane = `${promotion.headBranch} → ${promotion.baseBranch}`;
+        try {
+            await this.inbox.notice(promotion.userId, {
+                title: `Revert prepared for ${lane} — your decision`.slice(0, 300),
+                body: [
+                    `The ${releaseEnvironmentForRung(promotion.rung) ?? 'deployed'} environment failed its ` +
+                        `post-deploy checks after ${lane} landed, so a revert has been PREPARED.`,
+                    '',
+                    'NOTHING HAS BEEN REVERTED. This platform does not revert production, and it will not ' +
+                        'start now. What exists is a Task holding the coordinates:',
+                    `  · Task: ${revertTask.slug ?? revertTask.id} — "${revertTask.title}"`,
+                    `  · Promotion pull request: ${promotion.prUrl ?? `#${promotion.prNumber ?? '?'}`}`,
+                    `  · Branch to undo it on: ${promotion.baseBranch}`,
+                    `  · Commit the failing deployment was serving: ${promotion.verifyExpectedSha ?? 'unknown'}`,
+                    '',
+                    'What you decide:',
+                    '  1. Do nothing — the release stands. The Task sits in review and changes nothing.',
+                    '  2. Roll forward — fix it on the integration branch and promote again.',
+                    '  3. Revert — start the Task. It opens an ordinary pull request, and landing that pull ' +
+                        'request needs the same "Merge pull request" approval in this Inbox as any other ' +
+                        'merge, verified against the head commit at merge time.',
+                    '',
+                    'The next rung is not opened automatically, and neither is this one undone automatically.',
+                ]
+                    .join('\n')
+                    .slice(0, 8000),
+                taskId: revertTask.id,
+                workId: promotion.workId,
+                agentId: revertTask.agentId ?? null,
+                organizationId: promotion.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: revert inbox notice failed: ${describe(error)}`,
+            );
+        }
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────
+
+    /**
+     * The base branch's tip, from the git provider, right after the merge.
+     *
+     * Owner, repository and credentials come from the WORK — the same
+     * resolution the promotion lane uses, so a promotion and its
+     * verification cannot end up reading different repositories.
+     */
+    private async readBaseTip(work: Work, promotion: ReleasePromotion): Promise<string | null> {
+        if (!this.gitFacade) return null;
+        const target = this.resolveRepo(work, promotion.userId);
+        try {
+            const branches = await this.gitFacade.listBranches(
+                target.owner,
+                target.repo,
+                target.gitOptions,
+            );
+            const match = branches.find((branch) => branch.name === promotion.baseBranch);
+            return normalizeCommitSha(match?.commit) ?? null;
+        } catch (error) {
+            this.logger.warn(
+                `Promotion ${promotion.id}: could not read ${promotion.baseBranch}: ${describe(error)}`,
+            );
+            return null;
+        }
+    }
+
+    private resolveRepo(
+        work: Work,
+        userId: string,
+    ): { owner: string; repo: string; gitOptions: GitFacadeOptions } {
+        return {
+            owner: work.getRepoOwner(),
+            repo: work.getDataRepo(),
+            gitOptions: { userId, providerId: work.gitProvider, workId: work.id },
+        };
+    }
+
+    private async loadTask(promotion: ReleasePromotion): Promise<Task | null> {
+        if (!promotion.taskId) return null;
+        try {
+            return await this.tasks.findById(promotion.taskId);
+        } catch {
+            return null;
+        }
+    }
+
+    private async reportOnPromotionTask(promotion: ReleasePromotion, body: string): Promise<void> {
+        await this.report(await this.loadTask(promotion), body);
+    }
+
+    /** One line of narrative on the promotion Task's own thread. Best-effort. */
+    private async report(task: Task | null, body: string): Promise<void> {
+        if (!task?.agentId) return;
+        try {
+            await this.chat.create({
+                taskId: task.id,
+                authorType: 'agent',
+                authorId: task.agentId,
+                body,
+                tenantId: task.tenantId ?? null,
+                organizationId: task.organizationId ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(`Task ${task.id}: verification report failed: ${describe(error)}`);
+        }
+    }
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+/** Host of a stored probe URL, for narration. Never throws on a bad value. */
+function hostOf(url: string): string | null {
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * A short reading for a check this lane had to recover off the job row,
+ * because nothing recorded its completion (see `reconcileInFlight`).
+ *
+ * Deliberately the same vocabulary the completion listener produces, and
+ * everything in it is NODE-REPORTED and therefore untrusted — the caller
+ * flattens and caps it before it touches a row.
+ */
+function describeSettledJob(job: FleetJob): string {
+    if (job.error) return `Node reported: ${job.error}`;
+    const result = job.result as { ok?: unknown; error?: unknown } | null | undefined;
+    if (!result) return `The check settled ${job.status} with no result.`;
+    if (result.ok === true) return 'Page loaded.';
+    return typeof result.error === 'string' && result.error
+        ? `Check failed: ${result.error}`
+        : `Check settled ${job.status} without passing.`;
+}
+
+/**
+ * Cap and flatten a note before it touches the row.
+ *
+ * Half of what reaches here is derived from a NODE-REPORTED browser
+ * result, which is untrusted data that ends up in an Inbox body and a Task
+ * thread. Newlines and control characters are collapsed so a node cannot
+ * forge extra lines in either.
+ */
+function trim(value: string): string {
+    return (
+        value
+            // Escapes, never literal control bytes in the source.
+            .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .slice(0, DETAIL_MAX)
+    );
+}
+
+function verdictNarrative(
+    promotion: ReleasePromotion,
+    state: ReleaseVerifyState,
+    detail: string,
+    proof?: ReleaseVerifyAppProof,
+): string {
+    switch (state) {
+        case 'passed':
+            return (
+                `Deployment VERIFIED. ${detail} ` +
+                // "Nothing further is required" is a claim, and it is only
+                // true when the app probe proved the promoted artefact. On
+                // the shipped fixed-string health probe it did not, and
+                // telling a founder to stop looking would be exactly the
+                // overclaim this lane exists to prevent.
+                (proof === 'liveness'
+                    ? 'Confirm the app deployment itself by hand, or point the app probe at a page that ' +
+                      'carries the build commit.'
+                    : 'Nothing further is required.')
+            );
+        case 'failed':
+            return (
+                `Deployment FAILED its post-deploy checks. ${detail} ` +
+                (promotion.revertTaskId
+                    ? 'A revert has been prepared for a human to decide on.'
+                    : 'A revert could NOT be prepared — decide by hand.') +
+                ' NOTHING HAS BEEN REVERTED.'
+            );
+        default:
+            return (
+                `Deployment NOT VERIFIED. ${detail} ` +
+                'This is not a pass and it is not a failure — it is the absence of a measurement, so no ' +
+                'revert has been offered.'
+            );
+    }
+}
+
+function whatHappensNext(promotion: ReleasePromotion, state: ReleaseVerifyState): string {
+    switch (state) {
+        case 'passed':
+            return 'Nothing else happens. The next rung is a separate promotion and is not opened automatically.';
+        case 'failed':
+            return promotion.revertTaskId
+                ? 'A revert Task has been prepared and is waiting in review. NOTHING HAS BEEN REVERTED — ' +
+                      'this platform does not revert production, and starting that Task still leads to an ' +
+                      'ordinary pull request that needs your merge approval.'
+                : 'A revert Task could NOT be filed for this failure, so there is nothing waiting in ' +
+                      'review — do not go looking for one. NOTHING HAS BEEN REVERTED. Decide by hand: read ' +
+                      'the environment yourself, and roll forward or revert deliberately.';
+        default:
+            return (
+                'No revert has been offered, because nothing was measured — offering to undo a release on ' +
+                'the strength of a check that did not happen is worse than saying so. Decide by hand: read ' +
+                'the environment yourself, and roll forward or revert deliberately.'
+            );
+    }
+}
+
+function revertTaskDescription(
+    promotion: ReleasePromotion,
+    work: Work | null,
+    withReading: boolean,
+): string {
+    const repo = work ? `${work.getRepoOwner()}/${work.getDataRepo()}` : 'the release repository';
+    return [
+        `Post-deploy verification FAILED after \`${promotion.headBranch}\` → \`${promotion.baseBranch}\` ` +
+            `landed in ${repo}.`,
+        '',
+        '## Nothing has been reverted',
+        '',
+        'This Task is an OFFER. It was filed in review so that it does nothing at all until you decide it',
+        'should. The platform will not revert production on its own, and starting this Task does not merge',
+        'anything either: whatever pull request it opens needs the same "Merge pull request" approval in',
+        'your Inbox as every other merge, verified against the head commit at merge time.',
+        '',
+        '## What failed',
+        '',
+        `- Environment: ${releaseEnvironmentForRung(promotion.rung) ?? 'unknown'}`,
+        `- URL last checked: ${promotion.verifyTargetUrl ?? 'unknown'}`,
+        `- Commit the environment was serving: \`${promotion.verifyExpectedSha ?? 'unknown'}\``,
+        // NODE-REPORTED, and therefore the one line that can be refused by
+        // the Task writer's secret scan. Dropped on the retry rather than
+        // losing the whole offer.
+        `- Reading: ${(withReading && promotion.verifyDetail) || 'see the promotion Task thread'}`,
+        '',
+        '## What to revert',
+        '',
+        `- Promotion pull request: ${promotion.prUrl ?? `#${promotion.prNumber ?? 'unknown'}`}`,
+        `- Branch to open the revert against: \`${promotion.baseBranch}\``,
+        `- The merge commit to undo is the one that landed that pull request on \`${promotion.baseBranch}\`;`,
+        `  \`${promotion.verifyExpectedSha ?? 'the recorded commit'}\` is the tip that was read immediately`,
+        '  afterwards and is what the failing deployment was serving.',
+        '',
+        '## Before you choose revert',
+        '',
+        'Rolling FORWARD is usually cheaper on this repository: the production build lane is measured at',
+        '215–243 minutes, so a revert is not a fast undo — it is another full release, and it needs its own',
+        'promotion and its own approval. Reverting is right when the fix is not obvious; rolling forward is',
+        'right when it is.',
+        '',
+        'This Task will not open the next rung, and no further checks are queued for the failed deployment.',
+    ].join('\n');
+}

--- a/packages/agent/src/tasks-domain/task-merge-gate.service.ts
+++ b/packages/agent/src/tasks-domain/task-merge-gate.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type { GitPullRequestStatus } from '@ever-works/plugin';
-import { isPromotionTask, normalizeCommitSha } from '@ever-works/contracts';
+import {
+    isPromotionTask,
+    isReleaseRevertTask,
+    normalizeCommitSha,
+    releaseRevertRungFromLabels,
+    resolvePromotionBranches,
+} from '@ever-works/contracts';
+import type { ReleaseLadder } from '@ever-works/contracts';
 import { Task } from '../entities/task.entity';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { MergePolicyService } from '../policy/merge-policy.service';
@@ -163,6 +170,41 @@ export class TaskMergeGateService {
         const work = await this.works.findById(task.workId);
         if (!work) return { action: 'skipped', reason: 'no-work' };
 
+        // Post-deploy verification and revert (slice AJ, EW-809) — the
+        // SECOND narrowing, and it exists because undoing a promotion is
+        // the same class of act as making one.
+        //
+        // A revert Task is deliberately an ORDINARY Task: it carries no
+        // `release:promotion` label, so `assessPromotion` above answers
+        // `{ promotion: null }` for it and, without this, `needsApproval`
+        // below would collapse back to the operator's policy flag —
+        // `requireHumanApproval: false` is a legitimate setting for
+        // ordinary agent work, and the release lane additionally REQUIRES
+        // `allowAgentMerge: true` with `main` unprotected or slice AI's own
+        // promotion merges are refused. On that configuration a revert
+        // pull request would have merged into production with no
+        // `merge_pull_request` approval ever raised, verified or recorded.
+        //
+        // It also resolves the branch the revert actually lands on. Every
+        // other Task pull request targets the Work's isolation base; a
+        // revert lands where the promotion landed, and that value is what
+        // the protected-branch rule is evaluated against AND what the
+        // approving human reads. Resolved from the Work's LADDER and the
+        // Task's own rung label — platform state on both sides, never
+        // anything a caller supplied.
+        //
+        // Fails closed: a revert Task whose rung or ladder cannot be
+        // resolved is not merged at all, rather than merged against a base
+        // this gate had to guess.
+        const revertBase = resolveRevertBase(task, work);
+        if (isReleaseRevertTask(task.labels) && !revertBase) {
+            this.logger.warn(
+                `Task ${task.id}: release revert Task has no resolvable base branch ` +
+                    '(missing rung label or unusable release ladder) — refusing the merge.',
+            );
+            return { action: 'skipped', reason: 'revert-base-unresolved' };
+        }
+
         // The Agent that owns this Task's runs. Without one there is no
         // scope to resolve an Agent-level policy against and nobody to
         // attribute the merge to, so the gate stands down rather than
@@ -197,7 +239,11 @@ export class TaskMergeGateService {
         // and `attemptMergeForOpenPullRequest` additionally RAISES the
         // requirement inside the facade so the property does not rest on
         // this branch alone.
-        const needsApproval = resolved.policy.requireHumanApproval || promotion !== null;
+        // `revertBase !== null` carries the slice-AJ half of the same
+        // property: a revert is never merged without a recorded human
+        // approval either.
+        const needsApproval =
+            resolved.policy.requireHumanApproval || promotion !== null || revertBase !== null;
 
         if (!needsApproval) {
             // The operator opted out of approvals for this scope. Green
@@ -227,10 +273,11 @@ export class TaskMergeGateService {
                 agentId,
                 gateStatus: 'green',
                 headSha,
-                // The promotion's own base, not the Work's default — see
+                // The promotion's own base — or, for a revert, the branch
+                // the promotion landed on. Never the Work's default; see
                 // `attemptMergeForOpenPullRequest`.
-                baseRef: promotion?.baseBranch ?? null,
-                requireHumanApproval: promotion !== null,
+                baseRef: promotion?.baseBranch ?? revertBase,
+                requireHumanApproval: promotion !== null || revertBase !== null,
             });
             return { action: 'merge-attempted', merge };
         }
@@ -252,6 +299,7 @@ export class TaskMergeGateService {
             // request targets the Work's isolation base.
             targetBranch:
                 promotion?.baseBranch ??
+                revertBase ??
                 ((work.taskIsolationBaseBranch && work.taskIsolationBaseBranch.trim()) || null),
             repository: `${work.getRepoOwner()}/${work.getDataRepo()}`,
             ciState: status.ciState,
@@ -345,4 +393,24 @@ export class TaskMergeGateService {
         );
         return { blocked: { action: 'skipped', reason: verdict.code }, promotion: null };
     }
+}
+
+/**
+ * The branch a release revert Task lands on, or `null` when this is not a
+ * revert Task (or is one whose base cannot be resolved).
+ *
+ * Post-deploy verification and revert (slice AJ, EW-809). BOTH inputs are
+ * platform state: the rung comes from the labels the verification service
+ * filed the Task with, and the branch comes from the Work's release
+ * ladder — the same `resolvePromotionBranches` slice AI opened the
+ * promotion with, so a revert and the promotion it undoes can never
+ * disagree about which branch is production.
+ */
+function resolveRevertBase(
+    task: Pick<Task, 'labels'>,
+    work: { releaseLadder?: ReleaseLadder | null },
+): string | null {
+    const rung = releaseRevertRungFromLabels(task.labels);
+    if (!rung) return null;
+    return resolvePromotionBranches(work.releaseLadder, rung)?.base ?? null;
 }

--- a/packages/contracts/src/release/__tests__/deployment-verification.types.spec.ts
+++ b/packages/contracts/src/release/__tests__/deployment-verification.types.spec.ts
@@ -1,0 +1,513 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	RELEASE_ENVIRONMENTS,
+	RELEASE_REVERT_TASK_LABEL,
+	RELEASE_VERIFY_ATTEMPT_INTERVAL_MS,
+	RELEASE_VERIFY_BUDGET_MS,
+	RELEASE_VERIFY_EXPECT_MIN_LENGTH,
+	RELEASE_VERIFY_FAILURE_CONFIRMATIONS,
+	RELEASE_VERIFY_MAX_ATTEMPTS,
+	RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS,
+	RELEASE_VERIFY_SHA_EXPECT_LENGTH,
+	RELEASE_VERIFY_STATES,
+	isReleaseRevertTask,
+	isReleaseVerifyCheckPass,
+	isReleaseVerifyExhausted,
+	isReleaseVerifyPass,
+	isReleaseVerifyRevertOffered,
+	isReleaseVerifyState,
+	isReleaseVerifyTerminal,
+	releaseEnvironmentForRung,
+	releaseRevertRungFromLabels,
+	releaseRevertTaskLabels,
+	releaseVerificationProbe,
+	releaseVerifyAppProof,
+	releaseVerifyIdempotencyKey,
+	resolveReleaseVerificationTarget,
+	sanitizeReleaseVerificationTargets,
+	type ReleaseVerifyState
+} from '../deployment-verification.types.js';
+import { PROMOTION_TASK_LABEL } from '../promotion.types.js';
+
+const STAGING = {
+	versionUrl: 'https://apistage.ever.works/api/version',
+	appUrl: 'https://appstage.ever.works/api/health',
+	appExpectText: '"status":"OK"'
+};
+const PRODUCTION = {
+	versionUrl: 'https://api.ever.works/api/version',
+	appUrl: 'https://app.ever.works/api/health',
+	appExpectText: '"status":"OK"'
+};
+const TARGETS = { staging: STAGING, production: PRODUCTION };
+const SHA = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+
+describe('releaseEnvironmentForRung — the rung deploys its BASE', () => {
+	it('maps develop-to-stage onto staging, not production', () => {
+		// THE mistake this mapping exists to make impossible: merging
+		// `develop -> stage` deploys STAGE. A check pointed at production
+		// would pass against a deployment the promotion never touched.
+		expect(releaseEnvironmentForRung('develop-to-stage')).toBe('staging');
+	});
+
+	it('maps stage-to-main onto production', () => {
+		expect(releaseEnvironmentForRung('stage-to-main')).toBe('production');
+	});
+
+	it('refuses an unknown rung rather than guessing production', () => {
+		expect(releaseEnvironmentForRung('develop-to-main' as never)).toBeNull();
+	});
+
+	it('covers every declared environment', () => {
+		expect(RELEASE_ENVIRONMENTS).toEqual(['staging', 'production']);
+	});
+});
+
+describe('sanitizeReleaseVerificationTargets', () => {
+	it('accepts a well-formed map', () => {
+		expect(sanitizeReleaseVerificationTargets(TARGETS)).toEqual(TARGETS);
+	});
+
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an array', [STAGING]],
+		['a string', 'https://app.ever.works'],
+		['an empty object', {}]
+	])('refuses %s', (_label, value) => {
+		expect(sanitizeReleaseVerificationTargets(value)).toBeNull();
+	});
+
+	it('drops ONE unusable environment without poisoning the other', () => {
+		// Fail closed PER ENVIRONMENT: a broken production entry must not
+		// take staging down with it, and must not survive as a half-target.
+		const result = sanitizeReleaseVerificationTargets({
+			staging: STAGING,
+			production: { ...PRODUCTION, appUrl: 'http://app.ever.works' }
+		});
+		expect(result).toEqual({ staging: STAGING });
+		expect(result?.production).toBeUndefined();
+	});
+
+	describe('URL refusals', () => {
+		it.each([
+			['plain http — a verdict forgeable in transit', 'http://api.ever.works/api/version'],
+			['embedded credentials', 'https://user:pass@api.ever.works/api/version'],
+			['an IPv4 literal', 'https://169.254.169.254/api/version'],
+			['a private IPv4 literal', 'https://10.0.0.1/api/version'],
+			['bracketed IPv6', 'https://[::1]/api/version'],
+			['a single-label host', 'https://localhost/api/version'],
+			['a bare service name', 'https://metadata/api/version'],
+			['a file URL', 'file:///etc/passwd'],
+			['a fragment', 'https://api.ever.works/api/version#x'],
+			['nonsense', 'not-a-url']
+		])('refuses %s', (_label, versionUrl) => {
+			expect(sanitizeReleaseVerificationTargets({ production: { ...PRODUCTION, versionUrl } })).toBeNull();
+		});
+	});
+
+	describe('expectation refusals', () => {
+		it('refuses an expectation shorter than the minimum', () => {
+			// A short expectation is satisfied by almost any HTML document,
+			// including a provider error page.
+			expect(
+				sanitizeReleaseVerificationTargets({ production: { ...PRODUCTION, appExpectText: 'O' } })
+			).toBeNull();
+			expect(RELEASE_VERIFY_EXPECT_MIN_LENGTH).toBeGreaterThan(1);
+		});
+
+		it.each([
+			['div', 'the commonest tag name in HTML'],
+			['<html>', 'the document element'],
+			['<html><head', 'eleven characters, and in every page ever served'],
+			['<!doctype', 'the prologue'],
+			['</body></html>', 'the end of every document'],
+			['<span></span>', 'an empty inline element'],
+			['DIV></DIV', 'the same, shouted']
+		])('refuses %s — %s', (appExpectText) => {
+			// THE guard the minimum length was documented as providing and
+			// did not. The node matches with a raw `dom.includes(expectText)`
+			// against the serialized document, so any slice of a bare page
+			// skeleton is a check that always passes — including against
+			// Chrome's own network-error page and a CDN 502 interstitial,
+			// both of which exit 0 under `--dump-dom` with a NON-empty
+			// document, so the executor's empty-document guard misses them
+			// too. Three characters (the old minimum) refused none of these.
+			expect(sanitizeReleaseVerificationTargets({ production: { ...PRODUCTION, appExpectText } })).toBeNull();
+		});
+
+		it('accepts an expectation that says something about THIS app', () => {
+			// The negative control: the guard must not refuse real
+			// expectations. Both of these are configurations the runbook
+			// recommends.
+			for (const appExpectText of ['"status":"OK"', 'a1b2c3d4e5f6', 'Ever Works directory']) {
+				expect(
+					sanitizeReleaseVerificationTargets({ production: { ...PRODUCTION, appExpectText } })
+				).not.toBeNull();
+			}
+		});
+
+		it('refuses a missing expectation rather than checking nothing', () => {
+			expect(
+				sanitizeReleaseVerificationTargets({
+					production: { versionUrl: PRODUCTION.versionUrl, appUrl: PRODUCTION.appUrl }
+				})
+			).toBeNull();
+		});
+
+		it('refuses an over-long expectation', () => {
+			expect(
+				sanitizeReleaseVerificationTargets({ production: { ...PRODUCTION, appExpectText: 'x'.repeat(201) } })
+			).toBeNull();
+		});
+	});
+
+	describe('the two URLs must be about the same deployment', () => {
+		it('refuses a target whose app and version URLs are unrelated hosts', () => {
+			// `confirming-failure` re-probes `versionUrl` to tell "the app is
+			// broken" apart from "this node lost the internet" — and that
+			// argument only holds while the two URLs are about the same
+			// deployment. With unrelated hosts the confirmation answers "can
+			// this node reach a DIFFERENT hostname", which is not the
+			// question: an app host behind a bot interstitial, an HTTP Basic
+			// wall or a DNS block fails three app probes, is "confirmed" by a
+			// healthy version host, and produces a `failed` verdict — a
+			// revert offer against a release serving every user correctly.
+			expect(
+				sanitizeReleaseVerificationTargets({
+					production: { ...PRODUCTION, appUrl: 'https://status.example.com/health' }
+				})
+			).toBeNull();
+		});
+
+		it('accepts the intended production pair, which differ only by subdomain', () => {
+			// `api.ever.works` + `app.ever.works`, and the staging pair. The
+			// rule must not break the configuration the runbook recommends.
+			expect(sanitizeReleaseVerificationTargets(TARGETS)).toEqual(TARGETS);
+		});
+
+		it('fails CLOSED per environment, so one unrelated pair does not verify anything', () => {
+			const result = sanitizeReleaseVerificationTargets({
+				staging: STAGING,
+				production: { ...PRODUCTION, appUrl: 'https://elsewhere.example.com/health' }
+			});
+			expect(result).toEqual({ staging: STAGING });
+		});
+	});
+
+	it('refuses a target missing its app URL — half a deployment is not a pass', () => {
+		expect(
+			sanitizeReleaseVerificationTargets({
+				production: { versionUrl: PRODUCTION.versionUrl, appExpectText: '"status":"OK"' }
+			})
+		).toBeNull();
+	});
+});
+
+describe('resolveReleaseVerificationTarget', () => {
+	it('resolves the environment the rung actually deployed', () => {
+		expect(resolveReleaseVerificationTarget(TARGETS, 'develop-to-stage')).toEqual(STAGING);
+		expect(resolveReleaseVerificationTarget(TARGETS, 'stage-to-main')).toEqual(PRODUCTION);
+	});
+
+	it('answers null when the rung’s environment has no target', () => {
+		expect(resolveReleaseVerificationTarget({ staging: STAGING }, 'stage-to-main')).toBeNull();
+	});
+
+	it.each([
+		['no targets at all', null],
+		['an unusable blob', { production: 'https://app.ever.works' }]
+	])('answers null for %s', (_label, targets) => {
+		expect(resolveReleaseVerificationTarget(targets as never, 'stage-to-main')).toBeNull();
+	});
+});
+
+describe('the verdict vocabulary', () => {
+	it('pins the seven states', () => {
+		expect(RELEASE_VERIFY_STATES).toEqual([
+			'awaiting-rollout',
+			'checking-app',
+			'confirming-failure',
+			'passed',
+			'failed',
+			'inconclusive',
+			'unsupported'
+		]);
+	});
+
+	it('treats only `passed` as a pass', () => {
+		// Written as an equality so a state added later is a not-a-pass by
+		// default. Every other state, INCLUDING the ones that sound benign,
+		// must be false here.
+		for (const state of RELEASE_VERIFY_STATES) {
+			expect(isReleaseVerifyPass(state)).toBe(state === 'passed');
+		}
+		expect(isReleaseVerifyPass(null)).toBe(false);
+		expect(isReleaseVerifyPass(undefined)).toBe(false);
+		expect(isReleaseVerifyPass('unsupported')).toBe(false);
+		expect(isReleaseVerifyPass('inconclusive')).toBe(false);
+	});
+
+	it('offers a revert for `failed` and for NOTHING else', () => {
+		// THE constraint. An inconclusive verdict is not a pass and is not a
+		// revert either: you cannot responsibly offer to undo a release on
+		// the strength of a measurement you failed to take.
+		for (const state of RELEASE_VERIFY_STATES) {
+			expect(isReleaseVerifyRevertOffered(state)).toBe(state === 'failed');
+		}
+		expect(isReleaseVerifyRevertOffered(null)).toBe(false);
+	});
+
+	it('knows which states are over', () => {
+		const terminal: ReleaseVerifyState[] = ['passed', 'failed', 'inconclusive', 'unsupported'];
+		for (const state of RELEASE_VERIFY_STATES) {
+			expect(isReleaseVerifyTerminal(state)).toBe(terminal.includes(state));
+		}
+		expect(isReleaseVerifyTerminal(null)).toBe(false);
+	});
+
+	it('narrows a value off a column', () => {
+		expect(isReleaseVerifyState('passed')).toBe(true);
+		expect(isReleaseVerifyState('PASSED')).toBe(false);
+		expect(isReleaseVerifyState(null)).toBe(false);
+		expect(isReleaseVerifyState('green')).toBe(false);
+	});
+});
+
+describe('releaseVerificationProbe — THE URL selection', () => {
+	it('probes the version endpoint for the promoted commit while awaiting rollout', () => {
+		expect(releaseVerificationProbe('awaiting-rollout', PRODUCTION, SHA)).toEqual({
+			phase: 'rollout',
+			url: PRODUCTION.versionUrl,
+			expectText: SHA.slice(0, RELEASE_VERIFY_SHA_EXPECT_LENGTH)
+		});
+	});
+
+	it('probes the app page once the rollout is confirmed', () => {
+		expect(releaseVerificationProbe('checking-app', PRODUCTION, SHA)).toEqual({
+			phase: 'app',
+			url: PRODUCTION.appUrl,
+			expectText: PRODUCTION.appExpectText
+		});
+	});
+
+	it('re-probes the VERSION endpoint when confirming a failure', () => {
+		// The confirmation asks "can this node still reach the environment,
+		// and is it still serving what we promoted" — not "is the app still
+		// broken". A node that lost its network answers no here, and that is
+		// evidence about the node, not about the release.
+		expect(releaseVerificationProbe('confirming-failure', PRODUCTION, SHA)?.phase).toBe('rollout');
+	});
+
+	it.each(['passed', 'failed', 'inconclusive', 'unsupported'] as const)(
+		'enqueues nothing in the terminal state %s',
+		(state) => {
+			expect(releaseVerificationProbe(state, PRODUCTION, SHA)).toBeNull();
+		}
+	);
+
+	it('refuses to probe with no target', () => {
+		expect(releaseVerificationProbe('awaiting-rollout', null, SHA)).toBeNull();
+	});
+
+	it.each([
+		['a missing commit', null],
+		['an empty commit', '   '],
+		['a non-hex commit', 'zzzzzzzzzzzz'],
+		['a commit too short to be one', 'a1b2c3']
+	])('refuses to probe with %s — an empty expectation asserts nothing', (_label, sha) => {
+		expect(releaseVerificationProbe('awaiting-rollout', PRODUCTION, sha)).toBeNull();
+	});
+
+	it('shortens the commit rather than demanding the whole 40 characters', () => {
+		// The rendered document carries whatever length the service stamped;
+		// a fixed 12-character prefix is what both ends agree to look for.
+		const probe = releaseVerificationProbe('awaiting-rollout', PRODUCTION, SHA.toUpperCase());
+		expect(probe?.expectText).toBe(SHA.slice(0, 12));
+	});
+});
+
+describe('isReleaseVerifyExhausted — the two independent stops', () => {
+	const now = new Date('2026-09-06T12:00:00.000Z');
+	const future = new Date('2026-09-06T20:00:00.000Z');
+
+	it('keeps going inside both bounds', () => {
+		expect(isReleaseVerifyExhausted(1, future, now)).toBe(false);
+	});
+
+	it('stops on the attempt cap even with time left', () => {
+		expect(isReleaseVerifyExhausted(RELEASE_VERIFY_MAX_ATTEMPTS, future, now)).toBe(true);
+	});
+
+	it('stops on the deadline even with attempts left', () => {
+		expect(isReleaseVerifyExhausted(1, new Date('2026-09-06T11:59:59.000Z'), now)).toBe(true);
+	});
+
+	it.each([
+		['a missing deadline', null],
+		['an undefined deadline', undefined],
+		['an unparseable deadline', 'not-a-date']
+	])('treats %s as exhausted, so an unusable clock cannot loop for ever', (_label, deadline) => {
+		expect(isReleaseVerifyExhausted(1, deadline as never, now)).toBe(true);
+	});
+
+	it('treats an unusable NOW as exhausted too', () => {
+		expect(isReleaseVerifyExhausted(1, future, new Date(Number.NaN))).toBe(true);
+	});
+
+	it('lines the two bounds up so neither is decorative', () => {
+		expect(RELEASE_VERIFY_MAX_ATTEMPTS * RELEASE_VERIFY_ATTEMPT_INTERVAL_MS).toBe(RELEASE_VERIFY_BUDGET_MS);
+	});
+
+	it('leaves room for the measured production build lane', () => {
+		// `k8s-build.yml` is measured at 215–243 minutes on `main`, and
+		// ArgoCD's sync follows it. A budget under that would report
+		// `inconclusive` for every real production release.
+		expect(RELEASE_VERIFY_BUDGET_MS).toBeGreaterThan(243 * 60 * 1000);
+	});
+});
+
+describe('the confirmation counts', () => {
+	it('requires more than one rollout sample, because pods roll gradually', () => {
+		expect(RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS).toBeGreaterThan(1);
+	});
+
+	it('requires more than one failure before even considering a revert offer', () => {
+		expect(RELEASE_VERIFY_FAILURE_CONFIRMATIONS).toBeGreaterThan(1);
+	});
+});
+
+describe('releaseVerifyIdempotencyKey', () => {
+	it('is deterministic in (promotion, attempt)', () => {
+		expect(releaseVerifyIdempotencyKey('p-1', 3)).toBe('release-verify:p-1:3');
+		expect(releaseVerifyIdempotencyKey('p-1', 3)).toBe(releaseVerifyIdempotencyKey('p-1', 3));
+	});
+
+	it('separates attempts, so a retry is a NEW job and not a silent no-op', () => {
+		expect(releaseVerifyIdempotencyKey('p-1', 3)).not.toBe(releaseVerifyIdempotencyKey('p-1', 4));
+	});
+
+	it('separates promotions', () => {
+		expect(releaseVerifyIdempotencyKey('p-1', 3)).not.toBe(releaseVerifyIdempotencyKey('p-2', 3));
+	});
+});
+
+describe('the revert offer is an ordinary Task', () => {
+	it('labels it as a revert', () => {
+		expect(releaseRevertTaskLabels('stage-to-main')).toEqual(['release:revert', 'release:revert:stage-to-main']);
+		expect(isReleaseRevertTask(releaseRevertTaskLabels('stage-to-main'))).toBe(true);
+	});
+
+	it('does NOT label it a promotion — that is what stops the cycle', () => {
+		// A revert Task that carried `release:promotion` would be picked up
+		// by the promotion refresh and the promotion merge guard, and a
+		// revert that opened a promotion would trigger another verification
+		// which could offer another revert.
+		expect(releaseRevertTaskLabels('stage-to-main')).not.toContain(PROMOTION_TASK_LABEL);
+		expect(RELEASE_REVERT_TASK_LABEL).not.toBe(PROMOTION_TASK_LABEL);
+		expect(RELEASE_REVERT_TASK_LABEL.startsWith(PROMOTION_TASK_LABEL)).toBe(false);
+	});
+
+	it.each([
+		['no labels', null],
+		['empty labels', []],
+		['a promotion Task', [PROMOTION_TASK_LABEL]]
+	])('does not recognise %s as a revert offer', (_label, labels) => {
+		expect(isReleaseRevertTask(labels as never)).toBe(false);
+	});
+});
+
+describe('releaseRevertRungFromLabels — which release a revert undoes', () => {
+	it('reads the rung a revert Task was filed with', () => {
+		// An AUTHORIZATION input, not a display value: the merge gate
+		// resolves the revert's base branch from this plus the Work's
+		// ladder, and that base is what the protected-branch rule is
+		// evaluated against and what the approving human reads.
+		expect(releaseRevertRungFromLabels(releaseRevertTaskLabels('stage-to-main'))).toBe('stage-to-main');
+		expect(releaseRevertRungFromLabels(releaseRevertTaskLabels('develop-to-stage'))).toBe('develop-to-stage');
+	});
+
+	it.each([
+		['a promotion Task', [PROMOTION_TASK_LABEL, 'release:promotion:stage-to-main']],
+		['an ordinary Task', ['chore']],
+		['a revert Task whose rung label was lost', [RELEASE_REVERT_TASK_LABEL]],
+		['no labels', null]
+	])('answers null for %s, so the caller must refuse rather than guess', (_label, labels) => {
+		expect(releaseRevertRungFromLabels(labels as never)).toBeNull();
+	});
+});
+
+describe('releaseVerifyAppProof — what a green app probe is entitled to claim', () => {
+	it('is `liveness` for a fixed health string, which an OLD build answers identically', () => {
+		// The shipped recommendation. The artefact identity is established
+		// at `versionUrl`; this expectation carries no commit, so a web
+		// deployment that never rolled out satisfies it.
+		expect(releaseVerifyAppProof(PRODUCTION, SHA)).toBe('liveness');
+	});
+
+	it('is `artefact` when the app expectation carries the promoted commit', () => {
+		expect(releaseVerifyAppProof({ ...PRODUCTION, appExpectText: SHA.slice(0, 12) }, SHA)).toBe('artefact');
+		expect(releaseVerifyAppProof({ ...PRODUCTION, appExpectText: `build ${SHA.slice(0, 12)} live` }, SHA)).toBe(
+			'artefact'
+		);
+	});
+
+	it.each([
+		['no target', null, SHA],
+		['no expected commit', PRODUCTION, null],
+		['an expected commit that is not one', PRODUCTION, 'not-a-sha'],
+		['a DIFFERENT commit in the expectation', { ...PRODUCTION, appExpectText: 'ffffffffffff' }, SHA]
+	])('claims the weaker thing for %s', (_label, target, sha) => {
+		expect(releaseVerifyAppProof(target as never, sha as never)).toBe('liveness');
+	});
+});
+
+describe('isReleaseVerifyCheckPass — the trust boundary, in ONE place', () => {
+	it('passes only a done job with an explicit ok: true', () => {
+		expect(isReleaseVerifyCheckPass('done', { ok: true })).toBe(true);
+	});
+
+	it.each([
+		['a failed job that reported ok', 'failed', { ok: true }],
+		['a queued job', 'queued', { ok: true }],
+		['a leased job', 'leased', { ok: true }],
+		['a done job with no result', 'done', null],
+		['a done job with an undefined result', 'done', undefined],
+		['ok as the STRING true', 'done', { ok: 'true' }],
+		['ok as 1', 'done', { ok: 1 }],
+		['ok as an object', 'done', { ok: {} }],
+		['a result that is an array', 'done', [{ ok: true }]],
+		['a result that is a string', 'done', 'ok'],
+		['no status at all', undefined, { ok: true }]
+	])('does not pass %s', (_label, status, result) => {
+		// Every ambiguity resolves to "not a pass". A false negative at
+		// worst settles a verification `inconclusive`, which offers nothing
+		// and reverts nothing; a false positive tells a human that a broken
+		// production deployment is healthy.
+		expect(isReleaseVerifyCheckPass(status, result)).toBe(false);
+	});
+});
+
+describe('the surface offers no way to revert', () => {
+	it('exports nothing that performs, merges or applies a revert', async () => {
+		// THE load-bearing absence, in the same shape as slice AI's
+		// no-cascade guard. A revert is an OFFER a human reads. If a future
+		// edit adds `applyRevert`, `performRevert` or `mergeRevert` here,
+		// this fails and the author has to argue for a platform that can
+		// undo production on its own.
+		const surface = Object.keys(await import('../index.js'));
+		const actors = surface.filter((name) =>
+			/^(apply|perform|execute|do|run|trigger|merge|deploy|rollback)/i.test(name)
+		);
+		expect(actors).toEqual([]);
+		expect(surface.filter((name) => /revert/i.test(name)).sort()).toEqual([
+			'RELEASE_REVERT_TASK_LABEL',
+			'isReleaseRevertTask',
+			'isReleaseVerifyRevertOffered',
+			'releaseRevertRungFromLabels',
+			'releaseRevertRungLabel',
+			'releaseRevertTaskLabels'
+		]);
+	});
+});

--- a/packages/contracts/src/release/__tests__/index.spec.ts
+++ b/packages/contracts/src/release/__tests__/index.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import * as release from '../index.js';
 
 /**
- * The barrel declares nothing of its own (two `export *` lines), but it IS the
- * public surface every consumer reaches through `@ever-works/contracts`. A
+ * The barrel declares nothing of its own (three `export *` lines), but it IS
+ * the public surface every consumer reaches through `@ever-works/contracts`. A
  * dropped re-export line compiles fine here and only breaks at the call site in
  * another package, so it is pinned explicitly — same shape as the `policy`
  * barrel guard.
@@ -26,7 +26,25 @@ const FUNCTION_EXPORTS = [
 	'isPromotionGateDecided',
 	'isPromotionGateDecisionOverdue',
 	'isPromotionGateOverridden',
-	'promotionGateVerdictFromRun'
+	'promotionGateVerdictFromRun',
+	// Post-deploy verification and revert (slice AJ, EW-809).
+	'releaseEnvironmentForRung',
+	'sanitizeReleaseVerificationTargets',
+	'resolveReleaseVerificationTarget',
+	'isReleaseVerifyState',
+	'isReleaseVerifyTerminal',
+	'isReleaseVerifyPass',
+	'isReleaseVerifyRevertOffered',
+	'releaseVerificationProbe',
+	'isReleaseVerifyExhausted',
+	'releaseVerifyIdempotencyKey',
+	'releaseRevertRungLabel',
+	'releaseRevertTaskLabels',
+	'isReleaseRevertTask',
+	// Added by the slice-AJ review.
+	'releaseRevertRungFromLabels',
+	'releaseVerifyAppProof',
+	'isReleaseVerifyCheckPass'
 ] as const;
 
 const VALUE_EXPORTS = [
@@ -38,7 +56,21 @@ const VALUE_EXPORTS = [
 	'PROMOTION_GATE_WORKFLOW_FILE',
 	'PROMOTION_GATE_VERDICTS',
 	'PROMOTION_GATE_DECISION_GRACE_MS',
-	'PROMOTION_GATE_OVERRIDE_LABEL'
+	'PROMOTION_GATE_OVERRIDE_LABEL',
+	// Post-deploy verification and revert (slice AJ, EW-809).
+	'RELEASE_ENVIRONMENTS',
+	'RELEASE_VERIFY_URL_MAX_LENGTH',
+	'RELEASE_VERIFY_EXPECT_MAX_LENGTH',
+	'RELEASE_VERIFY_EXPECT_MIN_LENGTH',
+	'RELEASE_VERIFY_STATES',
+	'RELEASE_VERIFY_SHA_EXPECT_LENGTH',
+	'RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS',
+	'RELEASE_VERIFY_FAILURE_CONFIRMATIONS',
+	'RELEASE_VERIFY_ATTEMPT_INTERVAL_MS',
+	'RELEASE_VERIFY_MAX_ATTEMPTS',
+	'RELEASE_VERIFY_BUDGET_MS',
+	'RELEASE_VERIFY_PROBE_TIMEOUT_SEC',
+	'RELEASE_REVERT_TASK_LABEL'
 ] as const;
 
 describe('release barrel', () => {
@@ -50,17 +82,18 @@ describe('release barrel', () => {
 		expect((release as Record<string, unknown>)[name]).toBeDefined();
 	});
 
-	it('exposes exactly these 22 runtime symbols', () => {
+	it('exposes exactly these 51 runtime symbols', () => {
 		// Regression guard in BOTH directions: a re-export accidentally deleted
 		// from index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — forcing the author back to cover it.
 		expect(Object.keys(release).sort()).toEqual([...FUNCTION_EXPORTS, ...VALUE_EXPORTS].sort());
-		expect(Object.keys(release)).toHaveLength(22);
+		expect(Object.keys(release)).toHaveLength(51);
 	});
 
-	it('names each of the two source modules in the barrel', () => {
+	it('names each of the three source modules in the barrel', () => {
 		// One symbol per `export *` line, so a whole missing line is unmissable.
 		expect(release.PROMOTION_RUNGS).toBeDefined(); // promotion.types.js
 		expect(release.PROMOTION_GATE_VERDICTS).toBeDefined(); // promotion-gate.types.js
+		expect(release.RELEASE_VERIFY_STATES).toBeDefined(); // deployment-verification.types.js
 	});
 });

--- a/packages/contracts/src/release/deployment-verification.types.ts
+++ b/packages/contracts/src/release/deployment-verification.types.ts
@@ -1,0 +1,687 @@
+/**
+ * Post-deploy verification and revert (self-build slice AJ, EW-809) — the
+ * half of the release lane that says whether the release WORKED.
+ *
+ * ## What this file is
+ *
+ * Slice AI opens the promotion pull request and reads the promotion gate.
+ * The gate judges the CODE at a commit; it says nothing about whether that
+ * code ever reached a running environment, and nothing at all about
+ * whether the environment still serves pages afterwards. On 2026-09-06 a
+ * whole batch was cascaded `develop → stage → main` and nothing on the
+ * platform confirmed the result. The prod build lane is measured at
+ * 215–243 minutes, so an unverified bad deploy is a multi-hour outage.
+ *
+ * These are the zero-dependency pieces every half of the verification lane
+ * must agree on byte-for-byte: which environment a rung deploys, where
+ * that environment lives, WHICH probe is run in which state, and what a
+ * verdict is allowed to mean. Two implementations of
+ * {@link resolveReleaseVerificationTarget} is how a `develop → stage`
+ * promotion gets verified against production.
+ *
+ * ## What this file deliberately is NOT
+ *
+ * It is not a revert. Nothing here reverts, merges, deploys or rolls back,
+ * and there is no function that turns a verdict into an action. A failed
+ * verification produces an OFFER a human reads and decides; undoing a
+ * promotion is the same class of act as making one, and slice AI's whole
+ * argument — the founder performs each rung deliberately — applies at
+ * least as strongly in reverse. {@link isReleaseVerifyRevertOffered} tells
+ * you an offer was FILED. Nothing tells you one was taken, because the
+ * platform never takes one.
+ *
+ * ## The vocabulary is deliberately not boolean
+ *
+ * "Did the deploy work" has three answers, not two, and collapsing the
+ * third into either of the others is the whole bug class this slice
+ * exists for. `passed` means we watched the promoted build serve and then
+ * watched the app render. `failed` means we watched the promoted build
+ * serve and then watched the app NOT render, repeatedly, with the serving
+ * re-confirmed afterwards. Everything else — the rollout never arrived,
+ * the fleet had no browser to check with, nobody configured a URL for this
+ * environment — is `inconclusive` or `unsupported`, which are NOT passes
+ * and are NOT grounds for offering a revert either. You cannot responsibly
+ * offer to undo a release on the strength of a measurement you failed to
+ * take.
+ */
+
+import { PROMOTION_RUNGS, type PromotionRung } from './promotion.types.js';
+
+// ── Which environment a rung deploys ─────────────────────────────────
+
+/**
+ * The environment a promotion's BASE branch is deployed as.
+ *
+ * The base, never the head: merging `develop → stage` deploys STAGE. A
+ * verification that checked the head's environment would check the one
+ * that was already running before the promotion, pass, and prove nothing
+ * — the "wrong URL" hazard in its most plausible form.
+ */
+export type ReleaseEnvironment = 'staging' | 'production';
+
+export const RELEASE_ENVIRONMENTS = ['staging', 'production'] as const satisfies readonly ReleaseEnvironment[];
+
+/**
+ * THE rung → environment mapping. One function, so the enqueue side and
+ * the operator surface cannot disagree about what was deployed.
+ */
+export function releaseEnvironmentForRung(rung: PromotionRung): ReleaseEnvironment | null {
+	switch (rung) {
+		case 'develop-to-stage':
+			return 'staging';
+		case 'stage-to-main':
+			return 'production';
+		default:
+			// An unknown rung has no environment. Refusing beats guessing
+			// `production`, which is the one guess that could point a check
+			// — and therefore a revert offer — at the wrong deployment.
+			return null;
+	}
+}
+
+// ── Where an environment lives, as PLATFORM STATE ────────────────────
+
+/** Longest URL accepted into a verification target. */
+export const RELEASE_VERIFY_URL_MAX_LENGTH = 512;
+
+/** Longest DOM expectation accepted into a verification target. */
+export const RELEASE_VERIFY_EXPECT_MAX_LENGTH = 200;
+
+/**
+ * Shortest DOM expectation accepted.
+ *
+ * A short expectation is satisfied by almost any HTML document, including
+ * a provider's own error page, so it is not an expectation — it is a check
+ * that always passes. Refused rather than accepted-and-warned.
+ *
+ * REVISED UPWARDS from 3 during the slice-AJ review, because 3 did not
+ * achieve what its own comment claimed. The node matches with a raw
+ * `dom.includes(expectText)` against the serialized document
+ * (`apps/node/src/core/executors/browser-check.ts`), and `div`, `htm`,
+ * `<ht`, `ody` and `</p` appear in essentially every rendered page —
+ * including Chrome's own network-error page and a CDN 502 interstitial,
+ * both of which exit 0 under `--dump-dom` and produce a NON-EMPTY
+ * document, so the executor's empty-document guard does not catch them
+ * either. Eight characters plus {@link isPageBoilerplate} below is the
+ * pair that makes the guarantee real.
+ */
+export const RELEASE_VERIFY_EXPECT_MIN_LENGTH = 8;
+
+/**
+ * Fragments of a bare HTML document, which every rendered page contains.
+ *
+ * An expectation that is a substring of this corpus asserts only "the
+ * browser produced a document", which is what the empty-document guard
+ * already covers — so accepting one would be accepting a check that
+ * passes when nothing was checked. Deliberately a CORPUS rather than a
+ * blocklist of tokens: `<div`, `div>`, `<body`, `y></bod` and every other
+ * slice of a skeleton page are all refused by the one rule.
+ */
+const PAGE_BOILERPLATE = [
+	'<!doctype html><html><head><meta charset="utf-8"><title></title></head><body></body></html>',
+	'<html lang="en"><body class="">',
+	'<div></div><p></p><span></span><br><hr><a href="#"></a><ul><li></li></ul><h1></h1>'
+];
+
+function isPageBoilerplate(value: string): boolean {
+	const lowered = value.toLowerCase();
+	return PAGE_BOILERPLATE.some((skeleton) => skeleton.includes(lowered));
+}
+
+/**
+ * Where ONE deployed environment can be observed from outside.
+ *
+ * Both URLs are absolute `https://` and both come from the Work row. A
+ * caller never supplies either: a request that could name the URL a
+ * verification checks could point a green verdict at a page it controls,
+ * and the verdict is what stands between a bad release and a human being
+ * told everything is fine.
+ */
+export interface ReleaseVerificationTarget {
+	/**
+	 * A URL whose rendered DOM contains the deployed commit sha.
+	 *
+	 * THE artefact-identity probe, and the reason this lane can claim to
+	 * have checked the build that was just promoted rather than the one
+	 * that happened to be running. For this platform that is the API's
+	 * `/api/version`, which serves `gitSha` stamped into the image at build
+	 * time (`GIT_SHA=${{ github.sha }}` in `docker-build-publish-prod.yml`).
+	 *
+	 * A plain health endpoint is NOT a substitute: `apps/web`'s
+	 * `/api/health` answers a fixed `{"status":"OK"}` with no version in
+	 * it, so it returns 200 for the OLD build throughout a rollout and for
+	 * a rollout that never happened at all.
+	 */
+	readonly versionUrl: string;
+	/** The human-facing page that must actually render once the rollout lands. */
+	readonly appUrl: string;
+	/**
+	 * Text that must appear in {@link appUrl}'s DOM.
+	 *
+	 * Required, not optional. A browser check with no expectation passes on
+	 * any document the browser managed to render — including a CDN error
+	 * page and a provider's "application failed to respond" — which is
+	 * precisely the check-that-passes-when-nothing-was-checked this lane
+	 * exists to prevent.
+	 */
+	readonly appExpectText: string;
+}
+
+/** Per-environment verification targets, stored on the Work. */
+export interface ReleaseVerificationTargets {
+	readonly staging?: ReleaseVerificationTarget | null;
+	readonly production?: ReleaseVerificationTarget | null;
+}
+
+/**
+ * Hostnames a verification target may name.
+ *
+ * Deliberately narrow: at least two dot-separated DNS labels with an
+ * alphabetic last label. That refuses every IP literal (`169.254.169.254`,
+ * `10.0.0.1`), every bracketed IPv6 form, and every single-label name
+ * (`localhost`, `metadata`, a Kubernetes service name).
+ *
+ * The check runs a real browser on an enrolled fleet node — somebody's
+ * actual PC, inside their actual network — so a target that could name a
+ * link-local or private address would be an SSRF primitive pointed at the
+ * node operator rather than at the server. The column holding these is
+ * `simple-json` and therefore contains whatever was last written to it,
+ * which is why this is enforced on READ and not only at write time.
+ */
+const PROBE_HOST_LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+function isPublicDnsHostname(hostname: string): boolean {
+	if (!hostname || hostname.length > 253) return false;
+	// `new URL()` renders an IPv6 host bracketed; no DNS label can contain
+	// a bracket or a colon, so the label test below would refuse it anyway.
+	// Checked explicitly so the reason is stated rather than incidental.
+	if (hostname.includes(':') || hostname.startsWith('[')) return false;
+	const labels = hostname.toLowerCase().split('.');
+	if (labels.length < 2) return false;
+	if (!labels.every((label) => PROBE_HOST_LABEL.test(label))) return false;
+	// An all-numeric last label means a dotted IP literal, which the label
+	// pattern happily accepts.
+	return /^[a-z]{2,}$/.test(labels[labels.length - 1]!);
+}
+
+function normalizeProbeUrl(raw: unknown): string | null {
+	if (typeof raw !== 'string') return null;
+	const trimmed = raw.trim();
+	if (!trimmed || trimmed.length > RELEASE_VERIFY_URL_MAX_LENGTH) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return null;
+	}
+	// https ONLY. Over plaintext http anything on the path between the node
+	// and the environment can serve the expected commit sha, and a verdict
+	// that can be forged in transit is worse than no verdict — it is a
+	// green one.
+	if (parsed.protocol !== 'https:') return null;
+	// Credentials never belong in platform state, and `user:pass@host` is
+	// also the classic way to make a URL LOOK like it points somewhere else.
+	if (parsed.username || parsed.password) return null;
+	// A fragment is never sent to the server; carrying one can only mislead
+	// the human reading the target back.
+	if (parsed.hash) return null;
+	if (!isPublicDnsHostname(parsed.hostname)) return null;
+	return parsed.toString();
+}
+
+function normalizeExpectText(raw: unknown): string | null {
+	if (typeof raw !== 'string') return null;
+	const trimmed = raw.trim();
+	if (trimmed.length < RELEASE_VERIFY_EXPECT_MIN_LENGTH) return null;
+	if (trimmed.length > RELEASE_VERIFY_EXPECT_MAX_LENGTH) return null;
+	// Length alone is not enough: `<html><head` is eleven characters and
+	// still appears in every page ever served.
+	if (isPageBoilerplate(trimmed)) return null;
+	return trimmed;
+}
+
+/**
+ * The registrable-ish site of a hostname: its last two DNS labels.
+ *
+ * An approximation of the public-suffix boundary, on purpose — this
+ * package has no dependencies and will not carry a PSL. It is used for
+ * ONE narrow question (below), where the cost of the approximation is a
+ * slightly weaker refusal and never a false pass.
+ */
+function siteOf(hostname: string): string {
+	return hostname.toLowerCase().split('.').slice(-2).join('.');
+}
+
+function normalizeTarget(raw: unknown): ReleaseVerificationTarget | null {
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+	const candidate = raw as Record<string, unknown>;
+	const versionUrl = normalizeProbeUrl(candidate.versionUrl);
+	const appUrl = normalizeProbeUrl(candidate.appUrl);
+	const appExpectText = normalizeExpectText(candidate.appExpectText);
+	// All three or nothing. A target with a version URL and no app URL
+	// would silently verify half of a deployment and report it as a pass.
+	if (!versionUrl || !appUrl || !appExpectText) return null;
+	// SAME SITE, added during the slice-AJ review.
+	//
+	// `confirming-failure` re-probes `versionUrl` to tell "the app is
+	// broken" apart from "this node lost the internet", and that argument
+	// only holds while the two URLs are about the same deployment. With
+	// unrelated hosts the confirmation answers "can this node reach a
+	// DIFFERENT hostname", which is not the question: an app host behind a
+	// bot interstitial, an HTTP Basic wall or a DNS block would fail three
+	// app probes, be "confirmed" by a healthy version host, and produce a
+	// `failed` verdict — a revert offer against a release serving every
+	// user correctly.
+	//
+	// The last two labels, not the full host: `api.ever.works` and
+	// `app.ever.works` are the intended production pair and must keep
+	// working. This does not make the two origins equivalent — a
+	// per-subdomain WAF still defeats it — so the `failed` narration names
+	// BOTH hosts and says so. It refuses the unrelated-host case outright,
+	// which is the one this cannot reason about at all.
+	if (siteOf(new URL(versionUrl).hostname) !== siteOf(new URL(appUrl).hostname)) return null;
+	return { versionUrl, appUrl, appExpectText };
+}
+
+/**
+ * Read a stored verification-target map, or `null` when it is not one.
+ *
+ * FAILS CLOSED per environment: an unusable `production` entry leaves
+ * production with no target, which makes a production promotion
+ * `unsupported` — reported to a human as NOT VERIFIED — rather than
+ * verified against a half-configured URL.
+ */
+export function sanitizeReleaseVerificationTargets(raw: unknown): ReleaseVerificationTargets | null {
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+	const candidate = raw as Record<string, unknown>;
+	const staging = normalizeTarget(candidate.staging);
+	const production = normalizeTarget(candidate.production);
+	if (!staging && !production) return null;
+	const result: { staging?: ReleaseVerificationTarget; production?: ReleaseVerificationTarget } = {};
+	if (staging) result.staging = staging;
+	if (production) result.production = production;
+	return result;
+}
+
+/**
+ * THE target resolution. One function, so nothing can verify a rung
+ * against an environment it did not deploy.
+ *
+ * `null` when the Work has no usable target for the environment this rung
+ * deploys — which is a legitimate, common state (most Works are not
+ * deployed by this platform at all) and is reported as `unsupported`,
+ * never as a pass.
+ */
+export function resolveReleaseVerificationTarget(
+	targets: ReleaseVerificationTargets | null | undefined,
+	rung: PromotionRung
+): ReleaseVerificationTarget | null {
+	const safe = sanitizeReleaseVerificationTargets(targets);
+	if (!safe) return null;
+	const environment = releaseEnvironmentForRung(rung);
+	if (!environment) return null;
+	return (environment === 'staging' ? safe.staging : safe.production) ?? null;
+}
+
+// ── The verdict vocabulary ───────────────────────────────────────────
+
+/**
+ * Where one promotion's post-deploy verification has got to.
+ *
+ * The three live states are also the three PROBES: which check runs is a
+ * pure function of this value (see {@link releaseVerificationProbe}), so
+ * there is no separate phase field that could disagree with the state.
+ */
+export type ReleaseVerifyState =
+	/** Watching for the promoted commit to become the one being served. */
+	| 'awaiting-rollout'
+	/** The promoted commit IS being served; watching the app render. */
+	| 'checking-app'
+	/**
+	 * The app check has failed enough times in a row to mean something.
+	 * Re-reading the version endpoint before saying so, because "the app is
+	 * broken" and "this node briefly lost the internet" are the same
+	 * browser result, and only one of them is about the release.
+	 */
+	| 'confirming-failure'
+	/** The promoted build served AND the app rendered. */
+	| 'passed'
+	/** The promoted build served AND the app did not, twice confirmed. */
+	| 'failed'
+	/**
+	 * We did not find out. The rollout never arrived inside the budget, no
+	 * node could run the check, the git provider would not name the
+	 * deployed commit. NOT a pass, and NOT grounds for a revert offer.
+	 */
+	| 'inconclusive'
+	/**
+	 * Nothing to check against: this Work has no verification target for
+	 * the environment this rung deploys. Recorded and reported rather than
+	 * left blank, so "we did not verify" is a fact on the row instead of an
+	 * absence somebody reads as fine.
+	 */
+	| 'unsupported';
+
+export const RELEASE_VERIFY_STATES = [
+	'awaiting-rollout',
+	'checking-app',
+	'confirming-failure',
+	'passed',
+	'failed',
+	'inconclusive',
+	'unsupported'
+] as const satisfies readonly ReleaseVerifyState[];
+
+export function isReleaseVerifyState(value: unknown): value is ReleaseVerifyState {
+	return typeof value === 'string' && (RELEASE_VERIFY_STATES as readonly string[]).includes(value);
+}
+
+/** Is this verification over? */
+export function isReleaseVerifyTerminal(state: ReleaseVerifyState | null | undefined): boolean {
+	return state === 'passed' || state === 'failed' || state === 'inconclusive' || state === 'unsupported';
+}
+
+/**
+ * Did the deployment verify?
+ *
+ * Written as an equality, exactly like `isPromotionGatePass`, so a state
+ * added later is a not-a-pass by default and has to be argued INTO the
+ * pass set by somebody editing this line.
+ */
+export function isReleaseVerifyPass(state: ReleaseVerifyState | null | undefined): boolean {
+	return state === 'passed';
+}
+
+/**
+ * May a revert be OFFERED for this verdict?
+ *
+ * `failed` and nothing else. In particular NOT `inconclusive`: offering to
+ * undo a production release on the strength of a measurement that did not
+ * happen is how a flapping check reverts a good release, and it is the
+ * hazard this predicate exists to make unreachable. An operator who wants
+ * to revert an inconclusive release can still do so by hand — they just
+ * do not get told by the platform that they should.
+ *
+ * This answers "may we FILE an offer", never "may we revert". Nothing in
+ * this platform reverts.
+ */
+export function isReleaseVerifyRevertOffered(state: ReleaseVerifyState | null | undefined): boolean {
+	return state === 'failed';
+}
+
+// ── The probe ────────────────────────────────────────────────────────
+
+/** Which check the current state runs. */
+export interface ReleaseVerificationProbe {
+	/** `rollout` reads the version endpoint; `app` reads the app page. */
+	readonly phase: 'rollout' | 'app';
+	readonly url: string;
+	readonly expectText: string;
+}
+
+/**
+ * Shortest commit sha accepted as a DOM expectation.
+ *
+ * A short sha is a substring match against a whole rendered document, and
+ * the shorter it is the likelier it is to appear by accident. Twelve hex
+ * characters is what the promotion lane already prints to humans and is
+ * far past the point where a collision inside one page is plausible.
+ */
+export const RELEASE_VERIFY_SHA_EXPECT_LENGTH = 12;
+
+/**
+ * THE probe selection: which URL is loaded, and what must be in it.
+ *
+ * One function, taking the state and the target, so "the URL for the
+ * environment that was actually promoted" has exactly one implementation
+ * and the enqueue side cannot pick a different one from the operator
+ * surface.
+ *
+ * `null` for every terminal state — a settled verification enqueues
+ * nothing, which is half of why this lane cannot loop — and `null` for a
+ * missing or malformed expected commit, because a probe with an empty
+ * `expectText` asserts nothing and would return `ok: true` for any page
+ * at all.
+ */
+export function releaseVerificationProbe(
+	state: ReleaseVerifyState | null | undefined,
+	target: ReleaseVerificationTarget | null | undefined,
+	expectedSha: string | null | undefined
+): ReleaseVerificationProbe | null {
+	if (!target) return null;
+	const sha = typeof expectedSha === 'string' ? expectedSha.trim().toLowerCase() : '';
+	if (!/^[0-9a-f]{7,64}$/.test(sha)) return null;
+	const shaExpect = sha.slice(0, RELEASE_VERIFY_SHA_EXPECT_LENGTH);
+	switch (state) {
+		case 'awaiting-rollout':
+		// The failure confirmation re-runs the ROLLOUT probe on purpose.
+		// The question it asks is not "is the app still broken" — we
+		// already know that — but "can this node reach the environment at
+		// all, and is the environment still serving the commit we
+		// promoted". A `no` there means the evidence is about the network
+		// or the node, not about the release.
+		case 'confirming-failure':
+			return { phase: 'rollout', url: target.versionUrl, expectText: shaExpect };
+		case 'checking-app':
+			return { phase: 'app', url: target.appUrl, expectText: target.appExpectText };
+		default:
+			return null;
+	}
+}
+
+// ── Bounds. Every one of them is a stop, not a tuning knob. ──────────
+
+/**
+ * Consecutive rollout probes that must find the promoted commit before the
+ * rollout counts as landed.
+ *
+ * ArgoCD replaces pods gradually, so immediately after a deploy the
+ * version endpoint alternates between the old and the new commit depending
+ * on which pod answers — sampling once is a coin flip. This is the same
+ * discipline `.github/workflows/smoke-deployed.yml` already encodes for
+ * the CI smoke lane ("5 consecutive samples"), at a much longer spacing.
+ */
+export const RELEASE_VERIFY_ROLLOUT_CONFIRMATIONS = 3;
+
+/**
+ * Consecutive app-probe failures before the lane will even CONSIDER
+ * calling a release broken — and it still re-confirms the rollout after
+ * these before saying so.
+ *
+ * One failed page load is a transient. Filing a revert offer on one is the
+ * "flapping check reverting a good release" failure this number exists to
+ * prevent.
+ */
+export const RELEASE_VERIFY_FAILURE_CONFIRMATIONS = 3;
+
+/** Spacing between probes. */
+export const RELEASE_VERIFY_ATTEMPT_INTERVAL_MS = 10 * 60 * 1000;
+
+/**
+ * Hard cap on probes per promotion, whatever the clock says.
+ *
+ * The FIRST of the two bounds to be reached ends the verification, and
+ * both of them end it as `inconclusive`. A cap counted in attempts
+ * survives a clock that jumps; a deadline survives a sweep that runs far
+ * more often than intended. Neither alone is enough, so there are two.
+ */
+export const RELEASE_VERIFY_MAX_ATTEMPTS = 48;
+
+/**
+ * Wall-clock budget from the moment the promotion merged.
+ *
+ * The production build lane (`k8s-build.yml`) is measured at 215–243
+ * minutes on `main`, and ArgoCD's sync follows it, so anything under about
+ * five hours would time out every real production release and report
+ * `inconclusive` forever. Eight hours is that plus room, and it lines up
+ * with {@link RELEASE_VERIFY_MAX_ATTEMPTS} at
+ * {@link RELEASE_VERIFY_ATTEMPT_INTERVAL_MS} spacing so neither bound is
+ * decorative.
+ */
+export const RELEASE_VERIFY_BUDGET_MS = 8 * 60 * 60 * 1000;
+
+/** Per-probe navigation budget handed to the node. Clamped node-side to 300. */
+export const RELEASE_VERIFY_PROBE_TIMEOUT_SEC = 60;
+
+/**
+ * Has this verification run out of road?
+ *
+ * FAILS CLOSED ON AN UNUSABLE CLOCK in the direction that keeps the lane
+ * bounded: a deadline that cannot be read is treated as REACHED, so a row
+ * with a corrupt timestamp settles `inconclusive` instead of probing for
+ * ever. That is the opposite of `isPromotionGateDecisionOverdue`, which
+ * fails closed by NOT filing a notice — and the difference is deliberate:
+ * there, an unreadable clock must not produce a false alarm; here, it must
+ * not produce an unbounded loop.
+ */
+export function isReleaseVerifyExhausted(
+	attempts: number | null | undefined,
+	deadlineAt: Date | string | number | null | undefined,
+	now: Date
+): boolean {
+	const used = typeof attempts === 'number' && Number.isFinite(attempts) ? attempts : 0;
+	if (used >= RELEASE_VERIFY_MAX_ATTEMPTS) return true;
+	if (deadlineAt === null || deadlineAt === undefined) return true;
+	const deadline = new Date(deadlineAt).getTime();
+	if (!Number.isFinite(deadline)) return true;
+	const at = now.getTime();
+	if (!Number.isFinite(at)) return true;
+	return at >= deadline;
+}
+
+// ── Enqueue identity ─────────────────────────────────────────────────
+
+/**
+ * The fleet job's idempotency key for one attempt.
+ *
+ * Deterministic in (promotion, attempt number) so that a sweep which dies
+ * between enqueuing the job and recording its id re-enqueues the SAME key
+ * on the following pass and is handed the same row back, rather than
+ * putting a second browser on the same environment. `FleetJobService`
+ * short-circuits on the key before it creates anything.
+ *
+ * It embeds a uuid, which matters: `FleetJobRepository.findByIdempotencyKey`
+ * is not owner-scoped, so a guessable key would be a way to read back
+ * somebody else's job. A promotion id is not guessable.
+ */
+export function releaseVerifyIdempotencyKey(promotionId: string, attempt: number): string {
+	return `release-verify:${promotionId}:${attempt}`;
+}
+
+// ── The revert OFFER ─────────────────────────────────────────────────
+
+/**
+ * Present on every Task this lane files to offer a revert.
+ *
+ * A label, matching how a promotion Task is marked, and for the same
+ * reason: the Task entity has no discriminator column and adding one for
+ * two rows a week would touch every Task read in the product.
+ *
+ * A revert Task is deliberately an ORDINARY Task. It carries no
+ * `release:promotion` label, so `ReleasePromotionService` answers
+ * `not-a-promotion` for it, the promotion merge guard leaves it to the
+ * ordinary path, and nothing about it can open a promotion — which is
+ * what stops "a revert triggers a promotion that triggers another check"
+ * from being a cycle. Landing whatever pull request it eventually produces
+ * still needs the same `merge_pull_request` Inbox approval as everything
+ * else.
+ */
+export const RELEASE_REVERT_TASK_LABEL = 'release:revert';
+
+/** Per-rung revert label, e.g. `release:revert:stage-to-main`. */
+export function releaseRevertRungLabel(rung: PromotionRung): string {
+	return `${RELEASE_REVERT_TASK_LABEL}:${rung}`;
+}
+
+/** The labels a revert-offer Task is filed with. */
+export function releaseRevertTaskLabels(rung: PromotionRung): string[] {
+	return [RELEASE_REVERT_TASK_LABEL, releaseRevertRungLabel(rung)];
+}
+
+/** Is this Task a revert offer? */
+export function isReleaseRevertTask(labels: readonly string[] | null | undefined): boolean {
+	return Array.isArray(labels) && labels.includes(RELEASE_REVERT_TASK_LABEL);
+}
+
+/**
+ * Which rung a revert Task undoes, or `null` if it is not a revert Task.
+ *
+ * Added during the slice-AJ review, and it is an AUTHORIZATION input, not
+ * a display value. A revert Task's pull request lands on the branch the
+ * promotion landed on — `stage` or `main` — while every other Task pull
+ * request on this platform targets the Work's `taskIsolationBaseBranch`.
+ * The merge gate needs the rung to resolve the real base from the Work's
+ * ladder, because that base is (a) what the protected-branch rule is
+ * evaluated against and (b) the branch named in the sentence the
+ * approving human reads. Computed from the Task's own labels so the
+ * answer does not depend on the promotion row still being readable.
+ */
+export function releaseRevertRungFromLabels(labels: readonly string[] | null | undefined): PromotionRung | null {
+	if (!isReleaseRevertTask(labels)) return null;
+	// `PROMOTION_RUNGS` rather than a restated list, so a rung added to
+	// the ladder cannot become a revert the merge gate silently fails to
+	// recognise — which would fall back to the Work's isolation base.
+	for (const rung of PROMOTION_RUNGS) {
+		if (labels!.includes(releaseRevertRungLabel(rung))) return rung;
+	}
+	return null;
+}
+
+// ── What a PASS is entitled to claim ─────────────────────────────────
+
+/**
+ * How much a green app probe actually proves about the promoted artefact.
+ *
+ *   - `artefact` — the app expectation contains the promoted commit, so a
+ *     pass means the NEW build rendered.
+ *   - `liveness` — the app expectation is a fixed string (the shipped
+ *     `"status":"OK"` health probe is one), so a pass means the app
+ *     answered. An old bundle that never rolled out answers it
+ *     identically.
+ *
+ * Added during the slice-AJ review because the verdict overclaimed: the
+ * artefact identity is established at `versionUrl` only, the app phase
+ * then reads a DIFFERENT url with a static expectation, and nothing
+ * requires the two deployments to roll out together. The API image can
+ * publish while the web deployment fails its rollout entirely, and the
+ * lane would still have filed "Deployment VERIFIED … Nothing further is
+ * required". It now says which of the two it measured.
+ */
+export type ReleaseVerifyAppProof = 'artefact' | 'liveness';
+
+export function releaseVerifyAppProof(
+	target: ReleaseVerificationTarget | null | undefined,
+	expectedSha: string | null | undefined
+): ReleaseVerifyAppProof {
+	if (!target) return 'liveness';
+	const sha = typeof expectedSha === 'string' ? expectedSha.trim().toLowerCase() : '';
+	if (!/^[0-9a-f]{7,64}$/.test(sha)) return 'liveness';
+	const shaExpect = sha.slice(0, RELEASE_VERIFY_SHA_EXPECT_LENGTH);
+	return target.appExpectText.toLowerCase().includes(shaExpect) ? 'artefact' : 'liveness';
+}
+
+// ── Reading one browser check back ───────────────────────────────────
+
+/**
+ * Did a `browser-check` PASS?
+ *
+ * THE trust boundary, and deliberately one function: the completion
+ * listener and the sweep's own reconciliation of an in-flight job both
+ * ask it, and a lane where those two disagreed could report a check green
+ * on one path and red on the other for the same row.
+ *
+ * `result` is whatever a node PUT on the completion endpoint — untrusted
+ * data from somebody's PC — so this narrows to a strict `=== true` on a
+ * `done` job and nothing else is allowed to mean "pass": a `failed` job,
+ * a cancelled one, a lease the reclaim sweep exhausted, a queue-SLA
+ * expiry, a result with no `ok`, `ok: "true"`, `ok: 1`, `ok: {}`. Every
+ * ambiguity resolves to "not a pass", because a false negative at worst
+ * settles a verification `inconclusive` — which offers nothing and
+ * reverts nothing — while a false positive tells a human that a broken
+ * production deployment is healthy.
+ */
+export function isReleaseVerifyCheckPass(status: unknown, result: unknown): boolean {
+	if (status !== 'done') return false;
+	if (!result || typeof result !== 'object' || Array.isArray(result)) return false;
+	return (result as { ok?: unknown }).ok === true;
+}

--- a/packages/contracts/src/release/index.ts
+++ b/packages/contracts/src/release/index.ts
@@ -1,2 +1,3 @@
 export * from './promotion.types.js';
 export * from './promotion-gate.types.js';
+export * from './deployment-verification.types.js';


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AJ**. Refs **EW-809**, closes finding R21. Depends on **AI**, merged earlier today.

**Nothing verified a deployment.** The `browser-check` job kind existed and a fleet node could execute it, but there was **no producer for it anywhere on the platform** — the only literal fleet-job-kind producer was the run router's `agent-task`. And there was no rollback concept on the Task or the fleet path at all.

That stopped being theoretical **today**: a whole batch was cascaded `develop → stage → main` and nothing on the platform confirmed the result. On a build lane measured at 215–243 minutes, an unverified bad deploy is a multi-hour outage the fleet can neither detect nor reverse.

## The design

A merged promotion records its **base branch's tip** as the commit it expects to see deployed — not the PR head, because the merge makes a new commit and `GitPullRequestStatus` carries no merge sha. A distributed-locked cron then enqueues **one** browser check at a time, ≥10 minutes apart, at the URL for the environment *that rung's base branch deploys*, from `works.releaseVerification`.

**Phase 1** loads the version endpoint and requires that commit in the rendered DOM, **three consecutive times**. Only then does **phase 2** check the app page.

## The revert is an offer, and the platform never takes it

Three consecutive app failures escalate to `confirming-failure`, which **re-probes the version endpoint**. That is what separates *"the release is broken"* from *"this node lost its network"*: if the endpoint still answers, the verdict is `failed` and a revert Task is filed; if it does not, the verdict is `inconclusive` and **nothing is offered**.

The vocabulary is deliberately three-valued. "Did the deploy work" has three answers, and collapsing them to a boolean is exactly what turns a node's network problem into a production rollback.

**Eleven paths could reach a revert; each is gated.** The load-bearing ones:

- The offer is gated at three layers, **one of them in SQL** (`WHERE verifyState='failed' AND revertTaskId IS NULL`).
- The offer Task is filed **`IN_REVIEW`**, so `TaskGraphFanoutService` never dispatches an agent at it.
- Landing it is an ordinary PR through **slice AE's human approval**, verified against the live head.
- The verification service **contains no merge, push, PR-open, promotion-open or rollback call at all** — asserted by a test that reads its own source, and confirmed independently here.
- There is **no API endpoint** that asks for a revert; a route-inventory test bans `revert|rollback|undo|redeploy`.
- A revert Task carries `release:revert`, never `release:promotion`, so it cannot start a promotion that starts another check.

## Two defects found in self-review and fixed

- **The anti-wedge did not work** — the claim cleared the very column the sweep selects on.
- **A node could have forged a pass.** `ok` must now be strictly `=== true` on a `done` job, so `"true"`, `1`, `{}`, `null`, a failed job, an exhausted lease, a cancellation and a queue expiry are each not-a-pass.

Bounded on both axes: 48 attempts **and** an 8-hour deadline, enforced even with a check in flight, an unreadable clock counted as *reached*, and every terminal state clearing the retry marker. The URL is sanitized on read (https only, no credentials, no fragment, no IP literal or single-label host) and the owner comes from the promotion row, re-checked against the Work on every probe.

## Verified locally

| Check | Result |
| --- | --- |
| `packages/contracts` whole suite | 42 files / 2097 tests, no type errors |
| `packages/agent` tasks-domain, database, entities, policy | 140 suites / 2184 tests |
| `apps/api` release + migrations | 57 suites / 321 tests |
| node-contract gate, both halves | 2 suites / 82 tests |
| `prettier --check` over all changed files | clean |
| conflict markers / NUL bytes / build output in diff | none |

Mutation checks were **executed, not asserted**: removing `FleetModule` reds 2 tests, removing the service provider reds 6, and reverting the retry-marker fix reds 2.

## Honest limits, stated in the runbook rather than buried

- **Artefact identity is proven by three sightings of the post-merge base tip**, which is a superset if another PR lands between the merge and the read — closing that needs a `mergeCommitSha` the provider status does not carry.
- Three samples are not every pod behind a load balancer.
- The web bundle is only sha-checked if you configure it to be.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added post-deployment verification for merged releases, including rollout and application checks.
  - Added staging and production verification-target configuration with URL and expectation validation.
  - Promotion details now show verification status, results, and any available revert offer.
  - Confirmed failures can create a human-reviewed revert task; reverts are not performed automatically.
  - Verification runs periodically and recovers incomplete checks without interrupting release recording.

- **Documentation**
  - Added a release verification runbook covering setup, lifecycle, limitations, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->