### PR TITLE
feat(fleet): a per-job, repo-scoped push credential, and commits that say who made them (EW-810)

### DIFF
--- a/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-dispatch.spec.ts
@@ -190,7 +190,11 @@ describe('fleet agent-task dispatch (AUDIT A46/A24 producer wiring)', () => {
         await buildTransition().dispatchAgentRun(buildTask(), 'agent-1');
 
         const enqueued = fleetJobs.enqueue.mock.calls[0][0];
-        expect(enqueued.requiredCapabilities).toEqual(['git', 'docker']);
+        // `git-push` joined the operator's own tags in slice AM (EW-810):
+        // every `agent-task` requires it now, because a node without it
+        // would publish with the machine's own long-lived Git credential
+        // helper. The old expectation was right for a token-free push.
+        expect(enqueued.requiredCapabilities).toEqual(['git', 'docker', 'git-push']);
         expect(enqueued.payload.workspacePath).toBe('/srv/ever-works');
     });
 

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-model-cli-dispatch.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-model-cli-dispatch.spec.ts
@@ -113,7 +113,10 @@ describe('fleet agent-task dispatch — model-cli plan wiring', () => {
         expect(store.enqueue).toHaveBeenCalledTimes(1);
         const request = store.enqueue.mock.calls[0][0];
         expect(request.kind).toBe('agent-task');
-        expect(request.requiredCapabilities).toEqual(['workspace', 'claude-code']);
+        // Slice AM (EW-810) adds `git-push` to every `agent-task` tag set:
+        // the fleet's publish is no longer token-free, so a node that
+        // cannot install a per-run credential must not be offered the work.
+        expect(request.requiredCapabilities).toEqual(['workspace', 'git-push', 'claude-code']);
         expect(request.payload).toEqual({
             taskId: 'task-1',
             agentId: 'agent-1',
@@ -172,7 +175,9 @@ describe('fleet agent-task dispatch — model-cli plan wiring', () => {
         const planner = { plan: jest.fn().mockResolvedValue(null) };
         await buildDispatcher(planner).enqueue(payload());
         const request = store.enqueue.mock.calls[0][0];
-        expect(request.requiredCapabilities).toEqual(['workspace']);
+        // Even the legacy (planner-returned-null) job carries `git-push`:
+        // it is a fact about the NODE, not about the plan.
+        expect(request.requiredCapabilities).toEqual(['workspace', 'git-push']);
         expect(request.payload.execution).toBeUndefined();
         expect(request.payload.workspace).toBeUndefined();
         expect(request.payload.steps).toEqual([

--- a/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-agent-task-planner.spec.ts
@@ -117,9 +117,16 @@ describe('FleetAgentTaskPlannerService', () => {
     let skills: { resolveActiveForAgent: jest.Mock };
     let pluginSettings: { getResolvedSettings: jest.Mock };
     let runs: { findById: jest.Mock };
+    let pushCredentials: { describeScope: jest.Mock };
 
     const build = (
-        opts: { assembler?: boolean; skills?: boolean; settings?: boolean; runs?: boolean } = {},
+        opts: {
+            assembler?: boolean;
+            skills?: boolean;
+            settings?: boolean;
+            runs?: boolean;
+            pushCredentials?: boolean;
+        } = {},
     ) =>
         new FleetAgentTaskPlannerService(
             tasks as never,
@@ -133,6 +140,7 @@ describe('FleetAgentTaskPlannerService', () => {
             opts.skills === false ? undefined : (skills as never),
             opts.settings === false ? undefined : (pluginSettings as never),
             opts.runs === false ? undefined : (runs as never),
+            opts.pushCredentials === false ? undefined : (pushCredentials as never),
         );
 
     beforeEach(() => {
@@ -180,6 +188,18 @@ describe('FleetAgentTaskPlannerService', () => {
             ]),
         };
         pluginSettings = { getResolvedSettings: jest.fn().mockResolvedValue({}) };
+        // Scoped push credentials (slice AM): the platform CAN mint for
+        // this run unless a case says otherwise.
+        pushCredentials = {
+            describeScope: jest.fn().mockResolvedValue({
+                ok: true,
+                reason: null,
+                installationEntityId: 'inst-entity-1',
+                installationId: '9001',
+                repositoryIds: ['556677'],
+                repositories: ['ever-works/ever-works'],
+            }),
+        };
     });
 
     afterAll(() => {
@@ -192,7 +212,144 @@ describe('FleetAgentTaskPlannerService', () => {
         expect(taskWorkspace.describeFleetWorkspace).not.toHaveBeenCalled();
     });
 
+    /**
+     * Scoped push credentials (self-build slice AM, EW-810) — the PLATFORM
+     * half of the pre-dispatch push-capability probe.
+     *
+     * A fleet node no longer pushes with the machine's own Git credential
+     * helper; it pushes with a repository-scoped installation token this
+     * platform mints per job. Whether that CAN be minted is a fact about
+     * platform state, so a run that could never publish is refused here —
+     * where the reason lands on the run row — instead of twenty minutes
+     * later at the push.
+     */
+    describe('push scope — refusing a run the platform could never publish', () => {
+        beforeEach(() => {
+            process.env.FLEET_NODE_AGENT_EXECUTION_MODE = 'model-cli';
+        });
+
+        it('asks about the PRIMARY repository and every writable mount', async () => {
+            taskWorkspace.describeFleetWorkspace.mockResolvedValue({
+                ...workspace,
+                mounts: [
+                    {
+                        repositoryId: 'ever-works/template',
+                        repoUrl: 'https://github.com/ever-works/template.git',
+                        baseRef: 'main',
+                        branch: 'task/task-1-tsk-7',
+                        mountDir: 'template',
+                        writable: true,
+                    },
+                    {
+                        repositoryId: 'ever-works/reference',
+                        repoUrl: 'https://github.com/ever-works/reference.git',
+                        baseRef: 'main',
+                        branch: 'task/task-1-tsk-7',
+                        mountDir: 'reference',
+                        writable: false,
+                    },
+                ],
+            });
+
+            await build().plan(payload);
+
+            // The CLONE URL travels with each name. `owner/repo` alone is
+            // not an identity a write credential may be scoped by: a `git`
+            // repo connection can point at any host and
+            // `repositoryIdFromCloneUrl` is host-agnostic, so a mount at
+            // `https://gitlab.example/acme/widgets` would otherwise resolve
+            // against a GitHub installation row called `acme/widgets` and
+            // buy a token for a repository this run never touches
+            // (slice AM review, F4).
+            expect(pushCredentials.describeScope).toHaveBeenCalledWith(USER, [
+                {
+                    repositoryId: 'ever-works/ever-works',
+                    repoUrl: 'https://github.com/ever-works/ever-works.git',
+                },
+                {
+                    repositoryId: 'ever-works/template',
+                    repoUrl: 'https://github.com/ever-works/template.git',
+                },
+            ]);
+        });
+
+        it('refuses when a writable mount is not on the host the credential can reach', async () => {
+            // The planner passes the URL through; the SERVICE decides. This
+            // pins the seam: a mount whose clone URL is not a github.com
+            // repository must reach `describeScope` with that URL, so the
+            // refusal can happen at plan time instead of twenty minutes into
+            // a node's run.
+            taskWorkspace.describeFleetWorkspace.mockResolvedValue({
+                ...workspace,
+                mounts: [
+                    {
+                        repositoryId: 'ever-works/template',
+                        repoUrl: 'https://gitlab.com/ever-works/template.git',
+                        baseRef: 'main',
+                        branch: 'task/task-1-tsk-7',
+                        mountDir: 'template',
+                        writable: true,
+                    },
+                ],
+            });
+
+            await build().plan(payload);
+
+            expect(pushCredentials.describeScope).toHaveBeenCalledWith(USER, [
+                {
+                    repositoryId: 'ever-works/ever-works',
+                    repoUrl: 'https://github.com/ever-works/ever-works.git',
+                },
+                {
+                    repositoryId: 'ever-works/template',
+                    repoUrl: 'https://gitlab.com/ever-works/template.git',
+                },
+            ]);
+        });
+
+        it('REFUSES the plan, naming the repositories and what an operator must fix', async () => {
+            pushCredentials.describeScope.mockResolvedValue({
+                ok: false,
+                reason: 'push-scope-unresolved',
+            });
+
+            await expect(build().plan(payload)).rejects.toBeInstanceOf(FleetAgentTaskPlanError);
+            await expect(build().plan(payload)).rejects.toThrow(/ever-works\/ever-works/);
+            await expect(build().plan(payload)).rejects.toThrow(/install the Ever Works app/);
+        });
+
+        it('does not ask at all for an Agent that may not commit', async () => {
+            // Nothing is published, so there is nothing to authorise — and
+            // a deployment with no GitHub App must still be able to run a
+            // read-only agent.
+            agents.findByIdAndUser.mockResolvedValue(
+                agent({ permissions: { canCommitToRepo: false } } as never),
+            );
+
+            await expect(build().plan(payload)).resolves.toMatchObject({
+                git: { commit: false, push: false },
+            });
+            expect(pushCredentials.describeScope).not.toHaveBeenCalled();
+        });
+
+        it('plans as before in a graph that cannot supply the checker', async () => {
+            // @Optional(): the NODE still fails closed at the publish, so an
+            // absent checker costs a late failure, never a token-free push.
+            await expect(build({ pushCredentials: false }).plan(payload)).resolves.toMatchObject({
+                git: { commit: true, push: true },
+            });
+        });
+    });
+
     describe('requirements — the tags the job will need, known BEFORE the plan (slice S)', () => {
+        /**
+         * Scoped push credentials (self-build slice AM, EW-810) added
+         * `git-push` to EVERY `agent-task` tag set. The old expectations
+         * were right for a fleet whose push was token-free; they are wrong
+         * now, because a node that does not advertise `git-push` would
+         * publish with the machine's own long-lived Git credential helper,
+         * which is precisely the work it must not be handed.
+         */
         beforeEach(() => {
             delete process.env.FLEET_NODE_REQUIRED_CAPABILITIES;
         });
@@ -201,7 +358,7 @@ describe('FleetAgentTaskPlannerService', () => {
             process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace,git';
 
             await expect(build().requirements(payload)).resolves.toEqual({
-                requiredCapabilities: ['workspace', 'git'],
+                requiredCapabilities: ['workspace', 'git', 'git-push'],
             });
             expect(tasks.findById).not.toHaveBeenCalled();
             expect(taskWorkspace.describeFleetWorkspace).not.toHaveBeenCalled();
@@ -213,7 +370,7 @@ describe('FleetAgentTaskPlannerService', () => {
             process.env.FLEET_NODE_REQUIRED_CAPABILITIES = 'workspace,codex';
 
             await expect(build().requirements(payload)).resolves.toEqual({
-                requiredCapabilities: ['workspace', 'codex'],
+                requiredCapabilities: ['workspace', 'codex', 'git-push'],
             });
         });
 
@@ -225,7 +382,7 @@ describe('FleetAgentTaskPlannerService', () => {
             });
 
             await expect(build().requirements(payload)).resolves.toEqual({
-                requiredCapabilities: ['codex'],
+                requiredCapabilities: ['git-push', 'codex'],
             });
         });
 
@@ -235,7 +392,7 @@ describe('FleetAgentTaskPlannerService', () => {
             pluginSettings.getResolvedSettings.mockRejectedValue(new Error('settings down'));
 
             await expect(build().requirements(payload)).resolves.toEqual({
-                requiredCapabilities: ['claude-code'],
+                requiredCapabilities: ['git-push', 'claude-code'],
             });
         });
     });

--- a/apps/api/src/fleet/__tests__/fleet-push-credential.service.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-push-credential.service.spec.ts
@@ -1,0 +1,669 @@
+import { generateKeyPairSync } from 'node:crypto';
+import {
+    FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON,
+    FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+    FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+} from '@ever-works/contracts';
+import { FleetJobStaleLeaseError } from '@ever-works/agent/fleet';
+import {
+    FleetPushCredentialError,
+    FleetPushCredentialService,
+} from '../fleet-push-credential.service';
+
+/**
+ * Scoped push credentials — the PLATFORM half (self-build slice AM,
+ * EW-810).
+ *
+ * What a review will look for, and what these cases pin:
+ *
+ *  - the token is narrowed by REPOSITORY IDS taken from the platform's own
+ *    installation snapshot, and by `contents: write` alone;
+ *  - a caller cannot influence the scope: the request body carries no
+ *    repository, and the repositories are re-read from the job's own
+ *    payload (which the planner wrote);
+ *  - every refusal is a stable token and a fail-closed answer, never a
+ *    partial credential and never a wider one;
+ *  - the token appears in no log line.
+ */
+
+const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const JOB_ID = '33333333-3333-4333-8333-333333333333';
+const USER_ID = 'user-1';
+const OTHER_USER = 'user-2';
+const TOKEN = 'ghs_0123456789abcdefghijklmnopqrstuvwxyz';
+
+const jobRow = (overrides: Record<string, unknown> = {}) => ({
+    id: JOB_ID,
+    userId: USER_ID,
+    payload: {
+        taskId: 'task-1',
+        agentId: '22222222-2222-4222-8222-222222222222',
+        runId: '44444444-4444-4444-8444-444444444444',
+        git: { commit: true, push: true, commitMessage: 'feat(task): x' },
+        workspace: {
+            repositoryId: 'ever-works/ever-works',
+            repoUrl: 'https://github.com/ever-works/ever-works.git',
+            baseRef: 'develop',
+            branch: 'task/x',
+        },
+    },
+    ...overrides,
+});
+
+const installationRow = (overrides: Record<string, unknown> = {}) => ({
+    id: 'inst-entity-1',
+    installationId: '9001',
+    createdByUserId: USER_ID,
+    deletedAt: null,
+    suspendedAt: null,
+    ...overrides,
+});
+
+const snapshotRow = (
+    fullName: string,
+    githubRepoId: string,
+    installationEntityId = 'inst-entity-1',
+) => ({
+    id: `snap-${fullName}`,
+    installationEntityId,
+    githubRepoId,
+    fullName,
+    owner: fullName.split('/')[0],
+    repo: fullName.split('/')[1],
+});
+
+function build(
+    overrides: {
+        job?: Record<string, unknown> | null;
+        claim?: unknown;
+        installations?: Array<Record<string, unknown>>;
+        snapshots?: Record<string, Array<Record<string, unknown>>>;
+        agent?: Record<string, unknown> | null;
+    } = {},
+) {
+    const claim =
+        overrides.claim === undefined
+            ? { jobId: JOB_ID, userId: USER_ID, nodeId: NODE_ID }
+            : overrides.claim;
+    const jobs = {
+        authorizeRunSecretRequest: jest.fn(async () => claim),
+    };
+    const jobRows = {
+        findById: jest.fn(async () => (overrides.job === undefined ? jobRow() : overrides.job)),
+    };
+    const nodes = { findById: jest.fn(async () => ({ id: NODE_ID, name: 'studio-win' })) };
+    const rows = overrides.installations ?? [installationRow()];
+    const installations = {
+        findById: jest.fn(async (id: string) => rows.find((row) => row.id === id) ?? null),
+    };
+    const snapshots = overrides.snapshots ?? {
+        'ever-works/ever-works': [snapshotRow('ever-works/ever-works', '556677')],
+    };
+    const installationRepos = {
+        // Models the REAL repository, which matches CASE-INSENSITIVELY
+        // (`LOWER(fullName) = LOWER(:fullName)`). It used to be an exact key
+        // lookup here, which faithfully reproduced the defect the slice AM
+        // review found (F6) and therefore could never fail on it: `fullName`
+        // is stored verbatim from GitHub's `full_name`, and this resolver
+        // asks with a lower-cased name.
+        findByFullName: jest.fn(async (fullName: string) => {
+            const key = Object.keys(snapshots).find(
+                (name) => name.toLowerCase() === fullName.toLowerCase(),
+            );
+            return key === undefined ? [] : snapshots[key];
+        }),
+    };
+    const agents = {
+        findByIdAndUser: jest.fn(async () =>
+            overrides.agent === undefined
+                ? { id: 'agent-1', name: 'Refactor Bot', slug: 'refactor-bot' }
+                : overrides.agent,
+        ),
+    };
+    const service = new FleetPushCredentialService(
+        jobs as never,
+        jobRows as never,
+        nodes as never,
+        installations as never,
+        installationRepos as never,
+        agents as never,
+    );
+    return { service, jobs, jobRows, nodes, installations, installationRepos, agents };
+}
+
+const githubOk = (body: unknown) =>
+    ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => body,
+    }) as unknown as Response;
+
+describe('FleetPushCredentialService', () => {
+    let fetchSpy: jest.SpyInstance | undefined;
+    const previousEnv = { id: process.env.GITHUB_APP_ID, key: process.env.GITHUB_APP_PRIVATE_KEY };
+
+    beforeEach(() => {
+        process.env.GITHUB_APP_ID = '12345';
+        process.env.GITHUB_APP_PRIVATE_KEY = privateKey;
+    });
+
+    afterEach(() => {
+        fetchSpy?.mockRestore();
+        fetchSpy = undefined;
+        if (previousEnv.id === undefined) delete process.env.GITHUB_APP_ID;
+        else process.env.GITHUB_APP_ID = previousEnv.id;
+        if (previousEnv.key === undefined) delete process.env.GITHUB_APP_PRIVATE_KEY;
+        else process.env.GITHUB_APP_PRIVATE_KEY = previousEnv.key;
+    });
+
+    describe('the scope is narrowed from platform state', () => {
+        it('mints with repository_ids from the installation SNAPSHOT and contents:write only', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN, expires_at: '2026-09-06T21:00:00Z' }));
+            const { service } = build();
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+                leaseGeneration: 4,
+            });
+
+            const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.github.com/app/installations/9001/access_tokens');
+            // The narrowing that makes this a SCOPE. Before this slice every
+            // installation token this platform minted was good for every
+            // repository in the installation with every permission the App
+            // holds — fine for the read-shaped callers, exactly wrong for a
+            // write credential handed to an unattended machine.
+            expect(JSON.parse(String(init.body))).toEqual({
+                repository_ids: [556677],
+                permissions: { contents: 'write' },
+            });
+            expect(answer?.push).toMatchObject({
+                token: TOKEN,
+                username: 'x-access-token',
+                repositories: ['ever-works/ever-works'],
+            });
+        });
+
+        it('covers every WRITABLE repository the job touches and no read-only mount', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service } = build({
+                job: jobRow({
+                    payload: {
+                        ...(jobRow().payload as Record<string, unknown>),
+                        workspace: {
+                            repositoryId: 'ever-works/ever-works',
+                            mounts: [
+                                {
+                                    repositoryId: 'ever-works/template',
+                                    writable: true,
+                                    mountDir: 't',
+                                },
+                                {
+                                    repositoryId: 'ever-works/reference',
+                                    writable: false,
+                                    mountDir: 'r',
+                                },
+                            ],
+                        },
+                    },
+                }),
+                snapshots: {
+                    'ever-works/ever-works': [snapshotRow('ever-works/ever-works', '556677')],
+                    'ever-works/template': [snapshotRow('ever-works/template', '778899')],
+                    'ever-works/reference': [snapshotRow('ever-works/reference', '990011')],
+                },
+            });
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            expect(answer?.push?.repositories).toEqual([
+                'ever-works/ever-works',
+                'ever-works/template',
+            ]);
+            // A credential that could write a read-only reference checkout
+            // would be wider than the run it was minted for.
+            expect(
+                JSON.parse(String((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body)),
+            ).toMatchObject({ repository_ids: [556677, 778899] });
+        });
+
+        // REGRESSION — a repository whose GitHub name carries any upper-case
+        // character resolved to nothing (slice AM review, F6).
+        //
+        // `fullName` is stored verbatim from GitHub's `full_name`, and this
+        // resolver normalizes to lower case before asking, so the old exact
+        // (case-sensitive on Postgres) lookup returned zero rows,
+        // `byInstallation` stayed empty and the answer was
+        // `push-scope-unresolved`. The planner then refused the Task at plan
+        // time, indistinguishably from a repository no installation covers —
+        // silently removing fleet execution for an entire class of
+        // repositories the installation did cover.
+        it('resolves a repository whose GitHub name is MIXED CASE', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service, installationRepos } = build({
+                job: jobRow({
+                    payload: {
+                        ...(jobRow().payload as Record<string, unknown>),
+                        workspace: { repositoryId: 'Ever-Works/Directory-Web-Template' },
+                    },
+                }),
+                // Stored exactly as GitHub reports it.
+                snapshots: {
+                    'Ever-Works/Directory-Web-Template': [
+                        snapshotRow('Ever-Works/Directory-Web-Template', '445566'),
+                    ],
+                },
+            });
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            // The numeric id still comes from the snapshot row, and the name
+            // the node compares its remote against is the normalized one.
+            expect(
+                JSON.parse(String((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body)),
+            ).toMatchObject({ repository_ids: [445566] });
+            expect(answer?.push?.repositories).toEqual(['ever-works/directory-web-template']);
+            // Asked with the normalized name — the repository is what has to
+            // be case-insensitive, not this resolver.
+            expect(installationRepos.findByFullName).toHaveBeenCalledWith(
+                'ever-works/directory-web-template',
+            );
+        });
+    });
+
+    describe('refusals — every one fails closed with a stable token', () => {
+        const refusalCases: Array<[string, Parameters<typeof build>[0], string]> = [
+            [
+                'no installation snapshot names the repository',
+                { snapshots: {} },
+                FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            ],
+            [
+                'the installation belongs to someone else',
+                { installations: [installationRow({ createdByUserId: OTHER_USER })] },
+                FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            ],
+            [
+                'the installation was suspended',
+                { installations: [installationRow({ suspendedAt: new Date() })] },
+                FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            ],
+            [
+                'the installation was deleted',
+                { installations: [installationRow({ deletedAt: new Date() })] },
+                FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            ],
+            [
+                'the job names no repository at all',
+                { job: jobRow({ payload: { git: { push: true } } }) },
+                FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            ],
+        ];
+
+        it.each(refusalCases)('refuses when %s', async (_name, overrides, reason) => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service } = build(overrides);
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).rejects.toMatchObject({ reason });
+            // Nothing was minted: the refusal happens before GitHub is asked.
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('refuses when the repositories span TWO installations rather than picking one', async () => {
+            // Picking by listing order would decide which installation's
+            // audit trail records the write by luck.
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service } = build({
+                job: jobRow({
+                    payload: {
+                        ...(jobRow().payload as Record<string, unknown>),
+                        workspace: {
+                            repositoryId: 'ever-works/ever-works',
+                            mounts: [
+                                {
+                                    repositoryId: 'ever-works/template',
+                                    writable: true,
+                                    mountDir: 't',
+                                },
+                            ],
+                        },
+                    },
+                }),
+                installations: [
+                    installationRow(),
+                    installationRow({ id: 'inst-entity-2', installationId: '9002' }),
+                ],
+                snapshots: {
+                    'ever-works/ever-works': [
+                        snapshotRow('ever-works/ever-works', '556677', 'inst-entity-1'),
+                    ],
+                    'ever-works/template': [
+                        snapshotRow('ever-works/template', '778899', 'inst-entity-2'),
+                    ],
+                },
+            });
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).rejects.toMatchObject({ reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON });
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('refuses when the deployment has no GitHub App configured', async () => {
+            delete process.env.GITHUB_APP_ID;
+            const { service } = build();
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).rejects.toMatchObject({ reason: FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON });
+        });
+
+        it('turns a GitHub refusal into a stable token and never echoes its body', async () => {
+            fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+                ok: false,
+                status: 403,
+                statusText: 'installation suspended: app 12345 for org ever-works',
+                json: async () => ({}),
+            } as unknown as Response);
+            const { service } = build();
+
+            const error = await service
+                .mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID })
+                .catch((e: unknown) => e);
+
+            expect(error).toBeInstanceOf(FleetPushCredentialError);
+            expect((error as FleetPushCredentialError).reason).toBe(
+                FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON,
+            );
+            expect((error as Error).message).not.toContain('org ever-works');
+        });
+
+        it('answers null — one undifferentiated 401 — when the claim proof fails', async () => {
+            const { service, jobRows } = build({ claim: null });
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).resolves.toBeNull();
+            // Nothing is read about the job at all: an unauthenticated
+            // caller must not be able to probe which jobs exist.
+            expect(jobRows.findById).not.toHaveBeenCalled();
+        });
+
+        it('lets a stale lease propagate as its own error, exactly as env-files does', async () => {
+            const jobs = {
+                authorizeRunSecretRequest: jest.fn(async () => {
+                    throw new FleetJobStaleLeaseError();
+                }),
+            };
+            const service = new FleetPushCredentialService(
+                jobs as never,
+                { findById: jest.fn() } as never,
+                { findById: jest.fn() } as never,
+                { findById: jest.fn() } as never,
+                { findByFullName: jest.fn() } as never,
+            );
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).rejects.toBeInstanceOf(FleetJobStaleLeaseError);
+        });
+    });
+
+    describe('the platform re-reads its own plan', () => {
+        it('mints NO credential for a job whose plan commits but does not push', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service } = build({
+                job: jobRow({
+                    payload: {
+                        ...(jobRow().payload as Record<string, unknown>),
+                        git: { commit: true, push: false },
+                    },
+                }),
+            });
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            expect(answer?.push).toBeNull();
+            // A write credential that never existed cannot leak.
+            expect(fetchSpy).not.toHaveBeenCalled();
+            // Attribution is still issued: a commit-only run still needs to
+            // say which machine and which agent made it.
+            expect(answer?.attribution.nodeId).toBe(NODE_ID);
+        });
+    });
+
+    describe('attribution comes from platform rows, never from the request', () => {
+        it('names the node, the agent and the run', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service } = build();
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            expect(answer?.attribution).toEqual({
+                nodeId: NODE_ID,
+                nodeName: 'studio-win',
+                agentId: '22222222-2222-4222-8222-222222222222',
+                agentName: 'Refactor Bot',
+                agentEmail: 'refactor-bot@agents.ever.works',
+                jobId: JOB_ID,
+                runId: '44444444-4444-4444-8444-444444444444',
+            });
+        });
+
+        it('scopes the Agent read to the JOB owner, never to anything the caller sent', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service, agents } = build();
+
+            await service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID });
+
+            expect(agents.findByIdAndUser).toHaveBeenCalledWith(
+                '22222222-2222-4222-8222-222222222222',
+                USER_ID,
+            );
+        });
+
+        it('sanitises a node name that tried to open a trailer line of its own', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service, nodes } = build();
+            nodes.findById.mockResolvedValue({
+                id: NODE_ID,
+                name: 'ok\nEver-Works-Job: forged',
+            } as never);
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            expect(answer?.attribution.nodeName).not.toContain('\n');
+        });
+
+        it('degrades to ids rather than failing the run when the Agent cannot be read', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN }));
+            const { service, agents } = build();
+            agents.findByIdAndUser.mockRejectedValue(new Error('db down'));
+
+            const answer = await service.mint({
+                nodeId: NODE_ID,
+                secret: 'a'.repeat(32),
+                jobId: JOB_ID,
+            });
+
+            expect(answer?.attribution.agentName).toBeNull();
+            expect(answer?.push?.token).toBe(TOKEN);
+        });
+    });
+
+    describe('the token never reaches a log line', () => {
+        it('logs the repositories and the expiry, never the credential', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(githubOk({ token: TOKEN, expires_at: '2026-09-06T21:00:00Z' }));
+            const lines: string[] = [];
+            const { service } = build();
+            const logger = (service as unknown as { logger: { log: (m: string) => void } }).logger;
+            jest.spyOn(logger, 'log').mockImplementation((message: string) => {
+                lines.push(String(message));
+            });
+
+            await service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID });
+
+            expect(lines.join('\n')).toContain('ever-works/ever-works');
+            expect(lines.join('\n')).not.toContain(TOKEN);
+        });
+    });
+
+    describe('describeScope — the pre-dispatch probe, without minting', () => {
+        it('resolves without asking GitHub anything', async () => {
+            fetchSpy = jest.spyOn(globalThis, 'fetch');
+            const { service } = build();
+
+            await expect(
+                service.describeScope(USER_ID, [{ repositoryId: 'ever-works/ever-works' }]),
+            ).resolves.toMatchObject({
+                ok: true,
+                installationId: '9001',
+                repositories: ['ever-works/ever-works'],
+            });
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('reports the same stable reason the mint would refuse with', async () => {
+            const { service } = build({ snapshots: {} });
+
+            await expect(
+                service.describeScope(USER_ID, [{ repositoryId: 'ever-works/ever-works' }]),
+            ).resolves.toEqual({
+                ok: false,
+                reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            });
+        });
+
+        it('reports the not-configured reason before it looks at any row', async () => {
+            delete process.env.GITHUB_APP_PRIVATE_KEY;
+            const { service, installationRepos } = build();
+
+            await expect(
+                service.describeScope(USER_ID, [{ repositoryId: 'ever-works/ever-works' }]),
+            ).resolves.toEqual({
+                ok: false,
+                reason: FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+            });
+            expect(installationRepos.findByFullName).not.toHaveBeenCalled();
+        });
+
+        // REGRESSION — `owner/repo` is not an identity (slice AM review, F4).
+        //
+        // A `git` repo connection's url is a bare `@IsString()` with no host
+        // constraint, and `repositoryIdFromCloneUrl` is host-agnostic, so a
+        // mount at `https://gitlab.com/ever-works/ever-works` used to yield
+        // `ever-works/ever-works`, match the GITHUB installation row of that
+        // name, and buy a `contents: write` token for
+        // `github.com/ever-works/ever-works` — a repository the run never
+        // touches. No attacker required.
+        it.each([
+            ['a different forge', 'https://gitlab.com/ever-works/ever-works.git'],
+            ['a suffix lookalike', 'https://github.com.evil.tld/ever-works/ever-works'],
+            ['a non-default port', 'https://github.com:8443/ever-works/ever-works'],
+            ['an ssh remote', 'git@github.com:ever-works/ever-works.git'],
+            ['a name that disagrees with its own url', 'https://github.com/someone-else/other.git'],
+        ])('refuses a push target whose clone URL is %s', async (_label, repoUrl) => {
+            const { service } = build();
+
+            await expect(
+                service.describeScope(USER_ID, [
+                    { repositoryId: 'ever-works/ever-works', repoUrl },
+                ]),
+            ).resolves.toEqual({
+                ok: false,
+                reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+            });
+        });
+
+        it('accepts the real clone URL and scopes by what the URL says', async () => {
+            const { service } = build();
+
+            await expect(
+                service.describeScope(USER_ID, [
+                    {
+                        repositoryId: 'ever-works/ever-works',
+                        repoUrl: 'https://github.com/Ever-Works/ever-works.git',
+                    },
+                ]),
+            ).resolves.toMatchObject({ ok: true, repositories: ['ever-works/ever-works'] });
+        });
+
+        it('refuses at MINT time too, on the job payload the planner wrote', async () => {
+            // The plan-time probe is @Optional() and only moves the failure
+            // earlier; this is the gate that actually decides whether a token
+            // is issued.
+            fetchSpy = jest.spyOn(globalThis, 'fetch');
+            const { service } = build({
+                job: jobRow({
+                    payload: {
+                        ...(jobRow().payload as Record<string, unknown>),
+                        workspace: {
+                            repositoryId: 'ever-works/ever-works',
+                            repoUrl: 'https://gitlab.com/ever-works/ever-works.git',
+                        },
+                    },
+                }),
+            });
+
+            await expect(
+                service.mint({ nodeId: NODE_ID, secret: 'a'.repeat(32), jobId: JOB_ID }),
+            ).rejects.toMatchObject({ reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON });
+            // Nothing was minted, so no write credential for a GitHub
+            // repository this run has nothing to do with ever existed.
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/fleet/__tests__/fleet-run-routing.spec.ts
+++ b/apps/api/src/fleet/__tests__/fleet-run-routing.spec.ts
@@ -298,7 +298,9 @@ describe('fleet run routing (local-runner preference matrix)', () => {
             expect(jobs.resolveAgentTaskTarget).toHaveBeenCalledWith('user-1', 'agent-1');
             expect(runners.availability).toHaveBeenCalledWith('user-1', {
                 targetNodeId: NODE_B,
-                requiredCapabilities: [],
+                // Slice AM (EW-810): with no operator tags configured, the
+                // set is exactly the one tag every `agent-task` now needs.
+                requiredCapabilities: ['git-push'],
             });
         });
 
@@ -390,9 +392,14 @@ describe('fleet run routing (local-runner preference matrix)', () => {
             runners.availability.mockClear();
             planner = undefined;
             await buildDispatcher().enqueue(payload());
+            // Scoped push credentials (self-build slice AM, EW-810):
+            // `agentTaskRequiredCapabilities` now always adds `git-push`,
+            // so the planner-free path counts the operator's config tags
+            // PLUS it. The old expectation was right for a fleet whose
+            // push was token-free.
             expect(runners.availability).toHaveBeenCalledWith('user-1', {
                 targetNodeId: null,
-                requiredCapabilities: ['workspace'],
+                requiredCapabilities: ['workspace', 'git-push'],
             });
         });
 
@@ -424,9 +431,11 @@ describe('fleet run routing (local-runner preference matrix)', () => {
             const result = await buildDispatcher().enqueue(payload());
 
             expect(result).toEqual({ runId: 'fleet-job-1' });
+            // Degraded means "the operator's config tags", which since
+            // slice AM includes the always-required `git-push`.
             expect(runners.availability).toHaveBeenCalledWith('user-1', {
                 targetNodeId: null,
-                requiredCapabilities: ['workspace'],
+                requiredCapabilities: ['workspace', 'git-push'],
             });
         });
 
@@ -449,7 +458,10 @@ describe('fleet run routing (local-runner preference matrix)', () => {
 
             const counted = runners.availability.mock.calls[0][1].requiredCapabilities;
             expect(store.enqueue.mock.calls[0][0].requiredCapabilities).toEqual(counted);
-            expect(counted).toEqual(['workspace']);
+            // The literal matters more than the equality above: it is what
+            // catches a tag being added to ONE of the two callers. Slice AM
+            // added `git-push` to the shared definition, so both moved.
+            expect(counted).toEqual(['workspace', 'git-push']);
         });
     });
 });

--- a/apps/api/src/fleet/__tests__/node-contract.conformance.spec.ts
+++ b/apps/api/src/fleet/__tests__/node-contract.conformance.spec.ts
@@ -233,12 +233,21 @@ describe('fleet node contract — the wire a deployed node actually speaks', () 
         // Slice Z (EW-782) adds the run-scoped MCP credential pair. Both are
         // node verbs on the same credential and the same lease proof, and an
         // older node simply never calls either, so they are admitted by name.
+        // Slice AM (EW-810) adds `pushCredential`: POST
+        // /api/fleet/jobs/:id/push-credential, the scoped write credential
+        // and commit attribution a node fetches right before it commits. It
+        // is a node verb like the others — same credential, same four lease
+        // checks, `@Public()` — and an older node simply never calls it,
+        // which is why the platform ALSO stops offering `agent-task` work to
+        // a node that does not advertise `git-push`: a node that would push
+        // with its own ambient helper must not be handed the work.
         expect(declared.sort()).toEqual([
             'complete',
             'envFiles',
             'heartbeat',
             'lease',
             'mintMcpCredential',
+            'pushCredential',
             'revokeMcpCredential',
         ]);
     });
@@ -675,8 +684,21 @@ function buildRealJobsController(options: { stopped?: boolean } = {}) {
             throw new Error('the node-contract routes must not revoke a run credential');
         },
     };
+    // Slice AM (EW-810): same posture as the run-credential stub above —
+    // the node-contract routes must never reach the scoped push credential,
+    // so its stub throws rather than answering.
+    const pushCredentials = {
+        mint: async () => {
+            throw new Error('the node-contract routes must not mint a push credential');
+        },
+    };
     return {
-        controller: new FleetJobsController(service, runSecrets as never, runCredentials as never),
+        controller: new FleetJobsController(
+            service,
+            runSecrets as never,
+            runCredentials as never,
+            pushCredentials as never,
+        ),
         secret,
         job,
     };

--- a/apps/api/src/fleet/dto/fleet-job.dto.ts
+++ b/apps/api/src/fleet/dto/fleet-job.dto.ts
@@ -215,3 +215,28 @@ export class FleetJobEnvFilesDto extends FleetJobNodeCredentialDto {
     @Type(() => FleetJobEnvFileRefDto)
     refs: FleetJobEnvFileRefDto[];
 }
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/jobs/:id/push-credential`
+ * (self-build slice AM, EW-810).
+ *
+ * The credential pair plus `leaseGeneration`, exactly as `env-files` —
+ * and for the same reason. This route hands a machine a WRITE credential
+ * for the owner's repositories, so a node whose claim lapsed while it
+ * slept must be refused here as strictly as it is on complete.
+ *
+ * Note what the body does NOT carry: no repository, no installation, no
+ * branch, no scope of any kind. Everything the token is narrowed by is
+ * read from platform state, because a caller that could name its own
+ * scope would have defeated the narrowing.
+ */
+export class FleetJobPushCredentialDto extends FleetJobNodeCredentialDto {
+    @ApiProperty({
+        minimum: 1,
+        description:
+            'Lease generation returned with the claim. A generation that is not the current one is refused with 409 stale-lease and mints nothing.',
+    })
+    @IsInt()
+    @Min(1)
+    leaseGeneration: number;
+}

--- a/apps/api/src/fleet/fleet-agent-task-capabilities.ts
+++ b/apps/api/src/fleet/fleet-agent-task-capabilities.ts
@@ -1,3 +1,4 @@
+import { FLEET_PUSH_CAPABILITY } from '@ever-works/contracts';
 import { config } from '@ever-works/agent/config';
 
 /**
@@ -19,11 +20,33 @@ import { config } from '@ever-works/agent/config';
  * resolved executable on the node, which is what keeps a Claude job off a
  * machine that only has Codex (and vice versa). `null` is the legacy
  * `command` mode, where only the operator tags apply.
+ *
+ * `git-push` (self-build slice AM, EW-810) is added UNCONDITIONALLY, and
+ * that is deliberate on three counts:
+ *
+ *  1. It is the pre-dispatch push-capability probe. A node advertises the
+ *     tag only when its Git can actually install a scoped, per-run
+ *     credential; a node that cannot must never be handed twenty minutes
+ *     of model time and then discover it at the push.
+ *  2. It is added regardless of whether THIS plan pushes, because the two
+ *     callers of this function see different things: the router asks
+ *     before a plan exists (settings only) and `enqueueAgentTask` asks
+ *     with one in hand. A tag that depended on the plan would make the
+ *     router count nodes against one set while the row demanded another —
+ *     the exact "placed, but nothing can take it" hole this module was
+ *     extracted to prevent. A non-pushing `agent-task` on a push-capable
+ *     node costs nothing; the reverse is a stuck queue.
+ *  3. The upgrade coupling is intentional and safe. A node running a build
+ *     from before this slice reports no `git-push` tag, so it stops
+ *     attracting `agent-task` work — and it MUST, because it would push
+ *     with the machine's own ambient credential helper. The dispatcher
+ *     already treats "no free runner" as a fallback to the cloud, so an
+ *     un-upgraded fleet degrades to cloud execution rather than stalling.
  */
 export function agentTaskRequiredCapabilities(provider: string | null | undefined): string[] {
-    const tags = config.fleetNode.getRequiredCapabilities();
+    const tags = [...config.fleetNode.getRequiredCapabilities(), FLEET_PUSH_CAPABILITY];
     if (!provider) {
-        return tags;
+        return Array.from(new Set(tags));
     }
     return Array.from(new Set([...tags, provider]));
 }

--- a/apps/api/src/fleet/fleet-agent-task-planner.service.ts
+++ b/apps/api/src/fleet/fleet-agent-task-planner.service.ts
@@ -28,6 +28,7 @@ import {
     FLEET_AGENT_EXECUTION_MIN_TIMEOUT_SEC,
     FLEET_AGENT_EXECUTION_MODEL_PATTERN,
     FLEET_AGENT_TASK_QUESTION_FILE,
+    describeFleetPushCredentialRefusal,
     fleetAgentExecutionProviderSupportsMountGrants,
     isFleetAgentExecutionEffort,
     isFleetAgentExecutionMode,
@@ -43,6 +44,7 @@ import {
     type TaskAcceptanceCheck,
 } from '@ever-works/contracts';
 import { agentTaskRequiredCapabilities } from './fleet-agent-task-capabilities';
+import { FleetPushCredentialService } from './fleet-push-credential.service';
 import type {
     FleetAgentTaskPlan,
     FleetAgentTaskPlanner,
@@ -164,6 +166,13 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
         // positional spec constructions keep compiling; absent = no owner
         // answer is ever rendered (today's instructions, unchanged).
         @Optional() private readonly runs?: AgentRunRepository,
+        // Scoped push credentials (self-build slice AM, EW-810) — the
+        // PLATFORM half of the pre-dispatch push-capability probe. Appended
+        // LAST + @Optional() so positional spec constructions keep
+        // compiling; absent = no plan-time refusal, and the NODE still
+        // fails closed at the publish (which is the guarantee that
+        // matters — this only moves the failure twenty minutes earlier).
+        @Optional() private readonly pushCredentials?: FleetPushCredentialService,
     ) {}
 
     /**
@@ -328,6 +337,53 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
             );
         }
 
+        // Scoped push credentials (self-build slice AM, EW-810) — refuse a
+        // run the platform could never publish, BEFORE it costs a node
+        // twenty minutes of model time.
+        //
+        // A fleet node no longer pushes with the machine's own Git
+        // credential helper; it pushes with a repository-scoped
+        // installation token this platform mints per job. Whether that
+        // token CAN be minted is a fact about platform state — is a GitHub
+        // App configured, does an installation this owner controls cover
+        // every repository this run writes to — and platform state is
+        // exactly what a plan is allowed to refuse on. Precedent: the
+        // writable-mount refusal above, and the no-repository refusal
+        // before it.
+        //
+        // No GitHub call happens here: this reads the installation
+        // snapshot the platform already keeps, so the check costs a query
+        // and cannot fail a plan because GitHub was slow.
+        const canCommit = agent.permissions?.canCommitToRepo !== false;
+        if (canCommit && this.pushCredentials) {
+            // The CLONE URL travels with the name. `owner/repo` alone is not
+            // an identity a write credential may be scoped by — a `git` repo
+            // connection can point anywhere, and `repositoryIdFromCloneUrl`
+            // is host-agnostic, so a mount at
+            // `https://gitlab.example/acme/widgets` would otherwise resolve
+            // against a GitHub installation row called `acme/widgets` and
+            // buy a `contents: write` token for a repository this run never
+            // touches (slice AM review, F4).
+            const pushTargets = [
+                { repositoryId: workspace.repositoryId, repoUrl: workspace.repoUrl },
+                ...writableMounts.map((mount) => ({
+                    repositoryId: mount.repositoryId,
+                    repoUrl: mount.repoUrl,
+                })),
+            ];
+            const scope = await this.pushCredentials.describeScope(payload.userId, pushTargets);
+            if (!scope.ok) {
+                throw new FleetAgentTaskPlanError(
+                    `Task ${task.slug ?? task.id} would push to ${pushTargets
+                        .map((target) => target.repositoryId)
+                        .join(', ')}, but ` +
+                        `${describeFleetPushCredentialRefusal(scope.reason)}. A fleet node never pushes with the ` +
+                        `machine's own Git credential helper, so this run is refused now rather than after the ` +
+                        `model has already done the work.`,
+                );
+            }
+        }
+
         const work = task.workId ? await this.works.findById(task.workId) : null;
         // Owner-authored, from the Work's defaults and the Task's own list.
         // `safeResolveChecks` swallows a read failure to `[]` deliberately:
@@ -425,7 +481,6 @@ export class FleetAgentTaskPlannerService implements FleetAgentTaskPlanner {
         if (settings.maxBudgetUsd !== undefined) execution.maxBudgetUsd = settings.maxBudgetUsd;
         if (settings.skipPermissions) execution.skipPermissions = true;
 
-        const canCommit = agent.permissions?.canCommitToRepo !== false;
         return {
             execution,
             workspace,

--- a/apps/api/src/fleet/fleet-jobs.controller.spec.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.spec.ts
@@ -6,6 +6,10 @@ import {
 import type { FleetJobView } from '@ever-works/contracts';
 import { FLEET_JOB_STALE_LEASE_REASON } from '@ever-works/contracts';
 import { FleetJobsController } from './fleet-jobs.controller';
+import {
+    FleetPushCredentialError,
+    FleetPushCredentialService,
+} from './fleet-push-credential.service';
 import { FleetRunSecretsError, FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetJobStaleLeaseError } from '@ever-works/agent/fleet';
 import type { FleetJobService, FleetRunCredentialService } from '@ever-works/agent/fleet';
@@ -63,11 +67,19 @@ function makeController(
     service: Partial<FleetJobService>,
     runSecrets: Partial<FleetRunSecretsService> = { resolve: jest.fn(async () => null) },
     runCredentials: Partial<FleetRunCredentialService> = {},
+    // Self-build slice AM (EW-810) — appended LAST, like every slot before
+    // it. Defaults to a refusal, not a permissive stub: a route that
+    // accidentally minted a WRITE credential for the owner's repositories
+    // must fail this suite rather than pass it quietly.
+    pushCredentials: Partial<FleetPushCredentialService> = {
+        mint: jest.fn(async () => null),
+    },
 ): FleetJobsController {
     return new FleetJobsController(
         service as FleetJobService,
         runSecrets as FleetRunSecretsService,
         runCredentials as FleetRunCredentialService,
+        pushCredentials as FleetPushCredentialService,
     );
 }
 
@@ -357,6 +369,101 @@ describe('FleetJobsController', () => {
                 },
             );
             const error = await controller.envFiles(JOB_ID, body).catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getResponse()).toMatchObject({
+                reason: FLEET_JOB_STALE_LEASE_REASON,
+            });
+        });
+    });
+
+    /**
+     * Scoped push credentials (self-build slice AM, EW-810) — the second
+     * route on this channel that returns a secret, and the FIRST that
+     * returns one which can WRITE.
+     *
+     * Same three answers as env-files, deliberately: one undifferentiated
+     * 401, one 409 stale-lease, and a 422 carrying a stable reason token.
+     * A node that gets the 422 fails the run; there is no fourth answer
+     * that lets it push some other way.
+     */
+    describe('POST /api/fleet/jobs/:id/push-credential', () => {
+        const body = { nodeId: NODE_ID, secret: SECRET, leaseGeneration: GENERATION };
+        const answer = {
+            attribution: {
+                nodeId: NODE_ID,
+                nodeName: 'studio-win',
+                agentId: null,
+                agentName: null,
+                agentEmail: null,
+                jobId: JOB_ID,
+                runId: null,
+            },
+            push: {
+                token: 'ghs_scoped',
+                username: 'x-access-token',
+                expiresAt: '2026-09-06T21:00:00.000Z',
+                repositories: ['ever-works/ever-works'],
+            },
+        };
+
+        it('forwards the claim exactly as the node sent it and returns the credential once', async () => {
+            const mint = jest.fn(async () => answer);
+            const controller = makeController({}, undefined, {}, { mint });
+
+            await expect(controller.pushCredential(JOB_ID, body)).resolves.toEqual(answer);
+            expect(mint).toHaveBeenCalledWith({
+                nodeId: NODE_ID,
+                secret: SECRET,
+                jobId: JOB_ID,
+                leaseGeneration: GENERATION,
+            });
+        });
+
+        it('collapses a refused claim to the SAME 401 as every other route', async () => {
+            const controller = makeController(
+                {},
+                undefined,
+                {},
+                { mint: jest.fn(async () => null) },
+            );
+
+            await expect(controller.pushCredential(JOB_ID, body)).rejects.toBeInstanceOf(
+                UnauthorizedException,
+            );
+        });
+
+        it('answers 422 with the stable reason token, and never the installation detail', async () => {
+            const controller = makeController(
+                {},
+                undefined,
+                {},
+                {
+                    mint: jest.fn(async () => {
+                        throw new FleetPushCredentialError('push-scope-unresolved');
+                    }),
+                },
+            );
+
+            const error = await controller.pushCredential(JOB_ID, body).catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(UnprocessableEntityException);
+            expect((error as UnprocessableEntityException).getResponse()).toEqual({
+                reason: 'push-scope-unresolved',
+            });
+        });
+
+        it('lets a stale lease surface as the channel-wide 409, not as a 422', async () => {
+            const controller = makeController(
+                {},
+                undefined,
+                {},
+                {
+                    mint: jest.fn(async () => {
+                        throw new FleetJobStaleLeaseError();
+                    }),
+                },
+            );
+
+            const error = await controller.pushCredential(JOB_ID, body).catch((e: unknown) => e);
             expect(error).toBeInstanceOf(ConflictException);
             expect((error as ConflictException).getResponse()).toMatchObject({
                 reason: FLEET_JOB_STALE_LEASE_REASON,

--- a/apps/api/src/fleet/fleet-jobs.controller.ts
+++ b/apps/api/src/fleet/fleet-jobs.controller.ts
@@ -19,6 +19,7 @@ import type {
     FleetJobLeaseResponse,
     FleetJobMcpCredentialResponse,
     FleetJobMcpCredentialRevokeResponse,
+    FleetJobPushCredentialResponse,
 } from '@ever-works/contracts';
 import { FleetJobService, FleetRunCredentialService } from '@ever-works/agent/fleet';
 import { Public } from '../auth/decorators/public.decorator';
@@ -27,8 +28,13 @@ import {
     FleetJobEnvFilesDto,
     FleetJobHeartbeatDto,
     FleetJobNodeCredentialDto,
+    FleetJobPushCredentialDto,
     LeaseFleetJobsDto,
 } from './dto/fleet-job.dto';
+import {
+    FleetPushCredentialError,
+    FleetPushCredentialService,
+} from './fleet-push-credential.service';
 import { FleetRunSecretsError, FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetEnabledGuard } from './guards/fleet-enabled.guard';
 import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
@@ -76,6 +82,15 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
  *
  *   POST /api/fleet/jobs/:id/mcp-credential          mint a run-scoped token
  *   POST /api/fleet/jobs/:id/mcp-credential/revoke   drop it early
+ *   POST /api/fleet/jobs/:id/push-credential         mint a scoped write token
+ *
+ * The push credential (self-build slice AM) takes the env-files posture
+ * exactly: the same four checks, a 422 with a stable token on refusal, and
+ * no partial answer. It is the second place a secret leaves the platform
+ * for a node, and the first place one leaves that can WRITE — so it is
+ * scoped from platform state alone (this job's repositories,
+ * `contents: write`, under the hour) and there is no degraded path back to
+ * the machine's own credential helper.
  *
  * Throttles are sized for polling: a node with a 5-second idle poll
  * needs ~12 lease calls/minute, and job heartbeats fire at a third of
@@ -103,6 +118,9 @@ export class FleetJobsController {
         private readonly service: FleetJobService,
         private readonly runSecrets: FleetRunSecretsService,
         private readonly runCredentials: FleetRunCredentialService,
+        // Self-build slice AM (EW-810). Appended LAST so the positional
+        // constructions in the existing controller specs keep compiling.
+        private readonly pushCredentials: FleetPushCredentialService,
     ) {}
 
     @Public()
@@ -225,6 +243,75 @@ export class FleetJobsController {
             throw new UnauthorizedException('Invalid node credential');
         }
         return { ok: true, revoked };
+    }
+
+    /**
+     * Self-build slice AM (EW-810) — the run's commit attribution and,
+     * when its plan pushes, a SCOPED write credential for the repositories
+     * this job touches.
+     *
+     * The gap it closes: before this route a node's `git push` was
+     * authenticated by the machine's own Git credential helper — a
+     * long-lived PAT with write access to every repository that OS user
+     * can reach, which the platform could neither scope, rotate, revoke
+     * nor observe. What comes back here is a GitHub App installation token
+     * narrowed to this job's repositories and to `contents: write`,
+     * expiring within the hour, revoked by the node the moment the run
+     * ends.
+     *
+     * Same posture as `env-files`, and the SAME four checks: credential,
+     * recorded holder, active status, current lease generation. Handing a
+     * machine a write credential for the owner's repositories is at least
+     * as consequential as handing it their decrypted `.env`.
+     *
+     * The request carries NO scope of any kind — no repository, no
+     * installation, no branch. Everything the token is narrowed by comes
+     * from platform state, because a caller that could name its own scope
+     * would have defeated the narrowing.
+     *
+     * A refusal (no App configured, no installation covering every
+     * repository this run writes to, a GitHub failure) answers 422 with a
+     * STABLE machine token. There is deliberately no degraded answer: a
+     * node that cannot get a scoped credential must fail the run, because
+     * the only other way it could push is the ambient helper this route
+     * exists to replace.
+     */
+    @Public()
+    @Post(':id/push-credential')
+    @ApiOperation({
+        summary:
+            "Mint a repository-scoped push credential and the commit attribution for a job this node holds (public, node-secret-authenticated). Scoped from platform state to this job's repositories with contents:write only, expiring within the hour. Returned once; never recoverable.",
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async pushCredential(
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: FleetJobPushCredentialDto,
+    ): Promise<FleetJobPushCredentialResponse> {
+        let response: FleetJobPushCredentialResponse | null;
+        try {
+            response = await this.pushCredentials.mint({
+                nodeId: body.nodeId,
+                secret: body.secret,
+                jobId: id,
+                leaseGeneration: body.leaseGeneration,
+            });
+        } catch (error) {
+            // The stable token, and only the stable token. The refusal has
+            // already been logged server-side with the job id; the node
+            // gets a reason it can report, never an installation id or a
+            // GitHub response body.
+            if (error instanceof FleetPushCredentialError) {
+                throw new UnprocessableEntityException({ reason: error.reason });
+            }
+            // `FleetJobStaleLeaseError` propagates untouched, as 409
+            // `{ reason: 'stale-lease' }` — same as heartbeat and complete.
+            throw error;
+        }
+        if (!response) {
+            throw new UnauthorizedException('Invalid node credential');
+        }
+        return response;
     }
 
     @Public()

--- a/apps/api/src/fleet/fleet-push-credential.service.ts
+++ b/apps/api/src/fleet/fleet-push-credential.service.ts
@@ -1,0 +1,515 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES,
+    FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON,
+    FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+    FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+    FLEET_PUSH_CREDENTIAL_USERNAME,
+    fleetPushRemoteRepositoryId,
+    normalizeFleetPushRepositoryId,
+    sanitizeFleetPushIdentityText,
+    type FleetJobPushCredentialResponse,
+    type FleetPushAttribution,
+} from '@ever-works/contracts';
+import { FleetJobRepository, FleetNodeRepository, FleetJobService } from '@ever-works/agent/fleet';
+import {
+    AgentRepository,
+    GitHubAppInstallationRepoRepository,
+    GitHubAppInstallationRepository,
+} from '@ever-works/agent/database';
+import { config } from '@ever-works/agent/config';
+import { requestGitHubAppInstallationAccessTokenDetails } from '@ever-works/agent/utils';
+
+/**
+ * A refusal the node can act on. Carries a STABLE machine token as its
+ * message and nothing else — no installation id, no repository name, no
+ * GitHub response body.
+ */
+export class FleetPushCredentialError extends Error {
+    constructor(readonly reason: string) {
+        super(reason);
+        this.name = 'FleetPushCredentialError';
+    }
+}
+
+/**
+ * What the scope resolver decided, before anything is minted.
+ *
+ * `reason` is present on BOTH arms (null when it resolved) rather than
+ * only on the refusal: `apps/api` compiles with `strictNullChecks: false`,
+ * where narrowing a discriminated union in the NEGATIVE branch does not
+ * reliably reach the refusal arm's own fields. A reader should not have to
+ * know that, so the shape simply does not depend on it.
+ */
+export type FleetPushScope =
+    | {
+          readonly ok: true;
+          readonly reason: null;
+          /** Installation ENTITY row id. */
+          readonly installationEntityId: string;
+          /** GitHub's own numeric installation id (what the mint URL uses). */
+          readonly installationId: string;
+          /** GitHub's numeric repository ids, from the platform's snapshot. */
+          readonly repositoryIds: string[];
+          /** The same repositories as normalized `owner/repo`, for the node. */
+          readonly repositories: string[];
+      }
+    | { readonly ok: false; readonly reason: string };
+
+/**
+ * One repository the mint must cover, as it appears in a job's workspace.
+ *
+ * The CLONE URL is carried alongside the name, and where it is present it
+ * is the authority. `repositoryId` is only ever `owner/repo`, and
+ * `owner/repo` is not an identity without a host in front of it: a `git`
+ * repo connection's url is a bare `@IsString()` with no host constraint
+ * (`repo-connection.dto.ts`), and `repositoryIdFromCloneUrl` is
+ * host-agnostic, so a mount at `https://gitlab.example/acme/widgets`
+ * yields `acme/widgets` — which would then match a GITHUB installation
+ * row of the same name and mint a `contents: write` token for
+ * `github.com/acme/widgets`, a repository this job has nothing to do
+ * with. Slice AM's review found that (F4); this type is what stops the
+ * platform issuing it in the first place, and the node's own host check
+ * is the second half.
+ */
+export interface FleetPushRepositoryRequest {
+    readonly repositoryId: string;
+    /** The token-free clone URL, when the caller has it. */
+    readonly repoUrl?: string | null;
+}
+
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) — the platform
+ * half of `POST /api/fleet/jobs/:id/push-credential`.
+ *
+ * ## What this service is for
+ *
+ * A fleet node's `git push` used to be authenticated by the machine's own
+ * Git credential helper: a long-lived personal access token, in the OS
+ * credential store, with write access to every repository that OS user
+ * can reach. The platform could not scope it, rotate it, revoke it or
+ * observe it. This service replaces it with a GitHub App INSTALLATION
+ * token, minted per job, narrowed to the repository ids the job actually
+ * writes to and to `contents: write` alone.
+ *
+ * ## The rules this file exists to keep
+ *
+ * - **The scope comes from PLATFORM STATE.** The repositories are read
+ *   from the job's own `payload.workspace` — which the PLANNER wrote, so
+ *   this is the platform re-reading its own decision, the same posture
+ *   `FleetRunCredentialService.bridgeRequested` takes — and then resolved
+ *   against `github_app_installation_repositories`, the snapshot
+ *   `GitHubAppSyncService` keeps from GitHub. The numeric repository ids
+ *   the token is narrowed by come from THAT table, never from a name a
+ *   node or a payload supplied.
+ * - **The installation must belong to the job's owner.** `findByFullName`
+ *   is global — it returns rows for every installation in the deployment —
+ *   so an ownership filter is the only thing between a job and a token for
+ *   somebody else's repository.
+ * - **Fail closed, with a stable reason.** No App configured, no
+ *   installation covering every repository, two installations, a suspended
+ *   or deleted installation, a GitHub refusal: each is a refusal the node
+ *   turns into a failed run that NAMES the gap. There is no fallback to
+ *   the node's ambient helper — that fallback is the hole this closes.
+ * - **Nothing about the token is logged, stored or echoed.** The log line
+ *   names the job, the node and the repositories. The token exists in this
+ *   process for the length of one response and is never written anywhere.
+ */
+@Injectable()
+export class FleetPushCredentialService {
+    private readonly logger = new Logger(FleetPushCredentialService.name);
+
+    constructor(
+        private readonly jobs: FleetJobService,
+        private readonly jobRows: FleetJobRepository,
+        private readonly nodes: FleetNodeRepository,
+        private readonly installations: GitHubAppInstallationRepository,
+        private readonly installationRepos: GitHubAppInstallationRepoRepository,
+        // Appended LAST and @Optional(): attribution degrades to "the job
+        // named an Agent we could not name" rather than refusing the mint,
+        // and a reduced module graph still constructs.
+        @Optional() private readonly agents?: AgentRepository,
+    ) {}
+
+    /**
+     * Authorize the caller, then answer with this run's attribution and —
+     * when the job's own plan pushes — a scoped write credential.
+     *
+     * Returns `null` when the node credential / holder / status proof
+     * fails, so the controller answers the SAME undifferentiated 401 every
+     * other route on this channel answers. A stale lease propagates as
+     * `FleetJobStaleLeaseError` (409). Everything else throws
+     * {@link FleetPushCredentialError}, which the controller renders as a
+     * 422 carrying only the stable token.
+     */
+    async mint(input: {
+        nodeId: unknown;
+        secret: unknown;
+        jobId: string;
+        leaseGeneration?: unknown;
+    }): Promise<FleetJobPushCredentialResponse | null> {
+        // The SAME four checks `env-files` runs, and for the same reason:
+        // handing a machine a write credential for the owner's
+        // repositories is at least as consequential as handing it their
+        // decrypted `.env`. Reused rather than re-implemented so the two
+        // sensitive deliveries on this channel cannot drift apart.
+        const claim = await this.jobs.authorizeRunSecretRequest({
+            nodeId: input.nodeId,
+            secret: input.secret,
+            jobId: input.jobId,
+            leaseGeneration: input.leaseGeneration,
+        });
+        if (!claim) return null;
+
+        const job = await this.jobRows.findById(claim.jobId);
+        // The row was there a moment ago (the authorizer read it), so its
+        // absence now is a race with deletion, not a caller error.
+        if (!job) return null;
+
+        const attribution = await this.describeAttribution(claim, job);
+
+        // The platform re-reads its OWN plan. A node cannot ask for a write
+        // credential on a job whose plan only commits, and cannot decline
+        // one on a job whose plan pushes.
+        if (!this.jobPushes(job)) {
+            this.logger.log(
+                `Fleet job ${claim.jobId}: attribution issued to node ${claim.nodeId} (plan does not push, no credential minted)`,
+            );
+            return { attribution, push: null };
+        }
+
+        const scope = await this.resolveScope(claim.userId, this.repositoriesOf(job));
+        if (!scope.ok) throw this.refusal(claim.jobId, scope.reason);
+
+        const credentials = this.appCredentials();
+        if (!credentials)
+            throw this.refusal(claim.jobId, FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON);
+
+        let minted: { token: string; expiresAt: string | null };
+        try {
+            minted = await requestGitHubAppInstallationAccessTokenDetails(
+                scope.installationId,
+                credentials,
+                {
+                    repositoryIds: scope.repositoryIds,
+                    // The ONE permission a push needs. Anything omitted is
+                    // not granted, so this token cannot open a pull request,
+                    // read a secret, or touch an Action — even though the
+                    // App itself may hold those permissions.
+                    permissions: { contents: 'write' },
+                },
+            );
+        } catch (error) {
+            // The GitHub message can name the installation and the App;
+            // it never reaches the node, and never the job row.
+            this.logger.error(
+                `Fleet job ${claim.jobId}: scoped push token mint failed (${
+                    error instanceof Error ? error.name : 'unknown error'
+                })`,
+            );
+            throw this.refusal(claim.jobId, FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON);
+        }
+
+        // This line is the audit record. It names the job, the node and the
+        // repositories the credential covers. The TOKEN is not in it and
+        // must never be.
+        this.logger.log(
+            `Fleet job ${claim.jobId}: scoped push credential minted for node ${claim.nodeId} ` +
+                `covering ${scope.repositories.join(', ')} (expires ${minted.expiresAt ?? 'in ~1h'})`,
+        );
+
+        return {
+            attribution,
+            push: {
+                token: minted.token,
+                username: FLEET_PUSH_CREDENTIAL_USERNAME,
+                // GitHub always expires an installation token within the
+                // hour; the fallback exists so the node always has an
+                // instant to compare against rather than a null.
+                expiresAt: minted.expiresAt ?? new Date(Date.now() + 55 * 60_000).toISOString(),
+                repositories: scope.repositories,
+            },
+        };
+    }
+
+    /**
+     * Can the platform mint a write credential for these repositories,
+     * WITHOUT minting one?
+     *
+     * This is the pre-dispatch half of the slice: the planner asks before
+     * a job exists, so a Task whose repository no installation covers is
+     * refused at plan time — with the reason on the run row — instead of
+     * consuming twenty minutes of model time and then failing at the push.
+     * Pure platform state; no GitHub call.
+     */
+    async describeScope(
+        userId: string,
+        repositories: readonly FleetPushRepositoryRequest[],
+    ): Promise<FleetPushScope> {
+        if (!this.appCredentials()) {
+            return { ok: false, reason: FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON };
+        }
+        return this.resolveScope(userId, repositories);
+    }
+
+    /**
+     * Which installation covers EVERY repository this job writes to.
+     *
+     * One installation or none: a token is minted against a single
+     * installation, so a run spanning two of them cannot be served by one
+     * credential and is refused rather than half-served. The refusal is
+     * the same stable token in every case — a differentiated answer here
+     * would let a caller enumerate which repositories the deployment has
+     * installations for.
+     */
+    private async resolveScope(
+        userId: string,
+        requested: readonly FleetPushRepositoryRequest[],
+    ): Promise<FleetPushScope> {
+        const wanted: string[] = [];
+        for (const entry of requested) {
+            const normalized = this.pushTargetOf(entry);
+            if (!normalized) return { ok: false, reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON };
+            if (!wanted.includes(normalized)) wanted.push(normalized);
+        }
+        if (wanted.length === 0 || wanted.length > FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES) {
+            return { ok: false, reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON };
+        }
+
+        // installationEntityId -> the snapshot rows that installation has
+        // for the repositories we want.
+        const byInstallation = new Map<string, Map<string, string>>();
+        for (const fullName of wanted) {
+            let rows: Awaited<ReturnType<GitHubAppInstallationRepoRepository['findByFullName']>>;
+            try {
+                rows = await this.installationRepos.findByFullName(fullName);
+            } catch {
+                return { ok: false, reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON };
+            }
+            for (const row of rows) {
+                // `findByFullName` matches case-INSENSITIVELY — `fullName` is
+                // stored verbatim from GitHub's `full_name`, so an exact
+                // comparison could never find `Ever-Works/Directory-Web-Template`
+                // from the lower-cased name this resolver asks with, and every
+                // repository carrying an upper-case character silently lost
+                // fleet execution. It is still global across the deployment, so
+                // the ownership filter below is what keeps a job away from
+                // somebody else's installation, and the normalized re-check
+                // here is what keeps a looser match from widening the scope.
+                if (normalizeFleetPushRepositoryId(row.fullName) !== fullName) continue;
+                if (!(await this.ownsInstallation(userId, row.installationEntityId))) continue;
+                const bucket =
+                    byInstallation.get(row.installationEntityId) ?? new Map<string, string>();
+                bucket.set(fullName, row.githubRepoId);
+                byInstallation.set(row.installationEntityId, bucket);
+            }
+        }
+
+        const complete = [...byInstallation.entries()].filter(
+            ([, repos]) => repos.size === wanted.length,
+        );
+        // Exactly one, or refuse. Zero means nothing covers the whole run.
+        // More than one means the owner installed the App twice over the
+        // same repositories, and picking by listing order would decide
+        // which installation's audit trail records the write by luck.
+        if (complete.length !== 1) {
+            return { ok: false, reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON };
+        }
+        const [installationEntityId, repos] = complete[0];
+        const installation = await this.loadInstallation(installationEntityId);
+        if (!installation) return { ok: false, reason: FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON };
+
+        return {
+            ok: true,
+            reason: null,
+            installationEntityId,
+            installationId: installation.installationId,
+            repositoryIds: wanted.map((fullName) => repos.get(fullName) as string),
+            repositories: wanted,
+        };
+    }
+
+    /**
+     * The `owner/repo` a mint may cover for this workspace entry, or null.
+     *
+     * FAILS CLOSED on any disagreement. When the entry carries a clone URL
+     * the URL decides, because it is the thing the node will actually push
+     * to, and {@link fleetPushRemoteRepositoryId} refuses anything that is
+     * not an `https://github.com/owner/repo` — an installation token is a
+     * GitHub credential and means nothing anywhere else. A `repositoryId`
+     * that disagrees with its own URL is refused rather than reconciled:
+     * the two come from the same planner in the same breath, so a
+     * disagreement is a bug, and picking either one would be picking which
+     * repository gets a write token by luck.
+     *
+     * Without a URL this falls back to the name alone, which is what the
+     * pre-slice payloads carry. That is still safe: the NODE re-derives the
+     * repository from the checkout's actual `origin` and refuses the push
+     * if the host is not github.com, so a name-only scope can waste a mint
+     * but can never aim a credential.
+     */
+    private pushTargetOf(entry: FleetPushRepositoryRequest): string | null {
+        const named = normalizeFleetPushRepositoryId(entry?.repositoryId);
+        const repoUrl = typeof entry?.repoUrl === 'string' ? entry.repoUrl.trim() : '';
+        if (!repoUrl) return named;
+        const fromUrl = fleetPushRemoteRepositoryId(repoUrl);
+        if (!fromUrl) return null;
+        if (named && named !== fromUrl) return null;
+        return fromUrl;
+    }
+
+    /**
+     * Is this installation the job owner's?
+     *
+     * Deleted and suspended installations are refused here as well as at
+     * mint time: GitHub honours a suspension, but a suspended installation
+     * that still answers would mean the platform believed it could write
+     * repositories the owner has revoked.
+     */
+    private async ownsInstallation(userId: string, installationEntityId: string): Promise<boolean> {
+        const installation = await this.loadInstallation(installationEntityId);
+        return Boolean(installation && installation.createdByUserId === userId);
+    }
+
+    private async loadInstallation(installationEntityId: string) {
+        let installation: Awaited<ReturnType<GitHubAppInstallationRepository['findById']>>;
+        try {
+            installation = await this.installations.findById(installationEntityId);
+        } catch {
+            return null;
+        }
+        if (!installation) return null;
+        if (installation.deletedAt || installation.suspendedAt) return null;
+        return installation;
+    }
+
+    /**
+     * The repositories this job may push to, from the job's OWN payload.
+     *
+     * The payload is written by the planner and is never writable by a
+     * node, so reading it here is the platform re-reading its own decision
+     * — the posture `FleetRunCredentialService` already takes with
+     * `payload.mcp.enabled`. Read-only mounts are excluded: a credential
+     * that could write a reference checkout is a credential wider than the
+     * run.
+     *
+     * WHAT THIS IS NOT. These names are a SELECTOR, never an authority.
+     * Nothing they say reaches GitHub: {@link resolveScope} turns each one
+     * into a numeric repository id read from the platform's own
+     * installation snapshot, and refuses any that does not resolve to an
+     * installation THIS JOB'S OWNER controls. So the worst a tampered
+     * payload could buy — and tampering means write access to `fleet_jobs`,
+     * which is already game over — is a token for another of that same
+     * owner's own repositories. It can never reach a repository, an
+     * installation or an account the owner does not already hold.
+     */
+    private repositoriesOf(job: {
+        payload?: Record<string, unknown> | null;
+    }): FleetPushRepositoryRequest[] {
+        const workspace = (
+            job.payload as { workspace?: Record<string, unknown> } | null | undefined
+        )?.workspace;
+        if (!workspace || typeof workspace !== 'object') return [];
+        const out: FleetPushRepositoryRequest[] = [];
+        // The clone URL rides along with the name wherever the planner wrote
+        // one: see {@link pushTargetOf} for why the name alone is not an
+        // identity a write credential may be scoped by.
+        if (typeof workspace.repositoryId === 'string') {
+            out.push({
+                repositoryId: workspace.repositoryId,
+                repoUrl: typeof workspace.repoUrl === 'string' ? workspace.repoUrl : null,
+            });
+        }
+        const mounts = Array.isArray(workspace.mounts) ? workspace.mounts : [];
+        for (const mount of mounts) {
+            if (!mount || typeof mount !== 'object') continue;
+            const entry = mount as {
+                repositoryId?: unknown;
+                repoUrl?: unknown;
+                writable?: unknown;
+            };
+            if (entry.writable === false) continue;
+            if (typeof entry.repositoryId === 'string') {
+                out.push({
+                    repositoryId: entry.repositoryId,
+                    repoUrl: typeof entry.repoUrl === 'string' ? entry.repoUrl : null,
+                });
+            }
+        }
+        return out;
+    }
+
+    /** `git.push !== false` on the plan the platform itself wrote. */
+    private jobPushes(job: { payload?: Record<string, unknown> | null }): boolean {
+        const git = (job.payload as { git?: { push?: unknown } } | null | undefined)?.git;
+        return !git || git.push !== false;
+    }
+
+    /**
+     * Who this commit is by, entirely from platform rows.
+     *
+     * Nothing here reads free text off the payload: the node name comes
+     * from the `fleet_nodes` row, the Agent name and email from the
+     * `agents` row (the same `committerName` / `committerEmail` ?? slug
+     * convention the cloud commit tool uses), and the ids from the job
+     * row. The only payload reads are the `agentId` and `runId` KEYS,
+     * which are ids the platform wrote and which are re-validated by the
+     * contracts composer before they can appear in a trailer.
+     */
+    private async describeAttribution(
+        claim: { jobId: string; userId: string; nodeId: string },
+        job: { payload?: Record<string, unknown> | null },
+    ): Promise<FleetPushAttribution> {
+        const node = await this.nodes.findById(claim.nodeId);
+        const payload = (job.payload ?? {}) as { agentId?: unknown; runId?: unknown };
+        const agentId =
+            typeof payload.agentId === 'string' && payload.agentId ? payload.agentId : null;
+        const runId = typeof payload.runId === 'string' && payload.runId ? payload.runId : null;
+
+        let agentName: string | null = null;
+        let agentEmail: string | null = null;
+        if (agentId && this.agents) {
+            try {
+                // Scoped to the JOB's owner, never to anything the caller
+                // sent: an authenticated node must not be able to name
+                // another tenant's Agent on a commit.
+                const agent = await this.agents.findByIdAndUser(agentId, claim.userId);
+                if (agent) {
+                    agentName =
+                        sanitizeFleetPushIdentityText(agent.committerName || agent.name, 48) ||
+                        null;
+                    agentEmail =
+                        agent.committerEmail ||
+                        (agent.slug ? `${agent.slug}@agents.ever.works` : null);
+                }
+            } catch {
+                // Attribution degrades to ids; it never fails a run.
+                agentName = null;
+                agentEmail = null;
+            }
+        }
+
+        return {
+            nodeId: claim.nodeId,
+            nodeName: sanitizeFleetPushIdentityText(node?.name, 48),
+            agentId,
+            agentName,
+            agentEmail,
+            jobId: claim.jobId,
+            runId,
+        };
+    }
+
+    private appCredentials(): { appId: string; privateKey: string } | null {
+        const appId = config.githubApp.getAppId();
+        const privateKey = config.githubApp.getPrivateKey();
+        if (!appId || !privateKey) return null;
+        return { appId, privateKey };
+    }
+
+    /** Log the refusal (job + stable token only) and build the error to throw. */
+    private refusal(jobId: string, reason: string): FleetPushCredentialError {
+        this.logger.warn(`Fleet job ${jobId}: scoped push credential refused — ${reason}`);
+        return new FleetPushCredentialError(reason);
+    }
+}

--- a/apps/api/src/fleet/fleet.module.spec.ts
+++ b/apps/api/src/fleet/fleet.module.spec.ts
@@ -1,0 +1,174 @@
+import { Global, Inject, Injectable, Module, Optional } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+    ENTITIES,
+    GitHubAppInstallationRepoRepository,
+    GitHubAppInstallationRepository,
+} from '@ever-works/agent/database';
+import {
+    PluginRegistryService,
+    PluginSettingsService,
+    WorkPluginRepository,
+} from '@ever-works/agent/plugins';
+import { PluginUsageService } from '@ever-works/agent/usage';
+import { BudgetGuardService } from '@ever-works/agent/budgets';
+import { ScopeContextService } from '../scope';
+import { FleetApiModule } from './fleet.module';
+import { FleetJobsController } from './fleet-jobs.controller';
+import { FleetPushCredentialService } from './fleet-push-credential.service';
+
+/**
+ * `FleetApiModule` against a REAL Nest container.
+ *
+ * WHY THIS EXISTS. `_repository-inventory.ts` is not "every repository",
+ * and a service that injects one the module cannot reach passes every unit
+ * spec in this directory — `fleet-push-credential.service.spec.ts`
+ * constructs the service positionally, and `fleet-jobs.controller.spec.ts`
+ * hands the controller a stub — and then the API refuses to BOOT. A
+ * previous slice in this program shipped exactly that. Reading
+ * `Reflect.getMetadata('imports', …)` does not catch it either: that only
+ * proves a name is in a list, never that the graph resolves.
+ *
+ * MUTATION CHECK, executed rather than assumed. Both were run against this
+ * file and both go red:
+ *
+ *   1. Removing `DatabaseModule` from `FleetApiModule`'s imports — the
+ *      module that supplies `GitHubAppInstallationRepoRepository`, the
+ *      installation SNAPSHOT the scoped push credential is narrowed by.
+ *      Nest reports `Nest can't resolve dependencies of the
+ *      FleetRunSecretsService (FleetJobService, ?)` — it happens to name
+ *      the first provider that misses the module rather than this slice's,
+ *      which is exactly why the assertion below reaches for the
+ *      repositories BY NAME instead of trusting the message.
+ *   2. Removing `FleetPushCredentialService` from the providers list:
+ *      the controller case and the repository case both fail.
+ *
+ * Before this file existed, either change left `apps/api` entirely green.
+ *
+ * The `@Global()` stub stands in for what the running API supplies from
+ * its ROOT module and reaches transitively. Nothing the fleet work channel
+ * itself depends on is stubbed.
+ */
+const APP_ROOT_PROVIDERS = [
+    PluginRegistryService,
+    PluginSettingsService,
+    WorkPluginRepository,
+    PluginUsageService,
+    BudgetGuardService,
+    // Bound app-wide by the root module's @Global() scope module; the
+    // owner-scoped fleet controllers resolve it through that.
+    ScopeContextService,
+];
+
+@Global()
+@Module({
+    providers: APP_ROOT_PROVIDERS.map((token) => ({ provide: token, useValue: {} })),
+    exports: APP_ROOT_PROVIDERS,
+})
+class AppRootStubModule {}
+
+describe('FleetApiModule — dependency injection', () => {
+    async function compile() {
+        return Test.createTestingModule({
+            imports: [
+                AppRootStubModule,
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                }),
+                FleetApiModule,
+            ],
+        }).compile();
+    }
+
+    it('resolves the node work channel with ALL FOUR of its constructor dependencies', async () => {
+        const moduleRef = await compile();
+
+        const controller = moduleRef.get(FleetJobsController);
+        expect(controller).toBeInstanceOf(FleetJobsController);
+        // The one this slice adds. A controller that could not resolve it
+        // is an API that will not boot — and every unit spec above would
+        // still be green, because they construct it by hand.
+        expect(moduleRef.get(FleetPushCredentialService, { strict: false })).toBeInstanceOf(
+            FleetPushCredentialService,
+        );
+
+        await moduleRef.close();
+    });
+
+    it('reaches the installation SNAPSHOT the push scope is narrowed by', async () => {
+        // The pointed guard. Without both of these the service constructs
+        // (they are required, so actually it does not — which is the
+        // point) and the scope could only ever come from something a
+        // caller supplied.
+        const moduleRef = await compile();
+
+        expect(
+            moduleRef.get(GitHubAppInstallationRepoRepository, { strict: false }),
+        ).toBeInstanceOf(GitHubAppInstallationRepoRepository);
+        expect(moduleRef.get(GitHubAppInstallationRepository, { strict: false })).toBeInstanceOf(
+            GitHubAppInstallationRepository,
+        );
+
+        await moduleRef.close();
+    });
+
+    it('SATISFIES an @Optional() consumer that imports it, which is how the planner gets its pre-dispatch check', async () => {
+        // `FleetAgentTaskPlannerService` is provided by the api-side
+        // `TasksModule`, which imports this one, and takes
+        // `@Optional() pushCredentials`. An unsatisfied optional is SILENT:
+        // the plan-time refusal would simply never run, and a Task no
+        // installation covers would burn twenty minutes on a node before
+        // failing at the push.
+        //
+        // This case used to read `Reflect.getMetadata('exports', …)` and
+        // assert the name was in the list — the exact pattern this file's
+        // own header rejects, and one that cannot tell "exported and
+        // reachable from an importing module" from "exported but shadowed
+        // or unreachable" (slice AM review, F10). So it compiles a real
+        // consumer instead and reads what Nest actually injected.
+        //
+        // MUTATION CHECK, executed: removing `FleetPushCredentialService`
+        // from `FleetApiModule`'s `exports` leaves the container compiling
+        // fine and `injected` `undefined`, which is precisely the silent
+        // failure being guarded — and this case then goes red where the
+        // metadata assertion also would. Removing it from `providers`
+        // instead fails the compile, which the two cases above already
+        // catch.
+        @Injectable()
+        class PlannerLikeConsumer {
+            constructor(
+                @Optional()
+                @Inject(FleetPushCredentialService)
+                readonly pushCredentials?: FleetPushCredentialService,
+            ) {}
+        }
+
+        @Module({ imports: [FleetApiModule], providers: [PlannerLikeConsumer] })
+        class ConsumerModule {}
+
+        const moduleRef = await Test.createTestingModule({
+            imports: [
+                AppRootStubModule,
+                TypeOrmModule.forRoot({
+                    type: 'better-sqlite3',
+                    database: ':memory:',
+                    entities: ENTITIES,
+                    synchronize: true,
+                }),
+                ConsumerModule,
+            ],
+        }).compile();
+
+        const injected = moduleRef.get(PlannerLikeConsumer).pushCredentials;
+        expect(injected).toBeInstanceOf(FleetPushCredentialService);
+        // The SAME singleton the controller resolves, not a second copy
+        // resolving a second set of repositories.
+        expect(injected).toBe(moduleRef.get(FleetPushCredentialService, { strict: false }));
+
+        await moduleRef.close();
+    });
+});

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -13,6 +13,7 @@ import { FleetKillSwitchController } from './fleet-kill-switch.controller';
 import { FleetPanicController } from './fleet-panic.controller';
 import { FleetPanicService } from './fleet-panic.service';
 import { FleetMcpCredentialListener } from './fleet-mcp-credential.listener';
+import { FleetPushCredentialService } from './fleet-push-credential.service';
 import { FleetRunRouterService } from './fleet-run-router.service';
 import { FleetRunSecretsService } from './fleet-run-secrets.service';
 import { FleetRunnerStatusService } from './fleet-runner-status.service';
@@ -126,6 +127,15 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
         // agent fleet graph would widen that module's dependency surface
         // for a route only this app exposes.
         FleetRunSecretsService,
+        // Scoped push credentials (self-build slice AM, EW-810). Provided
+        // HERE for the same reason as `FleetRunSecretsService`: it needs
+        // the GitHub App installation repositories from `DatabaseModule`,
+        // and pulling that into the agent-side fleet graph would widen a
+        // module every importer of this one carries. Exported below, too,
+        // because the api-side `TasksModule` gives it to the PLANNER — the
+        // pre-dispatch check that refuses a Task no installation can cover
+        // before it costs a node twenty minutes.
+        FleetPushCredentialService,
         // Self-build slice Z (EW-796) — revokes a job's run-scoped MCP
         // credentials on EVERY terminal path, by subscribing to the one
         // completion event they all emit. Additive: no edit to
@@ -148,6 +158,7 @@ import { FleetNodeAuthGuard } from './guards/fleet-node-auth.guard';
         FleetRunRouterService,
         FleetRunnerStatusService,
         FleetPanicService,
+        FleetPushCredentialService,
     ],
 })
 export class FleetApiModule {}

--- a/apps/desktop-node/src/renderer/wizard/WizardView.tsx
+++ b/apps/desktop-node/src/renderer/wizard/WizardView.tsx
@@ -36,9 +36,21 @@ const STEP_TITLES: Record<WizardStepId, string> = {
 	running: 'Running'
 };
 
-/** Tags that describe the machine itself — always advertised, never a choice. */
+/**
+ * Tags that are always advertised and are never an operator choice.
+ *
+ * Two families. The `os:` / `arch:` / `node:` prefixes describe the machine
+ * itself. `git-push` (self-build slice AM, EW-810) describes something it
+ * can DO, but withholding it is not a narrower offer: every agent run
+ * requires it, so an unchecked box would only stop this machine doing the
+ * work it already does — and the node re-adds the tag regardless, which
+ * would make the checkbox a lie. Kept as a literal rather than imported
+ * from the node core: this is renderer code, and the core is a Node
+ * module. The node's own `isAlwaysAdvertisedCapability` is the authority;
+ * this mirrors it for the UI only.
+ */
 function isIdentityTag(tag: string): boolean {
-	return tag.startsWith('os:') || tag.startsWith('arch:') || tag.startsWith('node:');
+	return tag.startsWith('os:') || tag.startsWith('arch:') || tag.startsWith('node:') || tag === 'git-push';
 }
 
 /**
@@ -337,7 +349,7 @@ export function WizardView({ bridge, onEnrolled }: WizardViewProps) {
 								</label>
 							))
 						)}
-						<p className="muted">Always reported (machine identity):</p>
+						<p className="muted">Always reported (machine identity and required capabilities):</p>
 						<div className="tags">
 							{identityTags.map((tag) => (
 								<span className="badge" key={tag}>

--- a/apps/mcp/test/whitelist-fleet-run-surface.spec.ts
+++ b/apps/mcp/test/whitelist-fleet-run-surface.spec.ts
@@ -102,6 +102,12 @@ describe('fleet-run token surface vs. the MCP whitelist', () => {
 
 	it('refuses the credential routes themselves — a token cannot mint another', () => {
 		expect(isFleetRunTokenRouteAllowed('POST', '/api/fleet/jobs/j1/mcp-credential')).toBe(false);
+		// Scoped push credentials (self-build slice AM, EW-810). This one
+		// matters more than its siblings: it is the only route on the whole
+		// surface that answers with a credential able to WRITE the owner's
+		// repositories. It is refused by the same `/api/fleet/jobs` rule, and
+		// pinned by name so a future widening of that rule is caught here.
+		expect(isFleetRunTokenRouteAllowed('POST', '/api/fleet/jobs/j1/push-credential')).toBe(false);
 		expect(isFleetRunTokenRouteAllowed('POST', '/api/auth/api-keys')).toBe(false);
 		expect(WHITELIST.some((entry) => entry.path.startsWith('/api/auth'))).toBe(false);
 		// The run terminal is NOT a whitelisted tool, but it hangs off the

--- a/apps/node/src/core/capabilities.spec.ts
+++ b/apps/node/src/core/capabilities.spec.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { FLEET_PUSH_CAPABILITY } from '@ever-works/contracts';
 import {
 	describePlatform,
 	describeSelf,
 	detectCapabilities,
 	detectDisplay,
+	gitSupportsScopedPush,
 	nodeMajor,
 	normalizeCapabilities,
+	probeGit,
 	readEnvironment,
 	type CapabilityEnvironment,
 	type CommandRunner
@@ -402,5 +405,73 @@ describe('describeSelf', () => {
 			expect('minFreeDiskBytes' in description).toBe(false);
 			expect('workspaceBytes' in description).toBe(false);
 		});
+	});
+});
+
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) — the
+ * pre-dispatch push-capability probe.
+ *
+ * The tag is a promise the node can keep, in the sense the rest of this
+ * detector means it: the same fact the push depends on is the fact that
+ * turns it on. A machine whose Git cannot take the per-run credential
+ * through its environment would fall back to the operator's own
+ * long-lived credential helper — so the tag is withheld and the platform
+ * never hands it `agent-task` work at all.
+ */
+describe('git-push capability (scoped push credentials)', () => {
+	const gitRunner = (version: string | null): CommandRunner => ({
+		run: async (command) => {
+			if (command !== 'git') return { code: 127, stdout: '', stderr: 'not found' };
+			if (version === null) return { code: 127, stdout: '', stderr: 'not found' };
+			return { code: 0, stdout: version, stderr: '' };
+		}
+	});
+
+	it.each([
+		['git version 2.53.0.windows.1', true],
+		['git version 2.31.0', true],
+		['git version 2.31.1', true],
+		['git version 3.0.0', true],
+		['git version 2.30.2', false],
+		['git version 2.9.5', false],
+		['git version 1.9.1', false],
+		// Unparseable fails CLOSED: guessing "probably new enough" would
+		// put the tag on a machine whose push silently falls back to the
+		// ambient helper, which is the exact hole it keeps work away from.
+		['git version unknown', false],
+		['', false]
+	])('%s → scoped push %s', (output, expected) => {
+		expect(gitSupportsScopedPush(output)).toBe(expected);
+	});
+
+	it('offers git-push alongside git when the version supports it', async () => {
+		const tags = await detectCapabilities(gitRunner('git version 2.53.0.windows.1'), environment());
+		expect(tags).toContain('git');
+		expect(tags).toContain(FLEET_PUSH_CAPABILITY);
+	});
+
+	it('offers git but NOT git-push on a machine whose Git is too old', async () => {
+		const tags = await detectCapabilities(gitRunner('git version 2.20.1'), environment());
+		expect(tags).toContain('git');
+		expect(tags).not.toContain(FLEET_PUSH_CAPABILITY);
+	});
+
+	it('offers neither when git is absent, and a throwing probe is absence not a crash', async () => {
+		expect(await detectCapabilities(gitRunner(null), environment())).not.toContain(FLEET_PUSH_CAPABILITY);
+		const throwing: CommandRunner = {
+			run: async () => {
+				throw new Error('spawn git ENOENT');
+			}
+		};
+		const tags = await detectCapabilities(throwing, environment());
+		expect(tags).not.toContain('git');
+		expect(tags).not.toContain(FLEET_PUSH_CAPABILITY);
+	});
+
+	it('probeGit reports both facts from one invocation', async () => {
+		expect(await probeGit(gitRunner('git version 2.43.0'))).toEqual({ present: true, scopedPush: true });
+		expect(await probeGit(gitRunner('git version 2.17.1'))).toEqual({ present: true, scopedPush: false });
+		expect(await probeGit(gitRunner(null))).toEqual({ present: false, scopedPush: false });
 	});
 });

--- a/apps/node/src/core/capabilities.ts
+++ b/apps/node/src/core/capabilities.ts
@@ -1,4 +1,9 @@
-import { FLEET_BROWSER_CAPABILITY, FLEET_GPU_CAPABILITY } from '@ever-works/contracts';
+import {
+	FLEET_BROWSER_CAPABILITY,
+	FLEET_GPU_CAPABILITY,
+	FLEET_PUSH_CAPABILITY,
+	FLEET_PUSH_MIN_GIT_VERSION
+} from '@ever-works/contracts';
 import type { BrowserProbeIo } from './browser-probe';
 import type { ModelCliPaths } from './executors/model-cli';
 import { detectGpu } from './gpu-probe';
@@ -167,10 +172,65 @@ async function hasTool(runner: CommandRunner, command: string): Promise<boolean>
 }
 
 /**
+ * What this machine's Git can do (self-build slice AM).
+ *
+ * `present` keeps the exact meaning the `git` tag has always had:
+ * `git --version` exited 0. `scopedPush` is the new, narrower promise —
+ * this Git accepts configuration through `GIT_CONFIG_COUNT` /
+ * `GIT_CONFIG_KEY_<n>`, which is how the platform's per-run push
+ * credential is installed. Git 2.31 (March 2021) introduced it.
+ *
+ * A version this probe cannot PARSE reports `scopedPush: false`. That
+ * fails closed on purpose: guessing "probably new enough" would put the
+ * `git-push` tag on a machine whose push would silently fall through to
+ * its own ambient credential helper, which is the exact hole the tag
+ * exists to keep work away from.
+ */
+export async function probeGit(runner: CommandRunner): Promise<{ present: boolean; scopedPush: boolean }> {
+	let stdout = '';
+	try {
+		const result = await runner.run('git', ['--version']);
+		if (result.code !== 0) return { present: false, scopedPush: false };
+		stdout = result.stdout ?? '';
+	} catch {
+		return { present: false, scopedPush: false };
+	}
+	return { present: true, scopedPush: gitSupportsScopedPush(stdout) };
+}
+
+/**
+ * Minimum Git that accepts environment-carried configuration, parsed from
+ * the CONTRACTS constant rather than restated here: the platform's own
+ * documentation and this probe must name the same version, and two
+ * literals are two chances to drift.
+ */
+const MIN_SCOPED_PUSH_GIT: readonly [number, number] = (() => {
+	const parts = FLEET_PUSH_MIN_GIT_VERSION.split('.').map((part) => Number.parseInt(part, 10));
+	return [parts[0] ?? 2, parts[1] ?? 31];
+})();
+
+/**
+ * Parse `git version 2.53.0.windows.1` and compare against 2.31.
+ *
+ * Exported so the rule is testable on its own — the version string a
+ * fleet machine reports is the one fact this whole capability turns on,
+ * and it varies by platform packaging far more than any other probe here.
+ */
+export function gitSupportsScopedPush(versionOutput: string): boolean {
+	const match = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(String(versionOutput ?? ''));
+	if (!match) return false;
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	if (!Number.isFinite(major) || !Number.isFinite(minor)) return false;
+	if (major !== MIN_SCOPED_PUSH_GIT[0]) return major > MIN_SCOPED_PUSH_GIT[0];
+	return minor >= MIN_SCOPED_PUSH_GIT[1];
+}
+
+/**
  * Detect this machine's capability tags:
  * `os:<platform>`, `arch:<arch>`, `node:<major>`, the always-on
- * `terminal`/`workspace`, plus `docker`, `git`, `display`, `browser`,
- * `gpu` and `gpu:<vendor>` when present.
+ * `terminal`/`workspace`, plus `docker`, `git`, `git-push`, `display`,
+ * `browser`, `gpu` and `gpu:<vendor>` when present.
  *
  * Two rules govern what may appear here:
  *
@@ -185,7 +245,7 @@ async function hasTool(runner: CommandRunner, command: string): Promise<boolean>
 export async function detectCapabilities(runner: CommandRunner, environment: CapabilityEnvironment): Promise<string[]> {
 	const [docker, git, gpu] = await Promise.all([
 		hasTool(runner, 'docker'),
-		hasTool(runner, 'git'),
+		probeGit(runner),
 		detectGpu(runner, environment.platform)
 	]);
 	const major = nodeMajor(environment.nodeVersion);
@@ -200,7 +260,15 @@ export async function detectCapabilities(runner: CommandRunner, environment: Cap
 		major === null ? null : `node:${major}`,
 		...BASE_CAPABILITIES,
 		docker ? 'docker' : null,
-		git ? 'git' : null,
+		git.present ? 'git' : null,
+		// Scoped push (self-build slice AM): the SAME fact the push
+		// depends on turns the tag on — a Git that accepts the per-run
+		// credential through its environment. A machine whose Git is too
+		// old is not "a machine that pushes a bit differently"; it is a
+		// machine whose push would fall back to the operator's own
+		// long-lived credential helper, which is the thing this tag keeps
+		// work away from.
+		git.scopedPush ? FLEET_PUSH_CAPABILITY : null,
 		environment.hasDisplay ? 'display' : null,
 		hasBrowser ? FLEET_BROWSER_CAPABILITY : null,
 		// Agent execution v2 — a model CLI the node can actually spawn.
@@ -229,12 +297,34 @@ export function isIdentityCapability(tag: string): boolean {
 }
 
 /**
+ * Tags that are detected but NOT offered as an operator choice.
+ *
+ * `git-push` (self-build slice AM) is here because withholding it is not
+ * a narrower offer, it is a broken one: every `agent-task` the platform
+ * dispatches requires it, so a node that hid the tag would simply stop
+ * doing the work it already does — and an operator whose config predates
+ * the tag has, by definition, not opted into it. Detection still decides
+ * whether it appears at all; the opt-in only decides what a machine
+ * ADVERTISES from what it can do, and there is nothing to opt out of
+ * here that does not also opt out of fleet runs entirely.
+ */
+const NON_SELECTABLE_TAGS = new Set<string>([FLEET_PUSH_CAPABILITY]);
+
+/**
+ * True when a tag is advertised whatever the operator selected: machine
+ * identity, or a capability whose absence would only strand work.
+ */
+export function isAlwaysAdvertisedCapability(tag: string): boolean {
+	return isIdentityCapability(tag) || NON_SELECTABLE_TAGS.has(tag);
+}
+
+/**
  * The tags an operator is actually allowed to choose between — everything the
  * detector found minus the identity tags. This is what the wizard's capability
  * step renders as checkboxes.
  */
 export function selectableCapabilities(detected: readonly string[]): string[] {
-	return detected.filter((tag) => !isIdentityCapability(tag));
+	return detected.filter((tag) => !isAlwaysAdvertisedCapability(tag));
 }
 
 /**
@@ -258,7 +348,7 @@ export function applyCapabilitySelection(detected: readonly string[], selection?
 		return normalizeCapabilities([...detected]);
 	}
 	const chosen = new Set(normalizeCapabilities([...selection]));
-	return normalizeCapabilities(detected.filter((tag) => isIdentityCapability(tag) || chosen.has(tag)));
+	return normalizeCapabilities(detected.filter((tag) => isAlwaysAdvertisedCapability(tag) || chosen.has(tag)));
 }
 
 /**

--- a/apps/node/src/core/capability-selection.spec.ts
+++ b/apps/node/src/core/capability-selection.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { FLEET_PUSH_CAPABILITY } from '@ever-works/contracts';
 import {
 	applyCapabilitySelection,
 	describeSelf,
+	isAlwaysAdvertisedCapability,
 	isIdentityCapability,
 	selectableCapabilities,
 	type CapabilityEnvironment,
@@ -159,5 +161,43 @@ describe('config round-trip for capability selection and limits', () => {
 		expect(view.limits.maxConcurrentJobs).toBe(2);
 		expect(view.capabilitySelection).toEqual(['terminal']);
 		expect(JSON.stringify(view)).not.toContain(base.secret);
+	});
+});
+
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) — `git-push` is
+ * detected but NOT offered as an operator choice.
+ *
+ * Withholding it is not a narrower offer, it is a broken one: every
+ * `agent-task` the platform dispatches requires the tag, so a node that
+ * hid it would simply stop doing the work it already does — and an
+ * operator whose capability selection predates the tag has, by
+ * definition, not opted into it.
+ */
+describe('git-push is always advertised when detected', () => {
+	it('survives an operator selection that does not mention it', () => {
+		expect(applyCapabilitySelection(['os:linux', 'terminal', 'git', FLEET_PUSH_CAPABILITY], ['terminal'])).toEqual([
+			'os:linux',
+			'terminal',
+			FLEET_PUSH_CAPABILITY
+		]);
+	});
+
+	it('is never offered as a checkbox', () => {
+		expect(selectableCapabilities(['os:linux', 'git', FLEET_PUSH_CAPABILITY, 'docker'])).toEqual(['git', 'docker']);
+	});
+
+	it('is still absent when the DETECTOR never found it', () => {
+		// The opt-in can only shrink an offer; it can never invent one.
+		expect(applyCapabilitySelection(['os:linux', 'terminal'], ['terminal', FLEET_PUSH_CAPABILITY])).toEqual([
+			'os:linux',
+			'terminal'
+		]);
+	});
+
+	it('is not classified as machine identity', () => {
+		// It is a promise about what this machine can DO, not what it IS.
+		expect(isIdentityCapability(FLEET_PUSH_CAPABILITY)).toBe(false);
+		expect(isAlwaysAdvertisedCapability(FLEET_PUSH_CAPABILITY)).toBe(true);
 	});
 });

--- a/apps/node/src/core/job-client.spec.ts
+++ b/apps/node/src/core/job-client.spec.ts
@@ -374,3 +374,110 @@ describe('FleetJobClient MCP run credentials (self-build slice Z)', () => {
 		await expect(client.revokeMcpCredential('job-1')).resolves.toBe(0);
 	});
 });
+
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) —
+ * `mintPushCredential`.
+ *
+ * The request carries the credential pair and the claim generation and
+ * NOTHING else — no repository, no installation, no scope of any kind,
+ * because a caller that could name its own scope would have defeated the
+ * narrowing. The response carries the only write credential this channel
+ * ever moves, and it is handed to the redactor before the method returns.
+ */
+describe('FleetJobClient scoped push credential', () => {
+	const PUSH_TOKEN = 'ghs_0123456789abcdefghijklmnopqrstuvwxyz';
+	const JOB = 'job-1';
+
+	const answer = (overrides: Record<string, unknown> = {}) => ({
+		attribution: {
+			nodeId: NODE_ID,
+			nodeName: 'studio-win',
+			agentId: null,
+			agentName: null,
+			agentEmail: null,
+			jobId: JOB,
+			runId: null
+		},
+		push: {
+			token: PUSH_TOKEN,
+			username: 'x-access-token',
+			expiresAt: '2026-09-06T20:00:00.000Z',
+			repositories: ['ever-works/ever-works']
+		},
+		...overrides
+	});
+
+	const clientWith = (fetchFn: FetchLike, logger?: { protect: (v: string) => void }) =>
+		new FleetJobClient({
+			apiUrl: 'https://api.ever.works',
+			nodeId: NODE_ID,
+			secret: SECRET,
+			fetchFn,
+			timeoutMs: 0,
+			...(logger ? { logger: logger as never } : {})
+		});
+
+	it('sends the claim and nothing that could widen the scope', async () => {
+		let sentBody = '';
+		const client = clientWith(async (_url, init) => {
+			sentBody = init.body;
+			return { ok: true, status: 200, text: async () => JSON.stringify(answer()) };
+		});
+
+		await client.mintPushCredential(JOB, 7);
+
+		expect(JSON.parse(sentBody) as Record<string, unknown>).toEqual({
+			nodeId: NODE_ID,
+			secret: SECRET,
+			leaseGeneration: 7
+		});
+	});
+
+	it('registers the token with the redactor BEFORE returning it', async () => {
+		const protect = vi.fn();
+		const client = clientWith(response(200, answer()), { protect });
+
+		await client.mintPushCredential(JOB, 7);
+
+		expect(protect).toHaveBeenCalledWith(PUSH_TOKEN);
+	});
+
+	it('REFUSES an answer that names a different node', async () => {
+		// The node holds the claim, so it knows which machine it is.
+		// Attribution that can name a machine the run did not use is worth
+		// less than none.
+		const client = clientWith(
+			response(200, answer({ attribution: { ...answer().attribution, nodeId: 'someone-else' } }))
+		);
+
+		await expect(client.mintPushCredential(JOB, 7)).rejects.toMatchObject({ kind: 'malformed' });
+	});
+
+	it('THROWS rather than returning a credential-shaped blank', async () => {
+		const client = clientWith(response(200, answer({ push: { username: 'x-access-token' } })));
+
+		await expect(client.mintPushCredential(JOB, 7)).rejects.toMatchObject({ kind: 'malformed' });
+	});
+
+	it('accepts a commit-only run, which legitimately has no credential', async () => {
+		const client = clientWith(response(200, answer({ push: null })));
+
+		await expect(client.mintPushCredential(JOB, 7)).resolves.toMatchObject({ push: null });
+	});
+
+	it('maps 422 to a refusal that says the run failed rather than pushed another way', async () => {
+		const client = clientWith(response(422, { reason: 'push-scope-unresolved', detail: 'private' }));
+		const error = await client.mintPushCredential(JOB, 7).catch((e: unknown) => e);
+
+		expect(error).toMatchObject({ kind: 'unresolved', status: 422 });
+		expect((error as Error).message).toContain('scoped push credential');
+		expect((error as Error).message).not.toContain('private');
+	});
+
+	it('keeps 409 as stale-lease, from the STATUS alone', async () => {
+		const client = clientWith(response(409, { reason: 'stale-lease' }));
+
+		await expect(client.mintPushCredential(JOB, 7)).rejects.toMatchObject({ kind: 'stale-lease' });
+	});
+});

--- a/apps/node/src/core/job-client.ts
+++ b/apps/node/src/core/job-client.ts
@@ -5,6 +5,7 @@ import type {
 	FleetJobLeaseResponse,
 	FleetJobMcpCredentialResponse,
 	FleetJobMcpCredentialRevokeResponse,
+	FleetJobPushCredentialResponse,
 	FleetJobView,
 	FleetRunEnvFileContent,
 	FleetRunEnvFileRequestRef
@@ -23,6 +24,7 @@ import { extractRunEnvSecretValues } from './workspaces/run-env-files';
  *   POST /api/fleet/jobs/:id/env-files   → fetch the run's seed .env files
  *   POST /api/fleet/jobs/:id/mcp-credential          → mint a run token
  *   POST /api/fleet/jobs/:id/mcp-credential/revoke   → drop it early
+ *   POST /api/fleet/jobs/:id/push-credential         → mint a scoped write token
  *
  * Same posture as {@link FleetClient}: all three are `@Public()` and
  * self-authenticating (the `(nodeId, secret)` pair in the body IS the
@@ -292,6 +294,55 @@ export class FleetJobClient {
 		return typeof payload?.revoked === 'number' ? payload.revoked : 0;
 	}
 
+	/**
+	 * Self-build slice AM (EW-810) — fetch this run's commit attribution
+	 * and, when the job's plan pushes, the repository-scoped write
+	 * credential the finalize will authenticate with.
+	 *
+	 * Authenticated with the node secret and the CURRENT lease generation:
+	 * a claim that lapsed while this machine slept must not receive a
+	 * write credential for the owner's repositories, exactly as it must
+	 * not receive their decrypted `.env`.
+	 *
+	 * The token is registered with the redacting logger before it leaves
+	 * this method, so from that instant it cannot appear in any node log
+	 * line even by accident, and it is NOT stored on this client: the
+	 * caller holds it in one closure for the length of the finalize.
+	 *
+	 * A `422` is a REFUSAL the run must fail on, not a hint to push some
+	 * other way; `errorForJobStatus` maps it, and the caller reports it.
+	 */
+	async mintPushCredential(jobId: string, leaseGeneration?: number): Promise<FleetJobPushCredentialResponse> {
+		const body: Record<string, unknown> = { nodeId: this.nodeId, secret: this.secret };
+		if (leaseGeneration !== undefined) body.leaseGeneration = leaseGeneration;
+
+		const payload = (await this.post(
+			`api/fleet/jobs/${encodeURIComponent(jobId)}/push-credential`,
+			'job-push-credential',
+			body
+		)) as FleetJobPushCredentialResponse;
+		const attribution = payload?.attribution;
+		if (!attribution || typeof attribution.nodeId !== 'string' || typeof attribution.jobId !== 'string') {
+			throw new FleetClientError('malformed', 'Push credential response did not contain attribution');
+		}
+		// The node holds the claim, so it knows which machine it is. An
+		// answer naming a DIFFERENT node is refused rather than signed:
+		// attribution that can name a machine the run did not use is worth
+		// less than none.
+		if (attribution.nodeId !== this.nodeId) {
+			throw new FleetClientError('malformed', 'Push credential response named a different node');
+		}
+		const push = payload.push ?? null;
+		if (push !== null) {
+			if (typeof push.token !== 'string' || !push.token || !Array.isArray(push.repositories)) {
+				throw new FleetClientError('malformed', 'Push credential response did not contain a usable token');
+			}
+			// BEFORE it is used anywhere, and before this method returns.
+			this.logger?.protect(push.token);
+		}
+		return payload;
+	}
+
 	private async post(
 		path: string,
 		operation: string,
@@ -374,6 +425,22 @@ export function errorForJobStatus(status: number, operation: string): FleetClien
 		return new FleetClientError(
 			'stale-lease',
 			'The platform holds a newer lease on this job (stale-lease); the claim this node is renewing or finalizing is void',
+			status
+		);
+	}
+	if (status === 422 && operation === 'job-push-credential') {
+		// Scoped push credentials (slice AM): the SAME posture as the
+		// env-file 422 below — a stable reason token is recorded
+		// platform-side against this job and this client still does not
+		// read the body. Named separately only so the run's failure text
+		// sends an operator to the right place: this refusal is about the
+		// GitHub App installation, not about a repository connection.
+		return new FleetClientError(
+			'unresolved',
+			'The platform could not issue a scoped push credential for this run (no GitHub App configured, or no ' +
+				'installation this owner controls covers every repository this run writes to). The run fails rather ' +
+				'than pushing with this machine’s own credential helper. The precise reason is recorded ' +
+				'platform-side against this job.',
 			status
 		);
 	}

--- a/apps/node/src/core/logger.spec.ts
+++ b/apps/node/src/core/logger.spec.ts
@@ -55,6 +55,44 @@ describe('createLogger redaction', () => {
 		logger.protect(SECRET);
 		expect(logger.redact(`connect failed: ${SECRET}`)).toBe(`connect failed: ${REDACTED}`);
 	});
+
+	// REGRESSION — the protected set had no eviction path (slice AM review, F3).
+	//
+	// That is correct for the two credentials this process holds for its
+	// whole life, and wrong for a per-run one: the scoped push token was
+	// protected on every mint and never dropped, so a node running forty
+	// agent-tasks across a multi-day uptime accumulated forty raw
+	// `contents: write` installation tokens in a process-lifetime closure —
+	// recoverable from a heap snapshot or a crash dump, and the recent ones
+	// still live at GitHub. `unprotect()` is what lets the owner of a
+	// short-lived credential say when it stops existing.
+	it('forgets a per-run credential on unprotect, and keeps the rest', () => {
+		const { logger, text } = capture();
+		logger.protect(SECRET);
+		logger.protect(TOKEN);
+
+		logger.unprotect(TOKEN);
+
+		logger.info(`run over: token=${TOKEN} secret=${SECRET}`);
+		// The long-lived secret is still scrubbed; only the value whose
+		// owner declared it dead comes back through.
+		expect(text()).toBe(`run over: token=${TOKEN} secret=${REDACTED}`);
+	});
+
+	it('is safe to unprotect a value that was never protected, or none at all', () => {
+		const { logger, text } = capture();
+		logger.protect(SECRET);
+
+		logger.unprotect('never-registered-value');
+		logger.unprotect(null);
+		logger.unprotect(undefined);
+		// Idempotent: the second call has nothing left to remove.
+		logger.unprotect(SECRET);
+		logger.unprotect(SECRET);
+
+		logger.info(`secret=${SECRET}`);
+		expect(text()).toBe(`secret=${SECRET}`);
+	});
 });
 
 describe('createBufferedLogger', () => {

--- a/apps/node/src/core/logger.ts
+++ b/apps/node/src/core/logger.ts
@@ -24,6 +24,24 @@ export interface Logger {
 	error(message: string): void;
 	/** Register a credential that must never appear in output. No-op for short/empty values. */
 	protect(value: string | null | undefined): void;
+	/**
+	 * Forget a credential that no longer exists.
+	 *
+	 * The redactor keeps every protected value verbatim, so a `protect()`
+	 * with no matching `unprotect()` pins that credential in the node
+	 * process's heap for the rest of its uptime. That is fine for the two
+	 * credentials this process holds for its whole life (the enrollment
+	 * token and the heartbeat secret) and WRONG for a short-lived one: a
+	 * node that runs forty agent-tasks across a multi-day uptime would
+	 * otherwise accumulate forty raw `contents: write` installation tokens,
+	 * every one of them recoverable from a heap snapshot or a crash dump,
+	 * and the most recent still live at GitHub.
+	 *
+	 * So a caller that protects a per-run credential unprotects it when the
+	 * run ends — see `PushCredentialSession.dispose`. Idempotent, and a
+	 * no-op for a value that was never protected.
+	 */
+	unprotect(value: string | null | undefined): void;
 	/** Scrub every protected value out of arbitrary text. */
 	redact(text: string): string;
 }
@@ -79,6 +97,9 @@ export function createLogger(options: LoggerOptions = {}): Logger {
 			if (typeof value === 'string' && value.length >= MIN_PROTECTED_LENGTH) {
 				protectedValues.add(value);
 			}
+		},
+		unprotect: (value) => {
+			if (typeof value === 'string') protectedValues.delete(value);
 		},
 		redact
 	};

--- a/apps/node/src/core/runtime.spec.ts
+++ b/apps/node/src/core/runtime.spec.ts
@@ -670,6 +670,210 @@ describe('createNodeRuntime — agent-task publish fence', () => {
 	});
 });
 
+/**
+ * The join between the lease and the SCOPED PUSH CREDENTIAL.
+ *
+ * REGRESSION — the whole production wiring of slice AM had no coverage
+ * (its review, F8). Creating the session, threading it into
+ * `finalizeWorkspace` / `finalizeMounts`, and disposing it in the terminal
+ * `finally` all live in one closure in `runtime.ts`, and two mutations that
+ * destroy the slice's central guarantees left the entire `apps/node` suite
+ * green (1216 passed, only the pre-existing cargo-dependent
+ * windows-job-helper-trust failure):
+ *
+ *   1. Replacing `await pushCredentials?.dispose()` with a no-op. The
+ *      headline claim — "revoked on every terminal path" — was then
+ *      unprotected: every run would leave a live `contents: write`
+ *      installation token for the owner's repositories un-revoked.
+ *   2. Removing the `pushCredentials` spread from BOTH finalize calls.
+ *      `authorizePublish` then takes its no-provider branch and turns
+ *      EVERY fleet publish into a `push-credential` refusal — a fleet-wide
+ *      publish outage — and nothing said so.
+ *
+ * Both go red here now.
+ */
+describe('createNodeRuntime — agent-task scoped push credential', () => {
+	const LEASED_AT = Date.parse('2026-09-04T09:00:00.000Z');
+
+	interface PushHarness {
+		finalizeOpts: Record<string, unknown>[];
+		finalizeMountsOpts: Record<string, unknown>[];
+		disposals: number;
+		completedBodies: Record<string, unknown>[];
+	}
+
+	/**
+	 * Runs ONE leased `agent-task` through the real runtime with the
+	 * executor stubbed, a provisioner that records what `finalize` was
+	 * handed, and the REAL `PushCredentialSession` class instrumented on its
+	 * prototype — so what is asserted is the production class, not a double.
+	 */
+	async function withPushSession(run: (agentIo: Record<string, unknown>) => Promise<void>): Promise<PushHarness> {
+		const harness: PushHarness = {
+			finalizeOpts: [],
+			finalizeMountsOpts: [],
+			disposals: 0,
+			completedBodies: []
+		};
+		let leased = false;
+		const job = {
+			id: 'job-push-1',
+			kind: 'agent-task',
+			status: 'leased',
+			nodeId: NODE_ID,
+			requiredCapabilities: [],
+			payload: { taskId: 'task-push', steps: [] },
+			leaseExpiresAt: new Date(LEASED_AT + 60_000).toISOString(),
+			attempts: 1,
+			maxAttempts: 3,
+			createdAt: null,
+			startedAt: null,
+			completedAt: null
+		};
+		const fetchFn: FetchLike = async (url, init) => {
+			if (url.endsWith('/api/fleet/jobs/lease')) {
+				const jobs = leased ? [] : [job];
+				leased = true;
+				return { ok: true, status: 200, text: async () => JSON.stringify({ jobs }) };
+			}
+			if (url.endsWith('/heartbeat')) {
+				return {
+					ok: true,
+					status: 200,
+					text: async () => JSON.stringify({ ok: true, job: { ...job, status: 'running' } })
+				};
+			}
+			if (url.endsWith('/complete')) {
+				harness.completedBodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+				return { ok: true, status: 200, text: async () => JSON.stringify({ ok: true, job: {} }) };
+			}
+			throw new Error(`unexpected request: ${url}`);
+		};
+
+		vi.resetModules();
+		vi.doMock('./executors/agent-task', () => ({
+			runAgentTaskJob: async (_job: unknown, agentIo: Record<string, unknown>) => {
+				await run(agentIo);
+				return {};
+			}
+		}));
+		try {
+			// Imported BEFORE `./runtime`, inside the same post-reset module
+			// registry, so the runtime binds this very module object and the
+			// prototype spy observes the production class.
+			const { PushCredentialSession } = await import('./workspaces/push-credential');
+			const realDispose = PushCredentialSession.prototype.dispose;
+			vi.spyOn(PushCredentialSession.prototype, 'dispose').mockImplementation(async function (
+				this: InstanceType<typeof PushCredentialSession>
+			) {
+				harness.disposals += 1;
+				await realDispose.call(this);
+			});
+
+			const { createNodeRuntime: create } = await import('./runtime');
+			const { io: deps } = io(fetchFn);
+			const config: NodeConfig = {
+				apiUrl: 'https://api.ever.works',
+				nodeId: NODE_ID,
+				secret: SECRET,
+				kind: 'node',
+				capabilities: ['os:linux'],
+				heartbeatIntervalMs: 30_000,
+				enrolledAt: '2026-07-25T10:00:00.000Z'
+			};
+			const runtime = create(
+				config,
+				{
+					...deps,
+					scheduler: { setTimeout: () => ({ scheduled: true }), clearTimeout: () => undefined },
+					now: () => LEASED_AT,
+					monotonicNow: () => LEASED_AT
+				},
+				{
+					workerEnabled: true,
+					workspaceProvisioner: {
+						provision: vi.fn(),
+						finalize: async (_taskId: string, _descriptor: unknown, opts: Record<string, unknown>) => {
+							harness.finalizeOpts.push(opts);
+							return { pushed: true, headSha: 'a'.repeat(40), empty: false };
+						},
+						finalizeMounts: async (
+							_taskId: string,
+							_descriptor: unknown,
+							opts: Record<string, unknown>
+						) => {
+							harness.finalizeMountsOpts.push(opts);
+							return [];
+						}
+					} as never
+				}
+			);
+			await runtime.worker?.start();
+			await runtime.worker?.drained();
+			await runtime.worker?.stop();
+		} finally {
+			vi.restoreAllMocks();
+			vi.resetModules();
+		}
+		return harness;
+	}
+
+	it('hands BOTH finalize seams a push-credential provider', async () => {
+		// Mutation 2 above. Without the spread, `authorizePublish` takes its
+		// no-provider branch and every fleet publish becomes a
+		// `push-credential` refusal — a fleet-wide outage that no other spec
+		// in the repository notices.
+		const harness = await withPushSession(async (agentIo) => {
+			const finalizeWorkspace = agentIo.finalizeWorkspace as (
+				taskId: string,
+				descriptor: unknown,
+				opts: Record<string, unknown>
+			) => Promise<unknown>;
+			const finalizeMounts = agentIo.finalizeMounts as (
+				taskId: string,
+				descriptor: unknown,
+				opts: Record<string, unknown>
+			) => Promise<unknown>;
+			await finalizeWorkspace('task-push', {}, { commitMessage: 'feat: x', push: true });
+			await finalizeMounts('task-push', {}, { commitMessage: 'feat: x', push: true });
+		});
+
+		expect(harness.finalizeOpts).toHaveLength(1);
+		expect(harness.finalizeMountsOpts).toHaveLength(1);
+		for (const opts of [...harness.finalizeOpts, ...harness.finalizeMountsOpts]) {
+			const provider = opts.pushCredentials as { attribute?: unknown; credentialFor?: unknown } | undefined;
+			// The real provider interface, not merely a truthy value: a stub
+			// missing either half would refuse at publish just as loudly.
+			expect(typeof provider?.attribute).toBe('function');
+			expect(typeof provider?.credentialFor).toBe('function');
+		}
+		// And the caller's own options survive alongside it.
+		expect(harness.finalizeOpts[0].commitMessage).toBe('feat: x');
+	});
+
+	it('disposes the session when the run SUCCEEDS', async () => {
+		// Mutation 1 above, success path.
+		const harness = await withPushSession(async () => undefined);
+		expect(harness.disposals).toBe(1);
+	});
+
+	it('disposes the session when the run THROWS', async () => {
+		// The path that matters most: a thrown model step, an operator
+		// cancel and a lapsed lease all arrive at the same `finally`. A
+		// credential left un-revoked because the failure path skipped
+		// disposal is a live write token for the owner's repositories.
+		const harness = await withPushSession(async () => {
+			throw new Error('model step exploded');
+		});
+
+		expect(harness.disposals).toBe(1);
+		// The failure still reaches the platform — disposal is not allowed
+		// to swallow it.
+		expect(harness.completedBodies).toHaveLength(1);
+		expect(harness.completedBodies[0]).toMatchObject({ success: false });
+	});
+});
+
 describe('installShutdownHandlers', () => {
 	it('registers both signals and runs the shutdown exactly once', () => {
 		const handlers = new Map<string, () => void>();

--- a/apps/node/src/core/runtime.ts
+++ b/apps/node/src/core/runtime.ts
@@ -25,6 +25,7 @@ import {
 	FleetTaskWorkspaceProvisioner
 } from './workspaces/fleet-task-workspace';
 import { measureWorkspaceFreeBytes } from './workspaces/disk-headroom';
+import { PushCredentialSession } from './workspaces/push-credential';
 import type { Logger } from './logger';
 import {
 	clampResourceLimits,
@@ -505,122 +506,167 @@ export function createNodeRuntime(config: NodeConfig, io: NodeIo, options: Creat
 		// either CLI: a job that asks for model execution then fails naming
 		// the missing CLI rather than pretending to have run it.
 		const modelCli = options.modelCli ?? io.environment.modelCli ?? {};
-		worker.register('agent-task', (job, signal, lease) =>
-			runAgentTaskJob(
-				job,
-				{
-					provisionWorkspace: (taskId, spec, provisionSignal) =>
-						workspaceProvisioner.provision(taskId, spec, provisionSignal),
-					...(workspaceProvisioner.finalize
-						? {
-								finalizeWorkspace: (taskId, descriptor, opts, finalizeSignal) =>
-									workspaceProvisioner.finalize!(taskId, descriptor, opts, finalizeSignal)
+		worker.register('agent-task', async (job, signal, lease) => {
+			// Scoped push credentials (self-build slice AM, EW-810). ONE
+			// session per job: a multi-repo run publishes its mounts and its
+			// primary branch seconds apart under the same claim, and the
+			// platform scopes a single token to every repository the job
+			// writes, so a second mint would only widen the number of live
+			// write credentials.
+			//
+			// It hangs off the LEASE, exactly as run secrets do: the
+			// platform proves this node still holds an active claim before
+			// it hands a machine a write credential for the owner's
+			// repositories. A caller with no lease has no session, and the
+			// provisioner then REFUSES to publish rather than falling back
+			// to this machine's own Git credential helper.
+			const pushCredentials = lease
+				? new PushCredentialSession({
+						jobId: job.id,
+						client: { mintPushCredential: () => lease.mintPushCredential() },
+						...(io.logger ? { logger: io.logger } : {})
+					})
+				: null;
+			try {
+				return await runAgentTaskJob(
+					job,
+					{
+						provisionWorkspace: (taskId, spec, provisionSignal) =>
+							workspaceProvisioner.provision(taskId, spec, provisionSignal),
+						...(workspaceProvisioner.finalize
+							? {
+									finalizeWorkspace: (taskId, descriptor, opts, finalizeSignal) =>
+										workspaceProvisioner.finalize!(
+											taskId,
+											descriptor,
+											{ ...opts, ...(pushCredentials ? { pushCredentials } : {}) },
+											finalizeSignal
+										)
+								}
+							: {}),
+						...(workspaceProvisioner.finalizeMounts
+							? {
+									finalizeMounts: (taskId, descriptor, opts, finalizeSignal) =>
+										workspaceProvisioner.finalizeMounts!(
+											taskId,
+											descriptor,
+											{ ...opts, ...(pushCredentials ? { pushCredentials } : {}) },
+											finalizeSignal
+										)
+								}
+							: {}),
+						// Drops the on-disk lease the provisioner took on the worktree
+						// (and its mounts) so the workspace reaper can tell "a job is
+						// in here" from "a job WAS in here".
+						...(workspaceProvisioner.release
+							? {
+									releaseWorkspace: (taskId, descriptor) =>
+										workspaceProvisioner.release!(taskId, descriptor)
+								}
+							: {}),
+						// Run secrets (self-build slice Y). The WRITE and the
+						// DELETE are the provisioner's — it owns the worktree, its
+						// canonical-path checks and its Git exclude rules — while
+						// the FETCH hangs off the lease below, because "may this
+						// node still be trusted with this job?" is the same
+						// question the publish fence asks and must have the same
+						// answer.
+						...(workspaceProvisioner.writeRunEnvFiles
+							? {
+									writeRunEnvFiles: (taskId, descriptor, files) =>
+										workspaceProvisioner.writeRunEnvFiles!(taskId, descriptor, files)
+								}
+							: {}),
+						...(workspaceProvisioner.removeRunEnvFiles
+							? {
+									removeRunEnvFiles: (_taskId, descriptor) =>
+										workspaceProvisioner.removeRunEnvFiles!(descriptor)
+								}
+							: {}),
+						// `agent-task` is the only kind that writes to a remote, so
+						// it is the only kind that has to know when this node stops
+						// being allowed to. Resolved through the handle, never
+						// captured: the deadline moves with every renewal, and
+						// `confirmDeadline` re-asks the platform at the moment of
+						// the write — which is the only way to see a claim that was
+						// taken away (an operator drained this node) while its
+						// deadline was still minutes in the future.
+						...(lease
+							? {
+									publishFence: async () => ({
+										deadlineAt: await lease.confirmDeadline(),
+										marginMs: lease.publishMarginMs
+									}),
+									// A withheld publish is not a verdict about the
+									// work — nothing ran to a conclusion — so the
+									// job goes back unsettled rather than terminal.
+									onPublishWithheld: (reason: string) => lease.defer(reason),
+									// A provision the node declined before writing a byte
+									// (below the disk floor, or the reaper mid-removal of
+									// that very worktree) is about this machine, not the
+									// work: hand the job back so a node with room takes it.
+									onProvisionDeclined: (reason: string) => lease.defer(reason),
+									// Run secrets: fetched THROUGH the lease, so the
+									// platform proves this node still holds an active
+									// claim on this job before a decrypted `.env`
+									// leaves it. A node with no lease (the cloud
+									// runner) has no seam here, and a job that needs
+									// env files fails naming the gap rather than
+									// running against an environment nobody set up.
+									fetchRunEnvFiles: (refs) => lease.fetchRunEnvFiles(refs)
+								}
+							: {}),
+						modelCli,
+						// Self-build slice Z (EW-796) — the platform side of the
+						// MCP bridge, wired through the SAME authenticated job
+						// client the lease protocol uses. No new endpoint, no new
+						// credential on the node: the node secret is what proves
+						// this machine holds the claim, and what it gets back is a
+						// separate, short-lived token the model step keeps in
+						// memory only.
+						logger: io.logger,
+						mcpBridge: {
+							mint: (id: string) => jobClient.mintMcpCredential(id),
+							revoke: async (id: string) => {
+								await jobClient.revokeMcpCredential(id);
 							}
-						: {}),
-					...(workspaceProvisioner.finalizeMounts
-						? {
-								finalizeMounts: (taskId, descriptor, opts, finalizeSignal) =>
-									workspaceProvisioner.finalizeMounts!(taskId, descriptor, opts, finalizeSignal)
-							}
-						: {}),
-					// Drops the on-disk lease the provisioner took on the worktree
-					// (and its mounts) so the workspace reaper can tell "a job is
-					// in here" from "a job WAS in here".
-					...(workspaceProvisioner.release
-						? {
-								releaseWorkspace: (taskId, descriptor) =>
-									workspaceProvisioner.release!(taskId, descriptor)
-							}
-						: {}),
-					// Run secrets (self-build slice Y). The WRITE and the
-					// DELETE are the provisioner's — it owns the worktree, its
-					// canonical-path checks and its Git exclude rules — while
-					// the FETCH hangs off the lease below, because "may this
-					// node still be trusted with this job?" is the same
-					// question the publish fence asks and must have the same
-					// answer.
-					...(workspaceProvisioner.writeRunEnvFiles
-						? {
-								writeRunEnvFiles: (taskId, descriptor, files) =>
-									workspaceProvisioner.writeRunEnvFiles!(taskId, descriptor, files)
-							}
-						: {}),
-					...(workspaceProvisioner.removeRunEnvFiles
-						? {
-								removeRunEnvFiles: (_taskId, descriptor) =>
-									workspaceProvisioner.removeRunEnvFiles!(descriptor)
-							}
-						: {}),
-					// `agent-task` is the only kind that writes to a remote, so
-					// it is the only kind that has to know when this node stops
-					// being allowed to. Resolved through the handle, never
-					// captured: the deadline moves with every renewal, and
-					// `confirmDeadline` re-asks the platform at the moment of
-					// the write — which is the only way to see a claim that was
-					// taken away (an operator drained this node) while its
-					// deadline was still minutes in the future.
-					...(lease
-						? {
-								publishFence: async () => ({
-									deadlineAt: await lease.confirmDeadline(),
-									marginMs: lease.publishMarginMs
-								}),
-								// A withheld publish is not a verdict about the
-								// work — nothing ran to a conclusion — so the
-								// job goes back unsettled rather than terminal.
-								onPublishWithheld: (reason: string) => lease.defer(reason),
-								// A provision the node declined before writing a byte
-								// (below the disk floor, or the reaper mid-removal of
-								// that very worktree) is about this machine, not the
-								// work: hand the job back so a node with room takes it.
-								onProvisionDeclined: (reason: string) => lease.defer(reason),
-								// Run secrets: fetched THROUGH the lease, so the
-								// platform proves this node still holds an active
-								// claim on this job before a decrypted `.env`
-								// leaves it. A node with no lease (the cloud
-								// runner) has no seam here, and a job that needs
-								// env files fails naming the gap rather than
-								// running against an environment nobody set up.
-								fetchRunEnvFiles: (refs) => lease.fetchRunEnvFiles(refs)
-							}
-						: {}),
-					modelCli,
-					// Self-build slice Z (EW-796) — the platform side of the
-					// MCP bridge, wired through the SAME authenticated job
-					// client the lease protocol uses. No new endpoint, no new
-					// credential on the node: the node secret is what proves
-					// this machine holds the claim, and what it gets back is a
-					// separate, short-lived token the model step keeps in
-					// memory only.
-					logger: io.logger,
-					mcpBridge: {
-						mint: (id: string) => jobClient.mintMcpCredential(id),
-						revoke: async (id: string) => {
-							await jobClient.revokeMcpCredential(id);
-						}
+						},
+						// The disk floor on the OTHER workspace path (review
+						// AO-10). A payload that carries `workspacePath` — or
+						// neither field, which falls back to the node's own
+						// working directory — never reaches the provisioner, so
+						// neither of the slice's two gates looked at the volume
+						// it is about to run on. The lease gate had already
+						// passed, because it measures the FLEET root's volume,
+						// which in the installer's own recommended layout is a
+						// different drive. Same floor, same fail-closed rule,
+						// applied to the path the steps actually run in.
+						checkWorkspaceHeadroom: (path, signal) =>
+							assertWorkspaceDiskHeadroom(io.diskProbe, effectiveMinFreeDiskBytes(limits), path, signal),
+						...(options.agentTaskScratchRoot !== undefined
+							? { scratchRoot: options.agentTaskScratchRoot }
+							: {}),
+						...(options.agentTaskWorkspacePath !== undefined
+							? { defaultWorkspacePath: options.agentTaskWorkspacePath }
+							: {})
 					},
-					// The disk floor on the OTHER workspace path (review
-					// AO-10). A payload that carries `workspacePath` — or
-					// neither field, which falls back to the node's own
-					// working directory — never reaches the provisioner, so
-					// neither of the slice's two gates looked at the volume
-					// it is about to run on. The lease gate had already
-					// passed, because it measures the FLEET root's volume,
-					// which in the installer's own recommended layout is a
-					// different drive. Same floor, same fail-closed rule,
-					// applied to the path the steps actually run in.
-					checkWorkspaceHeadroom: (path, signal) =>
-						assertWorkspaceDiskHeadroom(io.diskProbe, effectiveMinFreeDiskBytes(limits), path, signal),
-					...(options.agentTaskScratchRoot !== undefined
-						? { scratchRoot: options.agentTaskScratchRoot }
-						: {}),
-					...(options.agentTaskWorkspacePath !== undefined
-						? { defaultWorkspacePath: options.agentTaskWorkspacePath }
-						: {})
-				},
-				signal
-			)
-		);
+					signal
+				);
+			} finally {
+				// Every exit path this process can still execute: success, a
+				// reported failure, a thrown model step, an operator cancel
+				// and a lapsed lease all arrive here. The token is cleared
+				// from memory BEFORE the revoke is awaited, so a revoke that
+				// hangs cannot leave a live reference behind, and the revoke
+				// itself tells GitHub to stop honouring it immediately.
+				//
+				// The one path this cannot cover is a hard kill (SIGKILL,
+				// power loss), and it does not have to: the credential was
+				// never written to disk, so the process dying takes it with
+				// it, and GitHub expires it within the hour regardless.
+				await pushCredentials?.dispose();
+			}
+		});
 		// `browser-check` is registered ONLY when this machine actually
 		// resolved a browser executable (audit A26). A node advertising
 		// the `browser` capability with no executor behind it would fail

--- a/apps/node/src/core/worker-loop.ts
+++ b/apps/node/src/core/worker-loop.ts
@@ -1,6 +1,7 @@
 import { performance } from 'node:perf_hooks';
 import type {
 	FleetJobKind,
+	FleetJobPushCredentialResponse,
 	FleetJobView,
 	FleetRunEnvFileContent,
 	FleetRunEnvFileRequestRef
@@ -234,6 +235,14 @@ export interface JobLeaseCapableClient {
 		refs: readonly FleetRunEnvFileRequestRef[],
 		leaseGeneration?: number
 	): Promise<FleetRunEnvFileContent[]>;
+	/**
+	 * Scoped push credentials (self-build slice AM). Optional for the same
+	 * reason as `fetchRunEnvFiles`: an embedder with an older client still
+	 * satisfies this interface. A run that intends to PUBLISH and finds it
+	 * absent fails naming the gap — it never publishes with the machine's
+	 * own credential helper instead.
+	 */
+	mintPushCredential?(jobId: string, leaseGeneration?: number): Promise<FleetJobPushCredentialResponse>;
 }
 
 /**
@@ -312,6 +321,21 @@ export interface JobLeaseHandle {
 	 * with part of its environment is worse than one that does not start.
 	 */
 	fetchRunEnvFiles(refs: readonly FleetRunEnvFileRequestRef[]): Promise<FleetRunEnvFileContent[]>;
+	/**
+	 * Mint this run's commit attribution and — when the job's own plan
+	 * pushes — the repository-scoped write credential the publish uses
+	 * (self-build slice AM).
+	 *
+	 * On the LEASE handle for the same reason `fetchRunEnvFiles` is: the
+	 * platform proves the claim with the same four checks before it hands
+	 * a machine a WRITE credential for the owner's repositories, and the
+	 * generation echoed is the one THIS run holds, so a claim that lapsed
+	 * while the machine slept is refused rather than served.
+	 *
+	 * Rejects rather than degrading: there is no version of this run that
+	 * publishes without the credential.
+	 */
+	mintPushCredential(): Promise<FleetJobPushCredentialResponse>;
 }
 
 /** The keep-alive as the LOOP sees it: the executor's half, plus control. */
@@ -1442,6 +1466,19 @@ export class WorkerLoop {
 						);
 					}
 					return fetchFn.call(this.options.client, jobId, refs, generation);
+				},
+				// Scoped push credentials: same channel, same claim, same
+				// generation. A write credential for the owner's
+				// repositories is at least as consequential as their
+				// decrypted `.env`, so it is proven the same way.
+				mintPushCredential: async () => {
+					const mintFn = this.options.client.mintPushCredential;
+					if (!mintFn) {
+						throw new Error(
+							'This node cannot mint a scoped push credential (the job client predates the push-credential protocol)'
+						);
+					}
+					return mintFn.call(this.options.client, jobId, generation);
 				}
 			}
 		};

--- a/apps/node/src/core/workspaces/fleet-task-workspace-mounts.spec.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace-mounts.spec.ts
@@ -39,6 +39,57 @@ const git = (cwd: string, ...args: string[]): string =>
 const temporaryRoot = (prefix: string): string =>
 	realpathSync.native(mkdtempSync(join(realpathSync.native(process.env.RUNNER_TEMP ?? tmpdir()), prefix)));
 
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) TIGHTENED the
+ * finalize contract: a finalize that PUBLISHES must be handed a credential
+ * provider. The old contract - "push with whatever this machine's own Git
+ * credential helper answers" - is the security gap the slice closes, so
+ * every `push: true` case below satisfies the new precondition rather than
+ * bypassing it, and each goes on proving exactly what it proved before.
+ *
+ * A STUB provider rather than the real `PushCredentialSession`, and the
+ * reason is specific to this suite: it fakes HTTPS origins by rewriting
+ * them to local bare repositories with `url.<file://>.insteadOf`, and
+ * `git remote get-url` returns the REWRITTEN url. A scoped installation
+ * credential cannot cover a `file://` remote, so the real session would
+ * (correctly) refuse every case here. That refusal is asserted where it
+ * belongs, against the real session, in `push-credential.spec.ts`; what
+ * this suite is for is mount verdicts.
+ */
+const TEST_NODE_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_JOB_ID = '33333333-3333-4333-8333-333333333333';
+
+const pushSession = () => ({
+	attribute: async (commitMessage: string) => ({
+		attribution: {
+			nodeId: TEST_NODE_ID,
+			nodeName: 'fleet-test',
+			agentId: null,
+			agentName: null,
+			agentEmail: null,
+			jobId: TEST_JOB_ID,
+			runId: null
+		},
+		identity: {
+			authorName: 'Ever Works Agent',
+			authorEmail: 'agent@ever.works',
+			committerName: 'Ever Works node fleet-test',
+			committerEmail: `node-${TEST_NODE_ID}@nodes.ever.works`
+		},
+		commitMessage: `${commitMessage}
+
+Ever-Works-Node: fleet-test (${TEST_NODE_ID})
+Ever-Works-Job: ${TEST_JOB_ID}`
+	}),
+	// Echoes the remote it was asked about, which is what the provider
+	// then re-reads and compares against before it uses the credential.
+	credentialFor: async (remoteUrl: string) => ({
+		username: 'x-access-token',
+		token: 'ghs_test_push_token_value',
+		remoteUrl
+	})
+});
+
 describe.sequential('FleetTaskWorkspaceProvisioner — mounts (real Git)', { timeout: 30_000 }, () => {
 	let ownedRoot: string;
 	let workspaceRoot: string;
@@ -219,7 +270,8 @@ describe.sequential('FleetTaskWorkspaceProvisioner — mounts (real Git)', { tim
 
 		const results = await provisioner.finalizeMounts('task-m3', descriptor, {
 			commitMessage: 'Task mounts-3: template change',
-			push: true
+			push: true,
+			pushCredentials: pushSession()
 		});
 
 		expect(results).toHaveLength(1);
@@ -256,6 +308,7 @@ describe.sequential('FleetTaskWorkspaceProvisioner — mounts (real Git)', { tim
 		const results = await provisioner.finalizeMounts('task-m14', descriptor, {
 			commitMessage: 'Task mounts-14: must not reach the remote',
 			push: true,
+			pushCredentials: pushSession(),
 			// A minute in the past on the real clock: expired by arithmetic,
 			// with nothing to wait for.
 			publishFence: { deadlineAt: Date.now() - 60_000, marginMs: 60_000 }
@@ -278,16 +331,21 @@ describe.sequential('FleetTaskWorkspaceProvisioner — mounts (real Git)', { tim
 		const untouched = await provisioner.provision('task-m4', spec('task/mounts-4'));
 		const emptyResults = await provisioner.finalizeMounts('task-m4', untouched, {
 			commitMessage: 'noop',
-			push: true
+			push: true,
+			pushCredentials: pushSession()
 		});
 		expect(emptyResults).toHaveLength(1);
 		expect(emptyResults[0]).toMatchObject({ empty: true, pushed: false });
 
 		const readOnly = await provisioner.provision('task-m5', spec('task/mounts-5', false));
 		writeFileSync(join(readOnly.mounts![0]!.linkPath, 'ignored.txt'), 'never committed\n');
-		expect(await provisioner.finalizeMounts('task-m5', readOnly, { commitMessage: 'noop', push: true })).toEqual(
-			[]
-		);
+		expect(
+			await provisioner.finalizeMounts('task-m5', readOnly, {
+				commitMessage: 'noop',
+				push: true,
+				pushCredentials: pushSession()
+			})
+		).toEqual([]);
 		expect(() => git(mountOrigin, 'rev-parse', '--verify', 'refs/heads/task/mounts-5')).toThrow();
 	});
 
@@ -545,7 +603,11 @@ describe('FleetTaskWorkspaceProvisioner — mounts and cancellation (faked Git)'
 			const provisioner = new FleetTaskWorkspaceProvisioner({
 				rootPath: root,
 				plugin,
-				inspectHead: async () => SHA
+				inspectHead: async () => SHA,
+				// Faked Git: these checkouts are bare directories, so the
+				// real `remote get-url` read the scoped push credential is
+				// checked against has nothing to answer.
+				readOriginUrl: async () => 'https://fleet-mounts.invalid/ever/template.git'
 			});
 			const worktree = (name: string) => join(root, 'repositories', 'pool', 'worktrees', name);
 			for (const name of ['primary', 'template', 'docs']) {
@@ -577,7 +639,7 @@ describe('FleetTaskWorkspaceProvisioner — mounts and cancellation (faked Git)'
 				provisioner.finalizeMounts(
 					'task-cancel',
 					descriptor,
-					{ commitMessage: 'Task cancel: mounts', push: true },
+					{ commitMessage: 'Task cancel: mounts', push: true, pushCredentials: pushSession() },
 					controller.signal
 				)
 			).rejects.toMatchObject({ code: 'cancelled' });

--- a/apps/node/src/core/workspaces/fleet-task-workspace.push-credential.spec.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.push-credential.spec.ts
@@ -1,0 +1,280 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { FleetTaskWorkspaceProvisioner, type FleetWorkspacePlugin } from './fleet-task-workspace';
+import { PushCredentialSession } from './push-credential';
+
+/**
+ * Scoped push credentials at the PROVISIONER boundary (self-build slice
+ * AM, EW-810).
+ *
+ * This is where the fleet's fail-closed rule lives: a node publishes with
+ * a repository-scoped credential minted for this job, or it does not
+ * publish. The alternative it used to take — letting Git answer with the
+ * machine's own credential helper, a long-lived personal access token
+ * with write access to every repository that OS user can reach — is the
+ * gap the slice closes, so every case here checks that nothing reaches
+ * the provider unless the credential did.
+ */
+
+const SHA = 'a'.repeat(40);
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const JOB_ID = '33333333-3333-4333-8333-333333333333';
+const TOKEN = 'ghs_0123456789abcdefghijklmnopqrstuvwxyz';
+const ORIGIN = 'https://github.com/ever-works/ever-works.git';
+
+const descriptorFor = (path: string) => ({
+	path,
+	repositoryId: 'ever-works/ever-works',
+	baseRef: 'main',
+	branch: 'task/scoped-push',
+	baseSha: SHA,
+	headSha: SHA,
+	reused: false
+});
+
+const session = (repositories: string[] = ['ever-works/ever-works'], push = true) =>
+	new PushCredentialSession({
+		jobId: JOB_ID,
+		client: {
+			mintPushCredential: async () => ({
+				attribution: {
+					nodeId: NODE_ID,
+					nodeName: 'studio-win',
+					agentId: null,
+					agentName: null,
+					agentEmail: null,
+					jobId: JOB_ID,
+					runId: null
+				},
+				push: push
+					? {
+							token: TOKEN,
+							username: 'x-access-token',
+							expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+							repositories
+						}
+					: null
+			})
+		}
+	});
+
+function harness(options: { originUrl?: string; finalizeImpl?: () => Promise<unknown> } = {}) {
+	const root = mkdtempSync(join(tmpdir(), 'ew-fleet-scoped-push-'));
+	const worktree = join(root, 'repositories', 'r', 'worktrees', 'w');
+	mkdirSync(worktree, { recursive: true });
+	const finalize = vi.fn(
+		(options.finalizeImpl ?? (async () => ({ pushed: true, headSha: SHA, empty: false, changedFiles: 1 }))) as (
+			handle: unknown,
+			opts: Record<string, unknown>
+		) => Promise<unknown>
+	);
+	const plugin = { provision: vi.fn(), finalize } as unknown as FleetWorkspacePlugin;
+	const provisioner = new FleetTaskWorkspaceProvisioner({
+		rootPath: root,
+		plugin,
+		readOriginUrl: async () => options.originUrl ?? ORIGIN
+	});
+	return { root, worktree, finalize, provisioner, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe('FleetTaskWorkspaceProvisioner.finalize — a fleet publish is never token-free', () => {
+	it('REFUSES to publish when no credential provider is wired, and the provider is never called', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness();
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true
+				})
+			).rejects.toMatchObject({ code: 'push-credential' });
+			// Not "committed but not pushed": the provider never ran at all,
+			// so there is no chance of a `git push` reaching the network
+			// with whatever this machine's credential helper answers.
+			expect(finalize).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('names the reason an operator can act on', async () => {
+		const { worktree, provisioner, cleanup } = harness();
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true
+				})
+			).rejects.toThrow(/never pushes with the machine/);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('still allows a COMMIT-ONLY finalize without a provider — there is nothing to authorise', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness({
+			finalizeImpl: async () => ({ pushed: false, headSha: SHA, empty: false })
+		});
+		try {
+			const result = await provisioner.finalize('task-0001', descriptorFor(worktree), {
+				commitMessage: 'feat: x',
+				push: false
+			});
+			expect(result.pushed).toBe(false);
+			expect(finalize).toHaveBeenCalledTimes(1);
+			// No identity and no credential: exactly the shape a caller with
+			// no job channel (a test, an embedder) always got.
+			expect(Object.keys(finalize.mock.calls[0]![1]).sort()).toEqual(['commitMessage', 'push']);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('hands the provider the scoped credential and the attributed message', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness();
+		try {
+			await provisioner.finalize('task-0001', descriptorFor(worktree), {
+				commitMessage: 'feat: x',
+				push: true,
+				pushCredentials: session()
+			});
+
+			const opts = finalize.mock.calls[0]![1] as unknown as {
+				commitMessage: string;
+				pushCredential: { token: string; remoteUrl: string; username: string };
+				identity: { committerName: string };
+			};
+			expect(opts.pushCredential).toEqual({
+				username: 'x-access-token',
+				token: TOKEN,
+				// The remote READ FROM THE CHECKOUT, not one carried down
+				// from the job spec: the credential must be keyed to what
+				// Git is actually about to write.
+				remoteUrl: ORIGIN
+			});
+			expect(opts.identity.committerName).toBe('Ever Works node studio-win');
+			expect(opts.commitMessage).toContain(`Ever-Works-Node: studio-win (${NODE_ID})`);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('REFUSES when the checkout points at a repository the credential does not cover', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness({
+			originUrl: 'https://github.com/someone-else/private.git'
+		});
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true,
+					pushCredentials: session()
+				})
+			).rejects.toMatchObject({ code: 'push-credential' });
+			expect(finalize).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('REFUSES when the checkout has no readable origin at all', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness();
+		const broken = new FleetTaskWorkspaceProvisioner({
+			rootPath: (provisioner as unknown as { rootPath: string }).rootPath,
+			plugin: { provision: vi.fn(), finalize } as unknown as FleetWorkspacePlugin,
+			readOriginUrl: async () => {
+				throw new Error('not a git repository');
+			}
+		});
+		try {
+			await expect(
+				broken.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true,
+					pushCredentials: session()
+				})
+			).rejects.toMatchObject({ code: 'push-credential' });
+			expect(finalize).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('REFUSES a payload commit message that forged a reserved trailer', async () => {
+		// Attribution that a Task title could write is attribution that
+		// means nothing. Refused before any Git command runs.
+		const { worktree, finalize, provisioner, cleanup } = harness();
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x\n\nEver-Works-Node: someone-elses-laptop (deadbeef)',
+					push: true,
+					pushCredentials: session()
+				})
+			).rejects.toMatchObject({ code: 'push-credential' });
+			expect(finalize).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('REFUSES when the platform says this job does not push but the caller believes it does', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness();
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true,
+					pushCredentials: session(['ever-works/ever-works'], false)
+				})
+			).rejects.toMatchObject({ code: 'push-credential' });
+			expect(finalize).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('attributes a commit-only run and mints no write credential for it', async () => {
+		const { worktree, finalize, provisioner, cleanup } = harness({
+			finalizeImpl: async () => ({ pushed: false, headSha: SHA, empty: false })
+		});
+		try {
+			await provisioner.finalize('task-0001', descriptorFor(worktree), {
+				commitMessage: 'feat: x',
+				push: false,
+				pushCredentials: session(['ever-works/ever-works'], false)
+			});
+			const opts = finalize.mock.calls[0]![1];
+			expect(opts.identity).toBeDefined();
+			expect(opts.pushCredential).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('scrubs the token out of a Git failure before it can reach the job result', async () => {
+		// `FleetAgentTaskGitResult.error` is stored verbatim in
+		// `fleet_jobs.result` and rendered on the Task page.
+		const { worktree, provisioner, cleanup } = harness({
+			finalizeImpl: async () => {
+				throw new Error(`git push failed: remote rejected (token ${TOKEN})`);
+			}
+		});
+		try {
+			await expect(
+				provisioner.finalize('task-0001', descriptorFor(worktree), {
+					commitMessage: 'feat: x',
+					push: true,
+					pushCredentials: session()
+				})
+			).rejects.toThrow(
+				expect.objectContaining({
+					message: expect.not.stringContaining(TOKEN)
+				}) as Error
+			);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/apps/node/src/core/workspaces/fleet-task-workspace.spec.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.spec.ts
@@ -12,6 +12,7 @@ import {
 	FleetTaskWorkspaceProvisioner,
 	type FleetWorkspacePlugin
 } from './fleet-task-workspace';
+import { PushCredentialSession } from './push-credential';
 
 const git = (cwd: string, ...args: string[]): string =>
 	execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true }).trim();
@@ -572,6 +573,55 @@ describe('FleetTaskWorkspaceProvisioner — refusal and diagnostics', () => {
 	});
 });
 
+/**
+ * Scoped push credentials (self-build slice AM, EW-810) TIGHTENED the
+ * finalize contract: a finalize that PUBLISHES must be handed a credential
+ * provider. The old contract — "push with whatever the machine's own Git
+ * credential helper answers" — was the security gap the slice closes, so
+ * the cases below satisfy the new precondition rather than bypass it, and
+ * they go on proving exactly what they proved before (the fence, the
+ * cancellation, the commit-support refusal).
+ *
+ * The REAL `PushCredentialSession` is used, driven by a fake job client,
+ * so these cases also exercise the attribution composer and the
+ * repository-scope check rather than a hand-rolled double.
+ */
+const TEST_NODE_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_JOB_ID = '33333333-3333-4333-8333-333333333333';
+// `github.com`, not the RFC 2606 `.invalid` host this fixture used to
+// carry. The slice AM review found that the scope check never read
+// `url.host` at all, so ANY host with an `owner/repo` path passed — and a
+// fixture on an unreachable host was therefore indistinguishable from the
+// real one. With the host pinned (`FLEET_PUSH_CREDENTIAL_HOST`), an
+// installation token can only ever be offered to github.com, so a fixture
+// that means "the legitimate origin" has to say so. Nothing here contacts
+// it: `readOriginUrl` is stubbed and no Git command runs.
+const TEST_ORIGIN = 'https://github.com/ever/repository.git';
+
+const pushSession = (repositories: string[] = ['ever/repository']) =>
+	new PushCredentialSession({
+		jobId: TEST_JOB_ID,
+		client: {
+			mintPushCredential: async () => ({
+				attribution: {
+					nodeId: TEST_NODE_ID,
+					nodeName: 'fleet-test',
+					agentId: null,
+					agentName: null,
+					agentEmail: null,
+					jobId: TEST_JOB_ID,
+					runId: null
+				},
+				push: {
+					token: 'ghs_test_push_token_value',
+					username: 'x-access-token',
+					expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+					repositories
+				}
+			})
+		}
+	});
+
 describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent execution v2 review follow-up)', () => {
 	it('forwards the abort signal to the provider and maps an abort into a cancelled error', async () => {
 		const root = mkdtempSync(join(tmpdir(), 'ew-fleet-finalize-'));
@@ -586,7 +636,11 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 			throw error;
 		});
 		const plugin = { provision: vi.fn(), finalize } as unknown as FleetWorkspacePlugin;
-		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath: root, plugin });
+		const provisioner = new FleetTaskWorkspaceProvisioner({
+			rootPath: root,
+			plugin,
+			readOriginUrl: async () => TEST_ORIGIN
+		});
 		const descriptor = {
 			path: worktree,
 			repositoryId: 'ever/repository',
@@ -601,12 +655,19 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 				provisioner.finalize(
 					'task-0001',
 					descriptor,
-					{ commitMessage: 'agent: x', push: true },
+					{ commitMessage: 'agent: x', push: true, pushCredentials: pushSession() },
 					controller.signal
 				)
 			).rejects.toMatchObject({ code: 'cancelled' });
 			expect(finalize).toHaveBeenCalledTimes(1);
-			expect(finalize.mock.calls[0][1]).toMatchObject({ commitMessage: 'agent: x', push: true });
+			// The message the provider commits is the payload's PLUS the
+			// reserved attribution trailers (slice AM). The old assertion
+			// pinned the bare payload message, which is no longer what a
+			// fleet commit carries.
+			expect(finalize.mock.calls[0][1]).toMatchObject({ push: true });
+			expect((finalize.mock.calls[0][1] as { commitMessage: string }).commitMessage).toBe(
+				`agent: x\n\nEver-Works-Node: fleet-test (${TEST_NODE_ID})\nEver-Works-Job: ${TEST_JOB_ID}`
+			);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
@@ -625,7 +686,11 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 			publishWithheld: withheld
 		}));
 		const plugin = { provision: vi.fn(), finalize } as unknown as FleetWorkspacePlugin;
-		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath: root, plugin });
+		const provisioner = new FleetTaskWorkspaceProvisioner({
+			rootPath: root,
+			plugin,
+			readOriginUrl: async () => TEST_ORIGIN
+		});
 		const publishFence = { deadlineAt: Date.parse('2026-09-04T15:00:00.000Z'), marginMs: 60_000 };
 		try {
 			const result = await provisioner.finalize(
@@ -639,7 +704,7 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 					headSha: SHA,
 					reused: false
 				},
-				{ commitMessage: 'agent: fenced', push: true, publishFence }
+				{ commitMessage: 'agent: fenced', push: true, publishFence, pushCredentials: pushSession() }
 			);
 			expect(finalize.mock.calls[0][1]).toMatchObject({ publishFence });
 			expect(result).toEqual({
@@ -664,7 +729,11 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 			empty: false
 		}));
 		const plugin = { provision: vi.fn(), finalize } as unknown as FleetWorkspacePlugin;
-		const provisioner = new FleetTaskWorkspaceProvisioner({ rootPath: root, plugin });
+		const provisioner = new FleetTaskWorkspaceProvisioner({
+			rootPath: root,
+			plugin,
+			readOriginUrl: async () => TEST_ORIGIN
+		});
 		try {
 			const result = await provisioner.finalize(
 				'task-0001',
@@ -677,11 +746,22 @@ describe('FleetTaskWorkspaceProvisioner.finalize — cancellation (agent executi
 					headSha: SHA,
 					reused: false
 				},
-				{ commitMessage: 'agent: unfenced', push: true }
+				{ commitMessage: 'agent: unfenced', push: true, pushCredentials: pushSession() }
 			);
 			// No `publishFence` key at all, not an undefined one: the provider
 			// must take the same path a lease-free caller has always taken.
-			expect(Object.keys(finalize.mock.calls[0][1]).sort()).toEqual(['commitMessage', 'push']);
+			//
+			// `identity` and `pushCredential` joined the list in slice AM and
+			// are NOT optional decoration: a fleet publish now carries the
+			// author/committer split and the scoped write credential, and a
+			// finalize that reached the provider without them would be one
+			// that pushed with the machine's own credential helper.
+			expect(Object.keys(finalize.mock.calls[0][1]).sort()).toEqual([
+				'commitMessage',
+				'identity',
+				'push',
+				'pushCredential'
+			]);
 			expect(result).toEqual({ pushed: true, headSha: SHA, empty: false });
 		} finally {
 			rmSync(root, { recursive: true, force: true });

--- a/apps/node/src/core/workspaces/fleet-task-workspace.ts
+++ b/apps/node/src/core/workspaces/fleet-task-workspace.ts
@@ -13,11 +13,17 @@ import {
 	type FleetTaskWorkspaceSpec
 } from '@ever-works/contracts';
 import { execFileWithVerifiedCancellation, LocalWorkspacePlugin } from '@ever-works/local-workspace-plugin';
-import type { IWorkspacePlugin, WorkspaceHandle, WorkspacePublishFence } from '@ever-works/plugin';
+import type {
+	IWorkspacePlugin,
+	WorkspaceCommitIdentity,
+	WorkspaceHandle,
+	WorkspacePublishFence
+} from '@ever-works/plugin';
 import { formatBytes } from '../resource-limits';
 import type { DiskProbeIo } from '../telemetry-probe';
 import { effectiveMinFreeDiskBytes } from '../types';
 import { measureWorkspaceFreeBytes } from './disk-headroom';
+import { PushCredentialError, type PushCredentialProvider, type ScopedPushCredential } from './push-credential';
 import { removeRunEnvFiles, sweepStaleRunEnvFiles, writeRunEnvFiles, type RunEnvFileWrite } from './run-env-files';
 
 export type FleetTaskWorkspaceErrorCode =
@@ -38,7 +44,19 @@ export type FleetTaskWorkspaceErrorCode =
 	 * The worktree is being reclaimed by the workspace reaper right now;
 	 * nothing was written. Transient — a retry lands on a fresh checkout.
 	 */
-	| 'workspace-busy';
+	| 'workspace-busy'
+	/**
+	 * Scoped push credentials (self-build slice AM): this run may not
+	 * publish, because the platform could not issue a repository-scoped
+	 * write credential for it, or the checkout points at a remote the
+	 * credential does not cover.
+	 *
+	 * TERMINAL, not a deferral: retrying on another node reaches the same
+	 * platform state, and the one thing that would let the push succeed
+	 * without it — the machine's own long-lived credential helper — is
+	 * exactly what this code exists to stop from being used.
+	 */
+	| 'push-credential';
 
 /** Stable, non-secret failure surface suitable for Fleet job diagnostics. */
 export class FleetTaskWorkspaceError extends Error {
@@ -80,6 +98,21 @@ export interface FleetTaskWorkspaceFinalizeOptions {
 	 * platform cannot be asked.
 	 */
 	publishFence?: WorkspacePublishFence;
+	/**
+	 * Scoped push credentials + commit attribution (self-build slice AM).
+	 *
+	 * Absent is NOT "push the way we used to": a finalize that intends to
+	 * publish and finds this absent is refused with `push-credential`. The
+	 * only other way a node could authenticate a push is the machine's own
+	 * Git credential helper — a long-lived, unscoped, unrevocable token
+	 * with write access to every repository that OS user can reach — and
+	 * falling back to it would leave the gap exactly where it was.
+	 *
+	 * A commit-only finalize (`push: false`) may proceed without one; it
+	 * then commits with the provider's default identity, which is what a
+	 * caller with no job channel (a test, an embedder) already got.
+	 */
+	pushCredentials?: PushCredentialProvider;
 }
 
 /**
@@ -448,6 +481,13 @@ export interface FleetTaskWorkspaceProvisionerOptions {
 	/** Test seam; production always resolves HEAD with shell-free `execFile`. */
 	readonly inspectHead?: (workspacePath: string, signal?: AbortSignal) => Promise<string>;
 	/**
+	 * Test seam; production reads the checkout's `origin` with shell-free
+	 * `execFile`. Read from the WORKTREE rather than taken from the job
+	 * spec on purpose (self-build slice AM): the scoped push credential is
+	 * checked against the remote Git is actually going to write to.
+	 */
+	readonly readOriginUrl?: (workspacePath: string, signal?: AbortSignal) => Promise<string>;
+	/**
 	 * Free-space probe for the disk floor, measured on the root's volume
 	 * right before anything is written there. Absent = no pre-provision
 	 * check (the worker loop's gate, when wired, still applies).
@@ -554,6 +594,7 @@ export class FleetTaskWorkspaceProvisioner {
 	private readonly rootPath: string;
 	private readonly plugin: FleetWorkspacePlugin;
 	private readonly inspectHead: (workspacePath: string, signal?: AbortSignal) => Promise<string>;
+	private readonly readOriginUrl: (workspacePath: string, signal?: AbortSignal) => Promise<string>;
 	private readonly diskProbe: DiskProbeIo | undefined;
 	private readonly minFreeDiskBytes: number | null;
 	private readonly isProcessAlive: (pid: number) => boolean;
@@ -579,6 +620,7 @@ export class FleetTaskWorkspaceProvisioner {
 		this.rootPath = validateRootPath(options.rootPath);
 		this.plugin = options.plugin ?? new LocalWorkspacePlugin();
 		this.inspectHead = options.inspectHead ?? inspectGitHead;
+		this.readOriginUrl = options.readOriginUrl ?? inspectGitOrigin;
 		this.diskProbe = options.diskProbe;
 		this.minFreeDiskBytes = effectiveMinFreeDiskBytes({ minFreeDiskBytes: options.minFreeDiskBytes });
 		this.isProcessAlive = options.isProcessAlive ?? defaultIsProcessAlive;
@@ -1123,9 +1165,29 @@ export class FleetTaskWorkspaceProvisioner {
 	 *
 	 * Delegates to the local-workspace provider's own `finalize` — the
 	 * same `git add -A` / commit / `push HEAD:refs/heads/<branch>` the
-	 * cloud worker runs — so a node-pushed branch is indistinguishable
-	 * from a cloud-pushed one. The push is token-free: the node's own Git
-	 * credential helper authenticates, exactly as the fetch did.
+	 * cloud worker runs.
+	 *
+	 * The push is NOT token-free (self-build slice AM, EW-810). It used to
+	 * be: the node's own Git credential helper authenticated it, exactly
+	 * as the fetch still does. In practice that helper holds a long-lived
+	 * personal access token with write access to every repository the
+	 * service account can reach, which the platform can neither scope per
+	 * run, nor rotate, nor revoke, nor observe. So a publish now carries a
+	 * repository-scoped installation token minted for THIS job over the
+	 * node-authenticated channel, installed for the single `git push`
+	 * child through its environment, and dropped when the run ends. A
+	 * finalize that intends to publish and has no such credential is
+	 * REFUSED (`push-credential`) rather than falling back — see
+	 * {@link authorizePublish}.
+	 *
+	 * The commit also stops being anonymous: the Agent is the author and
+	 * this node is the committer, and a reserved `Ever-Works-` trailer
+	 * block records the node, agent, job and run. Both come from platform
+	 * state on the same authenticated response as the credential.
+	 *
+	 * The FETCH is unchanged and still uses the machine's own helper: it
+	 * needs read access only, and it happens before the run's first model
+	 * byte. Scoping it is a separate change.
 	 *
 	 * The descriptor is re-validated against the configured root before
 	 * any Git command runs, so a job cannot point this at a directory the
@@ -1173,6 +1235,13 @@ export class FleetTaskWorkspaceProvisioner {
 		}
 		throwIfCancelled(signal);
 
+		// Scoped push credentials (self-build slice AM). Resolved HERE —
+		// after the path is proven, before any Git command — so the
+		// credential exists for exactly the commit-and-push and not one
+		// instant of the model's run.
+		const authorization = await this.authorizePublish(opts, canonicalPath, commitMessage, signal);
+		throwIfCancelled(signal);
+
 		const bindingKey = taskBindingKey(normalizedTaskId, repositoryId);
 		try {
 			const result = await this.plugin.finalize(
@@ -1189,10 +1258,12 @@ export class FleetTaskWorkspaceProvisioner {
 				// abort that arrives mid-push is already too late: the remote may
 				// have accepted the ref before the kill landed.
 				{
-					commitMessage,
+					commitMessage: authorization.commitMessage,
 					push: opts.push,
 					...(signal ? { signal } : {}),
-					...(opts.publishFence ? { publishFence: opts.publishFence } : {})
+					...(opts.publishFence ? { publishFence: opts.publishFence } : {}),
+					...(authorization.identity ? { identity: authorization.identity } : {}),
+					...(authorization.credential ? { pushCredential: authorization.credential } : {})
 				}
 			);
 			return {
@@ -1207,9 +1278,104 @@ export class FleetTaskWorkspaceProvisioner {
 			if (signal?.aborted) throw cancelledError();
 			throw new FleetTaskWorkspaceError(
 				'git-failed',
-				`Commit or push failed for branch '${branch}': ${error instanceof Error ? error.message : String(error)}`
+				// Last line of defence before this text becomes
+				// `FleetAgentTaskGitResult.error` and is stored verbatim in
+				// `fleet_jobs.result`. The provider scrubs its own stderr;
+				// this scrubs whatever else may have wrapped it on the way
+				// out, because a write credential in a job row is a finding
+				// no matter which layer put it there.
+				redactToken(
+					`Commit or push failed for branch '${branch}': ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					authorization.credential
+				)
 			);
 		}
+	}
+
+	/**
+	 * May this finalize publish, who is it by, and with what credential?
+	 *
+	 * FAILS CLOSED in both directions:
+	 *
+	 *  - a publish with no credential provider wired is refused, because
+	 *    the only other way this node could authenticate a push is the
+	 *    machine's own Git credential helper — the long-lived, unscoped,
+	 *    unrevocable token this slice exists to stop using;
+	 *  - a provider that refuses (no installation covers this repository,
+	 *    the checkout points somewhere the credential does not reach, the
+	 *    commit message forged a reserved trailer) fails the finalize with
+	 *    the reason, and the run reports it.
+	 *
+	 * A commit-only finalize with no provider keeps the pre-slice
+	 * behaviour: nothing is published, so there is nothing to authorise,
+	 * and the provider's default identity applies.
+	 */
+	private async authorizePublish(
+		opts: FleetTaskWorkspaceFinalizeOptions,
+		canonicalPath: string,
+		commitMessage: string,
+		signal?: AbortSignal
+	): Promise<{
+		commitMessage: string;
+		identity?: WorkspaceCommitIdentity;
+		credential?: ScopedPushCredential;
+	}> {
+		const provider = opts.pushCredentials;
+		if (!provider) {
+			if (opts.push) {
+				throw new FleetTaskWorkspaceError(
+					'push-credential',
+					'Refusing to publish: this run has no scoped push credential, and a fleet node never pushes with the machine’s own Git credential helper'
+				);
+			}
+			return { commitMessage };
+		}
+
+		let attributed: Awaited<ReturnType<PushCredentialProvider['attribute']>>;
+		try {
+			attributed = await provider.attribute(commitMessage);
+		} catch (error) {
+			throw this.pushCredentialFailure(error);
+		}
+		if (!opts.push) {
+			return { commitMessage: attributed.commitMessage, identity: attributed.identity };
+		}
+
+		let originUrl: string;
+		try {
+			originUrl = (await this.readOriginUrl(canonicalPath, signal)).trim();
+		} catch (error) {
+			if (error instanceof Error && error.name === 'ProcessTreeTerminationError') throw error;
+			if (signal?.aborted) throw cancelledError();
+			throw new FleetTaskWorkspaceError(
+				'push-credential',
+				'Refusing to publish: this checkout has no readable origin remote to scope a push credential to'
+			);
+		}
+		let credential: ScopedPushCredential;
+		try {
+			credential = await provider.credentialFor(originUrl);
+		} catch (error) {
+			throw this.pushCredentialFailure(error);
+		}
+		return {
+			commitMessage: attributed.commitMessage,
+			identity: attributed.identity,
+			credential
+		};
+	}
+
+	private pushCredentialFailure(error: unknown): FleetTaskWorkspaceError {
+		if (error instanceof FleetTaskWorkspaceError) return error;
+		if (error instanceof PushCredentialError) {
+			return new FleetTaskWorkspaceError('push-credential', `Refusing to publish: ${error.message}`);
+		}
+		return new FleetTaskWorkspaceError(
+			'push-credential',
+			`Refusing to publish: ${error instanceof Error ? error.message : String(error)}`
+		);
 	}
 	/**
 	 * Multi-repo Task workspaces (self-build slice C): commit + push every
@@ -1688,6 +1854,37 @@ function cancelledError(): FleetTaskWorkspaceError {
 
 function inspectGitHead(workspacePath: string, signal?: AbortSignal): Promise<string> {
 	return runGitOutput(['rev-parse', '--verify', 'HEAD'], workspacePath, signal);
+}
+
+/**
+ * The remote this checkout actually pushes to (self-build slice AM).
+ *
+ * Read here, from the worktree, rather than carried down from the job
+ * spec: the scoped push credential is only allowed to authenticate the
+ * remote Git is about to write, and the pool repo's `origin` is the value
+ * Git will use. The provider re-reads the same value and refuses when it
+ * does not match the credential, so the two reads fence each other.
+ */
+function inspectGitOrigin(workspacePath: string, signal?: AbortSignal): Promise<string> {
+	return runGitOutput(['remote', 'get-url', 'origin'], workspacePath, signal);
+}
+
+/**
+ * Strip a scoped push credential — raw and in its base64 basic-auth
+ * form — from text that is about to become a job result.
+ *
+ * The node's own `logger.redact` only covers LOG lines; what a node
+ * REPORTS is scrubbed by `model-cli`'s redactor, which never sees a git
+ * error. So this is the seam that keeps a write credential out of
+ * `fleet_jobs.result` on the one path that could carry it.
+ */
+function redactToken(text: string, credential?: ScopedPushCredential): string {
+	if (!credential?.token) return text;
+	let out = text.split(credential.token).join('[redacted]');
+	out = out
+		.split(Buffer.from(`${credential.username}:${credential.token}`, 'utf8').toString('base64'))
+		.join('[redacted]');
+	return out;
 }
 
 function runGitOutput(args: string[], workspacePath: string, signal?: AbortSignal): Promise<string> {

--- a/apps/node/src/core/workspaces/push-credential.spec.ts
+++ b/apps/node/src/core/workspaces/push-credential.spec.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FLEET_PUSH_CREDENTIAL_REVOKE_URL, type FleetJobPushCredentialResponse } from '@ever-works/contracts';
+import { PushCredentialError, PushCredentialSession, type PushCredentialFetch } from './push-credential';
+
+/**
+ * The node half of scoped push credentials (self-build slice AM, EW-810).
+ *
+ * What these cases are for, in order of what a review will look for:
+ * the token never leaves memory, every REFUSAL fails closed, and the
+ * credential is gone — at GitHub, not merely dropped — on every exit path
+ * the process can still execute.
+ */
+
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const JOB_ID = '33333333-3333-4333-8333-333333333333';
+const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+const RUN_ID = '44444444-4444-4444-8444-444444444444';
+const TOKEN = 'ghs_0123456789abcdefghijklmnopqrstuvwxyz';
+const REMOTE = 'https://github.com/ever-works/ever-works.git';
+
+const response = (overrides: Partial<FleetJobPushCredentialResponse> = {}): FleetJobPushCredentialResponse => ({
+	attribution: {
+		nodeId: NODE_ID,
+		nodeName: 'studio-win',
+		agentId: AGENT_ID,
+		agentName: 'Refactor Bot',
+		agentEmail: 'refactor-bot@agents.ever.works',
+		jobId: JOB_ID,
+		runId: RUN_ID
+	},
+	push: {
+		token: TOKEN,
+		username: 'x-access-token',
+		expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+		repositories: ['ever-works/ever-works']
+	},
+	...overrides
+});
+
+const sessionWith = (
+	answer: FleetJobPushCredentialResponse | (() => Promise<FleetJobPushCredentialResponse>),
+	fetchFn?: PushCredentialFetch
+) => {
+	const mint = vi.fn(typeof answer === 'function' ? answer : async () => answer);
+	const session = new PushCredentialSession({
+		jobId: JOB_ID,
+		client: { mintPushCredential: mint },
+		...(fetchFn ? { fetchFn } : {})
+	});
+	return { session, mint };
+};
+
+describe('PushCredentialSession — minting', () => {
+	it('mints ONCE for a job, however many repositories it publishes', async () => {
+		// A multi-repo run publishes its mounts and its primary branch
+		// seconds apart under the same claim, and the platform already
+		// scopes one token to every repository the job writes. A second
+		// mint would only widen the number of live write credentials.
+		const { session, mint } = sessionWith(response());
+
+		await session.attribute('feat: x');
+		await session.credentialFor(REMOTE);
+		await session.credentialFor(REMOTE);
+
+		expect(mint).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not re-mint concurrently either', async () => {
+		let resolveMint: (value: FleetJobPushCredentialResponse) => void = () => undefined;
+		const { session, mint } = sessionWith(
+			() => new Promise<FleetJobPushCredentialResponse>((resolve) => (resolveMint = resolve))
+		);
+
+		const first = session.credentialFor(REMOTE);
+		const second = session.credentialFor(REMOTE);
+		resolveMint(response());
+		await Promise.all([first, second]);
+
+		expect(mint).toHaveBeenCalledTimes(1);
+	});
+
+	it('carries the platform attribution into the commit message and identity', async () => {
+		const { session } = sessionWith(response());
+
+		const attributed = await session.attribute('feat(task): do a thing');
+
+		expect(attributed.commitMessage).toBe(
+			[
+				'feat(task): do a thing',
+				'',
+				`Ever-Works-Node: studio-win (${NODE_ID})`,
+				`Ever-Works-Agent: Refactor Bot (${AGENT_ID})`,
+				`Ever-Works-Job: ${JOB_ID}`,
+				`Ever-Works-Run: ${RUN_ID}`
+			].join('\n')
+		);
+		// Author is the Agent, committer is the machine — the whole answer
+		// to "which agent and which node produced this change".
+		expect(attributed.identity).toEqual({
+			authorName: 'Refactor Bot',
+			authorEmail: 'refactor-bot@agents.ever.works',
+			committerName: 'Ever Works node studio-win',
+			committerEmail: `node-${NODE_ID}@nodes.ever.works`
+		});
+	});
+});
+
+describe('PushCredentialSession — refusals (all fail closed)', () => {
+	it('refuses a commit message that already claims a machine', async () => {
+		// `git.commitMessage` is payload text derived from a Task title,
+		// and the node's own validation permits newlines. Appending our
+		// trailers after a forged block would leave a reader unable to tell
+		// which the platform wrote.
+		const { session } = sessionWith(response());
+
+		await expect(session.attribute('feat: x\n\nEver-Works-Node: someone-elses-laptop (deadbeef)')).rejects.toThrow(
+			PushCredentialError
+		);
+	});
+
+	it('refuses when the platform issued no credential for a run that wants to push', async () => {
+		const { session } = sessionWith(response({ push: null }));
+
+		await expect(session.credentialFor(REMOTE)).rejects.toThrow(/no push credential/);
+	});
+
+	it('refuses a remote the credential was not scoped to', async () => {
+		// The token covers `ever-works/ever-works`. A checkout pointed at
+		// anything else must not be offered it — this is the difference
+		// between a scope and a decoration.
+		const { session } = sessionWith(response());
+
+		await expect(session.credentialFor('https://github.com/someone-else/private.git')).rejects.toThrow(
+			/does not cover someone-else\/private/
+		);
+	});
+
+	it.each([
+		['git@github.com:ever-works/ever-works.git'],
+		['ssh://git@github.com/ever-works/ever-works.git'],
+		['http://github.com/ever-works/ever-works.git'],
+		['file:///tmp/ever-works.git'],
+		['not a url']
+	])('refuses the non-https remote %s', async (remote) => {
+		const { session } = sessionWith(response());
+
+		await expect(session.credentialFor(remote)).rejects.toThrow(/not an https GitHub repository URL/);
+	});
+
+	// REGRESSION — the scope check never looked at the HOST (slice AM
+	// review, F1/F4).
+	//
+	// `fleetPushRemoteRepositoryId` validated the scheme, the userinfo, the
+	// query and the path-segment count and never read `url.host`, so every
+	// URL below answered `ever-works/ever-works` — the exact value the
+	// legitimate remote answers — and sailed through
+	// `push.repositories.includes(repositoryId)` right here. The plugin then
+	// keyed `http.<that URL>.extraheader` to the installation token, and Git
+	// sends an extraheader on its FIRST request to a host, unprompted and
+	// before any challenge, so a `404` from an attacker-chosen host was
+	// still enough to disclose a live `contents: write` credential for the
+	// owner's repositories.
+	//
+	// Reachable two ways: a model with acceptEdits writing
+	// `url.<evil>.insteadOf` into the pool config (which `git remote get-url
+	// origin` DOES apply, so this method sees the rewritten URL), and with
+	// no attacker at all — a non-GitHub repo connection whose `owner/repo`
+	// happens to match an installation row.
+	it.each([
+		['https://evil.tld/ever-works/ever-works.git'],
+		['https://github.com.evil.tld/ever-works/ever-works'],
+		['https://api.github.com/ever-works/ever-works'],
+		['https://github.com:8443/ever-works/ever-works'],
+		['https://gitlab.com/ever-works/ever-works.git']
+	])('refuses %s even though its owner/repo matches the scope', async (remote) => {
+		const { session } = sessionWith(response());
+
+		await expect(session.credentialFor(remote)).rejects.toThrow(/not an https GitHub repository URL/);
+	});
+
+	it('still serves the real remote, however it is cased', async () => {
+		// The host pin must not cost the legitimate path: `URL` lower-cases
+		// the host and drops a default `:443`.
+		const { session } = sessionWith(response());
+
+		await expect(session.credentialFor('https://GitHub.com/Ever-Works/ever-works.git')).resolves.toMatchObject({
+			token: TOKEN
+		});
+	});
+
+	it('never echoes a credential that was already embedded in the remote it refuses', async () => {
+		// This text becomes the run's failure reason and reaches
+		// `fleet_jobs.result` and the Task page.
+		const { session } = sessionWith(response());
+
+		await expect(
+			session.credentialFor('https://x-access-token:ghp_leaked_secret_value@github.com/ever-works/ever-works')
+		).rejects.toThrow(
+			expect.objectContaining({
+				message: expect.not.stringContaining('ghp_leaked_secret_value')
+			}) as Error
+		);
+	});
+
+	it('turns a mint failure into a refusal that says nothing was published', async () => {
+		const { session } = sessionWith(async () => {
+			throw new Error('The platform could not issue a scoped push credential for this run');
+		});
+
+		await expect(session.credentialFor(REMOTE)).rejects.toThrow(/nothing was published/);
+	});
+
+	it('refuses after the session has been released', async () => {
+		const { session } = sessionWith(response());
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+
+		await expect(session.credentialFor(REMOTE)).rejects.toThrow(/already been released/);
+	});
+});
+
+describe('PushCredentialSession — the credential is gone on every exit path', () => {
+	it('revokes at GitHub with the token itself and drops it from memory', async () => {
+		const calls: Array<{ url: string; init: { method: string; headers: Record<string, string> } }> = [];
+		const fetchFn: PushCredentialFetch = async (url, init) => {
+			calls.push({ url, init });
+			return { ok: true, status: 204 };
+		};
+		const { session } = sessionWith(response(), fetchFn);
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.url).toBe(FLEET_PUSH_CREDENTIAL_REVOKE_URL);
+		expect(calls[0]!.init.method).toBe('DELETE');
+		expect(calls[0]!.init.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it('clears the token BEFORE awaiting the revoke, so a hung revoke leaves no live reference', async () => {
+		let released = false;
+		const fetchFn: PushCredentialFetch = async () => {
+			// While this is in flight, the session must already have
+			// forgotten the token — a revoke that never returns must not
+			// keep a write credential reachable for the rest of the run.
+			await expect(session.credentialFor(REMOTE)).rejects.toThrow(/already been released/);
+			released = true;
+			return { ok: true, status: 204 };
+		};
+		const { session } = sessionWith(response(), fetchFn);
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+
+		expect(released).toBe(true);
+	});
+
+	it('is idempotent and never revokes twice', async () => {
+		const fetchFn = vi.fn(async () => ({ ok: true, status: 204 }));
+		const { session } = sessionWith(response(), fetchFn);
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+		await session.dispose();
+
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('swallows a failed revoke — the token still expires on GitHub’s clock', async () => {
+		const fetchFn: PushCredentialFetch = async () => {
+			throw new Error('network down');
+		};
+		const { session } = sessionWith(response(), fetchFn);
+		await session.credentialFor(REMOTE);
+
+		await expect(session.dispose()).resolves.toBeUndefined();
+	});
+
+	it('revokes nothing when no credential was ever minted', async () => {
+		const fetchFn = vi.fn(async () => ({ ok: true, status: 204 }));
+		const { session } = sessionWith(response({ push: null }), fetchFn);
+		await session.attribute('feat: commit-only run');
+
+		await session.dispose();
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	// REGRESSION — the revoke could hang for as long as the HTTP client's
+	// own default (slice AM review, F7).
+	//
+	// `dispose()` is awaited in the agent-task handler's terminal `finally`,
+	// so an unbounded revoke holds job settlement behind a stalled
+	// connection to api.github.com on EVERY run — even though the revoke is
+	// documented as best-effort.
+	it('bounds the revoke with a timeout signal', async () => {
+		const seen: { signal?: AbortSignal }[] = [];
+		const fetchFn: PushCredentialFetch = async (_url, init) => {
+			seen.push(init);
+			return { ok: true, status: 204 };
+		};
+		const { session } = sessionWith(response(), fetchFn);
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0].signal).toBeInstanceOf(AbortSignal);
+		expect(seen[0].signal?.aborted).toBe(false);
+	});
+
+	// REGRESSION — disposal racing an in-flight mint (slice AM review, F11).
+	//
+	// `dispose()` used to read the token from `this.response` (still null
+	// while the mint was in flight), see nothing to revoke, and set
+	// `disposed = true`. The mint's `.then` then assigned `this.response`,
+	// so a DISPOSED session held a live `contents: write` installation token
+	// for the owner's repositories which `dispose()` — idempotent by design —
+	// could never revoke, and which stayed valid until GitHub's ~1h expiry.
+	// That is exactly the "lifetime that outlives the run" this module's
+	// header rules out.
+	it('revokes a mint that lands AFTER disposal instead of storing it', async () => {
+		let settleMint: (value: FleetJobPushCredentialResponse) => void = () => undefined;
+		const revoked: string[] = [];
+		const fetchFn: PushCredentialFetch = async (_url, init) => {
+			revoked.push(String(init.headers.Authorization));
+			return { ok: true, status: 204 };
+		};
+		const { session } = sessionWith(
+			() =>
+				new Promise<FleetJobPushCredentialResponse>((resolve) => {
+					settleMint = resolve;
+				}),
+			fetchFn
+		);
+
+		// Start the mint, then dispose while it is still in flight.
+		const pending = session.credentialFor(REMOTE);
+		await session.dispose();
+		expect(revoked).toEqual([]);
+
+		settleMint(response());
+		// The caller gets the same refusal a disposed session gives everyone
+		// else — never a credential the session cannot revoke.
+		await expect(pending).rejects.toThrow(PushCredentialError);
+		await expect(pending).rejects.toThrow(/already been released/);
+
+		// And the token that did get minted is dead at GitHub rather than
+		// orphaned for an hour.
+		expect(revoked).toEqual([`Bearer ${TOKEN}`]);
+	});
+});
+
+/**
+ * REGRESSION — the redactor outlived the credential (slice AM review, F3).
+ *
+ * `job-client` calls `logger.protect(push.token)` on every mint, and the
+ * node's `protectedValues` set had an `add` path only: no `unprotect`, no
+ * eviction, no per-job scoping. So after `dispose()` had nulled
+ * `this.response` and DELETEd the token at GitHub, the raw `ghs_…` string
+ * was still reachable from the logger closure held by the one
+ * `FleetJobClient` a node process constructs. Forty agent-tasks across a
+ * multi-day uptime meant forty raw write credentials in heap — recoverable
+ * from a crash dump or a heap snapshot, and the recent ones still live.
+ */
+describe('PushCredentialSession — the redactor does not outlive the token', () => {
+	it('unprotects the token once the revoke has run', async () => {
+		const protectedValues: string[] = [];
+		const logger = {
+			info: () => undefined,
+			warn: () => undefined,
+			error: () => undefined,
+			protect: (value?: string | null) => {
+				if (typeof value === 'string') protectedValues.push(value);
+			},
+			unprotect: (value?: string | null) => {
+				const index = protectedValues.indexOf(String(value));
+				if (index >= 0) protectedValues.splice(index, 1);
+			},
+			redact: (text: string) => text
+		};
+		// The client protects on mint; this session is what knows when the
+		// value stops existing.
+		logger.protect(TOKEN);
+
+		const session = new PushCredentialSession({
+			jobId: JOB_ID,
+			client: { mintPushCredential: async () => response() },
+			logger,
+			fetchFn: async () => ({ ok: true, status: 204 })
+		});
+		await session.credentialFor(REMOTE);
+		expect(protectedValues).toEqual([TOKEN]);
+
+		await session.dispose();
+
+		expect(protectedValues).toEqual([]);
+	});
+
+	it('unprotects even when the revoke itself fails', async () => {
+		// A network failure narrows nothing at GitHub, but it must not
+		// leave the value pinned in this process either.
+		const protectedValues = new Set<string>([TOKEN]);
+		const session = new PushCredentialSession({
+			jobId: JOB_ID,
+			client: { mintPushCredential: async () => response() },
+			logger: {
+				info: () => undefined,
+				warn: () => undefined,
+				error: () => undefined,
+				protect: (value?: string | null) => {
+					if (typeof value === 'string') protectedValues.add(value);
+				},
+				unprotect: (value?: string | null) => {
+					protectedValues.delete(String(value));
+				},
+				redact: (text: string) => text
+			},
+			fetchFn: async () => {
+				throw new Error('network down');
+			}
+		});
+		await session.credentialFor(REMOTE);
+
+		await session.dispose();
+
+		expect([...protectedValues]).toEqual([]);
+	});
+});

--- a/apps/node/src/core/workspaces/push-credential.ts
+++ b/apps/node/src/core/workspaces/push-credential.ts
@@ -1,0 +1,337 @@
+import {
+	FLEET_PUSH_CREDENTIAL_REVOKE_URL,
+	FLEET_PUSH_CREDENTIAL_USERNAME,
+	composeFleetPushCommitMessage,
+	fleetPushCommitIdentity,
+	fleetPushRemoteRepositoryId,
+	type FleetJobPushCredentialResponse,
+	type FleetPushAttribution,
+	type FleetPushCommitIdentity
+} from '@ever-works/contracts';
+import type { Logger } from '../logger';
+
+/**
+ * The node half of scoped push credentials (self-build slice AM, EW-810).
+ *
+ * ## Where the credential lives, at every instant
+ *
+ * platform response → ONE private field on the session below →
+ * `logger.protect()` → the `pushCredential` object handed to a single
+ * `finalize` call → the environment of one `git push` child → gone.
+ *
+ * It is never on the payload (slice Y: a value that reaches the payload
+ * reaches the job row, the lease response, the job view and
+ * `fleet_jobs.result`), never on disk, never in argv, never in the
+ * model's environment, and never in a log line.
+ *
+ * ## Why it is acquired at FINALIZE and not at provision
+ *
+ * The model runs with `acceptEdits` over the whole checkout for twenty
+ * minutes; the finalize is seconds long and happens after the model has
+ * exited. Minting late means the credential does not exist at any moment
+ * an untrusted process is running, which is a stronger guarantee than
+ * any cleanup could give — slice Y had to DELETE its `.env` files before
+ * the first Git command precisely because they existed while the model
+ * did.
+ *
+ * ## Why there is no fallback
+ *
+ * A mint that fails throws. The node does not push. The alternative —
+ * falling back to whatever the machine's own Git credential helper
+ * answers — is the long-lived, unscoped, unrevocable machine PAT this
+ * whole slice exists to stop using, so "degrade gracefully" here would
+ * mean "change nothing".
+ */
+export interface PushCredentialClient {
+	mintPushCredential(jobId: string, leaseGeneration?: number): Promise<FleetJobPushCredentialResponse>;
+}
+
+/** The scoped write credential, as one finalize consumes it. */
+export interface ScopedPushCredential {
+	readonly username: string;
+	readonly token: string;
+	readonly remoteUrl: string;
+}
+
+/** Who this run's commits are by, and the message they carry. */
+export interface PushAttribution {
+	readonly attribution: FleetPushAttribution;
+	readonly identity: FleetPushCommitIdentity;
+	/** The payload's message with the reserved trailer block appended. */
+	readonly commitMessage: string;
+}
+
+/**
+ * What {@link FleetTaskWorkspaceProvisioner} depends on, so the
+ * provisioner needs no knowledge of the job channel and a test can drive
+ * every refusal without a network.
+ */
+export interface PushCredentialProvider {
+	attribute(commitMessage: string): Promise<PushAttribution>;
+	/** Throws {@link PushCredentialError} when this remote may not be written. */
+	credentialFor(remoteUrl: string): Promise<ScopedPushCredential>;
+}
+
+/** Injected so the revoke is testable without a network. */
+export type PushCredentialFetch = (
+	input: string,
+	init: { method: string; headers: Record<string, string>; signal?: AbortSignal }
+) => Promise<{ ok: boolean; status: number }>;
+
+/**
+ * How long {@link PushCredentialSession.dispose} will wait for GitHub.
+ *
+ * `dispose()` is awaited in the agent-task handler's terminal `finally`,
+ * so a stalled connection to `api.github.com` holds job settlement for
+ * however long the HTTP client's own default is — undici's headers
+ * timeout, on EVERY run. The revoke is best-effort by contract (the token
+ * expires on GitHub's clock within the hour and covers only this job's
+ * repositories), so waiting longer than this buys nothing and costs the
+ * queue.
+ */
+export const PUSH_CREDENTIAL_REVOKE_TIMEOUT_MS = 5_000;
+
+export interface PushCredentialSessionOptions {
+	jobId: string;
+	client: PushCredentialClient;
+	logger?: Logger;
+	/** The claim generation this run holds; refused server-side when stale. */
+	leaseGeneration?: number;
+	fetchFn?: PushCredentialFetch;
+}
+
+/**
+ * Raised when this run may not push. Its message is what the operator
+ * reads on the Task, so it always says WHY and never says "retry".
+ */
+export class PushCredentialError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'PushCredentialError';
+	}
+}
+
+/**
+ * One job's push credential, minted at most once and dropped for good at
+ * {@link PushCredentialSession.dispose}.
+ *
+ * Minted once rather than per repository because a multi-repo run pushes
+ * the mounts and the primary under the SAME claim, seconds apart, and a
+ * second mint would only widen the number of live write tokens for no
+ * additional narrowing — the platform scopes one token to every
+ * repository the job writes.
+ */
+export class PushCredentialSession implements PushCredentialProvider {
+	private response: FleetJobPushCredentialResponse | null = null;
+	private inFlight: Promise<FleetJobPushCredentialResponse> | null = null;
+	private disposed = false;
+
+	constructor(private readonly options: PushCredentialSessionOptions) {}
+
+	/**
+	 * Who this run's commits are by, and the message they carry.
+	 *
+	 * REFUSES a payload message that already carries a reserved
+	 * `Ever-Works-` trailer: see `composeFleetPushCommitMessage`. The
+	 * commit message is derived from a Task title, so it is the one place
+	 * user-authored text could otherwise claim a machine the run never
+	 * used.
+	 */
+	async attribute(payloadMessage: string): Promise<PushAttribution> {
+		const response = await this.load();
+		const attribution = response.attribution;
+		let commitMessage: string;
+		try {
+			commitMessage = composeFleetPushCommitMessage({ message: payloadMessage, attribution });
+		} catch (error) {
+			throw new PushCredentialError(`this run's commit message could not be attributed: ${describeError(error)}`);
+		}
+		return { attribution, identity: fleetPushCommitIdentity(attribution), commitMessage };
+	}
+
+	/**
+	 * The scoped credential for ONE remote.
+	 *
+	 * Throws — never returns null — because every caller of this is about
+	 * to write to someone's repository, and "no credential" must not be a
+	 * value a caller can accidentally treat as "push anyway".
+	 */
+	async credentialFor(remoteUrl: string): Promise<ScopedPushCredential> {
+		if (this.disposed) {
+			throw new PushCredentialError('the push credential for this run has already been released');
+		}
+		const response = await this.load();
+		const push = response.push;
+		if (!push?.token) {
+			// The platform re-read its own plan and decided this job does
+			// not push, while the caller believes it does. A disagreement
+			// about whether a write is authorised is refused, never
+			// resolved in favour of writing.
+			throw new PushCredentialError(
+				'the platform issued no push credential for this run (its plan does not authorise a push)'
+			);
+		}
+		// The remote this checkout actually points at must be one the
+		// platform scoped the token to. `origin` is read from the worktree
+		// by the caller and the allowed set comes from platform state, so
+		// this is the one place the two are compared.
+		const repositoryId = fleetPushRemoteRepositoryId(remoteUrl);
+		if (!repositoryId) {
+			throw new PushCredentialError(
+				`this run's remote (${describeRemote(remoteUrl)}) is not an https GitHub repository URL, so a scoped push credential cannot authenticate it`
+			);
+		}
+		if (!push.repositories.includes(repositoryId)) {
+			throw new PushCredentialError(
+				`the scoped push credential for this run does not cover ${repositoryId}; it covers ${
+					push.repositories.join(', ') || 'nothing'
+				}`
+			);
+		}
+		return {
+			username: push.username || FLEET_PUSH_CREDENTIAL_USERNAME,
+			token: push.token,
+			remoteUrl
+		};
+	}
+
+	/**
+	 * Drop the credential and tell GitHub to stop honouring it.
+	 *
+	 * Idempotent, best-effort, and — importantly — the token is cleared
+	 * from memory BEFORE the `await`, so a revoke that hangs cannot leave
+	 * a live reference behind for the rest of the process's life. A revoke
+	 * that fails narrows nothing: the token still expires on GitHub's own
+	 * clock, within the hour, and covers only this job's repositories.
+	 *
+	 * "Cleared from memory" now means what it says. Two leaks made it a
+	 * claim rather than a fact:
+	 *
+	 *  - the REDACTOR outlived the session. `job-client` protects the raw
+	 *    token on every mint and the node's `protectedValues` set had no
+	 *    eviction path, so each run left a live `ghs_…` string reachable
+	 *    from a process-lifetime closure. {@link Logger.unprotect} closes
+	 *    that, and this is the only place that knows when the value stops
+	 *    existing.
+	 *  - a mint still IN FLIGHT when disposal ran re-populated
+	 *    `this.response` afterwards (see {@link load}), leaving a disposed
+	 *    session holding a live `contents: write` token that `dispose()`
+	 *    is idempotence-guarded against ever revoking.
+	 *
+	 * The revoke is also bounded now: it is awaited in the agent-task
+	 * handler's terminal `finally`, so an unbounded one holds settlement of
+	 * every run behind whatever the HTTP client's default timeout happens
+	 * to be.
+	 */
+	async dispose(): Promise<void> {
+		if (this.disposed) return;
+		this.disposed = true;
+		const token = this.response?.push?.token ?? null;
+		this.response = null;
+		this.inFlight = null;
+		await this.revoke(token);
+	}
+
+	/**
+	 * DELETE the token at GitHub and forget it locally.
+	 *
+	 * Split out of {@link dispose} because {@link load} needs it too: a
+	 * mint that lands after disposal has produced a live credential nobody
+	 * asked for, and the session it would have belonged to is already gone.
+	 */
+	private async revoke(token: string | null): Promise<void> {
+		if (!token) return;
+		const fetchFn = this.options.fetchFn ?? defaultFetch();
+		const timeout = revokeTimeoutSignal();
+		try {
+			if (!fetchFn) return;
+			await fetchFn(FLEET_PUSH_CREDENTIAL_REVOKE_URL, {
+				method: 'DELETE',
+				headers: {
+					Accept: 'application/vnd.github+json',
+					Authorization: `Bearer ${token}`,
+					'User-Agent': 'ever-works-node',
+					'X-GitHub-Api-Version': '2022-11-28'
+				},
+				...(timeout ? { signal: timeout } : {})
+			});
+		} catch {
+			// Best-effort by contract. Never fails a run: the work is
+			// already pushed (or already failed) by the time this runs.
+		} finally {
+			// AFTER the request, because the revoke is the last thing that
+			// legitimately holds this value and a failure in it is logged
+			// through the same redactor. From here the token exists in no
+			// node data structure at all.
+			this.options.logger?.unprotect(token);
+		}
+	}
+
+	private load(): Promise<FleetJobPushCredentialResponse> {
+		if (this.response) return Promise.resolve(this.response);
+		if (this.inFlight) return this.inFlight;
+		this.inFlight = this.options.client
+			.mintPushCredential(this.options.jobId, this.options.leaseGeneration)
+			.then((response) => {
+				// The client already registered the token with the redactor;
+				// re-registering here would be free but would also mean this
+				// module had a reason to touch the raw value, which it does
+				// not beyond handing it to one `git push`.
+				//
+				// A mint that lands AFTER disposal is not this session's to
+				// keep. Storing it would leave a disposed session holding a
+				// live `contents: write` token for the owner's repositories
+				// that `dispose()` — idempotent by design — can never revoke,
+				// so it would survive to GitHub's ~1h expiry. Revoke it here
+				// instead and answer the caller with the refusal the disposed
+				// session already gives everyone else.
+				if (this.disposed) {
+					void this.revoke(response?.push?.token ?? null);
+					throw new PushCredentialError('the push credential for this run has already been released');
+				}
+				this.response = response;
+				return response;
+			})
+			.catch((error: unknown) => {
+				this.inFlight = null;
+				if (error instanceof PushCredentialError) throw error;
+				throw new PushCredentialError(
+					`this run could not obtain a scoped push credential, so nothing was published: ${
+						this.options.logger?.redact(describeError(error)) ?? describeError(error)
+					}`
+				);
+			});
+		return this.inFlight;
+	}
+}
+
+/** `AbortSignal.timeout` where the runtime has it; undefined otherwise. */
+function revokeTimeoutSignal(): AbortSignal | undefined {
+	if (typeof AbortSignal === 'undefined' || typeof AbortSignal.timeout !== 'function') return undefined;
+	return AbortSignal.timeout(PUSH_CREDENTIAL_REVOKE_TIMEOUT_MS);
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A remote URL rendered for an operator-facing message: host and path
+ * only, never userinfo. The fleet's clone URLs are token-free by
+ * contract, but this text reaches `fleet_jobs.result` and the Task page,
+ * and a URL that arrived carrying a credential must not be echoed there.
+ */
+function describeRemote(remoteUrl: string): string {
+	try {
+		const url = new URL(remoteUrl);
+		return `${url.protocol}//${url.host}${url.pathname}`;
+	} catch {
+		return 'an unparseable URL';
+	}
+}
+
+function defaultFetch(): PushCredentialFetch | null {
+	const globalFetch = (globalThis as { fetch?: unknown }).fetch;
+	if (typeof globalFetch !== 'function') return null;
+	return globalFetch.bind(globalThis) as PushCredentialFetch;
+}

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -326,9 +326,11 @@ Useful flags: `-i, --heartbeat-interval <seconds>` (cadence, default 60s), `-c, 
 
 ### The tags a node reports
 
-Tags are detected at enroll and **re-detected on every heartbeat**, so installing Docker or Git on a running node shows up in Fleet without a restart: `os:<platform>`, `arch:<arch>`, `node:<major>`, `terminal`, `workspace`, plus `docker`, `git`, `display`, `browser`, `gpu` and `gpu:<vendor>` when present. They are normalized with the same rules the server applies, so what the node reports is exactly what Fleet stores.
+Tags are detected at enroll and **re-detected on every heartbeat**, so installing Docker or Git on a running node shows up in Fleet without a restart: `os:<platform>`, `arch:<arch>`, `node:<major>`, `terminal`, `workspace`, plus `docker`, `git`, `git-push`, `display`, `browser`, `gpu` and `gpu:<vendor>` when present. They are normalized with the same rules the server applies, so what the node reports is exactly what Fleet stores.
 
 Two rules govern what may appear. **A tag is a promise the node can keep** — `browser` is emitted only when a browser executable was actually resolved, the same path `browser-check` will spawn. And **detection never fails the beat** — a missing tool is a missing tag, not a missing heartbeat. `EVER_WORKS_NODE_BROWSER` pins the executable explicitly; a pinned path that does not exist disables the tag rather than falling through to some other browser.
+
+`git-push` is the one tag you cannot turn off. It means "this machine's Git can install the platform's per-run push credential" (Git 2.31 or newer), and **every** agent run requires it — a node without it would have to push with the machine's own credential helper, which is exactly the work it must not be handed. It is detected like any other tag, so a machine with no Git, or with a Git too old, simply does not offer it; it is only the operator opt-in that cannot remove it.
 
 You can also hand-edit a node's tags under **Settings → Fleet → Capability tags**. Editing them hands you ownership: the set is marked **Pinned** and the node's heartbeats stop overwriting it.
 
@@ -711,6 +713,102 @@ the token's own scope wins and a mismatch is refused.
 The run's result records whether the bridge was up and how many tool calls went through it. If the
 bridge cannot start for any reason, the run proceeds exactly as a run without it and says so — a
 tool channel that fails never fails a Task.
+
+### How a fleet node pushes (scoped push credentials)
+
+A fleet node used to push **token-free**: `git push` ran against the plain remote and the machine's
+own Git credential helper answered. In practice that is a long-lived personal access token in the OS
+credential store with write access to **every repository that OS user can reach**. The platform
+could not scope it to one run, rotate it, revoke it when a laptop went missing, or even see that it
+had been used — and every unattended machine in the fleet held one.
+
+Now the node asks the platform for a credential, right before it commits, and pushes with that.
+
+**What the credential is.** A GitHub App **installation access token**, minted for that one job,
+narrowed to exactly the repositories the job writes (the Task's repository plus its writable mounts)
+and to the `contents: write` permission alone. GitHub expires installation tokens within the hour,
+and the node revokes it at GitHub the moment the run ends.
+
+**What it can and cannot do.** It can push branches to the repositories this run was planned for.
+It cannot touch any other repository the App is installed on, cannot open a pull request, cannot
+read a secret or an Action, cannot be used after the run, and cannot be used by a node that is not
+the recorded holder of the job's lease. It is never on the job payload, never on the job row, never
+in the run's result, never in a log line, never in a config file, never in a `git` command line and
+never in the model's environment: it exists in the node's memory for the length of one
+commit-and-push, reaches `git` through the environment of that single child process, and dies with
+it.
+
+**It only ever goes to `github.com`.** An installation token is a GitHub credential and means
+nothing anywhere else, and Git puts an `Authorization` header on its **first** request to a host —
+unprompted, before any challenge — so a remote merely _pointing_ somewhere else would be enough to
+hand that host a live write credential. Both ends therefore check the host, not just the
+`owner/repo` path: the platform refuses to scope a credential to a workspace whose clone URL is not
+an `https://github.com/owner/repo`, and the node re-derives the repository from the checkout's own
+`origin` and refuses to offer the credential if the host, the port or the scheme is anything else.
+A Task on a repository connection pointing at another forge is refused rather than pushed to with a
+GitHub token.
+
+**Nothing else on the machine can answer for the push, and nothing else can watch it.** The
+credentialed `git push` resets the credential-helper list _and_ the askpass hooks (`core.askpass`,
+`GIT_ASKPASS`, `SSH_ASKPASS`) and drops `GIT_CONFIG_PARAMETERS`, so a rejected credential **fails**
+instead of silently falling through to the machine's own long-lived one. It also runs **no Git
+hooks**: a `pre-push` hook is a child of the push and would inherit the credential, and hooks live
+in the shared pool directory rather than in the checkout, so one planted there would survive the run
+and harvest every later Task's token on that repository. The publish is refused outright if the
+repository's own config has grown a credential setting or a `url.*.insteadOf` / `pushInsteadOf`
+rewrite while the run was underway.
+
+**There is no fallback.** If the platform cannot mint — no GitHub App configured, no installation
+covering every repository the run writes to, GitHub refusing — the run **fails, and says why**. It
+does not quietly fall back to the machine's own credential helper; that fallback is the gap this
+replaces. The refusal is caught as early as it can be: when a run is planned, the platform checks
+whether it could mint at all, so a Task whose repository no installation covers is refused before it
+costs a machine twenty minutes of model time.
+
+**What an operator must configure.**
+
+1. `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` on the platform — the same GitHub App the rest of
+   the product uses. Without them, fleet runs that push are refused.
+2. The App installed on every repository your fleet Tasks write to, with **Contents: read & write**,
+   and installed by the same account that owns the Tasks — the platform will not mint against
+   somebody else's installation.
+3. All repositories of one run under a **single** installation. A run spanning two installations is
+   refused rather than half-served.
+4. Nodes upgraded to a build that advertises `git-push`. An older node stops attracting agent work
+   (see [The tags a node reports](#the-tags-a-node-reports)); depending on the tenant's execution
+   mode the work then falls back to the cloud rather than queueing.
+
+If the App's installation changes — you add a repository, or GitHub suspends the installation — the
+platform re-reads its own installation snapshot on the next run, so re-syncing the installation in
+**Settings → Integrations → GitHub** is what makes a newly added repository pushable.
+
+**The one thing this does not cover.** The _fetch_ still uses the machine's own credential helper.
+A fetch needs read access only and happens before the run's first model byte; scoping it is a
+separate change. And if a node is hard-killed mid-push (power cut, SIGKILL) it cannot run its own
+revoke — the token still expires on GitHub's clock, within the hour, scoped to that job's
+repositories.
+
+### Who a fleet commit is by
+
+Every fleet commit used to be authored `Ever Works Agent <agent@ever.works>`, on every machine, so
+Git history could not answer which machine or which agent produced a change. Now:
+
+- the **author** is the Agent (its committer name and email, or `<slug>@agents.ever.works`);
+- the **committer** is the node (`Ever Works node <node name>`, `node-<id>@nodes.ever.works`);
+- and the commit message carries a trailer block:
+
+```
+Ever-Works-Node: studio-win (0f2c…)
+Ever-Works-Agent: Refactor Bot (7a91…)
+Ever-Works-Job: 3b04…
+Ever-Works-Run: 91cd…
+```
+
+All of it comes from platform rows over the node-authenticated channel, and the node refuses an
+answer that names a machine other than itself. The `Ever-Works-` trailer namespace is **reserved**:
+a commit message that already contains one — a Task title can reach the message — fails the run
+rather than being appended to, because a trailer a reader cannot distinguish from the platform's own
+is worse than no trailer at all. If you see that failure, rename the Task.
 
 ## Related
 

--- a/packages/agent/src/database/repositories/github-app-installation-repository.repository.spec.ts
+++ b/packages/agent/src/database/repositories/github-app-installation-repository.repository.spec.ts
@@ -1,3 +1,6 @@
+import { DataSource } from 'typeorm';
+import { ENTITIES } from '../_entities-inventory';
+import { GitHubAppInstallationRepository as GitHubAppInstallationRepositoryEntity } from '../../entities/github-app-installation-repository.entity';
 import { GitHubAppInstallationRepoRepository } from './github-app-installation-repository.repository';
 
 describe('GitHubAppInstallationRepoRepository', () => {
@@ -71,5 +74,142 @@ describe('GitHubAppInstallationRepoRepository', () => {
         });
         expect(transactionalRepository.save).not.toHaveBeenCalled();
         expect(result).toEqual([]);
+    });
+});
+
+/**
+ * REGRESSION — `findByFullName` could never see a mixed-case repository
+ * (self-build slice AM review, EW-810, F6).
+ *
+ * `fullName` is written verbatim from GitHub's `full_name`, so the column
+ * holds whatever casing a repository declares. The fleet's scoped push
+ * credential lower-cases the repositories it wants (GitHub names ARE
+ * case-insensitive) before asking, so the old exact `where: { fullName }` —
+ * case-SENSITIVE on Postgres — returned zero rows for
+ * `Ever-Works/Directory-Web-Template`. The scope then came back
+ * `push-scope-unresolved` and the planner refused the Task at plan time,
+ * indistinguishably from a repository no installation covers. An entire
+ * class of repositories silently lost fleet execution even though the
+ * installation covered them.
+ *
+ * A real in-memory DataSource rather than the mocked repository the cases
+ * above use: the defect is what the DATABASE does with the comparison, and
+ * an assertion on the emitted SQL string would have passed against the
+ * broken version too.
+ */
+describe('GitHubAppInstallationRepoRepository.findByFullName (real DataSource)', () => {
+    let dataSource: DataSource;
+    let repository: GitHubAppInstallationRepoRepository;
+
+    const INSTALLATION_ID = '11111111-1111-4111-8111-111111111111';
+    const OTHER_INSTALLATION_ID = '22222222-2222-4222-8222-222222222222';
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: ENTITIES,
+            synchronize: true,
+        });
+        await dataSource.initialize();
+
+        const rows = dataSource.getRepository(GitHubAppInstallationRepositoryEntity);
+        repository = new GitHubAppInstallationRepoRepository(rows);
+        await rows.save([
+            rows.create({
+                installationEntityId: INSTALLATION_ID,
+                githubRepoId: '901',
+                owner: 'Ever-Works',
+                repo: 'Directory-Web-Template',
+                // Exactly how GitHub reports it, which is exactly how
+                // `GitHubAppSyncService` stores it.
+                fullName: 'Ever-Works/Directory-Web-Template',
+                isPrivate: true,
+            } as Partial<GitHubAppInstallationRepositoryEntity>),
+            rows.create({
+                installationEntityId: INSTALLATION_ID,
+                githubRepoId: '902',
+                owner: 'ever-works',
+                repo: 'ever-works',
+                fullName: 'ever-works/ever-works',
+                isPrivate: true,
+            } as Partial<GitHubAppInstallationRepositoryEntity>),
+            rows.create({
+                installationEntityId: OTHER_INSTALLATION_ID,
+                githubRepoId: '903',
+                owner: 'someone-else',
+                repo: 'private-repo',
+                fullName: 'someone-else/private-repo',
+                isPrivate: true,
+            } as Partial<GitHubAppInstallationRepositoryEntity>),
+        ]);
+    });
+
+    afterAll(async () => {
+        await dataSource?.destroy();
+    });
+
+    it('finds a mixed-case repository by its lower-cased name', async () => {
+        // The exact query the push-credential scope resolver issues.
+        const found = await repository.findByFullName('ever-works/directory-web-template');
+
+        expect(found.map((row) => row.githubRepoId)).toEqual(['901']);
+        // The row still carries GitHub's own casing — the MATCH is
+        // case-insensitive, the STORED value is untouched, so the caller's
+        // own re-check against its normalized name still means something.
+        expect(found[0].fullName).toBe('Ever-Works/Directory-Web-Template');
+    });
+
+    it('finds it from any casing the caller happens to use', async () => {
+        for (const query of [
+            'Ever-Works/Directory-Web-Template',
+            'EVER-WORKS/DIRECTORY-WEB-TEMPLATE',
+            'eVeR-wOrKs/dIrEcToRy-WeB-tEmPlAtE',
+        ]) {
+            const found = await repository.findByFullName(query);
+            expect(found.map((row) => row.githubRepoId)).toEqual(['901']);
+        }
+    });
+
+    it('still matches an all-lower-case row exactly as before', async () => {
+        const found = await repository.findByFullName('ever-works/ever-works');
+        expect(found.map((row) => row.githubRepoId)).toEqual(['902']);
+    });
+
+    it('does NOT widen the match to a different repository', async () => {
+        // Case-insensitivity is the only thing that loosened. A name that is
+        // not this repository — including one that merely shares the owner or
+        // the repo half — still finds nothing, which is what keeps the scope
+        // resolver's ownership filter meaningful.
+        for (const query of [
+            'ever-works/directory-web-templates',
+            'ever-works/directory-web-templat',
+            'other/directory-web-template',
+            'directory-web-template',
+            '',
+        ]) {
+            await expect(repository.findByFullName(query)).resolves.toEqual([]);
+        }
+    });
+
+    it('returns EVERY installation that holds the repository, not just one', async () => {
+        // The scope resolver refuses a run that two installations both cover
+        // rather than picking by listing order, so it has to be able to see
+        // both.
+        const rows = dataSource.getRepository(GitHubAppInstallationRepositoryEntity);
+        await rows.save(
+            rows.create({
+                installationEntityId: OTHER_INSTALLATION_ID,
+                githubRepoId: '904',
+                owner: 'Ever-Works',
+                repo: 'Directory-Web-Template',
+                fullName: 'ever-works/DIRECTORY-web-template',
+                isPrivate: true,
+            } as Partial<GitHubAppInstallationRepositoryEntity>),
+        );
+
+        const found = await repository.findByFullName('ever-works/directory-web-template');
+
+        expect(found.map((row) => row.githubRepoId).sort()).toEqual(['901', '904']);
     });
 });

--- a/packages/agent/src/database/repositories/github-app-installation-repository.repository.ts
+++ b/packages/agent/src/database/repositories/github-app-installation-repository.repository.ts
@@ -36,13 +36,36 @@ export class GitHubAppInstallationRepoRepository {
         });
     }
 
+    /**
+     * Every installation snapshot row for `owner/repo`, matched
+     * CASE-INSENSITIVELY.
+     *
+     * GitHub repository names are case-insensitive, but `fullName` is
+     * stored verbatim from GitHub's `full_name` (see
+     * `GitHubAppSyncService`), so the column holds whatever casing the
+     * repository declares — `Ever-Works/Directory-Web-Template` as readily
+     * as `ever-works/ever-works`. A plain `where: { fullName }` is an exact
+     * varchar comparison, which is case-SENSITIVE on Postgres.
+     *
+     * That mattered: the fleet's scoped push credential normalizes the
+     * repositories it wants to lower case before asking, so any repository
+     * with an upper-case character in its name resolved to ZERO rows, the
+     * scope came back `push-scope-unresolved`, and the planner refused the
+     * Task at plan time — indistinguishably from a repository no
+     * installation covers — silently removing fleet execution for an
+     * entire class of repositories the installation did in fact cover.
+     *
+     * `LOWER(...)` on both sides rather than a `citext` column or a
+     * functional index: this is a small per-installation table read once
+     * per plan, and changing the column type is a migration every
+     * deployment would have to take for no other benefit.
+     */
     async findByFullName(fullName: string): Promise<GitHubAppInstallationRepositoryEntity[]> {
-        return this.repository.find({
-            where: { fullName },
-            order: {
-                createdAt: 'DESC',
-            },
-        });
+        return this.repository
+            .createQueryBuilder('installationRepository')
+            .where('LOWER(installationRepository.fullName) = LOWER(:fullName)', { fullName })
+            .orderBy('installationRepository.createdAt', 'DESC')
+            .getMany();
     }
 
     async replaceForInstallation(

--- a/packages/agent/src/utils/__tests__/github-app.utils.spec.ts
+++ b/packages/agent/src/utils/__tests__/github-app.utils.spec.ts
@@ -157,6 +157,102 @@ describe('requestGitHubAppInstallationAccessTokenDetails', () => {
             json: jest.fn().mockResolvedValue(body),
         }) as unknown as Response;
 
+    /**
+     * Scoped installation tokens (self-build slice AM, EW-810).
+     *
+     * Every mint in this repository before that slice sent an EMPTY body,
+     * and an empty body means "every repository in the installation, with
+     * every permission the App holds". That is fine for the read-shaped
+     * callers and exactly wrong for a WRITE credential handed to an
+     * unattended fleet machine, so the narrowing is optional, appended
+     * last, and provably absent for every pre-existing caller.
+     */
+    describe('scope narrowing', () => {
+        it('sends NO body at all when no scope is given (every existing caller)', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(makeResponse({ token: 'ghs_xxx' }));
+
+            await requestGitHubAppInstallationAccessTokenDetails('inst-77', credentials);
+
+            const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            expect(init.body).toBeUndefined();
+            expect(init.headers).not.toHaveProperty('Content-Type');
+        });
+
+        it('narrows to repository_ids and permissions when a scope is given', async () => {
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(makeResponse({ token: 'ghs_xxx' }));
+
+            await requestGitHubAppInstallationAccessTokenDetails('inst-77', credentials, {
+                repositoryIds: ['556677', 778899],
+                permissions: { contents: 'write' },
+            });
+
+            const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            expect(JSON.parse(String(init.body))).toEqual({
+                // NUMBERS on the wire: GitHub rejects string ids, and the
+                // platform stores them as varchar.
+                repository_ids: [556677, 778899],
+                permissions: { contents: 'write' },
+            });
+            expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+        });
+
+        it('REFUSES a malformed repository id rather than silently dropping it', async () => {
+            // A silently shortened id list produces a token valid for fewer
+            // repositories than the caller asked for, and the failure then
+            // lands at the push of whichever one fell off the end.
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(makeResponse({ token: 'ghs_xxx' }));
+
+            await expect(
+                requestGitHubAppInstallationAccessTokenDetails('inst-77', credentials, {
+                    repositoryIds: ['not-a-number'],
+                }),
+            ).rejects.toThrow(/Invalid GitHub repository id/);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        // `1e30` and `556677abc` are the reason this validator does not use
+        // `parseInt`: both parse to a DIFFERENT repository than the caller
+        // named, which is a token scoped to the wrong thing.
+        it.each([[['0']], [['-4']], [['1e30']], [['556677abc']], [[' ']], [['']]])(
+            'refuses the id %s',
+            async (repositoryIds) => {
+                fetchSpy = jest
+                    .spyOn(globalThis, 'fetch')
+                    .mockResolvedValue(makeResponse({ token: 'ghs_xxx' }));
+
+                await expect(
+                    requestGitHubAppInstallationAccessTokenDetails('inst-77', credentials, {
+                        repositoryIds,
+                    }),
+                ).rejects.toThrow(/Invalid GitHub repository id/);
+            },
+        );
+
+        it('treats an EMPTY scope as no scope, so an accidental [] cannot widen the token', async () => {
+            // Reading `{ repository_ids: [] }` as "no narrowing" is
+            // GitHub's behaviour; sending it would be a full-installation
+            // token dressed up as a scoped one. Omitting the key entirely
+            // keeps the two cases textually distinguishable in review.
+            fetchSpy = jest
+                .spyOn(globalThis, 'fetch')
+                .mockResolvedValue(makeResponse({ token: 'ghs_xxx' }));
+
+            await requestGitHubAppInstallationAccessTokenDetails('inst-77', credentials, {
+                repositoryIds: [],
+                permissions: {},
+            });
+
+            const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            expect(init.body).toBeUndefined();
+        });
+    });
+
     it('POSTs to /app/installations/<id>/access_tokens with App-JWT headers', async () => {
         fetchSpy = jest
             .spyOn(globalThis, 'fetch')

--- a/packages/agent/src/utils/github-app.utils.ts
+++ b/packages/agent/src/utils/github-app.utils.ts
@@ -62,9 +62,38 @@ export const createGitHubOAuthHeaders = (accessToken: string) => ({
     'X-GitHub-Api-Version': '2022-11-28',
 });
 
+/**
+ * Narrowing applied to ONE installation token (self-build slice AM).
+ *
+ * Every mint in this repository before that slice sent an EMPTY body, and
+ * an empty body means "every repository in the installation, with every
+ * permission the App holds". That is fine for the read-shaped callers
+ * (analyze, list, clone) and is precisely the wrong shape for a WRITE
+ * credential handed to an unattended machine: a token minted so a node
+ * can push one Task branch could write every repository the owner ever
+ * installed the App on.
+ *
+ * Both fields are OPTIONAL and both are omitted by every pre-existing
+ * caller, so their behaviour is byte-for-byte unchanged.
+ */
+export type GitHubAppInstallationTokenScope = {
+    /**
+     * GitHub's NUMERIC repository ids. They must come from the platform's
+     * own installation snapshot (`github_app_installation_repositories`),
+     * never from a caller-supplied name: the whole point of the narrowing
+     * is that the set is decided by platform state.
+     */
+    repositoryIds?: readonly (string | number)[];
+    /** e.g. `{ contents: 'write' }`. Anything omitted is NOT granted. */
+    permissions?: Readonly<Record<string, string>>;
+};
+
 export const requestGitHubAppInstallationAccessTokenDetails = async (
     installationId: string,
     credentials: GitHubAppCredentials,
+    // Appended LAST and optional: every existing call site keeps its arity
+    // and its (unscoped) behaviour.
+    scope?: GitHubAppInstallationTokenScope,
 ): Promise<GitHubAppInstallationAccessToken> => {
     if (!/^[A-Za-z0-9_-]+$/.test(installationId)) {
         throw new Error(
@@ -72,11 +101,43 @@ export const requestGitHubAppInstallationAccessTokenDetails = async (
         );
     }
     const jwt = createGitHubAppJwt(credentials);
+    const body: Record<string, unknown> = {};
+    if (scope?.repositoryIds && scope.repositoryIds.length > 0) {
+        const repositoryIds = scope.repositoryIds.map((value) => {
+            // DIGITS ONLY, not `parseInt`: `parseInt('556677abc')` and
+            // `parseInt('1e30')` both succeed and both give a DIFFERENT
+            // repository than the caller named, which is a token scoped to
+            // the wrong thing rather than a refusal.
+            const text = String(value).trim();
+            const numeric =
+                typeof value === 'number'
+                    ? value
+                    : /^[0-9]+$/.test(text)
+                      ? Number(text)
+                      : Number.NaN;
+            if (!Number.isSafeInteger(numeric) || numeric <= 0) {
+                // REFUSE rather than drop. A silently shortened id list
+                // produces a token that is valid for fewer repositories
+                // than the caller asked for, and the failure then lands at
+                // the push of whichever one fell off the end.
+                throw new Error('Invalid GitHub repository id in installation token scope');
+            }
+            return numeric;
+        });
+        body.repository_ids = repositoryIds;
+    }
+    if (scope?.permissions && Object.keys(scope.permissions).length > 0) {
+        body.permissions = { ...scope.permissions };
+    }
+    const hasBody = Object.keys(body).length > 0;
     const response = await fetch(
         `https://api.github.com/app/installations/${installationId}/access_tokens`,
         {
             method: 'POST',
-            headers: createGitHubAppHeaders(jwt),
+            headers: hasBody
+                ? { ...createGitHubAppHeaders(jwt), 'Content-Type': 'application/json' }
+                : createGitHubAppHeaders(jwt),
+            ...(hasBody ? { body: JSON.stringify(body) } : {}),
         },
     );
 

--- a/packages/contracts/src/fleet/__tests__/fleet-push-credential.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/fleet-push-credential.spec.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	composeFleetPushCommitMessage,
+	containsReservedFleetPushTrailer,
+	describeFleetPushCredentialRefusal,
+	FLEET_PUSH_CAPABILITY,
+	FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES,
+	FLEET_PUSH_CREDENTIAL_HOST,
+	FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON,
+	FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+	FLEET_PUSH_CREDENTIAL_REASONS,
+	FLEET_PUSH_CREDENTIAL_REVOKE_URL,
+	FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+	FLEET_PUSH_CREDENTIAL_USERNAME,
+	FLEET_PUSH_DEFAULT_AUTHOR_EMAIL,
+	FLEET_PUSH_DEFAULT_AUTHOR_NAME,
+	FLEET_PUSH_TRAILER_KEYS,
+	FLEET_PUSH_TRAILER_NAMESPACE,
+	FleetPushAttributionError,
+	fleetPushCommitIdentity,
+	fleetPushRemoteRepositoryId,
+	isFleetPushTrailerLine,
+	normalizeFleetPushRepositoryId,
+	sanitizeFleetPushIdentityText,
+	type FleetPushAttribution
+} from '../fleet-push-credential.types.js';
+
+const attribution = (overrides: Partial<FleetPushAttribution> = {}): FleetPushAttribution => ({
+	nodeId: '11111111-1111-4111-8111-111111111111',
+	nodeName: 'studio-win',
+	agentId: '22222222-2222-4222-8222-222222222222',
+	agentName: 'Refactor Bot',
+	agentEmail: 'refactor-bot@agents.ever.works',
+	jobId: '33333333-3333-4333-8333-333333333333',
+	runId: '44444444-4444-4444-8444-444444444444',
+	...overrides
+});
+
+describe('scoped push credential constants', () => {
+	it('pins the values both ends of the fleet depend on', () => {
+		// The tag is the ONE string the node advertises and the platform
+		// stamps on the row the lease CAS filters on. A typo on either
+		// side is a fleet that queues forever, which no other test sees.
+		expect(FLEET_PUSH_CAPABILITY).toBe('git-push');
+		expect(FLEET_PUSH_CREDENTIAL_USERNAME).toBe('x-access-token');
+		expect(FLEET_PUSH_TRAILER_NAMESPACE).toBe('Ever-Works-');
+		// Primary worktree + the eight mounts a Task workspace allows.
+		expect(FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES).toBe(9);
+	});
+
+	it('revokes at a FIXED https endpoint, never one a response could choose', () => {
+		// The response is the one place a write credential exists outside
+		// the platform; a caller-supplied revoke URL would be a redirect
+		// an attacker could aim the credential at.
+		expect(FLEET_PUSH_CREDENTIAL_REVOKE_URL).toBe('https://api.github.com/installation/token');
+		expect(new URL(FLEET_PUSH_CREDENTIAL_REVOKE_URL).protocol).toBe('https:');
+	});
+
+	it('names every trailer key inside the reserved namespace', () => {
+		expect(FLEET_PUSH_TRAILER_KEYS).toHaveLength(4);
+		for (const key of FLEET_PUSH_TRAILER_KEYS) {
+			expect(key.startsWith(FLEET_PUSH_TRAILER_NAMESPACE)).toBe(true);
+			// Every key our composer may emit must also be one the
+			// anti-forgery predicate REFUSES from a payload.
+			expect(isFleetPushTrailerLine(`${key}: whatever`)).toBe(true);
+		}
+	});
+
+	it('gives every stable refusal token an operator sentence', () => {
+		expect([...FLEET_PUSH_CREDENTIAL_REASONS]).toEqual([
+			FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+			FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+			FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON
+		]);
+		for (const reason of FLEET_PUSH_CREDENTIAL_REASONS) {
+			const described = describeFleetPushCredentialRefusal(reason);
+			expect(described.length).toBeGreaterThan(20);
+			// The sentence explains; it never merely echoes the token, or
+			// the operator learns nothing they did not already have.
+			expect(described).not.toBe(reason);
+		}
+		expect(describeFleetPushCredentialRefusal('something-else')).toContain('could not be issued');
+	});
+});
+
+describe('reserved trailer detection — the anti-forgery half', () => {
+	it.each([
+		['Ever-Works-Node: someone-elses-machine (deadbeef)'],
+		['  Ever-Works-Agent: forged'],
+		['ever-works-job: lowercase still counts'],
+		['EVER-WORKS-RUN: shouting still counts'],
+		['Ever-Works-Node : spaced colon']
+	])('refuses %s', (line) => {
+		expect(isFleetPushTrailerLine(line)).toBe(true);
+	});
+
+	it.each([
+		['Co-Authored-By: someone <someone@example.com>'],
+		['fix(ever-works-node): a scope that merely contains the words'],
+		['Ever-Works-main is the branch we cut from'],
+		['see Ever-Works-Node for details'],
+		['']
+	])('leaves %s alone', (line) => {
+		expect(isFleetPushTrailerLine(line)).toBe(false);
+	});
+
+	it('scans EVERY line, not just the last paragraph', () => {
+		// Git parses only the final paragraph as trailers, so a forged
+		// line earlier in the body would be invisible to `--parse` and
+		// perfectly visible to a human reading `git log`. Both matter.
+		const message = 'feat: something\n\nEver-Works-Node: forged\n\nreal body text';
+		expect(containsReservedFleetPushTrailer(message)).toBe(true);
+	});
+
+	it('handles CR, LF and CRLF line endings alike', () => {
+		expect(containsReservedFleetPushTrailer('a\r\nEver-Works-Job: x')).toBe(true);
+		expect(containsReservedFleetPushTrailer('a\rEver-Works-Job: x')).toBe(true);
+		expect(containsReservedFleetPushTrailer('a\nEver-Works-Job: x')).toBe(true);
+	});
+
+	it('is not fooled by a non-string', () => {
+		expect(containsReservedFleetPushTrailer(undefined as unknown as string)).toBe(false);
+		expect(isFleetPushTrailerLine(42 as unknown as string)).toBe(false);
+	});
+});
+
+describe('repository and remote normalisation — the scope check', () => {
+	it('lower-cases and strips the .git suffix', () => {
+		expect(normalizeFleetPushRepositoryId('Ever-Works/Ever-Works')).toBe('ever-works/ever-works');
+		expect(normalizeFleetPushRepositoryId('  ever-works/ever-works.git ')).toBe('ever-works/ever-works');
+	});
+
+	it.each([
+		['ever-works'],
+		['ever-works/'],
+		['/ever-works'],
+		['a/b/c'],
+		['ever works/repo'],
+		['../etc/passwd'],
+		['']
+	])('refuses %s', (value) => {
+		expect(normalizeFleetPushRepositoryId(value)).toBeNull();
+	});
+
+	it('reads owner/repo out of an https remote', () => {
+		expect(fleetPushRemoteRepositoryId('https://github.com/Ever-Works/ever-works.git')).toBe(
+			'ever-works/ever-works'
+		);
+		expect(fleetPushRemoteRepositoryId('https://github.com/ever-works/ever-works')).toBe('ever-works/ever-works');
+	});
+
+	it.each([
+		// An installation token is HTTP Basic; it cannot authenticate SSH,
+		// and offering it to one would be handing a write credential to a
+		// transport that will not use it.
+		['git@github.com:ever-works/ever-works.git'],
+		['ssh://git@github.com/ever-works/ever-works.git'],
+		// Plaintext: a credential must never ride an unencrypted transport.
+		['http://github.com/ever-works/ever-works'],
+		// Userinfo means a credential is ALREADY embedded upstream, which
+		// the fleet's token-free clone URL contract forbids.
+		['https://x-access-token:secret@github.com/ever-works/ever-works'],
+		// Query/fragment can smuggle a second path past a naive matcher.
+		['https://github.com/ever-works/ever-works?x=1'],
+		['https://github.com/ever-works/ever-works#frag'],
+		['https://github.com/ever-works'],
+		['https://github.com/ever-works/ever-works/extra'],
+		['file:///tmp/repo'],
+		['not a url'],
+		['']
+	])('refuses to identify %s', (url) => {
+		expect(fleetPushRemoteRepositoryId(url)).toBeNull();
+	});
+
+	// REGRESSION — the host was not checked at all (slice AM review, F1/F4).
+	//
+	// Every case above uses `github.com`, so the whole suite was green while
+	// the function validated the scheme, the userinfo, the query and the
+	// path-segment COUNT and never once read `url.host`. Each URL below
+	// answered `ever-works/ever-works` — byte-identical to what the real
+	// remote answers — which is the only value the node's scope check
+	// (`push.repositories.includes(repositoryId)`) compares. The node then
+	// keyed `http.<that URL>.extraheader` to a live `contents: write`
+	// installation token, and Git puts that header on its FIRST request to
+	// the host, before any challenge, so a `404` from the attacker still
+	// discloses the credential.
+	it.each([
+		// A host the owner does not control, with a legitimate-looking path.
+		['https://evil.tld/ever-works/ever-works.git'],
+		// Suffix lookalike — the classic `startsWith`/`endsWith` escape.
+		['https://github.com.evil.tld/ever-works/ever-works'],
+		// Subdomain: `api.github.com` is not the Git transport host, and
+		// `raw.` / `codeload.` are not repositories at all.
+		['https://api.github.com/ever-works/ever-works'],
+		['https://raw.githubusercontent.com/ever-works/ever-works'],
+		// A non-default PORT is somebody's proxy sitting in front of the
+		// name, which is why the comparison is on `host` and not `hostname`.
+		['https://github.com:8443/ever-works/ever-works'],
+		// A different forge entirely. Reachable WITHOUT an attacker: a `git`
+		// repo connection is a bare string with no host constraint, and
+		// `repositoryIdFromCloneUrl` is host-agnostic, so a mount at
+		// `https://gitlab.com/acme/widgets` used to resolve to `acme/widgets`
+		// and match a GitHub installation row of the same name.
+		['https://gitlab.com/ever-works/ever-works.git'],
+		['https://bitbucket.org/ever-works/ever-works']
+	])('refuses %s — the host is part of the identity', (url) => {
+		expect(fleetPushRemoteRepositoryId(url)).toBeNull();
+	});
+
+	it('still accepts the real host however it is cased or explicitly ported', () => {
+		// `URL` lower-cases the host and drops a default `:443`, so these are
+		// the SAME remote and must not be collateral damage of the host pin.
+		expect(fleetPushRemoteRepositoryId('https://GitHub.COM/ever-works/ever-works')).toBe('ever-works/ever-works');
+		expect(fleetPushRemoteRepositoryId('https://github.com:443/ever-works/ever-works')).toBe(
+			'ever-works/ever-works'
+		);
+		expect(FLEET_PUSH_CREDENTIAL_HOST).toBe('github.com');
+	});
+
+	it('cannot be reached by a host that merely matches the mint endpoint', () => {
+		// The revoke/mint endpoint and the Git transport host are different
+		// names on purpose; neither may stand in for the other.
+		expect(new URL(FLEET_PUSH_CREDENTIAL_REVOKE_URL).host).not.toBe(FLEET_PUSH_CREDENTIAL_HOST);
+	});
+});
+
+describe('identity sanitisation', () => {
+	it('folds control characters into spaces so a name cannot open a trailer', () => {
+		expect(sanitizeFleetPushIdentityText('bad\nEver-Works-Node: forged')).toBe('bad Ever-Works-Node: forged');
+		expect(sanitizeFleetPushIdentityText('a\r\nb')).toBe('a b');
+		expect(sanitizeFleetPushIdentityText('tab\tsep')).toBe('tab sep');
+	});
+
+	it('drops the delimiters our own identity and trailer forms use', () => {
+		expect(sanitizeFleetPushIdentityText('evil <root@example.com>')).toBe('evil root@example.com');
+		expect(sanitizeFleetPushIdentityText('node (other-id)')).toBe('node other-id');
+	});
+
+	it('caps the length and answers empty for anything unusable', () => {
+		expect(sanitizeFleetPushIdentityText('x'.repeat(200), 10)).toHaveLength(10);
+		expect(sanitizeFleetPushIdentityText('   ')).toBe('');
+		expect(sanitizeFleetPushIdentityText(null)).toBe('');
+		expect(sanitizeFleetPushIdentityText(7)).toBe('');
+	});
+});
+
+describe('commit identity — author is the Agent, committer is the node', () => {
+	it('splits the two so git log answers both questions', () => {
+		expect(fleetPushCommitIdentity(attribution())).toEqual({
+			authorName: 'Refactor Bot',
+			authorEmail: 'refactor-bot@agents.ever.works',
+			committerName: 'Ever Works node studio-win',
+			committerEmail: 'node-11111111-1111-4111-8111-111111111111@nodes.ever.works'
+		});
+	});
+
+	it('falls back to the pre-slice literals for a job that named no Agent', () => {
+		const identity = fleetPushCommitIdentity(attribution({ agentId: null, agentName: null, agentEmail: null }));
+		expect(identity.authorName).toBe(FLEET_PUSH_DEFAULT_AUTHOR_NAME);
+		expect(identity.authorEmail).toBe(FLEET_PUSH_DEFAULT_AUTHOR_EMAIL);
+		// The COMMITTER still names the machine: a commit with no node
+		// identity is exactly the state this slice exists to leave.
+		expect(identity.committerName).toContain('studio-win');
+	});
+
+	it('refuses a malformed agent email rather than committing it', () => {
+		const identity = fleetPushCommitIdentity(attribution({ agentEmail: 'not an email\nEver-Works-Node: forged' }));
+		expect(identity.authorEmail).toBe(FLEET_PUSH_DEFAULT_AUTHOR_EMAIL);
+	});
+
+	it('still names the node when the operator left the name blank', () => {
+		const identity = fleetPushCommitIdentity(attribution({ nodeName: '' }));
+		expect(identity.committerName).toBe('Ever Works node 11111111-1111-4111-8111-111111111111');
+	});
+
+	it('throws rather than committing an unusable node id', () => {
+		expect(() => fleetPushCommitIdentity(attribution({ nodeId: 'has spaces' }))).toThrow(FleetPushAttributionError);
+		expect(() => fleetPushCommitIdentity(attribution({ nodeId: '' }))).toThrow(FleetPushAttributionError);
+	});
+});
+
+describe('commit message composition', () => {
+	it('appends the trailer block as the last paragraph', () => {
+		expect(composeFleetPushCommitMessage({ message: 'feat: x', attribution: attribution() })).toBe(
+			[
+				'feat: x',
+				'',
+				'Ever-Works-Node: studio-win (11111111-1111-4111-8111-111111111111)',
+				'Ever-Works-Agent: Refactor Bot (22222222-2222-4222-8222-222222222222)',
+				'Ever-Works-Job: 33333333-3333-4333-8333-333333333333',
+				'Ever-Works-Run: 44444444-4444-4444-8444-444444444444'
+			].join('\n')
+		);
+	});
+
+	it('omits the trailers whose facts the run does not have', () => {
+		const composed = composeFleetPushCommitMessage({
+			message: 'feat: x',
+			attribution: attribution({ agentId: null, agentName: null, runId: null })
+		});
+		expect(composed).not.toContain('Ever-Works-Agent');
+		expect(composed).not.toContain('Ever-Works-Run');
+		expect(composed).toContain('Ever-Works-Job: 33333333-3333-4333-8333-333333333333');
+	});
+
+	it('REFUSES a payload message that already claims a machine', () => {
+		// The whole attribution guarantee. `git.commitMessage` is payload
+		// text derived from a Task title, the node's own validation permits
+		// `\n`, and appending after a forged block would leave a reader —
+		// and `git interpret-trailers --parse`, which reads only the last
+		// paragraph — unable to tell which block the platform wrote.
+		expect(() =>
+			composeFleetPushCommitMessage({
+				message: 'feat: x\n\nEver-Works-Node: someone-elses-laptop (deadbeef)',
+				attribution: attribution()
+			})
+		).toThrow(/reserved 'Ever-Works-' trailer/);
+	});
+
+	it('refuses a forged trailer in any casing or position', () => {
+		for (const message of ['ever-works-agent: forged\n\nfeat: x', 'feat: x\n  Ever-Works-Job: forged\nmore body']) {
+			expect(() => composeFleetPushCommitMessage({ message, attribution: attribution() })).toThrow(
+				FleetPushAttributionError
+			);
+		}
+	});
+
+	it('refuses an empty message and an unusable job id', () => {
+		expect(() => composeFleetPushCommitMessage({ message: '   ', attribution: attribution() })).toThrow(
+			FleetPushAttributionError
+		);
+		expect(() =>
+			composeFleetPushCommitMessage({
+				message: 'feat: x',
+				attribution: attribution({ jobId: 'a b' })
+			})
+		).toThrow(FleetPushAttributionError);
+	});
+
+	it('sanitises a node name that tried to inject a second trailer line', () => {
+		const composed = composeFleetPushCommitMessage({
+			message: 'feat: x',
+			attribution: attribution({ nodeName: 'ok\nEver-Works-Job: forged' })
+		});
+		// One `Ever-Works-Job` trailer, not two: the newline in the NAME
+		// became a space before it could open a line of its own.
+		expect(composed.split('\n').filter((line) => line.startsWith('Ever-Works-Job:'))).toHaveLength(1);
+	});
+});

--- a/packages/contracts/src/fleet/__tests__/index.spec.ts
+++ b/packages/contracts/src/fleet/__tests__/index.spec.ts
@@ -228,6 +228,43 @@ const RUN_CREDENTIAL_EXPORTS = [
 	'fleetRunTokenExpiryFromLease'
 ] as const;
 
+/**
+ * Self-build slice AM (EW-810) — fleet-push-credential.types.ts.
+ *
+ * The scoped push credential and the attribution that rides with it: the
+ * `git-push` capability tag both ends agree on, the basic-auth username
+ * and the fixed revoke endpoint, the reserved `Ever-Works-` trailer
+ * namespace and its anti-forgery predicates, the remote/repository
+ * normalizers the node checks the credential's scope with (including the
+ * single HOST those normalizers pin the credential to), and the three
+ * stable refusal tokens a mint can answer with.
+ */
+const PUSH_CREDENTIAL_EXPORTS = [
+	'FLEET_PUSH_CAPABILITY',
+	'FLEET_PUSH_MIN_GIT_VERSION',
+	'FLEET_PUSH_CREDENTIAL_USERNAME',
+	'FLEET_PUSH_CREDENTIAL_REVOKE_URL',
+	'FLEET_PUSH_CREDENTIAL_HOST',
+	'FLEET_PUSH_TRAILER_NAMESPACE',
+	'FLEET_PUSH_TRAILER_KEYS',
+	'FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES',
+	'FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON',
+	'FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON',
+	'FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON',
+	'FLEET_PUSH_CREDENTIAL_REASONS',
+	'FLEET_PUSH_DEFAULT_AUTHOR_NAME',
+	'FLEET_PUSH_DEFAULT_AUTHOR_EMAIL',
+	'describeFleetPushCredentialRefusal',
+	'isFleetPushTrailerLine',
+	'containsReservedFleetPushTrailer',
+	'normalizeFleetPushRepositoryId',
+	'fleetPushRemoteRepositoryId',
+	'sanitizeFleetPushIdentityText',
+	'fleetPushCommitIdentity',
+	'composeFleetPushCommitMessage',
+	'FleetPushAttributionError'
+] as const;
+
 const ALL_EXPORTS = [
 	...CREDENTIAL_EXPORTS,
 	...EXECUTION_PREFERENCE_EXPORTS,
@@ -238,7 +275,8 @@ const ALL_EXPORTS = [
 	...WORKSPACE_EXPORTS,
 	...RUN_SECRETS_EXPORTS,
 	...QUESTION_EXPORTS,
-	...RUN_CREDENTIAL_EXPORTS
+	...RUN_CREDENTIAL_EXPORTS,
+	...PUSH_CREDENTIAL_EXPORTS
 ];
 
 const FUNCTION_EXPORTS = [
@@ -279,7 +317,16 @@ const FUNCTION_EXPORTS = [
 	'normalizeFleetAgentTaskQuestion',
 	'normalizeFleetNodeWorkerState',
 	'isFleetRunTokenRouteAllowed',
-	'fleetRunTokenExpiryFromLease'
+	'fleetRunTokenExpiryFromLease',
+	'describeFleetPushCredentialRefusal',
+	'isFleetPushTrailerLine',
+	'containsReservedFleetPushTrailer',
+	'normalizeFleetPushRepositoryId',
+	'fleetPushRemoteRepositoryId',
+	'sanitizeFleetPushIdentityText',
+	'fleetPushCommitIdentity',
+	'composeFleetPushCommitMessage',
+	'FleetPushAttributionError'
 ] as const;
 
 const bag = fleet as unknown as Record<string, unknown>;
@@ -294,7 +341,7 @@ describe('fleet barrel', () => {
 		expect(typeof bag[name]).toBe('function');
 	});
 
-	it('exposes exactly these 153 runtime symbols', () => {
+	it('exposes exactly these 176 runtime symbols', () => {
 		// Regression guard in BOTH directions: an `export *` line deleted from
 		// index.ts fails here, and a NEW runtime export added without a spec
 		// also fails here — which forces the author back to cover it.
@@ -316,8 +363,16 @@ describe('fleet barrel', () => {
 		// → 153 with acceptance checks that mean something (EW-807): the
 		// four setup-phase bounds. All three groups live in existing
 		// modules, so the witness table below needs no new row.
+		// → 175 with scoped push credentials (EW-810): the twenty-two
+		// symbols of `fleet-push-credential.types.ts` — a NEW module, so
+		// the witness table below gains a row as well.
+		// → 176 when that slice's review found the scope check never read
+		// the remote's HOST: `FLEET_PUSH_CREDENTIAL_HOST` is the one host a
+		// GitHub installation token may ever be offered to, and it is a
+		// named export precisely so the node, the plugin and this guard
+		// cannot disagree about it.
 		expect(Object.keys(fleet).sort()).toEqual([...ALL_EXPORTS].sort());
-		expect(Object.keys(fleet)).toHaveLength(153);
+		expect(Object.keys(fleet)).toHaveLength(176);
 	});
 
 	it.each([
@@ -329,7 +384,8 @@ describe('fleet barrel', () => {
 		['fleet-run-secrets.types.js', 'FLEET_RUN_ENV_FILE_MAX_COUNT'],
 		['fleet-runner-status.types.js', 'FLEET_RUNNER_STATUS_REFRESH_SEC'],
 		['fleet-task-workspace.types.js', 'FLEET_TASK_WORKSPACE_MAX_MOUNTS'],
-		['fleet-run-credential.types.js', 'FLEET_RUN_TOKEN_PREFIX']
+		['fleet-run-credential.types.js', 'FLEET_RUN_TOKEN_PREFIX'],
+		['fleet-push-credential.types.js', 'FLEET_PUSH_CAPABILITY']
 	])('keeps the %s module represented via %s', (_module, sentinel) => {
 		// One distinctive symbol per source module, so a whole missing
 		// `export * from` line is named in the failure rather than showing up

--- a/packages/contracts/src/fleet/fleet-push-credential.types.ts
+++ b/packages/contracts/src/fleet/fleet-push-credential.types.ts
@@ -1,0 +1,435 @@
+/**
+ * Scoped push credentials and commit attribution (self-build slice AM,
+ * EW-810) — the rules BOTH ends of the fleet share about how a node is
+ * allowed to write to a remote, and whose name goes on the commit.
+ *
+ * ## The gap this module closes
+ *
+ * Until this slice a fleet node's `git push` was token-free by design:
+ * the machine's own Git credential helper answered for it. In practice
+ * that is a long-lived personal access token in the OS credential store
+ * with write access to EVERY repository the service account can reach.
+ * The platform could not scope it to one run, could not rotate it, could
+ * not revoke it when a laptop was lost, and could not even observe that
+ * it had been used. Six unattended machines each held one.
+ *
+ * What replaces it is a GitHub App INSTALLATION token, minted per job
+ * over the node-authenticated job channel, narrowed to the repository
+ * ids this job actually needs and to `contents: write` alone. It reaches
+ * the node in one HTTPS response, lives in that process's memory for the
+ * length of one commit-and-push, rides into `git` as an
+ * `http.<url>.extraheader` carried in the CHILD ENVIRONMENT (never argv,
+ * never a config file, never a remote URL), and is revoked at GitHub the
+ * moment the run ends.
+ *
+ * ## Why the token is not on the payload
+ *
+ * Slice Y established that a value which reaches the job PAYLOAD reaches
+ * the job row, the lease response, the job view and `fleet_jobs.result`.
+ * So the payload carries no credential and no request for one: the node
+ * asks for it on the authenticated channel, authorised — exactly as
+ * slice Z's MCP credential is — by HOLDING THE LEASE.
+ *
+ * ## Attribution that cannot be forged
+ *
+ * Every fleet commit used to be authored `Ever Works Agent
+ * <agent@ever.works>` on every machine, so Git history could not answer
+ * WHICH node or WHICH agent produced a change. This module defines the
+ * author/committer split (author = the Agent, committer = the node) and
+ * a reserved `Ever-Works-` trailer namespace.
+ *
+ * The commit MESSAGE is payload-supplied and may contain newlines, so a
+ * Task title could otherwise write trailer-shaped lines of its own and
+ * claim a machine the run never used. {@link composeFleetPushCommitMessage}
+ * REFUSES such a message rather than appending after it: a trailer a
+ * reader cannot distinguish from ours is worse than no trailer at all.
+ */
+
+/**
+ * Capability tag a node advertises when it can perform a SCOPED push:
+ * `git` resolves and its version accepts environment-carried
+ * configuration (`GIT_CONFIG_COUNT`, Git >= 2.31), which is the
+ * mechanism the credential is installed through.
+ *
+ * It is a promise the node can keep, in the sense
+ * `apps/node/src/core/capabilities.ts` means: the same fact that turns
+ * the tag on is the fact the push depends on. A node without it is never
+ * handed `agent-task` work, which is the point — the alternative is
+ * twenty minutes of model time and then a refusal at the push.
+ */
+export const FLEET_PUSH_CAPABILITY = 'git-push';
+
+/** Lowest Git that accepts `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>`. */
+export const FLEET_PUSH_MIN_GIT_VERSION = '2.31.0';
+
+/**
+ * Basic-auth username GitHub expects alongside an installation access
+ * token. Not a secret; pinned here so the node, the plugin and the
+ * platform cannot disagree about it.
+ */
+export const FLEET_PUSH_CREDENTIAL_USERNAME = 'x-access-token';
+
+/**
+ * Where a node revokes its own installation token the instant the run
+ * ends (`DELETE`, authenticated with the token itself).
+ *
+ * A CONSTANT rather than a field on the mint response, deliberately: the
+ * response is the one place a write credential exists outside platform
+ * memory, and giving it a caller-supplied destination for that credential
+ * would be a redirect an attacker could aim. GitHub Enterprise hosts are
+ * out of scope here for the same reason every other GitHub call in this
+ * repository hardcodes `api.github.com`.
+ */
+export const FLEET_PUSH_CREDENTIAL_REVOKE_URL = 'https://api.github.com/installation/token';
+
+/**
+ * The ONE host a scoped push credential may ever be offered to.
+ *
+ * A GitHub App installation token is minted at `api.github.com` and is
+ * meaningful to `github.com` and nowhere else, so any other host is at
+ * best a wasted round trip and at worst a disclosure: Git sends an
+ * `http.<url>.extraheader` on its VERY FIRST request, unprompted and
+ * before any `401` challenge, so a remote merely POINTING somewhere else
+ * is enough to hand that host a live `contents: write` credential for
+ * the owner's repositories. A `404` from the attacker still gets the
+ * token.
+ *
+ * This is why {@link fleetPushRemoteRepositoryId} compares `url.host`
+ * and not just the path. `host` — not `hostname` — so a non-default
+ * PORT is refused too: `https://github.com:8443/o/r` is somebody's proxy,
+ * not GitHub. GitHub Enterprise is out of scope here for the same reason
+ * {@link FLEET_PUSH_CREDENTIAL_REVOKE_URL} is a constant.
+ */
+export const FLEET_PUSH_CREDENTIAL_HOST = 'github.com';
+
+/**
+ * Reserved trailer namespace. Nothing a payload writes may start a line
+ * with this: see the module header and
+ * {@link containsReservedFleetPushTrailer}.
+ */
+export const FLEET_PUSH_TRAILER_NAMESPACE = 'Ever-Works-';
+
+/**
+ * The complete set of trailers a fleet commit carries. Fixed and small:
+ * a trailer block that grows per slice becomes noise nobody reads, and
+ * these four answer the question the whole slice exists for — which
+ * machine, which agent, which job, which run.
+ */
+export const FLEET_PUSH_TRAILER_KEYS = [
+	'Ever-Works-Node',
+	'Ever-Works-Agent',
+	'Ever-Works-Job',
+	'Ever-Works-Run'
+] as const;
+
+/**
+ * Upper bound on repositories one push credential may be scoped to: the
+ * primary worktree plus the eight mounts `FLEET_TASK_WORKSPACE_MAX_MOUNTS`
+ * allows. A request that resolves to more is refused rather than
+ * truncated — a silently narrowed token fails at the push of whichever
+ * repository fell off the end.
+ */
+export const FLEET_PUSH_CREDENTIAL_MAX_REPOSITORIES = 9;
+
+/** The platform has no GitHub App configured, so it can mint nothing. */
+export const FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON = 'push-credential-not-configured';
+
+/**
+ * The platform could not decide, from its OWN state, which installation
+ * covers every repository this job writes to: no installation snapshot
+ * names the repository, the installation was suspended or removed, it
+ * belongs to somebody else, or the repositories span two installations.
+ */
+export const FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON = 'push-scope-unresolved';
+
+/** The scope resolved but GitHub refused (or failed) the mint. */
+export const FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON = 'push-credential-mint-failed';
+
+/** Every stable refusal token this channel can answer with. */
+export const FLEET_PUSH_CREDENTIAL_REASONS = [
+	FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON,
+	FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON,
+	FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON
+] as const;
+
+export type FleetPushCredentialReason = (typeof FLEET_PUSH_CREDENTIAL_REASONS)[number];
+
+/**
+ * One operator-readable sentence per stable token.
+ *
+ * The node reports the TOKEN on the wire (so the string is never a
+ * behavioural dependency) and renders this sentence into the run's
+ * failure reason, because "push-scope-unresolved" on a Task page sends a
+ * human hunting rather than to the page that fixes it.
+ */
+export function describeFleetPushCredentialRefusal(reason: string): string {
+	switch (reason) {
+		case FLEET_PUSH_CREDENTIAL_NOT_CONFIGURED_REASON:
+			return 'this deployment has no GitHub App configured, so no scoped push credential can be minted (set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY)';
+		case FLEET_PUSH_CREDENTIAL_UNRESOLVED_REASON:
+			return "no GitHub App installation this owner controls covers every repository this run writes to — install the Ever Works app on them, or re-sync the installation's repository list";
+		case FLEET_PUSH_CREDENTIAL_MINT_FAILED_REASON:
+			return 'GitHub refused to issue a scoped installation token for this run';
+		default:
+			return 'a scoped push credential could not be issued for this run';
+	}
+}
+
+/**
+ * True when `line` opens a trailer in the reserved namespace.
+ *
+ * Deliberately generous: leading whitespace is ignored and the match is
+ * case-insensitive, because Git's own trailer parsing is case-insensitive
+ * on the key and a reader skimming `git log` is more so. Anything that
+ * could READ as one of our trailers counts as one.
+ */
+export function isFleetPushTrailerLine(line: string): boolean {
+	if (typeof line !== 'string') return false;
+	const trimmed = line.trimStart();
+	if (!trimmed.toLowerCase().startsWith(FLEET_PUSH_TRAILER_NAMESPACE.toLowerCase())) return false;
+	// A trailer is `Key: value`; a bare word that merely starts with the
+	// namespace (a branch called `Ever-Works-main`) is prose, not a claim.
+	return /^[A-Za-z0-9-]+[ \t]*:/.test(trimmed);
+}
+
+/** True when any line of `message` is trailer-shaped in the reserved namespace. */
+export function containsReservedFleetPushTrailer(message: string): boolean {
+	if (typeof message !== 'string') return false;
+	return message.split(/\r\n|\r|\n/).some((line) => isFleetPushTrailerLine(line));
+}
+
+const REPOSITORY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * `owner/repo`, lower-cased, or null when the value is not one.
+ *
+ * Lower-cased because GitHub repository names are case-insensitive and
+ * the comparison this feeds — "is the remote I am about to push to one
+ * of the repositories the platform scoped this token to?" — must not
+ * turn on the casing a payload happened to use.
+ */
+export function normalizeFleetPushRepositoryId(value: unknown): string | null {
+	if (typeof value !== 'string') return null;
+	const trimmed = value.trim().replace(/\.git$/i, '');
+	if (!REPOSITORY_ID_PATTERN.test(trimmed)) return null;
+	return trimmed.toLowerCase();
+}
+
+/**
+ * The `owner/repo` an HTTPS remote URL points at, or null.
+ *
+ * Used by the node to check the worktree's ACTUAL `origin` against the
+ * repositories the platform scoped the credential to, BEFORE the token is
+ * handed to Git. Only `https:` is accepted: an installation token is an
+ * HTTP Basic credential and cannot authenticate an SSH remote, and any
+ * other scheme is a remote this credential has no business reaching. A
+ * URL carrying userinfo is refused outright — the fleet's clone URLs are
+ * token-free by contract, and one that is not has already gone wrong
+ * somewhere upstream.
+ *
+ * THE HOST IS PART OF THE IDENTITY, and this is the whole point of the
+ * function. An earlier version of this slice validated the scheme, the
+ * userinfo, the query and the number of path segments but never read
+ * `url.host`, so `https://evil.tld/ever-works/ever-works.git` and
+ * `https://github.com.evil.tld/ever-works/ever-works` both answered
+ * `ever-works/ever-works` — the identical value the legitimate URL
+ * answers — and therefore passed the node's only scope check. Git then
+ * put the credential in an `Authorization: Basic` header on its first
+ * request to that host, unchallenged. `owner/repo` is not an identity
+ * without the host in front of it: the scope check downstream compares
+ * only this return value, so anything this function is willing to
+ * collapse is a repository the credential can be aimed at.
+ */
+export function fleetPushRemoteRepositoryId(remoteUrl: unknown): string | null {
+	if (typeof remoteUrl !== 'string' || !remoteUrl.trim()) return null;
+	let url: URL;
+	try {
+		url = new URL(remoteUrl.trim());
+	} catch {
+		return null;
+	}
+	if (url.protocol !== 'https:') return null;
+	if (url.username || url.password) return null;
+	if (url.search || url.hash) return null;
+	// `host`, so a port is part of the comparison; `URL` has already
+	// lower-cased it and dropped an explicit `:443`, so `HTTPS://GitHub.COM`
+	// passes and `https://github.com:8443` does not.
+	if (url.host !== FLEET_PUSH_CREDENTIAL_HOST) return null;
+	const segments = url.pathname.split('/').filter((segment) => segment.length > 0);
+	if (segments.length !== 2) return null;
+	return normalizeFleetPushRepositoryId(`${segments[0]}/${segments[1]}`);
+}
+
+/**
+ * Free text that is about to become part of a Git identity or trailer.
+ *
+ * Replaces control characters (a newline here is a forged trailer) and
+ * the delimiters our own forms use — `<`/`>` around an address, `(`/`)`
+ * around the id — with spaces, folds whitespace, then caps the length.
+ * Written as a code-point walk rather than a regular expression so the
+ * source file itself contains no control characters.
+ *
+ * Returns `''` when nothing survives, and every caller treats that as
+ * "fall back to the fixed default" rather than emitting an empty name.
+ */
+export function sanitizeFleetPushIdentityText(value: unknown, maxLength = 64): string {
+	if (typeof value !== 'string') return '';
+	let out = '';
+	for (const char of value) {
+		const code = char.codePointAt(0) ?? 0;
+		const delimiter = char === '<' || char === '>' || char === '(' || char === ')';
+		out += code < 0x20 || code === 0x7f || delimiter ? ' ' : char;
+	}
+	return out.replace(/\s+/g, ' ').trim().slice(0, Math.max(1, maxLength)).trim();
+}
+
+/** Raised when attribution cannot be composed. Never carries a credential. */
+export class FleetPushAttributionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'FleetPushAttributionError';
+	}
+}
+
+/**
+ * Who a fleet commit is by, resolved entirely from PLATFORM STATE and
+ * handed to the node on the authenticated channel.
+ *
+ * Not from the payload: the payload is a place a Task title reaches, and
+ * a run that could name its own machine is a run whose attribution means
+ * nothing. The node additionally refuses an answer whose `nodeId` is not
+ * its own, so even a platform bug cannot make one machine sign for
+ * another.
+ */
+export interface FleetPushAttribution {
+	/** The node the platform believes holds this job's lease. */
+	readonly nodeId: string;
+	/** Operator-chosen node name, already sanitized. May be empty. */
+	readonly nodeName: string;
+	/** The Agent that produced the change, when the job named one. */
+	readonly agentId: string | null;
+	readonly agentName: string | null;
+	/** `agents.committerEmail`, or the `<slug>@agents.ever.works` convention. */
+	readonly agentEmail: string | null;
+	readonly jobId: string;
+	readonly runId: string | null;
+}
+
+/**
+ * The short-lived write credential itself. Present ONLY when this job's
+ * plan actually pushes (the platform re-reads its own `git.push`), so a
+ * commit-only run never causes a write token to exist.
+ */
+export interface FleetPushCredential {
+	/**
+	 * THE only place the raw credential exists outside the platform's
+	 * process, and it exists there for exactly the length of one HTTPS
+	 * response. Nothing recovers it afterwards: a node that loses it
+	 * re-mints.
+	 */
+	readonly token: string;
+	/** Always {@link FLEET_PUSH_CREDENTIAL_USERNAME}; sent so the node need not assume. */
+	readonly username: string;
+	/** ISO-8601 instant GitHub says the token stops working. */
+	readonly expiresAt: string;
+	/**
+	 * The repositories this token can write, as normalized `owner/repo`.
+	 * The node refuses to offer the credential to any other remote.
+	 */
+	readonly repositories: readonly string[];
+}
+
+/** Response body of `POST /api/fleet/jobs/:id/push-credential`. */
+export interface FleetJobPushCredentialResponse {
+	readonly attribution: FleetPushAttribution;
+	/** Null when this job's plan commits but does not push. */
+	readonly push: FleetPushCredential | null;
+}
+
+/** The four Git identity fields a fleet commit is made with. */
+export interface FleetPushCommitIdentity {
+	readonly authorName: string;
+	readonly authorEmail: string;
+	readonly committerName: string;
+	readonly committerEmail: string;
+}
+
+/** Fallbacks — the literals every fleet commit carried before this slice. */
+export const FLEET_PUSH_DEFAULT_AUTHOR_NAME = 'Ever Works Agent';
+export const FLEET_PUSH_DEFAULT_AUTHOR_EMAIL = 'agent@ever.works';
+
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+const EMAIL_PATTERN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
+function requireIdentifier(value: unknown, field: string): string {
+	if (typeof value !== 'string' || !IDENTIFIER_PATTERN.test(value)) {
+		throw new FleetPushAttributionError(`Push attribution ${field} is not a usable identifier`);
+	}
+	return value;
+}
+
+/**
+ * AUTHOR is the Agent, COMMITTER is the node.
+ *
+ * That split is the whole answer to "which machine and which agent
+ * produced this change": `git log --format='%an <%ae> / %cn <%ce>'` reads
+ * it directly, and every hosting UI shows the author while recording the
+ * committer. A single identity carrying both would have to lose one.
+ *
+ * Falls back to the pre-slice literals for a job that named no Agent —
+ * there is nobody to attribute to, and inventing one would be the lie
+ * this slice removes. The COMMITTER never falls back: a commit with no
+ * node identity is exactly the state we are leaving.
+ */
+export function fleetPushCommitIdentity(attribution: FleetPushAttribution): FleetPushCommitIdentity {
+	const nodeId = requireIdentifier(attribution?.nodeId, 'nodeId');
+	const nodeName = sanitizeFleetPushIdentityText(attribution?.nodeName, 48);
+	const hasAgent = typeof attribution?.agentId === 'string' && attribution.agentId.length > 0;
+	const agentName = sanitizeFleetPushIdentityText(attribution?.agentName, 48);
+	const agentEmail = typeof attribution?.agentEmail === 'string' ? attribution.agentEmail.trim() : '';
+	return {
+		authorName: hasAgent && agentName ? agentName : FLEET_PUSH_DEFAULT_AUTHOR_NAME,
+		authorEmail: hasAgent && EMAIL_PATTERN.test(agentEmail) ? agentEmail : FLEET_PUSH_DEFAULT_AUTHOR_EMAIL,
+		committerName: `Ever Works node ${nodeName || nodeId}`,
+		committerEmail: `node-${nodeId}@nodes.ever.works`
+	};
+}
+
+/**
+ * The commit message a fleet run actually commits: the payload's message,
+ * then a blank line, then the reserved trailer block.
+ *
+ * REFUSES a payload message that already contains a reserved trailer. The
+ * alternative — appending ours after theirs — produces two blocks a reader
+ * cannot tell apart, and Git's own `--parse` reads only the LAST
+ * paragraph, so the forged one would be the one a human sees at the top of
+ * `git log`. Failing the run with a named reason is the cheaper loss: the
+ * message comes from a Task title, and renaming a Task is a fix an owner
+ * can make.
+ */
+export function composeFleetPushCommitMessage(input: { message: string; attribution: FleetPushAttribution }): string {
+	const message = typeof input?.message === 'string' ? input.message.trim() : '';
+	if (!message) {
+		throw new FleetPushAttributionError('Commit message is empty');
+	}
+	if (containsReservedFleetPushTrailer(message)) {
+		throw new FleetPushAttributionError(
+			`Commit message contains a reserved '${FLEET_PUSH_TRAILER_NAMESPACE}' trailer, which only the platform may write`
+		);
+	}
+	const attribution = input.attribution;
+	const nodeId = requireIdentifier(attribution?.nodeId, 'nodeId');
+	const jobId = requireIdentifier(attribution?.jobId, 'jobId');
+	const nodeName = sanitizeFleetPushIdentityText(attribution?.nodeName, 48);
+	const trailers: string[] = [`Ever-Works-Node: ${nodeName ? `${nodeName} (${nodeId})` : nodeId}`];
+	if (attribution?.agentId) {
+		const agentId = requireIdentifier(attribution.agentId, 'agentId');
+		const agentName = sanitizeFleetPushIdentityText(attribution.agentName, 48);
+		trailers.push(`Ever-Works-Agent: ${agentName ? `${agentName} (${agentId})` : agentId}`);
+	}
+	trailers.push(`Ever-Works-Job: ${jobId}`);
+	if (attribution?.runId) {
+		trailers.push(`Ever-Works-Run: ${requireIdentifier(attribution.runId, 'runId')}`);
+	}
+	return `${message}\n\n${trailers.join('\n')}`;
+}

--- a/packages/contracts/src/fleet/index.ts
+++ b/packages/contracts/src/fleet/index.ts
@@ -3,6 +3,7 @@ export * from './fleet-execution-preference.types.js';
 export * from './fleet-jobs.types.js';
 export * from './fleet-node.types.js';
 export * from './fleet-panic.types.js';
+export * from './fleet-push-credential.types.js';
 export * from './fleet-run-secrets.types.js';
 export * from './fleet-run-credential.types.js';
 export * from './fleet-runner-status.types.js';

--- a/packages/plugin/src/contracts/capabilities/workspace.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/workspace.interface.ts
@@ -118,6 +118,55 @@ export interface WorkspacePublishFence {
 	readonly marginMs: number;
 }
 
+/**
+ * A short-lived, repository-scoped write credential lent to exactly ONE
+ * publish (self-build slice AM).
+ *
+ * Distinct from {@link WorkspaceProvisionSpec.auth}, which the cloud path
+ * injects as URL userinfo and which therefore appears in the `git` argv
+ * for the life of the command. A credential supplied HERE is installed
+ * through the child process ENVIRONMENT instead
+ * (`http.<url>.extraheader`, plus a `credential.helper` reset that leaves
+ * Git no ambient helper to fall back to), so it never reaches argv, never
+ * reaches a config file, and never reaches the remote URL.
+ *
+ * Providers that cannot honour it MUST refuse the push rather than fall
+ * back to whatever the machine's own credential helper would answer:
+ * that fallback is the exact hole this exists to close.
+ */
+export interface WorkspacePushCredential {
+	/** Basic-auth username (a GitHub installation token uses `x-access-token`). */
+	readonly username: string;
+	/** The secret. Held in memory for the length of one push and nowhere else. */
+	readonly token: string;
+	/**
+	 * The remote this credential was scoped to, verbatim.
+	 *
+	 * The provider refuses to push when the checkout's `origin` is not
+	 * byte-identical to it: the credential is good for a specific set of
+	 * repositories, and a checkout pointed somewhere else is either a
+	 * mistake or an attempt to aim a write token at a remote the platform
+	 * never authorised.
+	 */
+	readonly remoteUrl: string;
+}
+
+/**
+ * Who the commit is BY (self-build slice AM). Absent keeps the provider's
+ * own defaults, which is what every caller predating this field gets.
+ *
+ * Author and committer are separate on purpose: the author is the agent
+ * that produced the change and the committer is the machine that made it,
+ * so `git log` can answer both questions. Callers are responsible for
+ * sanitising these — a newline in a name is a forged trailer.
+ */
+export interface WorkspaceCommitIdentity {
+	readonly authorName: string;
+	readonly authorEmail: string;
+	readonly committerName: string;
+	readonly committerEmail: string;
+}
+
 /** Options for {@link IWorkspacePlugin.finalize}. */
 export interface WorkspaceFinalizeOptions {
 	commitMessage: string;
@@ -127,6 +176,10 @@ export interface WorkspaceFinalizeOptions {
 	signal?: AbortSignal;
 	/** Lease deadline the publish must fit inside; see {@link WorkspacePublishFence}. */
 	publishFence?: WorkspacePublishFence;
+	/** Per-publish scoped write credential; see {@link WorkspacePushCredential}. */
+	pushCredential?: WorkspacePushCredential;
+	/** Author / committer identity for this commit; see {@link WorkspaceCommitIdentity}. */
+	identity?: WorkspaceCommitIdentity;
 }
 
 export interface WorkspaceFinalizeResult {

--- a/packages/plugins/local-workspace/src/__tests__/local-workspace.push-credential.spec.ts
+++ b/packages/plugins/local-workspace/src/__tests__/local-workspace.push-credential.spec.ts
@@ -1,0 +1,703 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { LocalWorkspacePlugin } from '../local-workspace.plugin.js';
+import type { WorkspaceHandle } from '@ever-works/plugin';
+
+/**
+ * Scoped push credentials and commit attribution (self-build slice AM).
+ *
+ * Two halves, because the two questions need different instruments:
+ *
+ *  1. **Real git, hermetic loopback origin** — what a commit actually
+ *     carries (author vs committer), and what the repository's config
+ *     holds afterwards. Only real git can answer those.
+ *  2. **The `execFile` seam** — HOW the credential reaches git. The
+ *     assertion that matters most in this slice is a negative one (the
+ *     token appears in no argv element and no config file), and the only
+ *     way to prove it is to look at the exact invocation.
+ */
+
+const git = (cwd: string, ...args: string[]): string =>
+	execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true }).trim();
+
+let root: string;
+let originUrl: string;
+let baseDir: string;
+let seedDir: string;
+let plugin: LocalWorkspacePlugin;
+
+const settings = () => ({ baseDir, fetchDepth: 1 });
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), 'ew-lw-push-'));
+	const originDir = join(root, 'origin.git');
+	seedDir = join(root, 'seed');
+	baseDir = join(root, 'workspaces');
+	mkdirSync(originDir, { recursive: true });
+	mkdirSync(seedDir, { recursive: true });
+	git(originDir, 'init', '--bare', '--initial-branch', 'main');
+	originUrl = pathToFileURL(originDir).toString();
+	git(seedDir, 'init', '--initial-branch', 'main');
+	writeFileSync(join(seedDir, 'README.md'), 'hello\n');
+	git(seedDir, 'add', '-A');
+	git(seedDir, '-c', 'user.name=Seed', '-c', 'user.email=seed@test.local', 'commit', '-m', 'seed');
+	git(seedDir, 'push', originUrl, 'HEAD:refs/heads/main');
+	plugin = new LocalWorkspacePlugin();
+});
+
+afterAll(async () => {
+	await fs.rm(root, { recursive: true, force: true, maxRetries: 3 });
+});
+
+async function provision(bindingKey: string, branch: string): Promise<WorkspaceHandle> {
+	return plugin.provision({
+		repoUrl: originUrl,
+		baseRef: 'main',
+		branch,
+		bindingKey,
+		settings: settings()
+	});
+}
+
+describe('commit attribution (real git)', () => {
+	it('records the AGENT as author and the NODE as committer', async () => {
+		const handle = await provision('push-identity', 'task/identity-aaaa1111');
+		writeFileSync(join(handle.path, 'work.txt'), 'work\n');
+
+		await plugin.finalize(handle, {
+			commitMessage: 'feat: attributed run',
+			push: false,
+			identity: {
+				authorName: 'Refactor Bot',
+				authorEmail: 'refactor-bot@agents.ever.works',
+				committerName: 'Ever Works node studio-win',
+				committerEmail: 'node-11111111-1111-4111-8111-111111111111@nodes.ever.works'
+			}
+		});
+
+		// The whole point: `git log` can now answer WHICH agent and WHICH
+		// machine. Before this slice both were `Ever Works Agent
+		// <agent@ever.works>` on every node in the fleet.
+		expect(git(handle.path, 'log', '-1', '--format=%an|%ae')).toBe('Refactor Bot|refactor-bot@agents.ever.works');
+		expect(git(handle.path, 'log', '-1', '--format=%cn|%ce')).toBe(
+			'Ever Works node studio-win|node-11111111-1111-4111-8111-111111111111@nodes.ever.works'
+		);
+	});
+
+	it('keeps the pre-slice literals when no identity is supplied', async () => {
+		// The cloud runner passes none, and its commits must not change.
+		const handle = await provision('push-identity-default', 'task/identity-bbbb2222');
+		writeFileSync(join(handle.path, 'work.txt'), 'work\n');
+
+		await plugin.finalize(handle, { commitMessage: 'feat: default run', push: false });
+
+		expect(git(handle.path, 'log', '-1', '--format=%an|%ae')).toBe('Ever Works Agent|agent@ever.works');
+		expect(git(handle.path, 'log', '-1', '--format=%cn|%ce')).toBe('Ever Works Agent|agent@ever.works');
+	});
+});
+
+describe('scoped push credential (real git)', () => {
+	it('pushes with the credential and leaves NOTHING in the repository config', async () => {
+		const handle = await provision('push-scoped', 'task/scoped-cccc3333');
+		writeFileSync(join(handle.path, 'work.txt'), 'scoped\n');
+
+		const result = await plugin.finalize(handle, {
+			commitMessage: 'feat: scoped push',
+			push: true,
+			pushCredential: {
+				username: 'x-access-token',
+				token: 'ghs_scoped_push_token_value',
+				remoteUrl: originUrl
+			}
+		});
+
+		expect(result.pushed).toBe(true);
+		// The credential lived in the child's environment and nowhere else.
+		// `--local` inside a linked worktree reads the SHARED pool config,
+		// so this also proves nothing landed where a sibling Task's
+		// worktree could read it.
+		const config = git(handle.path, 'config', '--local', '--list');
+		expect(config).not.toContain('ghs_scoped_push_token_value');
+		expect(config.toLowerCase()).not.toContain('extraheader');
+		expect(config.toLowerCase()).not.toContain('credential.');
+	});
+
+	it('leaves the token in NO file anywhere under the workspace pool', async () => {
+		// The strongest form of "prove it is gone before anything can commit
+		// it": the credential is never written down at all, so `git add -A`
+		// (which ran moments earlier, in this very finalize) had nothing to
+		// stage and a crash has nothing to leave behind. Slice Y had to
+		// DELETE its `.env` files before the first Git command; there is
+		// nothing here to delete.
+		const handle = await provision('push-nofiles', 'task/nofiles-ffff6666');
+		writeFileSync(join(handle.path, 'work.txt'), 'no files\n');
+		const token = 'ghs_unique_sentinel_for_the_file_scan';
+
+		await plugin.finalize(handle, {
+			commitMessage: 'feat: no files',
+			push: true,
+			pushCredential: { username: 'x-access-token', token, remoteUrl: originUrl }
+		});
+
+		const offenders: string[] = [];
+		const walk = (dir: string): void => {
+			for (const entry of readdirSync(dir)) {
+				const full = join(dir, entry);
+				let stats;
+				try {
+					stats = statSync(full);
+				} catch {
+					continue;
+				}
+				if (stats.isDirectory()) {
+					walk(full);
+					continue;
+				}
+				if (stats.size > 4 * 1024 * 1024) continue;
+				try {
+					if (readFileSync(full, 'utf8').includes(token)) offenders.push(full);
+				} catch {
+					// Binary or unreadable: a token is utf8 text, so a file
+					// that cannot be read as utf8 cannot be holding one.
+				}
+			}
+		};
+		walk(baseDir);
+
+		expect(offenders).toEqual([]);
+		// And the checkout itself is clean, so nothing new appeared for a
+		// later `git add -A` to pick up either.
+		expect(git(handle.path, 'status', '--porcelain')).toBe('');
+	});
+
+	it('REFUSES to push when origin is not the remote the credential was issued for', async () => {
+		const handle = await provision('push-mismatch', 'task/mismatch-dddd4444');
+		writeFileSync(join(handle.path, 'work.txt'), 'mismatch\n');
+		const before = git(handle.path, 'rev-parse', 'HEAD');
+
+		await expect(
+			plugin.finalize(handle, {
+				commitMessage: 'feat: wrong remote',
+				push: true,
+				pushCredential: {
+					username: 'x-access-token',
+					token: 'ghs_scoped_push_token_value',
+					remoteUrl: 'https://github.com/someone-else/private-repo.git'
+				}
+			})
+		).rejects.toThrow(/does not cover this checkout/);
+
+		// The commit still exists locally (nothing is rolled back), but the
+		// branch was never published — a write credential must not be
+		// offered to a remote the platform did not scope it to.
+		expect(git(handle.path, 'rev-parse', 'HEAD')).not.toBe(before);
+		expect(() => git(seedDir, 'ls-remote', originUrl, 'task/mismatch-dddd4444')).not.toThrow();
+		expect(git(seedDir, 'ls-remote', originUrl, 'task/mismatch-dddd4444')).toBe('');
+	});
+
+	it('REFUSES to publish when a credential is already persisted in the repository config', async () => {
+		// Fail closed: a helper sitting in the pool config could answer the
+		// push instead of the scoped credential, which is the ambient
+		// fallback this slice exists to remove.
+		const handle = await provision('push-persisted', 'task/persisted-eeee5555');
+		writeFileSync(join(handle.path, 'work.txt'), 'persisted\n');
+		git(handle.path, 'config', '--local', 'credential.helper', 'store');
+
+		try {
+			await expect(
+				plugin.finalize(handle, {
+					commitMessage: 'feat: persisted helper',
+					push: true,
+					pushCredential: {
+						username: 'x-access-token',
+						token: 'ghs_scoped_push_token_value',
+						remoteUrl: originUrl
+					}
+				})
+				// The probe's message widened when the slice AM review added the
+				// `url.*.insteadOf` / `pushInsteadOf` family to it (see the
+				// rewrite cases below), so the assertion names the family this
+				// case actually seeds rather than the whole sentence.
+			).rejects.toThrow(/credential.*settings \(credential\.helper\)/);
+			expect(git(seedDir, 'ls-remote', originUrl, 'task/persisted-eeee5555')).toBe('');
+		} finally {
+			git(handle.path, 'config', '--local', '--unset', 'credential.helper');
+		}
+	});
+
+	// REGRESSION — a URL REWRITE aims the credential at another host
+	// (slice AM review, F1/F4, and the `pushInsteadOf` variant found while
+	// fixing them).
+	//
+	// `url.<x>.insteadOf` is visible to `git remote get-url origin`, so the
+	// node's host check sees the rewritten URL and refuses. `pushInsteadOf`
+	// is NOT: measured against git 2.53, with `url.<B>.pushInsteadOf = <A>`,
+	// `git remote get-url origin` still reports A while `git push A` writes
+	// to B — and this plugin pushes an EXPLICIT url, which Git rewrites just
+	// the same. So the publish could be aimed at a host nothing upstream ever
+	// saw. The pool config is exactly the scope a model with acceptEdits over
+	// the checkout can reach through the worktree's `.git` pointer, which is
+	// why the probe is `--local`.
+	it.each([['insteadOf'], ['pushInsteadOf']])(
+		'REFUSES to publish when the pool config carries a %s',
+		async (variable) => {
+			const branch = `task/rewrite-${variable.toLowerCase()}-9999`;
+			const handle = await provision(`push-rewrite-${variable}`, branch);
+			writeFileSync(join(handle.path, 'work.txt'), 'rewrite\n');
+			git(handle.path, 'config', '--local', `url.https://evil.tld/.${variable}`, 'https://github.com/');
+
+			try {
+				await expect(
+					plugin.finalize(handle, {
+						commitMessage: 'feat: rewritten remote',
+						push: true,
+						pushCredential: {
+							username: 'x-access-token',
+							token: 'ghs_scoped_push_token_value',
+							remoteUrl: originUrl
+						}
+					})
+				).rejects.toThrow(/remote-rewrite settings/);
+				// Nothing was published under the rewrite.
+				expect(git(seedDir, 'ls-remote', originUrl, branch)).toBe('');
+			} finally {
+				git(handle.path, 'config', '--local', '--unset', `url.https://evil.tld/.${variable}`);
+			}
+		}
+	);
+
+	// REGRESSION — a `pre-push` hook in the POOL reads the credential out of
+	// the push's own environment (slice AM review, F2).
+	//
+	// The hook lives in the common dir, so it is untracked, outside the
+	// checkout, invisible to `assertNoPersistedCredential`, and survives
+	// worktree teardown to fire on every later Task of this repository on
+	// this machine.
+	it('runs no pool hook on a credentialed push, so nothing can read the environment', async () => {
+		const handle = await provision('push-hook', 'task/hook-7777aaaa');
+		writeFileSync(join(handle.path, 'work.txt'), 'hooked\n');
+
+		// `<worktree>/.git` is a file pointing at `<pool>/worktrees/<name>`;
+		// the hooks dir is two levels up from there, in the common dir.
+		const gitDir = git(handle.path, 'rev-parse', '--git-common-dir');
+		const hooksDir = join(gitDir, 'hooks');
+		const receipt = join(root, `hook-receipt-${Date.now()}.txt`);
+		mkdirSync(hooksDir, { recursive: true });
+		writeFileSync(
+			join(hooksDir, 'pre-push'),
+			// Writes whatever credential material the environment hands it.
+			`#!/bin/sh\nprintf '%s' "fired:$GIT_CONFIG_VALUE_3" > '${receipt.replace(/\\/g, '/')}'\nexit 0\n`,
+			{ mode: 0o755 }
+		);
+
+		const result = await plugin.finalize(handle, {
+			commitMessage: 'feat: hooked push',
+			push: true,
+			pushCredential: {
+				username: 'x-access-token',
+				token: 'ghs_hook_harvest_sentinel_token',
+				remoteUrl: originUrl
+			}
+		});
+
+		expect(result.pushed).toBe(true);
+		// The hook never ran, so it never saw the header. If it had, the
+		// receipt would hold the base64 basic-auth form of a live token.
+		let harvested: string | null = null;
+		try {
+			harvested = readFileSync(receipt, 'utf8');
+		} catch {
+			harvested = null;
+		}
+		expect(harvested).toBeNull();
+	});
+});
+
+describe('how the credential reaches git (execFile seam)', () => {
+	type Invocation = { args: string[]; env: NodeJS.ProcessEnv };
+
+	const TOKEN = 'ghs_0123456789abcdefghijklmnopqrstuvwxyz';
+	const REMOTE = 'https://github.com/ever-works/ever-works.git';
+
+	function fakeGit(invocations: Invocation[], pushStderr?: string) {
+		return ((
+			_command: string,
+			args: string[],
+			options: { env?: NodeJS.ProcessEnv },
+			callback: (error: Error | null, stdout: string, stderr: string) => void
+		) => {
+			invocations.push({ args: [...args], env: { ...(options.env ?? {}) } });
+			const joined = args.join(' ');
+			let stdout = '';
+			let stderr = '';
+			let error: Error | null = null;
+			if (joined.startsWith('status')) stdout = ' M work.txt\n';
+			else if (joined.startsWith('rev-parse')) stdout = 'a'.repeat(40);
+			else if (joined.startsWith('remote get-url')) stdout = `${REMOTE}\n`;
+			else if (joined.startsWith('diff')) stdout = 'work.txt\n';
+			else if (joined.includes('--get-regexp')) {
+				// git exits 1 when nothing matches, which is the healthy answer.
+				error = Object.assign(new Error('no match'), { code: 1 });
+			} else if (joined.startsWith('push') && pushStderr) {
+				stderr = pushStderr;
+				error = Object.assign(new Error('push failed'), { code: 128 });
+			}
+			setImmediate(() => callback(error, stdout, stderr));
+			return { pid: 1 } as never;
+		}) as never;
+	}
+
+	const handle: WorkspaceHandle = {
+		path: '/tmp/does-not-matter',
+		baseSha: 'b'.repeat(40),
+		reused: false,
+		branch: 'task/seam-ffff6666',
+		bindingKey: 'seam'
+	};
+
+	const credential = { username: 'x-access-token', token: TOKEN, remoteUrl: REMOTE };
+
+	it('carries the credential in the ENVIRONMENT and never in argv', async () => {
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential });
+
+		const push = invocations.find((entry) => entry.args[0] === 'push');
+		expect(push).toBeDefined();
+
+		// NOT in argv. This is the hazard the cloud path's URL-userinfo form
+		// has: any local account can read a process listing.
+		for (const entry of invocations) {
+			// `\u0000` as the escape, never a raw NUL byte in the source: a
+			// control character in a file is invisible in review and in a
+			// diff, which is the same reason `sanitizeFleetPushIdentityText`
+			// is written as a code-point walk rather than a regex.
+			expect(entry.args.join('\u0000')).not.toContain(TOKEN);
+			// And the remote is still the token-free URL.
+			expect(entry.args).not.toContain(`https://x-access-token:${TOKEN}@github.com/ever-works/ever-works.git`);
+		}
+
+		// IN the environment of exactly the push, as a URL-scoped header.
+		// FOUR entries, not two: the slice AM review found that resetting
+		// `credential.helper` alone does not close the fallbacks —
+		// `core.askpass` is consulted before any helper, and `core.hooksPath`
+		// decides whether a `pre-push` hook gets handed this very
+		// environment. The header is LAST, so its index moves with them.
+		const basic = Buffer.from(`x-access-token:${TOKEN}`, 'utf8').toString('base64');
+		expect(push?.env.GIT_CONFIG_COUNT).toBe('4');
+		expect(push?.env.GIT_CONFIG_KEY_3).toBe(`http.${REMOTE}.extraheader`);
+		expect(push?.env.GIT_CONFIG_VALUE_3).toBe(`Authorization: Basic ${basic}`);
+	});
+
+	it('APPENDS to environment config the process already carries', async () => {
+		// `GIT_CONFIG_COUNT` may already be set — an operator pinning a
+		// setting, a harness rewriting remotes with `url.<x>.insteadOf`.
+		// Writing index 0 would silently drop theirs, and would also stop
+		// our `credential.helper` reset from being the LAST word in config
+		// order, which is the only reason it beats the system helper.
+		const previous = {
+			count: process.env.GIT_CONFIG_COUNT,
+			key: process.env.GIT_CONFIG_KEY_0,
+			value: process.env.GIT_CONFIG_VALUE_0
+		};
+		process.env.GIT_CONFIG_COUNT = '1';
+		process.env.GIT_CONFIG_KEY_0 = 'url.file:///local/.insteadOf';
+		process.env.GIT_CONFIG_VALUE_0 = 'https://github.com/';
+		try {
+			const invocations: Invocation[] = [];
+			const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+			await seamed.finalize(handle, {
+				commitMessage: 'feat: seam',
+				push: true,
+				pushCredential: credential
+			});
+
+			const push = invocations.find((entry) => entry.args[0] === 'push');
+			expect(push?.env.GIT_CONFIG_COUNT).toBe('5');
+			expect(push?.env.GIT_CONFIG_KEY_0).toBe('url.file:///local/.insteadOf');
+			expect(push?.env.GIT_CONFIG_KEY_1).toBe('credential.helper');
+			expect(push?.env.GIT_CONFIG_VALUE_1).toBe('');
+			expect(push?.env.GIT_CONFIG_KEY_2).toBe('core.askpass');
+			expect(push?.env.GIT_CONFIG_KEY_3).toBe('core.hooksPath');
+			expect(push?.env.GIT_CONFIG_KEY_4).toBe(`http.${REMOTE}.extraheader`);
+		} finally {
+			if (previous.count === undefined) delete process.env.GIT_CONFIG_COUNT;
+			else process.env.GIT_CONFIG_COUNT = previous.count;
+			if (previous.key === undefined) delete process.env.GIT_CONFIG_KEY_0;
+			else process.env.GIT_CONFIG_KEY_0 = previous.key;
+			if (previous.value === undefined) delete process.env.GIT_CONFIG_VALUE_0;
+			else process.env.GIT_CONFIG_VALUE_0 = previous.value;
+		}
+	});
+
+	it('resets the credential helper list so no ambient helper can answer', async () => {
+		// THE fail-closed guarantee. The fleet's Windows nodes carry
+		// `credential.helper=manager` in the SYSTEM gitconfig — no HOME
+		// override touches it — so without this reset the long-lived
+		// machine PAT authenticates the push exactly as before and the
+		// slice changes nothing. Verified against real git: with the reset,
+		// `git credential fill` goes straight to "terminal prompts
+		// disabled" instead of invoking the manager.
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential });
+
+		const push = invocations.find((entry) => entry.args[0] === 'push');
+		expect(push?.env.GIT_CONFIG_KEY_0).toBe('credential.helper');
+		expect(push?.env.GIT_CONFIG_VALUE_0).toBe('');
+		// And terminal prompting stays off, so a rejected header cannot fall
+		// through to an interactive read either.
+		expect(push?.env.GIT_TERMINAL_PROMPT).toBe('0');
+	});
+
+	// REGRESSION — the askpass fallback (slice AM review, F5).
+	//
+	// The doc above used to claim that with `GIT_TERMINAL_PROMPT=0` and the
+	// helper reset "Git has no other credential source and a rejected header
+	// FAILS". Measured against git 2.53, that was false: askpass is consulted
+	// BEFORE any credential helper and is not part of the helper list, so
+	//
+	//   GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=./a.sh GIT_CONFIG_COUNT=1 \
+	//   GIT_CONFIG_KEY_0=credential.helper GIT_CONFIG_VALUE_0= git credential fill
+	//
+	// returned a username and password from the helper with exit 0. So every
+	// 401 — an expired token, a token the platform scoped elsewhere — fell
+	// back to the machine's own long-lived credentials and the push succeeded
+	// with no trace in the run, which is precisely the gap this slice closes.
+	// Closing it needs BOTH halves, also measured: with `core.askpass` reset
+	// AND the environment ones deleted the same command dies `could not read
+	// Username ... terminal prompts disabled`.
+	it('closes the askpass fallback in BOTH of its forms', async () => {
+		const previous = {
+			ask: process.env.GIT_ASKPASS,
+			ssh: process.env.SSH_ASKPASS,
+			params: process.env.GIT_CONFIG_PARAMETERS
+		};
+		process.env.GIT_ASKPASS = 'C:\\ambient\\askpass.exe';
+		process.env.SSH_ASKPASS = '/usr/bin/ssh-askpass';
+		// Not askpass, but the same class of hole: `GIT_CONFIG_PARAMETERS` is
+		// the transport `git -c` uses and Git reads it AFTER `GIT_CONFIG_COUNT`,
+		// so it OVERRIDES the reset. Measured: `git config --get-all
+		// credential.helper` with our reset plus this variable ends with the
+		// variable's value, i.e. an inherited helper answers the push anyway.
+		process.env.GIT_CONFIG_PARAMETERS = "'credential.helper=imposter'";
+		try {
+			const invocations: Invocation[] = [];
+			const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+			await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential });
+
+			const push = invocations.find((entry) => entry.args[0] === 'push');
+			// Half one: the CONFIG form, for a `core.askpass` set in the
+			// system or global gitconfig, which the helper reset cannot
+			// displace because it is not a helper.
+			expect(push?.env.GIT_CONFIG_KEY_1).toBe('core.askpass');
+			expect(push?.env.GIT_CONFIG_VALUE_1).toBe('');
+			// Half two: the ENVIRONMENT forms, DELETED rather than emptied —
+			// an empty `GIT_ASKPASS` is still set, and Git would try to run
+			// "" as a program.
+			expect(push?.env).not.toHaveProperty('GIT_ASKPASS');
+			expect(push?.env).not.toHaveProperty('SSH_ASKPASS');
+			expect(push?.env).not.toHaveProperty('GIT_CONFIG_PARAMETERS');
+
+			// Every OTHER command keeps the operator's environment: none of
+			// them carries a write token, so none of them needs narrowing.
+			const status = invocations.find((entry) => entry.args[0] === 'status');
+			expect(status?.env.GIT_ASKPASS).toBe('C:\\ambient\\askpass.exe');
+		} finally {
+			for (const [name, value] of [
+				['GIT_ASKPASS', previous.ask],
+				['SSH_ASKPASS', previous.ssh],
+				['GIT_CONFIG_PARAMETERS', previous.params]
+			] as const) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+		}
+	});
+
+	// REGRESSION — the pre-push hook harvests the token (slice AM review, F2).
+	//
+	// Git hands a `pre-push` hook the whole child environment, so the hook
+	// can read `GIT_CONFIG_VALUE_<n>` — the base64 basic-auth form of a live
+	// `contents: write` token — and `exit 0` so the run still looks clean.
+	// Measured against git 2.53 in this plugin's exact layout (bare pool +
+	// `git worktree add`): a hook at `<poolDir>/hooks/pre-push` fired on a
+	// push from the linked worktree and printed
+	// `GIT_CONFIG_VALUE_1=Authorization: Basic eC1hY2Nlc3MtdG9rZW46Z2hzXy4uLg`.
+	// It is outside the checkout, so `git add -A` never stages it,
+	// `assertNoPersistedCredential` never sees it, and it survives worktree
+	// teardown to harvest the NEXT Task's token too.
+	it('runs no hooks on a credentialed push', async () => {
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential });
+
+		const push = invocations.find((entry) => entry.args[0] === 'push');
+		expect(push?.args).toContain('--no-verify');
+		expect(push?.env.GIT_CONFIG_KEY_2).toBe('core.hooksPath');
+		expect(push?.env.GIT_CONFIG_VALUE_2).toBe('');
+		// The refspec and the remote still follow, in that order — the flag
+		// was inserted, not substituted for one of them.
+		expect(push?.args.slice(-2)).toEqual([REMOTE, `HEAD:refs/heads/${handle.branch}`]);
+	});
+
+	it('leaves hooks alone when there is no credential to protect', async () => {
+		// The cloud runner's path. It authenticates through URL userinfo and
+		// carries no environment credential for a hook to read, so silencing
+		// its hooks would be an unrelated behaviour change.
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true });
+
+		const push = invocations.find((entry) => entry.args[0] === 'push');
+		expect(push?.args).not.toContain('--no-verify');
+	});
+
+	// REGRESSION — the post-push probe used to mask the push failure and to
+	// fail a push that had already landed (slice AM review, F9).
+	//
+	// No test reached this branch before: the only spec that makes the probe
+	// throw seeds `credential.helper` BEFORE finalize, so the PRE-push probe
+	// fires and the push never runs; in every seam test the `--get-regexp`
+	// fake exits 1, so the post-push probe runs but can never throw.
+	// Deleting the post-push call left the whole suite green.
+	describe('the post-push proof', () => {
+		/** A git fake whose `--get-regexp` answers differ before and after the push. */
+		function fakeGitWithLateConfig(invocations: Invocation[], pushFails: boolean) {
+			let pushed = false;
+			return ((
+				_command: string,
+				args: string[],
+				options: { env?: NodeJS.ProcessEnv },
+				callback: (error: Error | null, stdout: string, stderr: string) => void
+			) => {
+				invocations.push({ args: [...args], env: { ...(options.env ?? {}) } });
+				const joined = args.join(' ');
+				let stdout = '';
+				let stderr = '';
+				let error: Error | null = null;
+				if (joined.startsWith('status')) stdout = ' M work.txt\n';
+				else if (joined.startsWith('rev-parse')) stdout = 'a'.repeat(40);
+				else if (joined.startsWith('remote get-url')) stdout = `${REMOTE}\n`;
+				else if (joined.startsWith('diff')) stdout = 'work.txt\n';
+				else if (joined.includes('--get-regexp')) {
+					// Clean before the push, dirty after it — the shape of a
+					// credential that only appears once git has run.
+					if (pushed) stdout = 'credential.helper\n';
+					else error = Object.assign(new Error('no match'), { code: 1 });
+				} else if (joined.startsWith('push')) {
+					pushed = true;
+					if (pushFails) {
+						stderr = 'remote rejected: refs/heads/task/seam-ffff6666 (protected branch)';
+						error = Object.assign(new Error('push failed'), { code: 128 });
+					}
+				}
+				setImmediate(() => callback(error, stdout, stderr));
+				return { pid: 1 } as never;
+			}) as never;
+		}
+
+		it('never replaces the real push failure with its own', async () => {
+			const invocations: Invocation[] = [];
+			const seamed = new LocalWorkspacePlugin({ execFile: fakeGitWithLateConfig(invocations, true) });
+
+			const error = await seamed
+				.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential })
+				.then(
+					() => null,
+					(caught: Error) => caught
+				);
+
+			// The operator debugs the protected branch, which is what
+			// actually failed the run — not a config probe that fired
+			// afterwards. Before this fix `pushFailure` was silently
+			// discarded and only the probe's message survived.
+			expect(error?.message).toContain('protected branch');
+			// And the probe's finding is not dropped either: a credential in
+			// the shared pool config is a security event, not a footnote.
+			expect(error?.message).toContain('credential.helper');
+		});
+
+		it('says the branch IS on the remote when the push already succeeded', async () => {
+			const invocations: Invocation[] = [];
+			const seamed = new LocalWorkspacePlugin({ execFile: fakeGitWithLateConfig(invocations, false) });
+
+			const error = await seamed
+				.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential })
+				.then(
+					() => null,
+					(caught: Error) => caught
+				);
+
+			// The control still fails closed — a persisted credential stops
+			// the run — but the message no longer reads `refusing to
+			// publish` for a ref the remote has already accepted. The caller
+			// records `pushed: false`, so without this sentence the operator
+			// (and the reconciler behind them) chases state that diverged.
+			expect(error?.message).toContain('the push completed');
+			expect(error?.message).toContain('the branch IS on the remote');
+			expect(error?.message).not.toContain('refusing to publish');
+		});
+	});
+
+	it('gives no other git command the credential', async () => {
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential });
+
+		for (const entry of invocations.filter((call) => call.args[0] !== 'push')) {
+			expect(entry.env.GIT_CONFIG_COUNT).toBeUndefined();
+			expect(JSON.stringify(entry.env)).not.toContain(TOKEN);
+		}
+	});
+
+	it('scrubs the token — raw AND base64 — out of a failed push', async () => {
+		// `git push` stderr is wrapped into the fleet job's git result and
+		// stored verbatim in `fleet_jobs.result`, so anything git echoes
+		// back has to be scrubbed at the source.
+		const basic = Buffer.from(`x-access-token:${TOKEN}`, 'utf8').toString('base64');
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({
+			execFile: fakeGit(invocations, `remote rejected: header was 'Authorization: Basic ${basic}' (${TOKEN})`)
+		});
+
+		await expect(
+			seamed.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential })
+		).rejects.toThrow(/git push failed/);
+
+		await seamed
+			.finalize(handle, { commitMessage: 'feat: seam', push: true, pushCredential: credential })
+			.catch((error: Error) => {
+				expect(error.message).not.toContain(TOKEN);
+				expect(error.message).not.toContain(basic);
+				expect(error.message).toContain('***');
+			});
+	});
+
+	it('does not install anything when the caller supplied no credential', async () => {
+		// The cloud runner's path, byte-for-byte what it was.
+		const invocations: Invocation[] = [];
+		const seamed = new LocalWorkspacePlugin({ execFile: fakeGit(invocations) });
+
+		await seamed.finalize(handle, { commitMessage: 'feat: seam', push: true });
+
+		for (const entry of invocations) {
+			expect(entry.env.GIT_CONFIG_COUNT).toBeUndefined();
+		}
+		// And no persisted-credential probe runs either: the check belongs
+		// to the scoped path, not to every caller of this provider.
+		expect(invocations.some((entry) => entry.args.includes('--get-regexp'))).toBe(false);
+	});
+});

--- a/packages/plugins/local-workspace/src/local-workspace.plugin.ts
+++ b/packages/plugins/local-workspace/src/local-workspace.plugin.ts
@@ -10,7 +10,8 @@ import type {
 	WorkspaceFinalizeOptions,
 	WorkspaceFinalizeResult,
 	WorkspaceMergeSimulation,
-	WorkspacePublishFence
+	WorkspacePublishFence,
+	WorkspacePushCredential
 } from '@ever-works/plugin';
 import { WorkspaceNotProvisionedError } from '@ever-works/plugin';
 import { execFile, type ChildProcess } from 'node:child_process';
@@ -409,13 +410,22 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		const status = await this.gitOrThrow(['status', '--porcelain'], dir, opts.auth, 'git status failed', signal);
 		const dirty = status.stdout.trim().length > 0;
 		if (dirty) {
+			// Committer identity stays in `-c` flags — transient, never
+			// written to the shared pool config a linked worktree's
+			// `--local` would land in. The literals are the FALLBACK now
+			// rather than the only answer: a caller that knows which
+			// machine and which agent produced the change says so
+			// (self-build slice AM), and `--author` carries the agent while
+			// `user.*` carries the machine, so `git log` answers both.
+			const identity = opts.identity;
 			await this.gitOrThrow(
 				[
 					'-c',
-					'user.name=Ever Works Agent',
+					`user.name=${identity?.committerName || 'Ever Works Agent'}`,
 					'-c',
-					'user.email=agent@ever.works',
+					`user.email=${identity?.committerEmail || 'agent@ever.works'}`,
 					'commit',
+					...(identity ? [`--author=${identity.authorName} <${identity.authorEmail}>`] : []),
 					'-m',
 					opts.commitMessage
 				],
@@ -457,13 +467,84 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 			const repoUrl = (
 				await this.gitOrThrow(['remote', 'get-url', 'origin'], dir, opts.auth, 'origin remote missing', signal)
 			).stdout.trim();
-			await this.gitOrThrow(
-				['push', this.authedUrl(repoUrl, opts.auth), `HEAD:refs/heads/${handle.branch}`],
-				dir,
-				opts.auth,
-				'git push failed',
-				signal
-			);
+			const credential = this.resolvePushCredential(opts.pushCredential, repoUrl);
+			if (credential) {
+				// Fail closed BEFORE the write, twice: once because a
+				// credential already sitting in this repository's config
+				// could answer the push instead of ours, and once after,
+				// because the whole promise of an environment-carried
+				// credential is that nothing of it survives the command.
+				await this.assertNoPersistedCredential(dir, signal);
+			}
+			let pushFailure: unknown = null;
+			try {
+				await this.gitOrThrow(
+					[
+						'push',
+						// A credentialed push runs NO hooks. Git hands a
+						// `pre-push` hook the whole child environment, which
+						// is where the scoped credential rides — a hook can
+						// simply print `GIT_CONFIG_VALUE_<n>` and read the
+						// base64 basic-auth form of a live `contents: write`
+						// token, then `exit 0` so the run looks clean.
+						//
+						// The hook does not even have to be in the checkout:
+						// hooks resolve through the COMMON dir, so a file
+						// planted at `<poolDir>/hooks/pre-push` is untracked,
+						// invisible to `git add -A`, missed by
+						// `assertNoPersistedCredential`'s config probe,
+						// survives worktree teardown, and then fires on the
+						// push of EVERY later Task on that repository on that
+						// machine, harvesting each run's freshly minted token.
+						// The model holds acceptEdits over the checkout and can
+						// resolve the pool from the worktree's `.git` pointer,
+						// so writing that file is within its reach.
+						//
+						// Nothing legitimate is lost: the pool is a bare repo
+						// this plugin creates with `init --bare`, and the fleet
+						// never installs a hook into it. `core.hooksPath` is
+						// reset in `credentialEnv` as well, so neutralising the
+						// hooks does not depend on this one flag being right.
+						...(credential ? ['--no-verify'] : []),
+						this.authedUrl(repoUrl, opts.auth),
+						`HEAD:refs/heads/${handle.branch}`
+					],
+					dir,
+					opts.auth,
+					'git push failed',
+					signal,
+					credential
+				);
+			} catch (error) {
+				pushFailure = error;
+			}
+			// The proof runs whether or not the push succeeded — a REJECTED
+			// push is precisely when Git walks the helper list's `erase`
+			// path — but not after a cancellation, where the next Git call
+			// would only re-raise the abort and hide it.
+			//
+			// Its own failure NEVER replaces the push's. This probe used to
+			// run bare, so a throw here discarded `pushFailure` and an
+			// operator reading `refusing to publish: … persisted credential
+			// settings` went hunting for a config problem instead of the
+			// `remote rejected` that actually failed the run.
+			if (credential && !signal?.aborted) {
+				try {
+					await this.assertNoPersistedCredential(dir, signal, pushFailure === null);
+				} catch (probeFailure) {
+					if (pushFailure === null) throw probeFailure;
+					// The push already failed and is the more useful answer.
+					// The probe's finding is appended rather than dropped: a
+					// credential persisted into the shared pool config is a
+					// security event, not a footnote.
+					throw new Error(
+						`${pushFailure instanceof Error ? pushFailure.message : String(pushFailure)} (additionally: ${
+							probeFailure instanceof Error ? probeFailure.message : String(probeFailure)
+						})`
+					);
+				}
+			}
+			if (pushFailure) throw pushFailure;
 			pushed = true;
 		}
 
@@ -784,10 +865,218 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		}
 	}
 
+	/**
+	 * The scoped credential this publish may use, or null.
+	 *
+	 * REFUSES — rather than degrading to the ambient helper — when the
+	 * checkout's `origin` is not byte-identical to the remote the caller
+	 * scoped the credential to. A credential is issued for a named set of
+	 * repositories; a checkout pointing anywhere else is either a bug or
+	 * an attempt to aim a write token somewhere the platform never
+	 * authorised, and "push it with whatever the machine's own helper
+	 * answers" is the exact hole this slice closes.
+	 *
+	 * A caller that supplied no credential at all keeps the pre-slice
+	 * behaviour: this provider also serves the cloud runner, which
+	 * authenticates through {@link WorkspaceProvisionSpec.auth}. Requiring
+	 * a scoped credential is the FLEET's rule and is enforced by the node,
+	 * which is the only side that can tell a fleet job from a cloud one.
+	 */
+	private resolvePushCredential(
+		credential: WorkspacePushCredential | undefined,
+		repoUrl: string
+	): WorkspacePushCredential | null {
+		if (!credential?.token) return null;
+		if (!credential.remoteUrl || credential.remoteUrl !== repoUrl) {
+			throw new Error(
+				'scoped push credential does not cover this checkout: the origin remote is not the one it was issued for'
+			);
+		}
+		return credential;
+	}
+
+	/**
+	 * Install a scoped credential for ONE `git` invocation, through the
+	 * child ENVIRONMENT.
+	 *
+	 * Two variables, and both are load-bearing:
+	 *
+	 *  - `credential.helper` with an EMPTY value resets Git's helper list
+	 *    to nothing. Without it the machine's system-level helper (Git
+	 *    Credential Manager on the fleet's Windows nodes) answers first
+	 *    and the long-lived machine PAT authenticates the push exactly as
+	 *    before — a fallback that would leave this slice's gap open.
+	 *  - `core.askpass` with an EMPTY value closes the OTHER fallback.
+	 *    `GIT_TERMINAL_PROMPT=0` disables only the TERMINAL prompt; Git
+	 *    consults `GIT_ASKPASS`, then `core.askpass`, then `SSH_ASKPASS`
+	 *    FIRST, and none of those is a credential helper, so resetting
+	 *    `credential.helper` does not displace them. Measured with git
+	 *    2.53: `GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=./a.sh` plus this
+	 *    module's exact `credential.helper` reset still returned a
+	 *    username and password from the askpass helper, exit 0 — so any
+	 *    rejected header (an expired token, a `401`) silently fell back to
+	 *    the machine's own long-lived credentials and the push succeeded
+	 *    anyway, leaving no trace in the run. Both halves are needed: this
+	 *    config reset for a configured `core.askpass`, and the deletion of
+	 *    `GIT_ASKPASS`/`SSH_ASKPASS` from the child env (see
+	 *    {@link credentialEnvRemovals}) for the environment ones. With
+	 *    both, the same command dies `could not read Username … terminal
+	 *    prompts disabled`, which is the fail-closed behaviour this
+	 *    paragraph used to merely claim.
+	 *  - `core.hooksPath` with an EMPTY value stops Git running any hook
+	 *    for this command. A `pre-push` hook is a child of the push and
+	 *    inherits `GIT_CONFIG_VALUE_<n>`, i.e. the base64 basic-auth form
+	 *    of the token; hooks resolve through the COMMON dir, so one
+	 *    planted at `<poolDir>/hooks/pre-push` is outside the checkout,
+	 *    untracked, survives teardown, and harvests every later run's
+	 *    token on that repository. `--no-verify` on the push covers the
+	 *    same ground; both are here because either one alone is a single
+	 *    edit away from being lost.
+	 *  - `http.<remote>.extraheader` carries the credential itself, keyed
+	 *    to the exact remote URL, so Git never offers it to another host.
+	 *
+	 * Why the environment and not `git -c` or a config file:
+	 *
+	 *  - `-c` puts the credential in the process ARGV, where any local
+	 *    account can read it out of a process listing for the life of the
+	 *    push. That is how the cloud path's URL-userinfo form leaks, and
+	 *    it is named in this slice's brief as a hazard.
+	 *  - `git config --local` inside a LINKED WORKTREE writes the shared
+	 *    pool config: the credential would be visible to every other
+	 *    Task's worktree of that repository on that machine, and would
+	 *    survive a crash. There is no per-worktree config here
+	 *    (`extensions.worktreeConfig` is never set).
+	 *  - The environment of a child process dies with the child. Nothing
+	 *    has to be cleaned up on a crash, a cancel or a lapsed lease,
+	 *    because nothing was ever written down.
+	 */
+	private credentialEnv(credential: WorkspacePushCredential, inherited: NodeJS.ProcessEnv): Record<string, string> {
+		const basic = Buffer.from(`${credential.username}:${credential.token}`, 'utf8').toString('base64');
+		// APPEND, never overwrite. `GIT_CONFIG_COUNT` may already be set by
+		// whoever started this process — an operator pinning a setting, a
+		// harness rewriting remotes with `url.<x>.insteadOf` — and writing
+		// index 0 would silently drop their entry AND ours would not be the
+		// last word. Appending also keeps the `credential.helper` reset at
+		// the END of the config order, which is what makes it win over
+		// everything the system and global files set.
+		const parsed = Number.parseInt(String(inherited.GIT_CONFIG_COUNT ?? ''), 10);
+		const base = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+		return {
+			GIT_CONFIG_COUNT: String(base + 4),
+			[`GIT_CONFIG_KEY_${base}`]: 'credential.helper',
+			[`GIT_CONFIG_VALUE_${base}`]: '',
+			[`GIT_CONFIG_KEY_${base + 1}`]: 'core.askpass',
+			[`GIT_CONFIG_VALUE_${base + 1}`]: '',
+			[`GIT_CONFIG_KEY_${base + 2}`]: 'core.hooksPath',
+			[`GIT_CONFIG_VALUE_${base + 2}`]: '',
+			[`GIT_CONFIG_KEY_${base + 3}`]: `http.${credential.remoteUrl}.extraheader`,
+			[`GIT_CONFIG_VALUE_${base + 3}`]: `Authorization: Basic ${basic}`
+		};
+	}
+
+	/**
+	 * Environment variables that must NOT reach a credentialed `git`
+	 * child, whatever the node process happened to inherit.
+	 *
+	 * `git()` splats `...process.env` into every child, so each of these
+	 * is a credential source that outranks — or entirely bypasses — the
+	 * config resets {@link credentialEnv} installs:
+	 *
+	 *  - `GIT_ASKPASS` / `SSH_ASKPASS`: consulted BEFORE any credential
+	 *    helper, and unaffected by resetting `credential.helper`. See the
+	 *    measurement in {@link credentialEnv}.
+	 *  - `GIT_CONFIG_PARAMETERS`: the transport `git -c` uses, and it is
+	 *    read AFTER `GIT_CONFIG_COUNT`, so it WINS. Measured: with our
+	 *    exact reset plus `GIT_CONFIG_PARAMETERS="'credential.helper=X'"`,
+	 *    `git config --get-all credential.helper` ends with `X` — the
+	 *    reset is overridden and an inherited helper answers the push.
+	 *
+	 * Applied only to a credentialed command: every other Git call this
+	 * plugin makes (fetch, status, config probes) keeps whatever the
+	 * operator configured, because none of them carries a write token.
+	 */
+	private static readonly credentialEnvRemovals = ['GIT_ASKPASS', 'SSH_ASKPASS', 'GIT_CONFIG_PARAMETERS'] as const;
+
+	/**
+	 * Prove that nothing in this repository's own Git configuration can
+	 * answer for — or redirect — a credentialed push.
+	 *
+	 * `--name-only` so the check can never print a value it found; `--local`
+	 * because that is where a linked worktree's config writes land, i.e.
+	 * the shared pool config every other Task's worktree of this
+	 * repository reads, and it is the scope a model with acceptEdits over
+	 * the checkout can reach through the worktree's `.git` pointer. Exit 1
+	 * (no match) is the healthy answer.
+	 *
+	 * Three families, and the third is not about credential STORAGE:
+	 *
+	 *  - `credential.*` — a helper configured here would answer the push
+	 *    instead of the header we install, which is the ambient machine PAT
+	 *    this slice exists to stop using.
+	 *  - `http.<url>.extraheader` — the form this plugin itself uses. One
+	 *    persisted on disk is a write credential that outlived its run.
+	 *  - `url.<x>.insteadOf` / `url.<x>.pushInsteadOf` — REDIRECTS. Git
+	 *    rewrites the URL it actually connects to, including an explicit
+	 *    one given on the push command line (measured: with
+	 *    `url.<B>.pushInsteadOf = <A>`, `git push <A>` writes to B). The
+	 *    `insteadOf` half is visible to `git remote get-url origin`, so the
+	 *    node's host check sees it and refuses; the `pushInsteadOf` half is
+	 *    NOT — `get-url` reports the unrewritten URL and only
+	 *    `get-url --push` reveals it — so without this probe a rewrite
+	 *    planted in the pool config could aim the publish at another host
+	 *    with every upstream check still passing. Git lower-cases the
+	 *    variable name in the config, hence `insteadof` here.
+	 *
+	 * `afterSuccessfulPush` only changes the WORDING. A probe that fires
+	 * after the remote has already accepted the ref must say so, or the
+	 * operator reads `refusing to publish` and goes looking for a branch
+	 * that is in fact on the remote while the run reports `pushed: false`.
+	 * The refusal itself stands either way: this control fails closed.
+	 */
+	private async assertNoPersistedCredential(
+		dir: string,
+		signal?: AbortSignal,
+		afterSuccessfulPush = false
+	): Promise<void> {
+		const probe = await this.git(
+			[
+				'config',
+				'--local',
+				'--name-only',
+				'--get-regexp',
+				'^(credential\\.|http\\..*\\.extraheader$|url\\..*\\.(insteadof|pushinsteadof)$)'
+			],
+			dir,
+			undefined,
+			signal
+		);
+		if (probe.code === 0 && probe.stdout.trim().length > 0) {
+			const found = probe.stdout.trim().split(/\r?\n/).join(', ');
+			throw new Error(
+				afterSuccessfulPush
+					? `the push completed, but this repository's Git config now carries persisted credential or remote-rewrite settings (${found}); the branch IS on the remote`
+					: `refusing to publish: this repository's Git config carries persisted credential or remote-rewrite settings (${found})`
+			);
+		}
+	}
+
 	/** Remove any credential material from text before it can be logged. */
-	private scrub(text: string, auth: WorkspaceProvisionSpec['auth']): string {
+	private scrub(
+		text: string,
+		auth: WorkspaceProvisionSpec['auth'],
+		credential?: WorkspacePushCredential | null
+	): string {
 		let out = text;
 		if (auth?.token) out = out.split(auth.token).join('***');
+		if (credential?.token) {
+			out = out.split(credential.token).join('***');
+			// The header form too: Git quotes what it sent when a transport
+			// error names the request, and base64 of the token is still the
+			// token.
+			out = out
+				.split(Buffer.from(`${credential.username}:${credential.token}`, 'utf8').toString('base64'))
+				.join('***');
+		}
 		// Belt-and-braces: strip userinfo from any URL that slipped through.
 		out = out.replace(/(https?:\/\/)[^/@\s]+@/g, '$1***@');
 		return out;
@@ -797,12 +1086,27 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		args: string[],
 		cwd: string | undefined,
 		auth: WorkspaceProvisionSpec['auth'],
-		signal?: AbortSignal
+		signal?: AbortSignal,
+		// Appended LAST and optional: every existing call site keeps its
+		// arity, and only the publish ever passes one.
+		credential?: WorkspacePushCredential | null
 	): Promise<GitResult> {
 		throwIfAborted(signal);
+		const inherited: NodeJS.ProcessEnv = { ...process.env };
+		if (credential) {
+			// DELETE, not set-to-empty: an empty `GIT_ASKPASS` is still a
+			// set variable and Git would try to run "" as a program. See
+			// `credentialEnvRemovals` for what each of these would
+			// otherwise do to a credentialed push.
+			for (const name of LocalWorkspacePlugin.credentialEnvRemovals) delete inherited[name];
+		}
 		return execFileWithVerifiedCancellation('git', args, {
 			...(cwd ? { cwd } : {}),
-			env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+			env: {
+				...inherited,
+				GIT_TERMINAL_PROMPT: '0',
+				...(credential ? this.credentialEnv(credential, inherited) : {})
+			},
 			maxBuffer: 16 * 1024 * 1024,
 			windowsHide: true,
 			...(signal ? { signal } : {}),
@@ -817,8 +1121,12 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 						: 0;
 			return {
 				code,
-				stdout: String(stdout ?? ''),
-				stderr: this.scrub(String(stderr ?? ''), auth)
+				// stdout is scrubbed too when a credential is in play: the
+				// push is the one command whose output a caller forwards
+				// into a job result, and `git push` writes remote messages
+				// there.
+				stdout: credential ? this.scrub(String(stdout ?? ''), auth, credential) : String(stdout ?? ''),
+				stderr: this.scrub(String(stderr ?? ''), auth, credential)
 			};
 		});
 	}
@@ -828,9 +1136,10 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		cwd: string | undefined,
 		auth: WorkspaceProvisionSpec['auth'],
 		what: string,
-		signal?: AbortSignal
+		signal?: AbortSignal,
+		credential?: WorkspacePushCredential | null
 	): Promise<GitResult> {
-		const result = await this.git(args, cwd, auth, signal);
+		const result = await this.git(args, cwd, auth, signal, credential);
 		if (result.code !== 0) {
 			throw new Error(`${what}: ${result.stderr.trim() || `git exited ${result.code}`}`);
 		}


### PR DESCRIPTION
## Summary

Phase-2 fleet slice **AM**. Refs **EW-810**, closes OPS-06 and R24.

**This was the largest standing security gap in the fleet**, and both halves were still live.

The push was token-free *by design* — *"the node's own Git credential helper authenticates, exactly as the fetch did"*. In practice that is a **long-lived, machine-local token with write access to every repository that OS user can reach**, on six unattended PCs, which the platform could neither scope per run, rotate, revoke on a lost laptop, nor even observe. And every commit from every agent on every machine was authored identically, so git history could not answer *which machine* or *which agent* produced a change.

The plugin's auth seam already existed; the fleet path simply never filled it — the push passed `auth === undefined`, so the URL builder returned the bare URL.

## What replaces it

A **GitHub App installation token**, minted per job over the node-authenticated channel, narrowed to **this job's repository ids** and **`contents: write` alone**, installed for **one `git push` child through its environment**, and revoked at GitHub when the run ends.

### The delivery mechanism is the part worth reading

The token goes in `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` on the push child only, **appending** to whatever the process already carries, with a `credential.helper` reset so the ambient helper cannot answer instead.

It is **never written to git config on disk** — and the reason is written into the code: `git config --local` inside a *linked worktree* lands in the **shared pool config that every other Task's worktree of that repository reads**, and survives a crash. A runtime assertion checks nothing persisted it, before *and* after the push, reading **names only** so it can never print a value.

It **never reaches argv**: the push URL stays token-free, pinned by a negative test asserting the token appears in no argument of any invocation.

**The model can never see it.** The mint is lazy and first happens *inside finalize*, after the model process has exited. So unlike slice Y's env files, there is nothing on disk to remove before the first Git command — the credential does not exist while the model is running.

### Every other channel, closed and pinned

| Channel | Why not |
| --- | --- |
| payload / job row / lease response / job view / `result` | Slice Y's lesson: none of them carries a credential or a request for one |
| node logs | the token is registered with the redactor **before the mint method returns** |
| git stderr **and stdout** → `fleet_jobs.result` | scrubbed of the raw token *and* its base64 basic-auth form, then re-scrubbed when wrapped |
| platform logs | the mint line names job, node, repositories, expiry — not the token |
| a GitHub error body | collapsed to a stable refusal token, so an upstream message cannot leak scope |
| any file in the workspace pool | a real-git test walks the whole pool after a push and asserts no file contains it |

**Fail-closed throughout:** a mint failure refuses the publish rather than falling back to the ambient helper, which would have left the gap exactly where it was.

## Attribution

Author is the agent, committer is the node, and the `Ever-Works-` trailer namespace is **reserved** so payload content cannot forge one. `git-push` is now a **probed node capability** that every `agent-task` requires, so a node that cannot push is never handed twenty minutes of work.

## Verified locally

| Check | Result |
| --- | --- |
| `packages/contracts` whole suite | 42 files / 2060 tests, no type errors |
| `apps/api` fleet + migrations (incl. the node-contract gate) | 76 suites / 812 tests |
| `apps/node` `src/core` | 1149 tests |
| `packages/plugins/local-workspace` | 3 files / 52 tests |
| `prettier --check` over all changed files | clean |
| build output in the diff | none |

The barrel inventory guard moved 153 → 175 with the count in the test name, the `toHaveLength`, the provenance comment and a new witness-table row all updated. Contract reversals each carry an in-place comment — notably the two positional `new FleetJobsController(...)` sites, whose new 4th argument defaults to a **refusal** stub rather than a permissive one.

The mechanism was also **verified empirically against real git 2.53 on this machine**: `credential.helper=manager` sits in the system gitconfig and answers a `git credential fill`, and with the module's exact reset it goes straight to `fatal: could not read Username … terminal prompts disabled`. That is the fail-closed proof the design rests on.

## Not verified locally

- The only `apps/node` failure is the documented one: the Windows trust spec needs a Rust binary that is not built here, and this branch does not touch it.
- **No live GitHub App installation token was minted.** The platform half drives a real mint through a spied `fetch` with a real RSA key, but the round trip to GitHub is not exercised, and neither is the revoke. A human should watch the first real push.
- e2e never runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet jobs can now publish using short-lived, repository-scoped GitHub credentials.
  * Git push support is detected automatically and required for publishing jobs.
  * Commits now include Agent, node, job, and run attribution.
  * Push credentials are isolated from repository configuration and revoked after use.
* **Bug Fixes**
  * Improved handling of mixed-case GitHub repository names.
  * Added safeguards against unauthorized repositories, invalid remotes, stale leases, and credential exposure.
* **Documentation**
  * Documented scoped credential behavior, restrictions, expiry, and commit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->