### PR TITLE
test(tasks): name the setup field EW-807 added to the gate-runner call

### DIFF
--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -744,6 +744,13 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 runId: 'run-1',
                 policy: 'required',
                 attempt: 1,
+                // EW-807 gave the gate runner a setup phase, and this is an
+                // EXACT-match assertion, so the new field has to be named here
+                // even when it is empty. Kept exact rather than relaxed to
+                // `objectContaining`: the point of this assertion is that a red
+                // gate is handed precisely what it should be, and loosening it
+                // would stop it noticing the next field that appears.
+                setup: [],
             });
             expect(runs.markCompleted).toHaveBeenCalledTimes(1);
             expect(runs.markCompleted.mock.calls[0][1]).toContain('build');


### PR DESCRIPTION
**`develop` is red and this fixes it.**

`packages/tasks/src/__tests__/agent-task-execute.task.spec.ts` asserts the red-gate call with `toHaveBeenCalledWith` — an **exact** match — and **EW-807** gave the gate runner a setup phase. The call now carries `setup: []` and the assertion did not know about it.

Kept **exact** rather than relaxed to `objectContaining`: the point of that assertion is that a red gate is handed precisely what it should be, and loosening it would stop it noticing the next field that appears.

## How it reached `develop`, stated plainly

This batch was merged **without waiting for `lint-and-test`**, at the founder's explicit instruction, because the runner pool was saturated by the batch's own re-runs. Every branch was verified locally first — but `packages/tasks` was outside the areas each slice touched, and therefore outside what each slice verified. It then cascaded to `stage` and `main`.

So this is a **known cost of that decision**, not a surprise, and it is exactly the fix-forward that was the agreed answer.

## Verified

Whole `@ever-works/trigger-tasks` package: **31 files / 513 tests**, from 1 failed / 512 passed. `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quality-gate test expectations to account for the gate runner receiving an empty setup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->